### PR TITLE
feat(query-scan): analyze a slow query from ClickHouse's plan

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -50397,18 +50397,13 @@
             ]
         },
         "QueryScanFindingKind": {
-            "enum": [
-                "no_event_filter",
-                "event_filter_not_used",
-                "no_start_date",
-                "persons_join",
-                "all_events",
-                "all_time"
-            ],
+            "description": "What the analysis found. `no_event_filter`: nothing narrows the query to particular events, so it reads every event in its date range. `no_start_date`: nothing bounds the start, so it reads from the project's first event. `persons_join`: the join to the persons tables reads as much as the events do.",
+            "enum": ["no_event_filter", "no_start_date", "persons_join"],
             "type": "string"
         },
         "QueryScanFindingReason": {
-            "enum": ["in_or", "wrapped", "negated", "dynamic", "not_pruned", "column", "filters"],
+            "description": "Why a filter the query has did not narrow the read. On `no_event_filter`: `in_or`, the event filter is inside an OR; `wrapped`, `event` is inside a function call; `negated`, the filter excludes events (`!=`, `NOT IN`) and excluding narrows nothing; `dynamic`, `event` is compared to another column; `not_pruned`, ClickHouse reported the filter unused. On `no_start_date`: `filters`, the date range comes from the insight's date picker through `{filters}` and was left open.",
+            "enum": ["in_or", "wrapped", "negated", "dynamic", "not_pruned", "filters"],
             "type": "string"
         },
         "QueryScanMode": {
@@ -50463,11 +50458,11 @@
                     "$ref": "#/definitions/integer"
                 },
                 "evidence": {
-                    "description": "What ClickHouse reported did not use the filter, when EXPLAIN was available",
+                    "description": "The fact the finding rests on, in one sentence: what the plan reported, or the setting that caused it.",
                     "type": "string"
                 },
                 "fix": {
-                    "description": "The instruction handed to \"Fix with AI\" and to agents",
+                    "description": "The instruction \"Fix with AI\" and the assistant get for this finding.",
                     "type": "string"
                 },
                 "kind": {
@@ -50479,7 +50474,7 @@
                 },
                 "reason": {
                     "$ref": "#/definitions/QueryScanFindingReason",
-                    "description": "Why the filter could not be used; only for event_filter_not_used and no_start_date"
+                    "description": "Why the filter the query has did not narrow the read. Only on no_event_filter and no_start_date."
                 },
                 "rows_read": {
                     "$ref": "#/definitions/integer"

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -50428,11 +50428,11 @@
                     "$ref": "#/definitions/QueryScanMode"
                 },
                 "project_share": {
-                    "description": "Share of the granules across all the project's events that the query read, 0 to 1, written by the analysis.",
+                    "description": "How much of all the project's events the query read, 0 to 1. Set once the analysis is done.",
                     "type": "number"
                 },
                 "range_share": {
-                    "description": "Share of the granules in the query's date range that the query read, 0 to 1, written by the analysis.",
+                    "description": "How much of the project's events in the query's date range the query read, 0 to 1. Set once the analysis is done.",
                     "type": "number"
                 },
                 "rows_read": {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -229,7 +229,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -739,7 +739,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -1137,7 +1137,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -1356,7 +1356,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -1552,7 +1552,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -6653,7 +6653,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -6785,7 +6785,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -6902,7 +6902,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -7031,7 +7031,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -7142,7 +7142,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -7257,7 +7257,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -7363,7 +7363,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -7484,7 +7484,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -7590,7 +7590,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -7709,7 +7709,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -7818,7 +7818,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -7939,7 +7939,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -8060,7 +8060,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -8226,7 +8226,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -8352,7 +8352,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -8464,7 +8464,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -8594,7 +8594,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -9172,7 +9172,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -9277,7 +9277,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -9407,7 +9407,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -9555,7 +9555,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -9932,7 +9932,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -10052,7 +10052,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -10158,7 +10158,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -10268,7 +10268,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -10375,7 +10375,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -10481,7 +10481,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -10587,7 +10587,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -10693,7 +10693,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -10799,7 +10799,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -10905,7 +10905,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -11011,7 +11011,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -11117,7 +11117,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -11223,7 +11223,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -11329,7 +11329,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -11435,7 +11435,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -11541,7 +11541,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -11651,7 +11651,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -11758,7 +11758,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -11865,7 +11865,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -11971,7 +11971,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -12080,7 +12080,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -12211,7 +12211,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -12357,7 +12357,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -12495,7 +12495,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -12630,7 +12630,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -12736,7 +12736,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -12934,7 +12934,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -13037,7 +13037,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -13143,7 +13143,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -13256,7 +13256,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -13363,7 +13363,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -13481,7 +13481,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -13625,7 +13625,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -13749,7 +13749,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -13875,7 +13875,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -13987,7 +13987,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -14093,7 +14093,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -14267,7 +14267,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -14460,7 +14460,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -14573,7 +14573,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -14686,7 +14686,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -14800,7 +14800,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -14911,7 +14911,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -15025,7 +15025,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -15146,7 +15146,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -15263,7 +15263,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -15369,7 +15369,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -15472,7 +15472,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -15593,7 +15593,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -15714,7 +15714,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -15838,7 +15838,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -15969,7 +15969,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -16081,7 +16081,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -16203,7 +16203,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -16318,7 +16318,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -16453,7 +16453,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -16568,7 +16568,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -16674,7 +16674,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -16885,7 +16885,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -18244,7 +18244,7 @@
                                     "type": "array"
                                 },
                                 "warnings": {
-                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                                     "items": {
                                         "anyOf": [
                                             {
@@ -18338,7 +18338,7 @@
                                     "type": "array"
                                 },
                                 "warnings": {
-                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                                     "items": {
                                         "anyOf": [
                                             {
@@ -18433,7 +18433,7 @@
                                     "type": "array"
                                 },
                                 "warnings": {
-                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                                     "items": {
                                         "anyOf": [
                                             {
@@ -18540,7 +18540,7 @@
                                     "type": "array"
                                 },
                                 "warnings": {
-                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                                     "items": {
                                         "anyOf": [
                                             {
@@ -18627,7 +18627,7 @@
                                     "type": "array"
                                 },
                                 "warnings": {
-                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                                     "items": {
                                         "anyOf": [
                                             {
@@ -18727,7 +18727,7 @@
                                     "type": "array"
                                 },
                                 "warnings": {
-                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                                     "items": {
                                         "anyOf": [
                                             {
@@ -18816,7 +18816,7 @@
                                     "type": "array"
                                 },
                                 "warnings": {
-                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                                     "items": {
                                         "anyOf": [
                                             {
@@ -18902,7 +18902,7 @@
                                     "type": "array"
                                 },
                                 "warnings": {
-                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                                     "items": {
                                         "anyOf": [
                                             {
@@ -18998,7 +18998,7 @@
                                     "type": "array"
                                 },
                                 "warnings": {
-                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                                     "items": {
                                         "anyOf": [
                                             {
@@ -19078,7 +19078,7 @@
                                     "type": "array"
                                 },
                                 "warnings": {
-                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                                     "items": {
                                         "anyOf": [
                                             {
@@ -19161,7 +19161,7 @@
                                     "type": "array"
                                 },
                                 "warnings": {
-                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                                     "items": {
                                         "anyOf": [
                                             {
@@ -19252,7 +19252,7 @@
                                     "type": "array"
                                 },
                                 "warnings": {
-                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                                     "items": {
                                         "anyOf": [
                                             {
@@ -19346,7 +19346,7 @@
                                     "type": "array"
                                 },
                                 "warnings": {
-                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                                     "items": {
                                         "anyOf": [
                                             {
@@ -19420,7 +19420,7 @@
                                     "type": "array"
                                 },
                                 "warnings": {
-                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                                     "items": {
                                         "anyOf": [
                                             {
@@ -19506,7 +19506,7 @@
                                     "type": "array"
                                 },
                                 "warnings": {
-                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                                     "items": {
                                         "anyOf": [
                                             {
@@ -19592,7 +19592,7 @@
                                     "type": "array"
                                 },
                                 "warnings": {
-                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                                     "items": {
                                         "anyOf": [
                                             {
@@ -19832,7 +19832,7 @@
                                     "type": "array"
                                 },
                                 "warnings": {
-                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                                     "items": {
                                         "anyOf": [
                                             {
@@ -19918,7 +19918,7 @@
                                     "type": "array"
                                 },
                                 "warnings": {
-                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                                     "items": {
                                         "anyOf": [
                                             {
@@ -20004,7 +20004,7 @@
                                     "type": "array"
                                 },
                                 "warnings": {
-                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                                     "items": {
                                         "anyOf": [
                                             {
@@ -20106,7 +20106,7 @@
                                     "type": "array"
                                 },
                                 "warnings": {
-                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                                     "items": {
                                         "anyOf": [
                                             {
@@ -20197,7 +20197,7 @@
                                     "type": "array"
                                 },
                                 "warnings": {
-                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                                     "items": {
                                         "anyOf": [
                                             {
@@ -21611,7 +21611,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -22097,7 +22097,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -22235,7 +22235,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -22363,7 +22363,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -22604,7 +22604,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -22856,7 +22856,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -23154,7 +23154,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -23543,7 +23543,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -23818,7 +23818,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -23957,7 +23957,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -24194,7 +24194,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -24689,7 +24689,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -28725,7 +28725,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -29550,7 +29550,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -29930,7 +29930,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -30704,7 +30704,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -32395,7 +32395,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -32595,7 +32595,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -32861,7 +32861,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -33065,7 +33065,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -33235,7 +33235,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -33381,7 +33381,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -33504,7 +33504,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -33635,7 +33635,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -33766,7 +33766,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -33866,7 +33866,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -33980,7 +33980,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -34105,7 +34105,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -34242,7 +34242,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -34360,7 +34360,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -34547,7 +34547,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -34651,7 +34651,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -34774,7 +34774,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -34915,7 +34915,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -35099,7 +35099,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -35242,7 +35242,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -35377,7 +35377,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -35523,7 +35523,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -35715,7 +35715,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -35988,7 +35988,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -36210,7 +36210,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -36621,7 +36621,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -36904,7 +36904,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -39096,7 +39096,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -40056,7 +40056,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -40434,7 +40434,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -41366,7 +41366,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -41566,7 +41566,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -41657,7 +41657,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -41751,7 +41751,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -41846,7 +41846,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -42036,7 +42036,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -42162,7 +42162,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -42322,7 +42322,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -42408,7 +42408,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -42488,7 +42488,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -42562,7 +42562,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -42646,7 +42646,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -42777,7 +42777,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -42876,7 +42876,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -43262,7 +43262,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -43349,7 +43349,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -43449,7 +43449,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -43538,7 +43538,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -43624,7 +43624,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -43710,7 +43710,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -43806,7 +43806,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -43886,7 +43886,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -43966,7 +43966,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -44059,7 +44059,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -44153,7 +44153,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -44227,7 +44227,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -44334,7 +44334,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -44438,7 +44438,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -44541,7 +44541,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -44651,7 +44651,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -44745,7 +44745,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -44840,7 +44840,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -44947,7 +44947,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -45034,7 +45034,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -45134,7 +45134,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -45223,7 +45223,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -45309,7 +45309,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -45405,7 +45405,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -45485,7 +45485,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -45568,7 +45568,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -45659,7 +45659,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -45753,7 +45753,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -45827,7 +45827,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -45913,7 +45913,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -45999,7 +45999,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -46239,7 +46239,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -46325,7 +46325,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -46411,7 +46411,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -46513,7 +46513,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -46604,7 +46604,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -46686,7 +46686,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -46756,7 +46756,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -46827,7 +46827,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -46898,7 +46898,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -46966,7 +46966,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -47037,7 +47037,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -47108,7 +47108,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -47193,7 +47193,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -47290,7 +47290,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -47375,7 +47375,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -47449,7 +47449,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -47520,7 +47520,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -47591,7 +47591,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -47670,7 +47670,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -47748,7 +47748,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -47826,7 +47826,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -47904,7 +47904,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -48004,7 +48004,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -48081,7 +48081,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -48159,7 +48159,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -48245,7 +48245,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -48331,7 +48331,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -48417,7 +48417,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -48524,7 +48524,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -48595,7 +48595,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -48697,7 +48697,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -48788,7 +48788,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -48859,7 +48859,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -48945,7 +48945,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -49016,7 +49016,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -49087,7 +49087,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -49158,7 +49158,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -49229,7 +49229,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -49300,7 +49300,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -49371,7 +49371,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -49442,7 +49442,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -49513,7 +49513,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -49585,7 +49585,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -49656,7 +49656,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -49731,7 +49731,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -49802,7 +49802,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -49873,7 +49873,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -49944,7 +49944,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -50015,7 +50015,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -50086,7 +50086,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -50157,7 +50157,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -50228,7 +50228,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -50303,7 +50303,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -50374,7 +50374,7 @@
                             "type": "array"
                         },
                         "warnings": {
-                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                             "items": {
                                 "anyOf": [
                                     {
@@ -50397,12 +50397,12 @@
             ]
         },
         "QueryScanFindingKind": {
-            "description": "What the analysis found. `no_event_filter`: nothing narrows the query to particular events, so it reads every event in its date range. `no_start_date`: nothing bounds the start, so it reads from the project's first event. `persons_join`: the join to the persons tables reads as much as the events do.",
+            "description": "`no_event_filter`: nothing narrows the query to particular events. `no_start_date`: nothing bounds where it starts reading. `persons_join`: the join to the persons tables reads as much as the events do.",
             "enum": ["no_event_filter", "no_start_date", "persons_join"],
             "type": "string"
         },
         "QueryScanFindingReason": {
-            "description": "Why a filter the query has did not narrow the read. On `no_event_filter`: `in_or`, the event filter is inside an OR; `wrapped`, `event` is inside a function call; `negated`, the filter excludes events (`!=`, `NOT IN`) and excluding narrows nothing; `dynamic`, `event` is compared to another column; `not_pruned`, ClickHouse reported the filter unused. On `no_start_date`: `filters`, the date range comes from the insight's date picker through `{filters}` and was left open.",
+            "description": "Why a filter the query does have did not narrow the read. `in_or`: it sits inside an OR. `wrapped`: `event` is inside a function call. `negated`: it excludes events, which narrows nothing. `dynamic`: `event` is compared to a column. `not_pruned`: ClickHouse reported it unused. `filters`: the date range comes from `{filters}` and the insight left it open.",
             "enum": ["in_or", "wrapped", "negated", "dynamic", "not_pruned", "filters"],
             "type": "string"
         },
@@ -50449,39 +50449,39 @@
         },
         "QueryScanWarning": {
             "additionalProperties": false,
+            "description": "One finding of a query scan. Sits in the response's `warnings` list next to the other warning kinds.",
             "properties": {
                 "clause": {
-                    "description": "The offending condition printed back as HogQL, when there is one",
+                    "description": "The condition at fault, as HogQL.",
                     "type": "string"
                 },
                 "duration_ms": {
                     "$ref": "#/definitions/integer"
                 },
                 "evidence": {
-                    "description": "The fact the finding rests on, in one sentence: what the plan reported, or the setting that caused it.",
+                    "description": "The one fact the finding rests on.",
                     "type": "string"
                 },
                 "fix": {
-                    "description": "The instruction \"Fix with AI\" and the assistant get for this finding.",
+                    "description": "What \"Fix with AI\" and the assistant are told to do.",
                     "type": "string"
                 },
                 "kind": {
                     "$ref": "#/definitions/QueryScanFindingKind"
                 },
                 "message": {
-                    "description": "Shown to the person. Sentence case, says what happened and what to do.",
+                    "description": "Shown to the person: what happened and what to do.",
                     "type": "string"
                 },
                 "reason": {
                     "$ref": "#/definitions/QueryScanFindingReason",
-                    "description": "Why the filter the query has did not narrow the read. Only on no_event_filter and no_start_date."
+                    "description": "Only with `no_event_filter` and `no_start_date`."
                 },
                 "rows_read": {
                     "$ref": "#/definitions/integer"
                 },
                 "type": {
                     "const": "query_scan",
-                    "description": "Tells warning kinds apart in the shared `warnings` list",
                     "type": "string"
                 }
             },
@@ -51263,7 +51263,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -51741,7 +51741,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -52313,7 +52313,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -52554,7 +52554,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -52743,7 +52743,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -53120,7 +53120,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -53231,7 +53231,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -54328,7 +54328,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -55253,7 +55253,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -55329,7 +55329,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -55427,7 +55427,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -55762,7 +55762,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -55889,7 +55889,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -56028,7 +56028,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -56187,7 +56187,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -56302,7 +56302,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -56429,7 +56429,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -56586,7 +56586,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -57112,7 +57112,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -57316,7 +57316,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -57487,7 +57487,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -57918,7 +57918,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -58346,7 +58346,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -58529,7 +58529,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -58720,7 +58720,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -58924,7 +58924,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -59128,7 +59128,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -59305,7 +59305,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -59556,7 +59556,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -59785,7 +59785,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {
@@ -59989,7 +59989,7 @@
                     "type": "array"
                 },
                 "warnings": {
-                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access.",
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`.",
                     "items": {
                         "anyOf": [
                             {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -237,6 +237,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -744,6 +747,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -1139,6 +1145,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -1355,6 +1364,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -1548,6 +1560,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -6646,6 +6661,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -6775,6 +6793,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -6889,6 +6910,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -7015,6 +7039,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -7123,6 +7150,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -7235,6 +7265,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -7338,6 +7371,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -7456,6 +7492,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -7559,6 +7598,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -7675,6 +7717,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -7781,6 +7826,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -7899,6 +7947,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -8017,6 +8068,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -8180,6 +8234,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -8303,6 +8360,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -8412,6 +8472,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -8539,6 +8602,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -9114,6 +9180,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -9216,6 +9285,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -9343,6 +9415,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -9488,6 +9563,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -9862,6 +9940,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -9979,6 +10060,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -10082,6 +10166,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -10189,6 +10276,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -10293,6 +10383,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -10396,6 +10489,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -10499,6 +10595,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -10602,6 +10701,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -10705,6 +10807,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -10808,6 +10913,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -10911,6 +11019,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -11014,6 +11125,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -11117,6 +11231,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -11220,6 +11337,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -11323,6 +11443,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -11426,6 +11549,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -11533,6 +11659,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -11637,6 +11766,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -11741,6 +11873,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -11844,6 +11979,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -11950,6 +12088,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -12078,6 +12219,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -12221,6 +12365,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -12356,6 +12503,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -12488,6 +12638,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -12591,6 +12744,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -12786,6 +12942,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -12886,6 +13045,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -12989,6 +13151,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -13099,6 +13264,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -13203,6 +13371,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -13318,6 +13489,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -13459,6 +13633,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -13580,6 +13757,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -13703,6 +13883,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -13812,6 +13995,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -13915,6 +14101,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -14086,6 +14275,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -14276,6 +14468,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -14386,6 +14581,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -14496,6 +14694,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -14607,6 +14808,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -14715,6 +14919,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -14826,6 +15033,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -14944,6 +15154,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -15058,6 +15271,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -15161,6 +15377,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -15261,6 +15480,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -15379,6 +15601,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -15497,6 +15722,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -15618,6 +15846,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -15746,6 +15977,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -15855,6 +16089,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -15974,6 +16211,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -16086,6 +16326,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -16218,6 +16461,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -16330,6 +16576,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -16433,6 +16682,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -16641,6 +16893,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -17997,6 +18252,9 @@
                                             },
                                             {
                                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                                            },
+                                            {
+                                                "$ref": "#/definitions/QueryScanWarning"
                                             }
                                         ]
                                     },
@@ -18088,6 +18346,9 @@
                                             },
                                             {
                                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                                            },
+                                            {
+                                                "$ref": "#/definitions/QueryScanWarning"
                                             }
                                         ]
                                     },
@@ -18180,6 +18441,9 @@
                                             },
                                             {
                                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                                            },
+                                            {
+                                                "$ref": "#/definitions/QueryScanWarning"
                                             }
                                         ]
                                     },
@@ -18284,6 +18548,9 @@
                                             },
                                             {
                                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                                            },
+                                            {
+                                                "$ref": "#/definitions/QueryScanWarning"
                                             }
                                         ]
                                     },
@@ -18368,6 +18635,9 @@
                                             },
                                             {
                                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                                            },
+                                            {
+                                                "$ref": "#/definitions/QueryScanWarning"
                                             }
                                         ]
                                     },
@@ -18465,6 +18735,9 @@
                                             },
                                             {
                                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                                            },
+                                            {
+                                                "$ref": "#/definitions/QueryScanWarning"
                                             }
                                         ]
                                     },
@@ -18551,6 +18824,9 @@
                                             },
                                             {
                                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                                            },
+                                            {
+                                                "$ref": "#/definitions/QueryScanWarning"
                                             }
                                         ]
                                     },
@@ -18634,6 +18910,9 @@
                                             },
                                             {
                                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                                            },
+                                            {
+                                                "$ref": "#/definitions/QueryScanWarning"
                                             }
                                         ]
                                     },
@@ -18727,6 +19006,9 @@
                                             },
                                             {
                                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                                            },
+                                            {
+                                                "$ref": "#/definitions/QueryScanWarning"
                                             }
                                         ]
                                     },
@@ -18804,6 +19086,9 @@
                                             },
                                             {
                                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                                            },
+                                            {
+                                                "$ref": "#/definitions/QueryScanWarning"
                                             }
                                         ]
                                     },
@@ -18884,6 +19169,9 @@
                                             },
                                             {
                                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                                            },
+                                            {
+                                                "$ref": "#/definitions/QueryScanWarning"
                                             }
                                         ]
                                     },
@@ -18972,6 +19260,9 @@
                                             },
                                             {
                                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                                            },
+                                            {
+                                                "$ref": "#/definitions/QueryScanWarning"
                                             }
                                         ]
                                     },
@@ -19063,6 +19354,9 @@
                                             },
                                             {
                                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                                            },
+                                            {
+                                                "$ref": "#/definitions/QueryScanWarning"
                                             }
                                         ]
                                     },
@@ -19134,6 +19428,9 @@
                                             },
                                             {
                                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                                            },
+                                            {
+                                                "$ref": "#/definitions/QueryScanWarning"
                                             }
                                         ]
                                     },
@@ -19217,6 +19514,9 @@
                                             },
                                             {
                                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                                            },
+                                            {
+                                                "$ref": "#/definitions/QueryScanWarning"
                                             }
                                         ]
                                     },
@@ -19300,6 +19600,9 @@
                                             },
                                             {
                                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                                            },
+                                            {
+                                                "$ref": "#/definitions/QueryScanWarning"
                                             }
                                         ]
                                     },
@@ -19537,6 +19840,9 @@
                                             },
                                             {
                                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                                            },
+                                            {
+                                                "$ref": "#/definitions/QueryScanWarning"
                                             }
                                         ]
                                     },
@@ -19620,6 +19926,9 @@
                                             },
                                             {
                                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                                            },
+                                            {
+                                                "$ref": "#/definitions/QueryScanWarning"
                                             }
                                         ]
                                     },
@@ -19703,6 +20012,9 @@
                                             },
                                             {
                                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                                            },
+                                            {
+                                                "$ref": "#/definitions/QueryScanWarning"
                                             }
                                         ]
                                     },
@@ -19802,6 +20114,9 @@
                                             },
                                             {
                                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                                            },
+                                            {
+                                                "$ref": "#/definitions/QueryScanWarning"
                                             }
                                         ]
                                     },
@@ -19890,6 +20205,9 @@
                                             },
                                             {
                                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                                            },
+                                            {
+                                                "$ref": "#/definitions/QueryScanWarning"
                                             }
                                         ]
                                     },
@@ -21301,6 +21619,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -21784,6 +22105,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -21919,6 +22243,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -22044,6 +22371,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -22282,6 +22612,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -22531,6 +22864,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -22826,6 +23162,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -23212,6 +23551,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -23484,6 +23826,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -23620,6 +23965,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -23854,6 +24202,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -24346,6 +24697,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -28379,6 +28733,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -29201,6 +29558,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -29578,6 +29938,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -30349,6 +30712,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -32037,6 +32403,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -32234,6 +32603,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -32497,6 +32869,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -32698,6 +33073,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -32865,6 +33243,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -33008,6 +33389,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -33128,6 +33512,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -33256,6 +33643,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -33384,6 +33774,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -33481,6 +33874,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -33592,6 +33988,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -33714,6 +34113,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -33848,6 +34250,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -33963,6 +34368,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -34147,6 +34555,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -34248,6 +34659,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -34368,6 +34782,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -34506,6 +34923,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -34687,6 +35107,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -34827,6 +35250,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -34959,6 +35385,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -35102,6 +35531,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -35291,6 +35723,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -35561,6 +35996,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -35780,6 +36218,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -36188,6 +36629,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -36468,6 +36912,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -38657,6 +39104,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -39614,6 +40064,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -39989,6 +40442,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -40918,6 +41374,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -41115,6 +41574,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -41203,6 +41665,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -41294,6 +41759,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -41386,6 +41854,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -41573,6 +42044,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -41696,6 +42170,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -41853,6 +42330,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -41936,6 +42416,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -42013,6 +42496,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -42084,6 +42570,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -42165,6 +42654,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -42293,6 +42785,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -42389,6 +42884,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -42772,6 +43270,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -42856,6 +43357,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -42953,6 +43457,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -43039,6 +43546,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -43122,6 +43632,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -43205,6 +43718,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -43298,6 +43814,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -43375,6 +43894,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -43452,6 +43974,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -43542,6 +44067,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -43633,6 +44161,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -43704,6 +44235,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -43808,6 +44342,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -43909,6 +44446,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -44009,6 +44549,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -44116,6 +44659,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -44207,6 +44753,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -44299,6 +44848,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -44403,6 +44955,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -44487,6 +45042,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -44584,6 +45142,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -44670,6 +45231,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -44753,6 +45317,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -44846,6 +45413,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -44923,6 +45493,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -45003,6 +45576,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -45091,6 +45667,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -45182,6 +45761,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -45253,6 +45835,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -45336,6 +45921,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -45419,6 +46007,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -45656,6 +46247,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -45739,6 +46333,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -45822,6 +46419,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -45921,6 +46521,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -46009,6 +46612,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -46088,6 +46694,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -46155,6 +46764,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -46223,6 +46835,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -46291,6 +46906,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -46356,6 +46974,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -46424,6 +47045,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -46492,6 +47116,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -46574,6 +47201,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -46668,6 +47298,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -46750,6 +47383,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -46821,6 +47457,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -46889,6 +47528,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -46957,6 +47599,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -47033,6 +47678,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -47108,6 +47756,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -47183,6 +47834,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -47258,6 +47912,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -47355,6 +48012,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -47429,6 +48089,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -47504,6 +48167,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -47587,6 +48253,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -47670,6 +48339,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -47753,6 +48425,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -47857,6 +48532,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -47925,6 +48603,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -48024,6 +48705,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -48112,6 +48796,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -48180,6 +48867,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -48263,6 +48953,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -48331,6 +49024,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -48399,6 +49095,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -48467,6 +49166,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -48535,6 +49237,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -48603,6 +49308,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -48671,6 +49379,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -48739,6 +49450,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -48807,6 +49521,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -48876,6 +49593,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -48944,6 +49664,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -49016,6 +49739,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -49084,6 +49810,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -49152,6 +49881,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -49220,6 +49952,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -49288,6 +50023,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -49356,6 +50094,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -49424,6 +50165,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -49492,6 +50236,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -49564,6 +50311,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -49632,6 +50382,9 @@
                                     },
                                     {
                                         "$ref": "#/definitions/AccessControlFilterWarning"
+                                    },
+                                    {
+                                        "$ref": "#/definitions/QueryScanWarning"
                                     }
                                 ]
                             },
@@ -49642,6 +50395,21 @@
                     "type": "object"
                 }
             ]
+        },
+        "QueryScanFindingKind": {
+            "enum": [
+                "no_event_filter",
+                "event_filter_not_used",
+                "no_start_date",
+                "persons_join",
+                "all_events",
+                "all_time"
+            ],
+            "type": "string"
+        },
+        "QueryScanFindingReason": {
+            "enum": ["in_or", "wrapped", "negated", "dynamic", "not_pruned", "column", "filters"],
+            "type": "string"
         },
         "QueryScanMode": {
             "description": "Variant of the `query-scan-warnings` flag for the team. `log_only`: analyze but show nothing, to calibrate the thresholds. `show`: clients may show findings. Clients read it here and never evaluate the flag themselves.",
@@ -49664,6 +50432,14 @@
                 "mode": {
                     "$ref": "#/definitions/QueryScanMode"
                 },
+                "project_share": {
+                    "description": "Share of the granules across all the project's events that the query read, 0 to 1, written by the analysis.",
+                    "type": "number"
+                },
+                "range_share": {
+                    "description": "Share of the granules in the query's date range that the query read, 0 to 1, written by the analysis.",
+                    "type": "number"
+                },
                 "rows_read": {
                     "$ref": "#/definitions/integer",
                     "description": "Rows ClickHouse read for the last fresh run, all tables included."
@@ -49674,6 +50450,47 @@
                 }
             },
             "required": ["mode", "rows_read", "duration_ms"],
+            "type": "object"
+        },
+        "QueryScanWarning": {
+            "additionalProperties": false,
+            "properties": {
+                "clause": {
+                    "description": "The offending condition printed back as HogQL, when there is one",
+                    "type": "string"
+                },
+                "duration_ms": {
+                    "$ref": "#/definitions/integer"
+                },
+                "evidence": {
+                    "description": "What ClickHouse reported did not use the filter, when EXPLAIN was available",
+                    "type": "string"
+                },
+                "fix": {
+                    "description": "The instruction handed to \"Fix with AI\" and to agents",
+                    "type": "string"
+                },
+                "kind": {
+                    "$ref": "#/definitions/QueryScanFindingKind"
+                },
+                "message": {
+                    "description": "Shown to the person. Sentence case, says what happened and what to do.",
+                    "type": "string"
+                },
+                "reason": {
+                    "$ref": "#/definitions/QueryScanFindingReason",
+                    "description": "Why the filter could not be used; only for event_filter_not_used and no_start_date"
+                },
+                "rows_read": {
+                    "$ref": "#/definitions/integer"
+                },
+                "type": {
+                    "const": "query_scan",
+                    "description": "Tells warning kinds apart in the shared `warnings` list",
+                    "type": "string"
+                }
+            },
+            "required": ["type", "kind", "message", "fix", "rows_read", "duration_ms"],
             "type": "object"
         },
         "QuerySchema": {
@@ -50459,6 +51276,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -50934,6 +51754,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -51503,6 +52326,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -51741,6 +52567,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -51927,6 +52756,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -52301,6 +53133,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -52409,6 +53244,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -53503,6 +54341,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -54425,6 +55266,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -54498,6 +55342,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -54593,6 +55440,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -54925,6 +55775,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -55049,6 +55902,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -55185,6 +56041,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -55341,6 +56200,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -55453,6 +56315,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -55577,6 +56442,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -55731,6 +56599,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -56254,6 +57125,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -56455,6 +57329,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -56623,6 +57500,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -57051,6 +57931,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -57476,6 +58359,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -57656,6 +58542,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -57844,6 +58733,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -58045,6 +58937,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -58246,6 +59141,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -58420,6 +59318,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -58668,6 +59569,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -58894,6 +59798,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },
@@ -59095,6 +60002,9 @@
                             },
                             {
                                 "$ref": "#/definitions/AccessControlFilterWarning"
+                            },
+                            {
+                                "$ref": "#/definitions/QueryScanWarning"
                             }
                         ]
                     },

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -609,6 +609,38 @@ export interface QueryScanSummary {
     duration_ms: integer
     /** Absent when the run was too fast to analyze. */
     status?: QueryScanStatus
+    /** Share of the granules in the query's date range that the query read, 0 to 1, written by the analysis. */
+    range_share?: number
+    /** Share of the granules across all the project's events that the query read, 0 to 1, written by the analysis. */
+    project_share?: number
+}
+
+export type QueryScanFindingKind =
+    | 'no_event_filter'
+    | 'event_filter_not_used'
+    | 'no_start_date'
+    | 'persons_join'
+    | 'all_events'
+    | 'all_time'
+
+export type QueryScanFindingReason = 'in_or' | 'wrapped' | 'negated' | 'dynamic' | 'not_pruned' | 'column' | 'filters'
+
+export interface QueryScanWarning {
+    /** Tells warning kinds apart in the shared `warnings` list */
+    type: 'query_scan'
+    kind: QueryScanFindingKind
+    /** Why the filter could not be used; only for event_filter_not_used and no_start_date */
+    reason?: QueryScanFindingReason
+    /** Shown to the person. Sentence case, says what happened and what to do. */
+    message: string
+    /** The instruction handed to "Fix with AI" and to agents */
+    fix: string
+    /** The offending condition printed back as HogQL, when there is one */
+    clause?: string
+    /** What ClickHouse reported did not use the filter, when EXPLAIN was available */
+    evidence?: string
+    rows_read: integer
+    duration_ms: integer
 }
 
 export interface HogQLQueryResponse<T = any[]> extends AnalyticsQueryResponseBase {
@@ -630,7 +662,7 @@ export interface HogQLQueryResponse<T = any[]> extends AnalyticsQueryResponseBas
      * is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data.
      * Also carries access control warnings when a system-table query filters out objects the user can't access.
      */
-    warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[]
+    warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[]
     query_scan?: QueryScanSummary
     hasMore?: boolean
     limit?: integer
@@ -2721,7 +2753,7 @@ export interface AnalyticsQueryResponseBase {
      * by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.
      * Also carries access control warnings when a system-table query filters out objects the user can't access.
      */
-    warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[]
+    warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[]
     query_scan?: QueryScanSummary
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsage[]

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -609,9 +609,9 @@ export interface QueryScanSummary {
     duration_ms: integer
     /** Absent when the run was too fast to analyze. */
     status?: QueryScanStatus
-    /** Share of the granules in the query's date range that the query read, 0 to 1, written by the analysis. */
+    /** How much of the project's events in the query's date range the query read, 0 to 1. Set once the analysis is done. */
     range_share?: number
-    /** Share of the granules across all the project's events that the query read, 0 to 1, written by the analysis. */
+    /** How much of all the project's events the query read, 0 to 1. Set once the analysis is done. */
     project_share?: number
 }
 

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -615,29 +615,35 @@ export interface QueryScanSummary {
     project_share?: number
 }
 
-export type QueryScanFindingKind =
-    | 'no_event_filter'
-    | 'event_filter_not_used'
-    | 'no_start_date'
-    | 'persons_join'
-    | 'all_events'
-    | 'all_time'
+/**
+ * What the analysis found. `no_event_filter`: nothing narrows the query to particular events, so it
+ * reads every event in its date range. `no_start_date`: nothing bounds the start, so it reads from the
+ * project's first event. `persons_join`: the join to the persons tables reads as much as the events do.
+ */
+export type QueryScanFindingKind = 'no_event_filter' | 'no_start_date' | 'persons_join'
 
-export type QueryScanFindingReason = 'in_or' | 'wrapped' | 'negated' | 'dynamic' | 'not_pruned' | 'column' | 'filters'
+/**
+ * Why a filter the query has did not narrow the read. On `no_event_filter`: `in_or`, the event filter
+ * is inside an OR; `wrapped`, `event` is inside a function call; `negated`, the filter excludes events
+ * (`!=`, `NOT IN`) and excluding narrows nothing; `dynamic`, `event` is compared to another column;
+ * `not_pruned`, ClickHouse reported the filter unused. On `no_start_date`: `filters`, the date range
+ * comes from the insight's date picker through `{filters}` and was left open.
+ */
+export type QueryScanFindingReason = 'in_or' | 'wrapped' | 'negated' | 'dynamic' | 'not_pruned' | 'filters'
 
 export interface QueryScanWarning {
     /** Tells warning kinds apart in the shared `warnings` list */
     type: 'query_scan'
     kind: QueryScanFindingKind
-    /** Why the filter could not be used; only for event_filter_not_used and no_start_date */
+    /** Why the filter the query has did not narrow the read. Only on no_event_filter and no_start_date. */
     reason?: QueryScanFindingReason
     /** Shown to the person. Sentence case, says what happened and what to do. */
     message: string
-    /** The instruction handed to "Fix with AI" and to agents */
+    /** The instruction "Fix with AI" and the assistant get for this finding. */
     fix: string
     /** The offending condition printed back as HogQL, when there is one */
     clause?: string
-    /** What ClickHouse reported did not use the filter, when EXPLAIN was available */
+    /** The fact the finding rests on, in one sentence: what the plan reported, or the setting that caused it. */
     evidence?: string
     rows_read: integer
     duration_ms: integer

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -616,34 +616,32 @@ export interface QueryScanSummary {
 }
 
 /**
- * What the analysis found. `no_event_filter`: nothing narrows the query to particular events, so it
- * reads every event in its date range. `no_start_date`: nothing bounds the start, so it reads from the
- * project's first event. `persons_join`: the join to the persons tables reads as much as the events do.
+ * `no_event_filter`: nothing narrows the query to particular events. `no_start_date`: nothing bounds
+ * where it starts reading. `persons_join`: the join to the persons tables reads as much as the events do.
  */
 export type QueryScanFindingKind = 'no_event_filter' | 'no_start_date' | 'persons_join'
 
 /**
- * Why a filter the query has did not narrow the read. On `no_event_filter`: `in_or`, the event filter
- * is inside an OR; `wrapped`, `event` is inside a function call; `negated`, the filter excludes events
- * (`!=`, `NOT IN`) and excluding narrows nothing; `dynamic`, `event` is compared to another column;
- * `not_pruned`, ClickHouse reported the filter unused. On `no_start_date`: `filters`, the date range
- * comes from the insight's date picker through `{filters}` and was left open.
+ * Why a filter the query does have did not narrow the read. `in_or`: it sits inside an OR. `wrapped`:
+ * `event` is inside a function call. `negated`: it excludes events, which narrows nothing. `dynamic`:
+ * `event` is compared to a column. `not_pruned`: ClickHouse reported it unused. `filters`: the date
+ * range comes from `{filters}` and the insight left it open.
  */
 export type QueryScanFindingReason = 'in_or' | 'wrapped' | 'negated' | 'dynamic' | 'not_pruned' | 'filters'
 
+/** One finding of a query scan. Sits in the response's `warnings` list next to the other warning kinds. */
 export interface QueryScanWarning {
-    /** Tells warning kinds apart in the shared `warnings` list */
     type: 'query_scan'
     kind: QueryScanFindingKind
-    /** Why the filter the query has did not narrow the read. Only on no_event_filter and no_start_date. */
+    /** Only with `no_event_filter` and `no_start_date`. */
     reason?: QueryScanFindingReason
-    /** Shown to the person. Sentence case, says what happened and what to do. */
+    /** Shown to the person: what happened and what to do. */
     message: string
-    /** The instruction "Fix with AI" and the assistant get for this finding. */
+    /** What "Fix with AI" and the assistant are told to do. */
     fix: string
-    /** The offending condition printed back as HogQL, when there is one */
+    /** The condition at fault, as HogQL. */
     clause?: string
-    /** The fact the finding rests on, in one sentence: what the plan reported, or the setting that caused it. */
+    /** The one fact the finding rests on. */
     evidence?: string
     rows_read: integer
     duration_ms: integer
@@ -667,6 +665,7 @@ export interface HogQLQueryResponse<T = any[]> extends AnalyticsQueryResponseBas
      * Warnings about data warehouse sources referenced by the query whose latest sync failed,
      * is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data.
      * Also carries access control warnings when a system-table query filters out objects the user can't access.
+     * Also carries query scan findings, see `QueryScanWarning`.
      */
     warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[]
     query_scan?: QueryScanSummary
@@ -2758,6 +2757,7 @@ export interface AnalyticsQueryResponseBase {
      * Accumulated across every HogQL execution that contributes to this response — so insights backed
      * by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.
      * Also carries access control warnings when a system-table query filters out objects the user can't access.
+     * Also carries query scan findings, see `QueryScanWarning`.
      */
     warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[]
     query_scan?: QueryScanSummary

--- a/posthog/query_scan/analyze.py
+++ b/posthog/query_scan/analyze.py
@@ -1,9 +1,7 @@
-"""Turn ClickHouse's plans and the thresholds into findings and the two shares.
+"""Turn ClickHouse's plans into findings and the two shares.
 
-Everything here is pure: no ClickHouse, no Redis, no Celery. The job hands over the outer query's
-plan, one plan per stubbed ``IN`` subquery, and two denominators: the granules of the project's
-events over the query's date range, and over all time. Each share is the outer read's granules
-against one denominator, so a person sees how much of their data the query read.
+Pure: no ClickHouse, Redis or Celery. A share is the outer read's granules over a denominator, the
+project's events in the query's date range or over all time.
 """
 
 from posthog.schema import QueryScanWarning
@@ -21,17 +19,14 @@ from posthog.query_scan.findings import (
 
 __all__ = ["PlanSet", "QueryScanResult", "analyze"]
 
-# The kind the runner reports for a raw HogQL query. Any other kind is an insight built from
-# pickers; the same rules apply, only the finding copy differs.
+# Raw SQL and an insight built from pickers get different finding copy.
 _SQL_QUERY_KIND = "HogQLQuery"
 
 
 @frozen
 class PlanSet:
-    """The plans one job produced, plus the denominators for the two shares.
-
-    ``team_granules`` and ``range_granules`` are the selected granules of the two denominator
-    ``EXPLAIN``s the job ran: the team's whole data, and the team's data over the query's range.
+    """The plans one job produced. ``team_granules`` and ``range_granules`` are the denominators:
+    the project's events over all time, and over the query's date range.
     """
 
     outer: QueryPlan | None
@@ -71,8 +66,7 @@ def analyze(
     project_share = _share(numerator, plans.team_granules)
 
     findings: list[QueryScanWarning] = []
-    # The outer plan's events read is the one the range share measures, so its no-event-filter gate
-    # can use the share. A subquery has no share of its own, so it gates on the skip-step fallback.
+    # Only the outer read has a range share; a subquery gates on the skip-step fallback.
     findings += _findings_for_plan(
         plans.outer,
         thresholds,
@@ -161,11 +155,8 @@ def _event_key_missing(read: PlanTableRead) -> bool:
 
 
 def _passes_event_gate(read: PlanTableRead, range_share: float | None, thresholds: ScanThresholds) -> bool:
-    """The read is a large share of the range, so an event filter would have saved real work.
-
-    With the range share known, the gate is that share against `event_ratio`. Without it (a
-    subquery, or a failed denominator), fall back to whether any skip index already pruned most of
-    the read, which means something else narrowed it and an event filter would not help much.
+    """With the range share known, gate on it. Without one (a subquery, or a failed denominator), a
+    skip index that already pruned most of the read means an event filter would not help much.
     """
     if range_share is not None:
         return range_share >= thresholds.event_ratio

--- a/posthog/query_scan/analyze.py
+++ b/posthog/query_scan/analyze.py
@@ -1,8 +1,9 @@
-"""Turn ClickHouse's plans and the thresholds into findings and the two granule shares.
+"""Turn ClickHouse's plans and the thresholds into findings and the two shares.
 
 Everything here is pure: no ClickHouse, no Redis, no Celery. The job hands over the outer query's
-plan, one plan per stubbed ``IN`` subquery, and the two denominator granule counts from 16.6; this
-module reads the findings and the shares off them.
+plan, one plan per stubbed ``IN`` subquery, and two denominators: the granules of the project's
+events over the query's date range, and over all time. Each share is the outer read's granules
+against one denominator, so a person sees how much of their data the query read.
 """
 
 from posthog.schema import QueryScanWarning
@@ -27,7 +28,7 @@ _SQL_QUERY_KIND = "HogQLQuery"
 
 @frozen
 class PlanSet:
-    """The plans one job produced, plus the denominators for the granule shares (16.6).
+    """The plans one job produced, plus the denominators for the two shares.
 
     ``team_granules`` and ``range_granules`` are the selected granules of the two denominator
     ``EXPLAIN``s the job ran: the team's whole data, and the team's data over the query's range.

--- a/posthog/query_scan/analyze.py
+++ b/posthog/query_scan/analyze.py
@@ -1,0 +1,217 @@
+"""Turn ClickHouse's plans and the thresholds into findings and the two granule shares.
+
+Everything here is pure: no ClickHouse, no Redis, no Celery. The job hands over the outer query's
+plan, one plan per stubbed ``IN`` subquery, and the two denominator granule counts from 16.6; this
+module reads the findings and the shares off them.
+"""
+
+from posthog.schema import QueryScanWarning
+
+from posthog.dataclasses import frozen
+from posthog.query_scan.explain import PlanTableRead, QueryPlan
+from posthog.query_scan.findings import (
+    FindingKind,
+    FindingReason,
+    ScanMeasurements,
+    ScanThresholds,
+    build_warning,
+    explain_evidence,
+)
+
+__all__ = ["PlanSet", "QueryScanResult", "analyze"]
+
+# The kind the runner reports for a raw HogQL query. Any other kind is an insight built from
+# pickers; the same rules apply, only the finding copy differs.
+_SQL_QUERY_KIND = "HogQLQuery"
+
+
+@frozen
+class PlanSet:
+    """The plans one job produced, plus the denominators for the granule shares (16.6).
+
+    ``team_granules`` and ``range_granules`` are the selected granules of the two denominator
+    ``EXPLAIN``s the job ran: the team's whole data, and the team's data over the query's range.
+    """
+
+    outer: QueryPlan | None
+    subqueries: tuple[QueryPlan, ...] = ()
+    team_granules: int | None = None
+    range_granules: int | None = None
+
+
+@frozen(eq=False)
+class QueryScanResult:
+    findings: list[QueryScanWarning]
+    explain_ok: bool
+    reads_events: bool = False
+    range_share: float | None = None
+    project_share: float | None = None
+
+    def finding_kinds(self) -> list[str]:
+        return [str(finding.kind) for finding in self.findings]
+
+
+def analyze(
+    plans: PlanSet,
+    thresholds: ScanThresholds,
+    *,
+    query_kind: str,
+    open_filters_placeholder: bool,
+    measurements: ScanMeasurements,
+) -> QueryScanResult:
+    """`open_filters_placeholder` is true when the query left its date range to a `{filters}`
+    placeholder that expanded to no bound, so the fix is on the insight, not in the SQL."""
+    if plans.outer is None:
+        return QueryScanResult(findings=[], explain_ok=False)
+
+    outer_events = plans.outer.events_read()
+    numerator = outer_events.selected_granules() if outer_events is not None else None
+    range_share = _share(numerator, plans.range_granules)
+    project_share = _share(numerator, plans.team_granules)
+
+    findings: list[QueryScanWarning] = []
+    # The outer plan's events read is the one the range share measures, so its no-event-filter gate
+    # can use the share. A subquery has no share of its own, so it gates on the skip-step fallback.
+    findings += _findings_for_plan(
+        plans.outer,
+        thresholds,
+        measurements,
+        query_kind=query_kind,
+        open_filters_placeholder=open_filters_placeholder,
+        range_share=range_share,
+        subquery_index=None,
+    )
+    for index, subquery in enumerate(plans.subqueries):
+        findings += _findings_for_plan(
+            subquery,
+            thresholds,
+            measurements,
+            query_kind=query_kind,
+            open_filters_placeholder=open_filters_placeholder,
+            range_share=None,
+            subquery_index=index,
+        )
+
+    return QueryScanResult(
+        findings=findings,
+        explain_ok=True,
+        reads_events=outer_events is not None,
+        range_share=range_share,
+        project_share=project_share,
+    )
+
+
+def _findings_for_plan(
+    plan: QueryPlan,
+    thresholds: ScanThresholds,
+    measurements: ScanMeasurements,
+    *,
+    query_kind: str,
+    open_filters_placeholder: bool,
+    range_share: float | None,
+    subquery_index: int | None,
+) -> list[QueryScanWarning]:
+    events_read = plan.events_read()
+    # A plan that does not read the events table has no denominator and nothing to advise on.
+    if events_read is None:
+        return []
+
+    findings: list[QueryScanWarning] = []
+
+    if not events_read.has_timestamp_key():
+        reason = FindingReason.FILTERS if open_filters_placeholder and query_kind == _SQL_QUERY_KIND else None
+        findings.append(
+            build_warning(
+                kind=FindingKind.NO_START_DATE,
+                query_kind=query_kind,
+                reason=reason,
+                measurements=measurements,
+                evidence=_min_max_evidence(events_read, subquery_index),
+            )
+        )
+
+    if _event_key_missing(events_read) and _passes_event_gate(events_read, range_share, thresholds):
+        findings.append(
+            build_warning(
+                kind=FindingKind.NO_EVENT_FILTER,
+                query_kind=query_kind,
+                measurements=measurements,
+                evidence=_primary_key_evidence(events_read, subquery_index),
+            )
+        )
+
+    person_read = _persons_join_read(plan, events_read, thresholds)
+    if person_read is not None:
+        findings.append(
+            build_warning(
+                kind=FindingKind.PERSONS_JOIN,
+                query_kind=query_kind,
+                measurements=measurements,
+                evidence=_primary_key_evidence(person_read, subquery_index),
+            )
+        )
+
+    return findings
+
+
+def _event_key_missing(read: PlanTableRead) -> bool:
+    primary_key = read.primary_key()
+    return primary_key is None or "event" not in primary_key.keys
+
+
+def _passes_event_gate(read: PlanTableRead, range_share: float | None, thresholds: ScanThresholds) -> bool:
+    """The read is a large share of the range, so an event filter would have saved real work.
+
+    With the range share known, the gate is that share against `event_ratio`. Without it (a
+    subquery, or a failed denominator), fall back to whether any skip index already pruned most of
+    the read, which means something else narrowed it and an event filter would not help much.
+    """
+    if range_share is not None:
+        return range_share >= thresholds.event_ratio
+    return not _any_skip_pruned_half(read)
+
+
+def _any_skip_pruned_half(read: PlanTableRead) -> bool:
+    for skip in read.skip_steps():
+        if (
+            skip.initial_granules is not None
+            and skip.initial_granules > 0
+            and skip.selected_granules is not None
+            and skip.selected_granules < 0.5 * skip.initial_granules
+        ):
+            return True
+    return False
+
+
+def _persons_join_read(plan: QueryPlan, events_read: PlanTableRead, thresholds: ScanThresholds) -> PlanTableRead | None:
+    events_granules = events_read.selected_granules()
+    if events_granules is None:
+        return None
+    threshold = thresholds.persons_ratio * events_granules
+    for read in plan.person_reads():
+        selected = read.selected_granules()
+        if selected is not None and selected >= threshold:
+            return read
+    return None
+
+
+def _min_max_evidence(read: PlanTableRead, subquery_index: int | None) -> str:
+    step = read.min_max()
+    keys = step.keys if step is not None else ()
+    before = step.initial_granules if step is not None else None
+    after = step.selected_granules if step is not None else None
+    return explain_evidence(keys, before=before, after=after, subquery_index=subquery_index)
+
+
+def _primary_key_evidence(read: PlanTableRead, subquery_index: int | None) -> str:
+    step = read.primary_key()
+    keys = step.keys if step is not None else ()
+    before = step.initial_granules if step is not None else None
+    after = step.selected_granules if step is not None else None
+    return explain_evidence(keys, before=before, after=after, subquery_index=subquery_index)
+
+
+def _share(numerator: int | None, denominator: int | None) -> float | None:
+    if numerator is None or denominator is None or denominator <= 0:
+        return None
+    return min(1.0, max(0.0, numerator / denominator))

--- a/posthog/query_scan/explain.py
+++ b/posthog/query_scan/explain.py
@@ -1,9 +1,7 @@
-"""Read the JSON that ``EXPLAIN indexes = 1, json = 1`` returns for a query.
+"""Read the JSON that ``EXPLAIN indexes = 1, json = 1`` returns.
 
-ClickHouse stores a table in granules, blocks of rows it reads or skips whole, so the granules a
-read kept measure how much of the table it touched. The plan says which table each node reads,
-which columns ClickHouse used to skip granules, how many each index step kept, and the timestamp
-range it could bound. The analysis reads its findings and its shares off this.
+ClickHouse reads a table in granules, blocks of rows it reads or skips whole, so the granules a
+read kept say how much of the table it touched. The plan reports that per table and per index step.
 """
 
 import re
@@ -12,8 +10,7 @@ from typing import Any
 
 from posthog.dataclasses import frozen
 
-# The events read prints as the sharded or the plain table, and the native-JSON schema has its own
-# pair. Spelled out rather than imported, so this parser does not pull in the model layer.
+# Spelled out rather than imported, so this parser does not pull in the model layer.
 _EVENTS_TABLE_NAMES = ("events", "events_json", "sharded_events", "sharded_events_json")
 
 _PERSON_TABLE_NAMES = ("person", "person_distinct_id2", "person_distinct_id_overrides")
@@ -22,8 +19,7 @@ _MIN_MAX_TYPE = "Min-Max"
 _PRIMARY_KEY_TYPE = "PrimaryKey"
 _SKIP_TYPE = "Skip"
 _MERGE_TREE_READ = "ReadFromMergeTree"
-# The other shards read through this node, and it carries no index report. It is not an object
-# storage or warehouse read, so it never sets `has_non_mergetree_read`.
+# The other shards' read. It carries no index report and is not a warehouse read.
 _REMOTE_READ = "ReadFromRemote"
 
 # ClickHouse prints a Min-Max timestamp condition in one canonical form: `timestamp in [A, +Inf)`,
@@ -62,8 +58,7 @@ class PlanTableRead:
     indexes: tuple[PlanIndex, ...]
 
     def reads_events(self) -> bool:
-        # The database qualifier is optional, but a longer name that merely ends in one of these is
-        # a different table.
+        # The database qualifier is optional; a longer name that only ends in one of these is another table.
         return self._matches(_EVENTS_TABLE_NAMES)
 
     def reads_persons(self) -> bool:
@@ -121,8 +116,7 @@ class QueryPlan:
 
 
 def parse_query_plan(payload: object) -> QueryPlan:
-    """Never raises. An unexpected shape yields a plan with no reads, which reads as
-    "EXPLAIN told us nothing" everywhere downstream."""
+    """Never raises: an unexpected shape yields a plan with no reads."""
     if isinstance(payload, str | bytes | bytearray):
         try:
             payload = json.loads(payload)

--- a/posthog/query_scan/explain.py
+++ b/posthog/query_scan/explain.py
@@ -1,8 +1,9 @@
 """Read the JSON that ``EXPLAIN indexes = 1, json = 1`` returns for a query.
 
-The plan says which table each node reads, which columns ClickHouse used to skip data, how many
-granules each index step kept, and the timestamp range it could bound. The analysis reads its
-findings and the granule shares off this, never off our own tree.
+ClickHouse stores a table in granules, blocks of rows it reads or skips whole, so the granules a
+read kept measure how much of the table it touched. The plan says which table each node reads,
+which columns ClickHouse used to skip granules, how many each index step kept, and the timestamp
+range it could bound. The analysis reads its findings and its shares off this.
 """
 
 import re

--- a/posthog/query_scan/explain.py
+++ b/posthog/query_scan/explain.py
@@ -1,0 +1,213 @@
+"""Read the JSON that ``EXPLAIN indexes = 1, json = 1`` returns for a query.
+
+The plan says which table each node reads, which columns ClickHouse used to skip data, how many
+granules each index step kept, and the timestamp range it could bound. The analysis reads its
+findings and the granule shares off this, never off our own tree.
+"""
+
+import re
+import json
+from typing import Any
+
+from posthog.dataclasses import frozen
+
+# The events read prints as the sharded or the plain table, and the native-JSON schema has its own
+# pair. Spelled out rather than imported, so this parser does not pull in the model layer.
+_EVENTS_TABLE_NAMES = ("events", "events_json", "sharded_events", "sharded_events_json")
+
+_PERSON_TABLE_NAMES = ("person", "person_distinct_id2", "person_distinct_id_overrides")
+
+_MIN_MAX_TYPE = "Min-Max"
+_PRIMARY_KEY_TYPE = "PrimaryKey"
+_SKIP_TYPE = "Skip"
+_MERGE_TREE_READ = "ReadFromMergeTree"
+# The other shards read through this node, and it carries no index report. It is not an object
+# storage or warehouse read, so it never sets `has_non_mergetree_read`.
+_REMOTE_READ = "ReadFromRemote"
+
+# ClickHouse prints a Min-Max timestamp condition in one canonical form: `timestamp in [A, +Inf)`,
+# `timestamp in (-Inf, B]`, or `timestamp in [A, B]`, all in unix seconds.
+_BOUNDS_RE = re.compile(r"in\s*[\[\(]\s*([^,\[\(]+?)\s*,\s*([^\]\)]+?)\s*[\]\)]")
+
+
+@frozen
+class TimestampBounds:
+    """The timestamp range the Min-Max step could bound, in unix seconds. None means unbounded."""
+
+    lower: int | None
+    upper: int | None
+
+
+@frozen
+class PlanIndex:
+    """One entry of a read node's ``Indexes`` list."""
+
+    type: str
+    # Only Skip steps carry a `Name`, the index that pruned; the other index types do not.
+    name: str | None
+    keys: tuple[str, ...]
+    condition: str | None
+    initial_parts: int | None
+    selected_parts: int | None
+    initial_granules: int | None
+    selected_granules: int | None
+
+
+@frozen
+class PlanTableRead:
+    """One ``ReadFromMergeTree`` node. ``table`` is the node's Description."""
+
+    table: str
+    indexes: tuple[PlanIndex, ...]
+
+    def reads_events(self) -> bool:
+        # The database qualifier is optional, but a longer name that merely ends in one of these is
+        # a different table.
+        return self._matches(_EVENTS_TABLE_NAMES)
+
+    def reads_persons(self) -> bool:
+        return self._matches(_PERSON_TABLE_NAMES)
+
+    def _matches(self, names: tuple[str, ...]) -> bool:
+        return any(self.table == name or self.table.endswith(f".{name}") for name in names)
+
+    def primary_key(self) -> PlanIndex | None:
+        return self._first(_PRIMARY_KEY_TYPE)
+
+    def min_max(self) -> PlanIndex | None:
+        return self._first(_MIN_MAX_TYPE)
+
+    def _first(self, index_type: str) -> PlanIndex | None:
+        for index in self.indexes:
+            if index.type == index_type:
+                return index
+        return None
+
+    def skip_steps(self) -> tuple[PlanIndex, ...]:
+        return tuple(index for index in self.indexes if index.type == _SKIP_TYPE)
+
+    def selected_granules(self) -> int | None:
+        """The granules the read kept after its last index step."""
+        for index in reversed(self.indexes):
+            if index.selected_granules is not None:
+                return index.selected_granules
+        return None
+
+    def has_timestamp_key(self) -> bool:
+        step = self.min_max()
+        return step is not None and any("timestamp" in key for key in step.keys)
+
+    def timestamp_bounds(self) -> TimestampBounds:
+        step = self.min_max()
+        if step is None or step.condition is None or not self.has_timestamp_key():
+            return TimestampBounds(lower=None, upper=None)
+        return _parse_timestamp_bounds(step.condition)
+
+
+@frozen
+class QueryPlan:
+    reads: tuple[PlanTableRead, ...]
+    has_non_mergetree_read: bool = False
+
+    def events_reads(self) -> tuple[PlanTableRead, ...]:
+        return tuple(read for read in self.reads if read.reads_events())
+
+    def events_read(self) -> PlanTableRead | None:
+        return next(iter(self.events_reads()), None)
+
+    def person_reads(self) -> tuple[PlanTableRead, ...]:
+        return tuple(read for read in self.reads if read.reads_persons())
+
+
+def parse_query_plan(payload: object) -> QueryPlan:
+    """Never raises. An unexpected shape yields a plan with no reads, which reads as
+    "EXPLAIN told us nothing" everywhere downstream."""
+    if isinstance(payload, str | bytes | bytearray):
+        try:
+            payload = json.loads(payload)
+        except (ValueError, TypeError):
+            return QueryPlan(reads=())
+
+    reads: list[PlanTableRead] = []
+    saw_other_read = _collect_reads(payload, reads)
+    return QueryPlan(reads=tuple(reads), has_non_mergetree_read=saw_other_read)
+
+
+def _collect_reads(node: object, reads: list[PlanTableRead]) -> bool:
+    """Append every MergeTree read to ``reads``; return whether a non-MergeTree read node was seen."""
+    if isinstance(node, list):
+        # Visit every item, not `any(...)`, which would stop appending reads at the first non-MergeTree.
+        saw_other = False
+        for item in node:
+            saw_other = _collect_reads(item, reads) or saw_other
+        return saw_other
+    if not isinstance(node, dict):
+        return False
+
+    saw_other = _collect_reads(node.get("Plan"), reads)
+
+    node_type = node.get("Node Type")
+    if node_type == _MERGE_TREE_READ:
+        read = _parse_read(node)
+        if read is not None:
+            reads.append(read)
+    elif isinstance(node_type, str) and node_type.startswith("ReadFrom") and node_type != _REMOTE_READ:
+        saw_other = True
+
+    return _collect_reads(node.get("Plans"), reads) or saw_other
+
+
+def _parse_read(node: dict[str, Any]) -> PlanTableRead | None:
+    table = node.get("Description")
+    if not isinstance(table, str):
+        return None
+    indexes = node.get("Indexes")
+    parsed_indexes: list[PlanIndex] = []
+    if isinstance(indexes, list):
+        for entry in indexes:
+            parsed = _parse_index(entry)
+            if parsed is not None:
+                parsed_indexes.append(parsed)
+    return PlanTableRead(table=table, indexes=tuple(parsed_indexes))
+
+
+def _parse_index(entry: object) -> PlanIndex | None:
+    if not isinstance(entry, dict):
+        return None
+    index_type = entry.get("Type")
+    if not isinstance(index_type, str):
+        return None
+    keys = entry.get("Keys")
+    name = entry.get("Name")
+    condition = entry.get("Condition")
+    return PlanIndex(
+        type=index_type,
+        name=name if isinstance(name, str) else None,
+        keys=tuple(key for key in keys if isinstance(key, str)) if isinstance(keys, list) else (),
+        condition=condition if isinstance(condition, str) else None,
+        initial_parts=_as_int(entry.get("Initial Parts")),
+        selected_parts=_as_int(entry.get("Selected Parts")),
+        initial_granules=_as_int(entry.get("Initial Granules")),
+        selected_granules=_as_int(entry.get("Selected Granules")),
+    )
+
+
+def _parse_timestamp_bounds(condition: str) -> TimestampBounds:
+    match = _BOUNDS_RE.search(condition)
+    if match is None:
+        return TimestampBounds(lower=None, upper=None)
+    return TimestampBounds(lower=_bound_value(match.group(1)), upper=_bound_value(match.group(2)))
+
+
+def _bound_value(token: str) -> int | None:
+    token = token.strip()
+    if token.lstrip("+-").lower() == "inf":
+        return None
+    try:
+        return int(float(token))
+    except ValueError:
+        return None
+
+
+def _as_int(value: object) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None

--- a/posthog/query_scan/findings.py
+++ b/posthog/query_scan/findings.py
@@ -12,8 +12,7 @@ from posthog.query_scan.flag import DEFAULT_EVENT_RATIO, DEFAULT_PERSONS_RATIO
 FindingKind = QueryScanFindingKind
 FindingReason = QueryScanFindingReason
 
-# The kind used by `to_query()` for a raw HogQL query. Any other kind is an insight built from
-# pickers, so the advice names the picker instead of a clause to add.
+# Raw SQL gets a clause to add; an insight built from pickers gets the name of its picker.
 _SQL_QUERY_KIND = "HogQLQuery"
 
 
@@ -27,8 +26,7 @@ class ScanThresholds:
 
 @frozen
 class ScanMeasurements:
-    # Every row ClickHouse read for the query, across every table it touched, so a joined table
-    # counts towards it. Both come from the run the person made, not from the plan.
+    # Rows across every table the run read, from the run itself rather than the plan.
     rows_read: int
     duration_ms: int
 
@@ -140,10 +138,8 @@ def build_warning(
 def explain_evidence(
     keys: tuple[str, ...], *, before: int | None, after: int | None, subquery_index: int | None
 ) -> str:
-    """What ClickHouse's deciding index step reported, for the person to check against.
-
-    ``before`` and ``after`` are the granules that step read and kept. ``subquery_index`` is set
-    when the finding is about an ``IN`` subquery, so the person can tell which one.
+    """What the deciding index step reported, for the person to check. ``before`` and ``after`` are
+    the granules it read and kept; ``subquery_index`` says which ``IN`` subquery, when it is one.
     """
     used = ", ".join(keys) if keys else "no columns"
     if before is None or after is None:

--- a/posthog/query_scan/findings.py
+++ b/posthog/query_scan/findings.py
@@ -1,0 +1,170 @@
+"""Turn an analysis outcome into the warning a person reads.
+
+The copy is the wording decided for the spec. A no-event-filter or no-start-date finding reads
+differently for raw SQL than for an insight built from pickers, so the query kind chooses which
+wording to use.
+"""
+
+from posthog.schema import QueryScanFindingKind, QueryScanFindingReason, QueryScanWarning
+
+from posthog.dataclasses import frozen
+from posthog.query_scan.flag import DEFAULT_EVENT_RATIO, DEFAULT_PERSONS_RATIO
+
+FindingKind = QueryScanFindingKind
+FindingReason = QueryScanFindingReason
+
+# The kind used by `to_query()` for a raw HogQL query. Any other kind is an insight built from
+# pickers, so the advice names the picker instead of a clause to add.
+_SQL_QUERY_KIND = "HogQLQuery"
+
+
+@frozen
+class ScanThresholds:
+    """Ratio gates, filled from the feature flag payload."""
+
+    event_ratio: float = DEFAULT_EVENT_RATIO
+    persons_ratio: float = DEFAULT_PERSONS_RATIO
+
+
+@frozen
+class ScanMeasurements:
+    # Every row ClickHouse read for the query, across every table it touched, so a joined table
+    # counts towards it. Both come from the run the person made, not from the plan.
+    rows_read: int
+    duration_ms: int
+
+
+@frozen
+class _Copy:
+    lead: str
+    advice: str
+    fix: str
+
+
+_NO_EVENT_FILTER_SQL = _Copy(
+    lead=(
+        "Queries are fastest when they name a fixed set of events. This query has no event filter, so it "
+        "reads every event you have ever sent, which is slow."
+    ),
+    advice="If the question is about specific events, add `WHERE event IN ('…')` naming them.",
+    fix=(
+        "If the query makes clear which events the question is about, add an event filter naming them and "
+        "change nothing else. If it does not, leave the query as it is; only the person knows which events "
+        "the question is about."
+    ),
+)
+
+_NO_EVENT_FILTER_INSIGHT = _Copy(
+    lead=(
+        "Insights are fastest when they look at a fixed set of events. This insight looks at all events, so "
+        "it reads everything you have ever sent, which is slow."
+    ),
+    advice="Pick specific events if the question is about some of them.",
+    fix="Pick the events this insight is about instead of All events.",
+)
+
+_NO_START_DATE_SQL = _Copy(
+    lead=(
+        "Queries are fastest when they start from a recent date. This query has no start date, so it reads "
+        "all your data back to the beginning, which is slow."
+    ),
+    advice="If you only need recent data, add `timestamp >= now() - interval 30 day` or the range you need.",
+    fix=(
+        "Add a start date on `timestamp` relative to now, for example `timestamp >= now() - interval 30 day`. "
+        "Never write a specific calendar date. Change nothing else."
+    ),
+)
+
+_NO_START_DATE_FILTERS = _Copy(
+    lead=(
+        "Queries are fastest when they start from a recent date. No date range is set on this insight or "
+        "dashboard, so this query reads all your data back to the beginning, which is slow."
+    ),
+    advice="Set a date range on the insight or the dashboard.",
+    fix="Set a date range on the insight or the dashboard. The SQL does not need to change.",
+)
+
+_NO_START_DATE_INSIGHT = _Copy(
+    lead=(
+        "Insights are fastest when they start from a recent date. This insight has no start date, so it reads "
+        "all your data back to the beginning, which is slow."
+    ),
+    advice="Set a date range if you only need recent data.",
+    fix="Set a date range on the insight instead of All time.",
+)
+
+_PERSONS_JOIN = _Copy(
+    lead=(
+        "Queries are fastest when they take person details from the events table. This query joins the "
+        "persons table, so every run reads every person in your project, which is slow."
+    ),
+    advice="Read person properties from the events table instead, for example `person.properties.email`.",
+    fix=(
+        "Read person properties from the events table, for example `person.properties.email`, instead "
+        "of joining the persons table. Change nothing else."
+    ),
+)
+
+
+def _copy_for(kind: FindingKind, reason: FindingReason | None, *, is_sql: bool) -> _Copy:
+    if kind == FindingKind.NO_EVENT_FILTER:
+        return _NO_EVENT_FILTER_SQL if is_sql else _NO_EVENT_FILTER_INSIGHT
+    if kind == FindingKind.NO_START_DATE:
+        if not is_sql:
+            return _NO_START_DATE_INSIGHT
+        return _NO_START_DATE_FILTERS if reason == FindingReason.FILTERS else _NO_START_DATE_SQL
+    if kind == FindingKind.PERSONS_JOIN:
+        return _PERSONS_JOIN
+    raise ValueError(f"No copy for finding kind {kind}")
+
+
+def build_warning(
+    *,
+    kind: FindingKind,
+    query_kind: str,
+    measurements: ScanMeasurements,
+    reason: FindingReason | None = None,
+    evidence: str | None = None,
+) -> QueryScanWarning:
+    copy = _copy_for(kind, reason, is_sql=query_kind == _SQL_QUERY_KIND)
+    return QueryScanWarning(
+        kind=kind,
+        reason=reason,
+        message=f"{copy.lead} {copy.advice}",
+        fix=copy.fix,
+        evidence=evidence,
+        rows_read=measurements.rows_read,
+        duration_ms=measurements.duration_ms,
+    )
+
+
+def explain_evidence(
+    keys: tuple[str, ...], *, before: int | None, after: int | None, subquery_index: int | None
+) -> str:
+    """What ClickHouse's deciding index step reported, for the person to check against.
+
+    ``before`` and ``after`` are the granules that step read and kept. ``subquery_index`` is set
+    when the finding is about an ``IN`` subquery, so the person can tell which one.
+    """
+    used = ", ".join(keys) if keys else "no columns"
+    if before is None or after is None:
+        evidence = f"ClickHouse's index used {used}."
+    else:
+        evidence = f"ClickHouse's index used {used} and kept {after:,} of {before:,} granules."
+    if subquery_index is not None:
+        return f"In subquery {subquery_index + 1}: {evidence}"
+    return evidence
+
+
+def format_rows(rows: int) -> str:
+    if rows >= 1_000_000_000_000:
+        return f"{rows / 1_000_000_000_000:.1f} trillion"
+    if rows >= 1_000_000_000:
+        return f"{rows / 1_000_000_000:.1f} billion"
+    if rows >= 1_000_000:
+        return f"{rows / 1_000_000:.1f} million"
+    return f"{rows:,}"
+
+
+def format_seconds(duration_ms: int) -> str:
+    return f"{duration_ms / 1000:.1f}"

--- a/posthog/query_scan/findings.py
+++ b/posthog/query_scan/findings.py
@@ -1,8 +1,7 @@
 """Turn an analysis outcome into the warning a person reads.
 
-The copy is the wording decided for the spec. A no-event-filter or no-start-date finding reads
-differently for raw SQL than for an insight built from pickers, so the query kind chooses which
-wording to use.
+A no-event-filter or no-start-date finding reads differently for raw SQL than for an insight built
+from pickers, so the query kind chooses which wording to use.
 """
 
 from posthog.schema import QueryScanFindingKind, QueryScanFindingReason, QueryScanWarning

--- a/posthog/query_scan/stub.py
+++ b/posthog/query_scan/stub.py
@@ -1,9 +1,8 @@
-"""Replace every ``x IN (subquery)`` with a constant before ClickHouse is asked for the plan.
+"""Replace every ``x IN (subquery)`` with a constant before asking ClickHouse for the plan.
 
-``EXPLAIN`` runs each ``IN (subquery)`` to completion to build its set before it plans the outer
-query. That reads real data, which defeats a plan-only analysis. Replacing the comparison with a
-constant keeps the rest of the query's shape, so the plan still shows how the outer query reads the
-events table. The replaced subqueries are collected so each can be explained on its own.
+``EXPLAIN`` runs each ``IN (subquery)`` to completion before it plans, which reads real data. The
+constant keeps the outer query's shape, so the plan still shows how it reads the events table. The
+subqueries are collected so each can be explained on its own.
 """
 
 from posthog.hogql import ast
@@ -11,8 +10,7 @@ from posthog.hogql.visitor import CloningVisitor
 
 from posthog.dataclasses import frozen
 
-# The global and cohort variants appear only after the tree is lowered, so covering them lets the
-# stub run on the lowered tree too. The subquery-right check keeps literal IN lists untouched.
+# The global and cohort variants appear only in the lowered tree; literal IN lists are kept.
 _IN_SUBQUERY_OPS = frozenset(
     {
         ast.CompareOperationOp.In,
@@ -71,8 +69,7 @@ class _StubVisitor(CloningVisitor):
         return super().visit_not(node)
 
     def visit_call(self, node: ast.Call) -> ast.Expr:
-        # The parser emits ``NOT (...)`` as a ``not(...)`` call, not an ``ast.Not``, keeping the source
-        # case, so the same fold applies here.
+        # The parser emits ``NOT (...)`` as a ``not(...)`` call rather than an ``ast.Not``.
         if node.name.lower() == "not" and len(node.args) == 1:
             right = _in_subquery_right(node.args[0])
             if right is not None:

--- a/posthog/query_scan/stub.py
+++ b/posthog/query_scan/stub.py
@@ -1,0 +1,81 @@
+"""Replace every ``x IN (subquery)`` with a constant before ClickHouse is asked for the plan.
+
+``EXPLAIN`` runs each ``IN (subquery)`` to completion to build its set before it plans the outer
+query. That reads real data, which defeats a plan-only analysis. Replacing the comparison with a
+constant keeps the rest of the query's shape, so the plan still shows how the outer query reads the
+events table. The replaced subqueries are collected so each can be explained on its own.
+"""
+
+from posthog.hogql import ast
+from posthog.hogql.visitor import CloningVisitor
+
+from posthog.dataclasses import frozen
+
+# The global and cohort variants appear only after the tree is lowered, so covering them lets the
+# stub run on the lowered tree too. The subquery-right check keeps literal IN lists untouched.
+_IN_SUBQUERY_OPS = frozenset(
+    {
+        ast.CompareOperationOp.In,
+        ast.CompareOperationOp.NotIn,
+        ast.CompareOperationOp.GlobalIn,
+        ast.CompareOperationOp.GlobalNotIn,
+        ast.CompareOperationOp.InCohort,
+        ast.CompareOperationOp.NotInCohort,
+    }
+)
+
+
+@frozen
+class StubResult:
+    """The stubbed tree and the subqueries taken out of it, in the order they were visited."""
+
+    stubbed: ast.Expr
+    subqueries: tuple[ast.SelectQuery | ast.SelectSetQuery, ...]
+
+
+def stub_in_subqueries(node: ast.Expr) -> StubResult:
+    visitor = _StubVisitor()
+    stubbed = visitor.visit(node)
+    return StubResult(stubbed=stubbed, subqueries=tuple(visitor.subqueries))
+
+
+def _in_subquery_right(node: ast.Expr) -> ast.SelectQuery | ast.SelectSetQuery | None:
+    if (
+        isinstance(node, ast.CompareOperation)
+        and node.op in _IN_SUBQUERY_OPS
+        and isinstance(node.right, (ast.SelectQuery, ast.SelectSetQuery))
+    ):
+        return node.right
+    return None
+
+
+class _StubVisitor(CloningVisitor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.subqueries: list[ast.SelectQuery | ast.SelectSetQuery] = []
+
+    def visit_compare_operation(self, node: ast.CompareOperation) -> ast.Expr:
+        right = _in_subquery_right(node)
+        if right is not None:
+            self.subqueries.append(right)
+            return ast.Constant(value=1)
+        return super().visit_compare_operation(node)
+
+    def visit_not(self, node: ast.Not) -> ast.Expr:
+        # Fold the whole ``NOT``: stubbing only the inner comparison leaves ``NOT 1``, which the key
+        # condition reads as always false, so the plan would report zero granules.
+        right = _in_subquery_right(node.expr)
+        if right is not None:
+            self.subqueries.append(right)
+            return ast.Constant(value=1)
+        return super().visit_not(node)
+
+    def visit_call(self, node: ast.Call) -> ast.Expr:
+        # The parser emits ``NOT (...)`` as a ``not(...)`` call, not an ``ast.Not``, keeping the source
+        # case, so the same fold applies here.
+        if node.name.lower() == "not" and len(node.args) == 1:
+            right = _in_subquery_right(node.args[0])
+            if right is not None:
+                self.subqueries.append(right)
+                return ast.Constant(value=1)
+        return super().visit_call(node)

--- a/posthog/query_scan/test/fixtures/event_filter_usable.json
+++ b/posthog/query_scan/test/fixtures/event_filter_usable.json
@@ -1,0 +1,93 @@
+[
+  {
+    "Plan": {
+      "Node Type": "Expression",
+      "Node Id": "Expression_75",
+      "Description": "(Project names + Projection)",
+      "Plans": [
+        {
+          "Node Type": "MergingAggregated",
+          "Node Id": "MergingAggregated_71",
+          "Plans": [
+            {
+              "Node Type": "Union",
+              "Node Id": "Union_65",
+              "Plans": [
+                {
+                  "Node Type": "Aggregating",
+                  "Node Id": "Aggregating_38",
+                  "Plans": [
+                    {
+                      "Node Type": "Expression",
+                      "Node Id": "Expression_37",
+                      "Description": "Before GROUP BY",
+                      "Plans": [
+                        {
+                          "Node Type": "Expression",
+                          "Node Id": "Expression_76",
+                          "Description": "(WHERE + Change column names to column identifiers)",
+                          "Plans": [
+                            {
+                              "Node Type": "ReadFromMergeTree",
+                              "Node Id": "ReadFromMergeTree_34",
+                              "Description": "posthog.sharded_events",
+                              "Indexes": [
+                                {
+                                  "Type": "Min-Max",
+                                  "Keys": ["timestamp"],
+                                  "Condition": "(timestamp in [1700000000, +Inf))",
+                                  "Initial Parts": 4000,
+                                  "Selected Parts": 60,
+                                  "Initial Granules": 3000000,
+                                  "Selected Granules": 60000
+                                },
+                                {
+                                  "Type": "Partition",
+                                  "Keys": ["toYYYYMM(timestamp)"],
+                                  "Condition": "(toYYYYMM(timestamp) in [202401, +Inf))",
+                                  "Initial Parts": 60,
+                                  "Selected Parts": 60,
+                                  "Initial Granules": 60000,
+                                  "Selected Granules": 60000
+                                },
+                                {
+                                  "Type": "PrimaryKey",
+                                  "Keys": ["team_id", "toDate(timestamp)", "event"],
+                                  "Condition": "and((toDate(timestamp) in [20000, +Inf)), and((event in ['$pageview', '$pageview']), (team_id in [1, 1])))",
+                                  "Search Algorithm": "generic exclusion search",
+                                  "Initial Parts": 60,
+                                  "Selected Parts": 50,
+                                  "Initial Granules": 60000,
+                                  "Selected Granules": 800
+                                },
+                                {
+                                  "Type": "Skip",
+                                  "Name": "minmax_sharded_events_timestamp",
+                                  "Description": "minmax GRANULARITY 1",
+                                  "Condition": "(timestamp in [1700000000, +Inf))",
+                                  "Initial Parts": 50,
+                                  "Selected Parts": 45,
+                                  "Initial Granules": 800,
+                                  "Selected Granules": 750
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Node Type": "ReadFromRemote",
+                  "Node Id": "ReadFromRemote_64",
+                  "Description": "Read from remote replica"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/posthog/query_scan/test/fixtures/no_event_filter.json
+++ b/posthog/query_scan/test/fixtures/no_event_filter.json
@@ -1,0 +1,100 @@
+[
+  {
+    "Plan": {
+      "Node Type": "Expression",
+      "Node Id": "Expression_75",
+      "Description": "(Project names + Projection)",
+      "Plans": [
+        {
+          "Node Type": "MergingAggregated",
+          "Node Id": "MergingAggregated_71",
+          "Plans": [
+            {
+              "Node Type": "Union",
+              "Node Id": "Union_65",
+              "Plans": [
+                {
+                  "Node Type": "Aggregating",
+                  "Node Id": "Aggregating_38",
+                  "Plans": [
+                    {
+                      "Node Type": "Expression",
+                      "Node Id": "Expression_37",
+                      "Description": "Before GROUP BY",
+                      "Plans": [
+                        {
+                          "Node Type": "Expression",
+                          "Node Id": "Expression_76",
+                          "Description": "(WHERE + Change column names to column identifiers)",
+                          "Plans": [
+                            {
+                              "Node Type": "ReadFromMergeTree",
+                              "Node Id": "ReadFromMergeTree_34",
+                              "Description": "posthog.sharded_events",
+                              "Indexes": [
+                                {
+                                  "Type": "Min-Max",
+                                  "Keys": [
+                                    "timestamp"
+                                  ],
+                                  "Condition": "(timestamp in [1700000000, +Inf))",
+                                  "Initial Parts": 4000,
+                                  "Selected Parts": 60,
+                                  "Initial Granules": 3000000,
+                                  "Selected Granules": 60000
+                                },
+                                {
+                                  "Type": "Partition",
+                                  "Keys": [
+                                    "toYYYYMM(timestamp)"
+                                  ],
+                                  "Condition": "(toYYYYMM(timestamp) in [202401, +Inf))",
+                                  "Initial Parts": 60,
+                                  "Selected Parts": 60,
+                                  "Initial Granules": 60000,
+                                  "Selected Granules": 60000
+                                },
+                                {
+                                  "Type": "PrimaryKey",
+                                  "Keys": [
+                                    "team_id",
+                                    "toDate(timestamp)"
+                                  ],
+                                  "Condition": "and((toDate(timestamp) in [20000, +Inf)), (team_id in [1, 1]))",
+                                  "Search Algorithm": "binary search",
+                                  "Initial Parts": 60,
+                                  "Selected Parts": 50,
+                                  "Initial Granules": 60000,
+                                  "Selected Granules": 40000
+                                },
+                                {
+                                  "Type": "Skip",
+                                  "Name": "minmax_sharded_events_timestamp",
+                                  "Description": "minmax GRANULARITY 1",
+                                  "Condition": "(timestamp in [1700000000, +Inf))",
+                                  "Initial Parts": 50,
+                                  "Selected Parts": 45,
+                                  "Initial Granules": 40000,
+                                  "Selected Granules": 39000
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Node Type": "ReadFromRemote",
+                  "Node Id": "ReadFromRemote_64",
+                  "Description": "Read from remote replica"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/posthog/query_scan/test/fixtures/plan_event_filter_in_or.json
+++ b/posthog/query_scan/test/fixtures/plan_event_filter_in_or.json
@@ -1,0 +1,120 @@
+[
+ {
+  "Plan": {
+   "Node Type": "Expression",
+   "Node Id": "Expression_75",
+   "Description": "(Project names + Projection)",
+   "Plans": [
+    {
+     "Node Type": "MergingAggregated",
+     "Node Id": "MergingAggregated_71",
+     "Plans": [
+      {
+       "Node Type": "Union",
+       "Node Id": "Union_65",
+       "Plans": [
+        {
+         "Node Type": "Aggregating",
+         "Node Id": "Aggregating_48",
+         "Plans": [
+          {
+           "Node Type": "Expression",
+           "Node Id": "Expression_47",
+           "Description": "Before GROUP BY",
+           "Plans": [
+            {
+             "Node Type": "Expression",
+             "Node Id": "Expression_76",
+             "Description": "(WHERE + Change column names to column identifiers)",
+             "Plans": [
+              {
+               "Node Type": "ReadFromMergeTree",
+               "Node Id": "ReadFromMergeTree_44",
+               "Description": "posthog.sharded_events",
+               "Indexes": [
+                {
+                 "Type": "Min-Max",
+                 "Keys": [
+                  "timestamp"
+                 ],
+                 "Condition": "(timestamp in [1788461220, +Inf))",
+                 "Initial Parts": 3564,
+                 "Selected Parts": 115,
+                 "Initial Granules": 270833110,
+                 "Selected Granules": 5538857
+                },
+                {
+                 "Type": "Partition",
+                 "Keys": [
+                  "toYYYYMM(timestamp)"
+                 ],
+                 "Condition": "(toYYYYMM(timestamp) in [202609, +Inf))",
+                 "Initial Parts": 115,
+                 "Selected Parts": 115,
+                 "Initial Granules": 5538857,
+                 "Selected Granules": 5538857
+                },
+                {
+                 "Type": "PrimaryKey",
+                 "Keys": [
+                  "team_id",
+                  "toDate(timestamp)",
+                  "event",
+                  "cityHash64(distinct_id)"
+                 ],
+                 "Condition": "and(or((cityHash64(distinct_id) in [11760547678682620745, 11760547678682620745]), (event in ['$pageview', '$pageview'])), and((toDate(timestamp) in [20699, +Inf)), (team_id in [2, 2])))",
+                 "Search Algorithm": "generic exclusion search",
+                 "Initial Parts": 115,
+                 "Selected Parts": 74,
+                 "Initial Granules": 5538857,
+                 "Selected Granules": 25745
+                },
+                {
+                 "Type": "Skip",
+                 "Name": "minmax_sharded_events_timestamp",
+                 "Description": "minmax GRANULARITY 1",
+                 "Condition": "(timestamp in [1788461220, +Inf))",
+                 "Initial Parts": 74,
+                 "Selected Parts": 70,
+                 "Initial Granules": 25745,
+                 "Selected Granules": 23018
+                },
+                {
+                 "Type": "Skip",
+                 "Name": "bloom_filter_distinct_id",
+                 "Description": "bloom_filter GRANULARITY 1",
+                 "Initial Parts": 70,
+                 "Selected Parts": 70,
+                 "Initial Granules": 23018,
+                 "Selected Granules": 23018
+                },
+                {
+                 "Type": "Skip",
+                 "Name": "<Combined skip indexes>",
+                 "Description": "Final set of granules after AND/OR processing",
+                 "Initial Parts": 70,
+                 "Selected Parts": 74,
+                 "Initial Granules": 23018,
+                 "Selected Granules": 23018
+                }
+               ]
+              }
+             ]
+            }
+           ]
+          }
+         ]
+        },
+        {
+         "Node Type": "ReadFromRemote",
+         "Node Id": "ReadFromRemote_64",
+         "Description": "Read from remote replica"
+        }
+       ]
+      }
+     ]
+    }
+   ]
+  }
+ }
+]

--- a/posthog/query_scan/test/fixtures/plan_event_filter_used.json
+++ b/posthog/query_scan/test/fixtures/plan_event_filter_used.json
@@ -1,0 +1,101 @@
+[
+ {
+  "Plan": {
+   "Node Type": "Expression",
+   "Node Id": "Expression_75",
+   "Description": "(Project names + Projection)",
+   "Plans": [
+    {
+     "Node Type": "MergingAggregated",
+     "Node Id": "MergingAggregated_71",
+     "Plans": [
+      {
+       "Node Type": "Union",
+       "Node Id": "Union_65",
+       "Plans": [
+        {
+         "Node Type": "Aggregating",
+         "Node Id": "Aggregating_48",
+         "Plans": [
+          {
+           "Node Type": "Expression",
+           "Node Id": "Expression_47",
+           "Description": "Before GROUP BY",
+           "Plans": [
+            {
+             "Node Type": "Expression",
+             "Node Id": "Expression_76",
+             "Description": "(WHERE + Change column names to column identifiers)",
+             "Plans": [
+              {
+               "Node Type": "ReadFromMergeTree",
+               "Node Id": "ReadFromMergeTree_44",
+               "Description": "posthog.sharded_events",
+               "Indexes": [
+                {
+                 "Type": "Min-Max",
+                 "Keys": [
+                  "timestamp"
+                 ],
+                 "Condition": "(timestamp in [1788461182, +Inf))",
+                 "Initial Parts": 3573,
+                 "Selected Parts": 108,
+                 "Initial Granules": 270832618,
+                 "Selected Granules": 5538361
+                },
+                {
+                 "Type": "Partition",
+                 "Keys": [
+                  "toYYYYMM(timestamp)"
+                 ],
+                 "Condition": "(toYYYYMM(timestamp) in [202609, +Inf))",
+                 "Initial Parts": 108,
+                 "Selected Parts": 108,
+                 "Initial Granules": 5538361,
+                 "Selected Granules": 5538361
+                },
+                {
+                 "Type": "PrimaryKey",
+                 "Keys": [
+                  "team_id",
+                  "toDate(timestamp)",
+                  "event"
+                 ],
+                 "Condition": "and((event in ['$pageview', '$pageview']), and((toDate(timestamp) in [20699, +Inf)), (team_id in [2, 2])))",
+                 "Search Algorithm": "generic exclusion search",
+                 "Initial Parts": 108,
+                 "Selected Parts": 67,
+                 "Initial Granules": 5538361,
+                 "Selected Granules": 9613
+                },
+                {
+                 "Type": "Skip",
+                 "Name": "minmax_sharded_events_timestamp",
+                 "Description": "minmax GRANULARITY 1",
+                 "Condition": "(timestamp in [1788461182, +Inf))",
+                 "Initial Parts": 67,
+                 "Selected Parts": 63,
+                 "Initial Granules": 9613,
+                 "Selected Granules": 8567
+                }
+               ]
+              }
+             ]
+            }
+           ]
+          }
+         ]
+        },
+        {
+         "Node Type": "ReadFromRemote",
+         "Node Id": "ReadFromRemote_64",
+         "Description": "Read from remote replica"
+        }
+       ]
+      }
+     ]
+    }
+   ]
+  }
+ }
+]

--- a/posthog/query_scan/test/fixtures/plan_no_date_bound.json
+++ b/posthog/query_scan/test/fixtures/plan_no_date_bound.json
@@ -1,0 +1,84 @@
+[
+ {
+  "Plan": {
+   "Node Type": "Expression",
+   "Node Id": "Expression_75",
+   "Description": "(Project names + Projection)",
+   "Plans": [
+    {
+     "Node Type": "MergingAggregated",
+     "Node Id": "MergingAggregated_71",
+     "Plans": [
+      {
+       "Node Type": "Union",
+       "Node Id": "Union_65",
+       "Plans": [
+        {
+         "Node Type": "Aggregating",
+         "Node Id": "Aggregating_23",
+         "Plans": [
+          {
+           "Node Type": "Expression",
+           "Node Id": "Expression_22",
+           "Description": "Before GROUP BY",
+           "Plans": [
+            {
+             "Node Type": "Expression",
+             "Node Id": "Expression_76",
+             "Description": "(WHERE + Change column names to column identifiers)",
+             "Plans": [
+              {
+               "Node Type": "ReadFromMergeTree",
+               "Node Id": "ReadFromMergeTree_19",
+               "Description": "posthog.sharded_events",
+               "Indexes": [
+                {
+                 "Type": "Min-Max",
+                 "Condition": "true",
+                 "Initial Parts": 3511,
+                 "Selected Parts": 3511,
+                 "Initial Granules": 265491928,
+                 "Selected Granules": 265491928
+                },
+                {
+                 "Type": "Partition",
+                 "Condition": "true",
+                 "Initial Parts": 3511,
+                 "Selected Parts": 3511,
+                 "Initial Granules": 265491928,
+                 "Selected Granules": 265491928
+                },
+                {
+                 "Type": "PrimaryKey",
+                 "Keys": [
+                  "team_id",
+                  "event"
+                 ],
+                 "Condition": "and((event in ['$pageview', '$pageview']), (team_id in [2, 2]))",
+                 "Search Algorithm": "generic exclusion search",
+                 "Initial Parts": 3511,
+                 "Selected Parts": 1659,
+                 "Initial Granules": 265491928,
+                 "Selected Granules": 412056
+                }
+               ]
+              }
+             ]
+            }
+           ]
+          }
+         ]
+        },
+        {
+         "Node Type": "ReadFromRemote",
+         "Node Id": "ReadFromRemote_64",
+         "Description": "Read from remote replica"
+        }
+       ]
+      }
+     ]
+    }
+   ]
+  }
+ }
+]

--- a/posthog/query_scan/test/fixtures/plan_no_event_filter.json
+++ b/posthog/query_scan/test/fixtures/plan_no_event_filter.json
@@ -1,0 +1,100 @@
+[
+ {
+  "Plan": {
+   "Node Type": "Expression",
+   "Node Id": "Expression_75",
+   "Description": "(Project names + Projection)",
+   "Plans": [
+    {
+     "Node Type": "MergingAggregated",
+     "Node Id": "MergingAggregated_71",
+     "Plans": [
+      {
+       "Node Type": "Union",
+       "Node Id": "Union_65",
+       "Plans": [
+        {
+         "Node Type": "Aggregating",
+         "Node Id": "Aggregating_23",
+         "Plans": [
+          {
+           "Node Type": "Expression",
+           "Node Id": "Expression_22",
+           "Description": "Before GROUP BY",
+           "Plans": [
+            {
+             "Node Type": "Expression",
+             "Node Id": "Expression_76",
+             "Description": "(WHERE + Change column names to column identifiers)",
+             "Plans": [
+              {
+               "Node Type": "ReadFromMergeTree",
+               "Node Id": "ReadFromMergeTree_19",
+               "Description": "posthog.sharded_events",
+               "Indexes": [
+                {
+                 "Type": "Min-Max",
+                 "Keys": [
+                  "timestamp"
+                 ],
+                 "Condition": "(timestamp in [1788461215, +Inf))",
+                 "Initial Parts": 3508,
+                 "Selected Parts": 66,
+                 "Initial Granules": 265491898,
+                 "Selected Granules": 5582406
+                },
+                {
+                 "Type": "Partition",
+                 "Keys": [
+                  "toYYYYMM(timestamp)"
+                 ],
+                 "Condition": "(toYYYYMM(timestamp) in [202609, +Inf))",
+                 "Initial Parts": 66,
+                 "Selected Parts": 66,
+                 "Initial Granules": 5582406,
+                 "Selected Granules": 5582406
+                },
+                {
+                 "Type": "PrimaryKey",
+                 "Keys": [
+                  "team_id",
+                  "toDate(timestamp)"
+                 ],
+                 "Condition": "and((toDate(timestamp) in [20699, +Inf)), (team_id in [2, 2]))",
+                 "Search Algorithm": "binary search",
+                 "Initial Parts": 66,
+                 "Selected Parts": 60,
+                 "Initial Granules": 5582406,
+                 "Selected Granules": 362907
+                },
+                {
+                 "Type": "Skip",
+                 "Name": "minmax_sharded_events_timestamp",
+                 "Description": "minmax GRANULARITY 1",
+                 "Condition": "(timestamp in [1788461215, +Inf))",
+                 "Initial Parts": 60,
+                 "Selected Parts": 56,
+                 "Initial Granules": 362907,
+                 "Selected Granules": 329267
+                }
+               ]
+              }
+             ]
+            }
+           ]
+          }
+         ]
+        },
+        {
+         "Node Type": "ReadFromRemote",
+         "Node Id": "ReadFromRemote_64",
+         "Description": "Read from remote replica"
+        }
+       ]
+      }
+     ]
+    }
+   ]
+  }
+ }
+]

--- a/posthog/query_scan/test/fixtures/plan_object_storage_read.json
+++ b/posthog/query_scan/test/fixtures/plan_object_storage_read.json
@@ -1,0 +1,106 @@
+[
+ {
+  "Plan": {
+   "Node Type": "Expression",
+   "Node Id": "Expression_30",
+   "Description": "Project names",
+   "Plans": [
+    {
+     "Node Type": "Limit",
+     "Node Id": "Limit_29",
+     "Description": "preliminary LIMIT",
+     "Plans": [
+      {
+       "Node Type": "Sorting",
+       "Node Id": "Sorting_28",
+       "Description": "Sorting for ORDER BY",
+       "Plans": [
+        {
+         "Node Type": "Expression",
+         "Node Id": "Expression_51",
+         "Description": "(Before ORDER BY + Projection)",
+         "Plans": [
+          {
+           "Node Type": "Aggregating",
+           "Node Id": "Aggregating_25",
+           "Plans": [
+            {
+             "Node Type": "Union",
+             "Node Id": "Union_47",
+             "Plans": [
+              {
+               "Node Type": "Expression",
+               "Node Id": "Expression_49",
+               "Description": "(Before GROUP BY + (Change column names to column identifiers + (Conversion before UNION + (Project names + Projection))))",
+               "Plans": [
+                {
+                 "Node Type": "Aggregating",
+                 "Node Id": "Aggregating_7",
+                 "Plans": [
+                  {
+                   "Node Type": "Expression",
+                   "Node Id": "Expression_6",
+                   "Description": "Before GROUP BY",
+                   "Plans": [
+                    {
+                     "Node Type": "Filter",
+                     "Node Id": "Filter_34",
+                     "Description": "(WHERE + (Change column names to column identifiers + (Project names + (Projection + Change column names to column identifiers))))",
+                     "Plans": [
+                      {
+                       "Node Type": "ReadFromObjectStorage",
+                       "Node Id": "ReadFromObjectStorage_0"
+                      }
+                     ]
+                    }
+                   ]
+                  }
+                 ]
+                }
+               ]
+              },
+              {
+               "Node Type": "Expression",
+               "Node Id": "Expression_50",
+               "Description": "(Before GROUP BY + (Change column names to column identifiers + (Conversion before UNION + (Project names + Projection))))",
+               "Plans": [
+                {
+                 "Node Type": "Aggregating",
+                 "Node Id": "Aggregating_17",
+                 "Plans": [
+                  {
+                   "Node Type": "Expression",
+                   "Node Id": "Expression_16",
+                   "Description": "Before GROUP BY",
+                   "Plans": [
+                    {
+                     "Node Type": "Filter",
+                     "Node Id": "Filter_40",
+                     "Description": "(WHERE + (Change column names to column identifiers + (Project names + (Projection + Change column names to column identifiers))))",
+                     "Plans": [
+                      {
+                       "Node Type": "ReadFromObjectStorage",
+                       "Node Id": "ReadFromObjectStorage_10"
+                      }
+                     ]
+                    }
+                   ]
+                  }
+                 ]
+                }
+               ]
+              }
+             ]
+            }
+           ]
+          }
+         ]
+        }
+       ]
+      }
+     ]
+    }
+   ]
+  }
+ }
+]

--- a/posthog/query_scan/test/fixtures/plan_persons_join.json
+++ b/posthog/query_scan/test/fixtures/plan_persons_join.json
@@ -1,0 +1,153 @@
+[
+ {
+  "Plan": {
+   "Node Type": "Expression",
+   "Node Id": "Expression_144",
+   "Description": "(Project names + Projection)",
+   "Plans": [
+    {
+     "Node Type": "MergingAggregated",
+     "Node Id": "MergingAggregated_134",
+     "Plans": [
+      {
+       "Node Type": "Union",
+       "Node Id": "Union_125",
+       "Plans": [
+        {
+         "Node Type": "Aggregating",
+         "Node Id": "Aggregating_67",
+         "Plans": [
+          {
+           "Node Type": "Expression",
+           "Node Id": "Expression_152",
+           "Plans": [
+            {
+             "Node Type": "Join",
+             "Node Id": "Join_150",
+             "Description": "JOIN FillRightFirst",
+             "Plans": [
+              {
+               "Node Type": "Expression",
+               "Node Id": "Expression_148",
+               "Description": "Left Pre Join Actions",
+               "Plans": [
+                {
+                 "Node Type": "Expression",
+                 "Node Id": "Expression_155",
+                 "Plans": [
+                  {
+                   "Node Type": "ReadFromMergeTree",
+                   "Node Id": "ReadFromMergeTree_58",
+                   "Description": "posthog.person",
+                   "Indexes": [
+                    {
+                     "Type": "PrimaryKey",
+                     "Keys": [
+                      "team_id"
+                     ],
+                     "Condition": "(team_id in [2, 2])",
+                     "Search Algorithm": "binary search",
+                     "Initial Parts": 86,
+                     "Selected Parts": 86,
+                     "Initial Granules": 9366597,
+                     "Selected Granules": 79160
+                    }
+                   ]
+                  }
+                 ]
+                }
+               ]
+              },
+              {
+               "Node Type": "Expression",
+               "Node Id": "Expression_149",
+               "Description": "Right Pre Join Actions",
+               "Plans": [
+                {
+                 "Node Type": "BuildRuntimeFilter",
+                 "Node Id": "BuildRuntimeFilter_146",
+                 "Description": "Build runtime join filter on __table1.person_id",
+                 "Plans": [
+                  {
+                   "Node Type": "Expression",
+                   "Node Id": "Expression_156",
+                   "Description": "(WHERE + Change column names to column identifiers)",
+                   "Plans": [
+                    {
+                     "Node Type": "ReadFromMergeTree",
+                     "Node Id": "ReadFromMergeTree_56",
+                     "Description": "posthog.sharded_events",
+                     "Indexes": [
+                      {
+                       "Type": "Min-Max",
+                       "Keys": [
+                        "timestamp"
+                       ],
+                       "Condition": "(timestamp in [1788461223, +Inf))",
+                       "Initial Parts": 2938,
+                       "Selected Parts": 50,
+                       "Initial Granules": 291514662,
+                       "Selected Granules": 5515706
+                      },
+                      {
+                       "Type": "Partition",
+                       "Keys": [
+                        "toYYYYMM(timestamp)"
+                       ],
+                       "Condition": "(toYYYYMM(timestamp) in [202609, +Inf))",
+                       "Initial Parts": 50,
+                       "Selected Parts": 50,
+                       "Initial Granules": 5515706,
+                       "Selected Granules": 5515706
+                      },
+                      {
+                       "Type": "PrimaryKey",
+                       "Keys": [
+                        "team_id",
+                        "toDate(timestamp)",
+                        "event"
+                       ],
+                       "Condition": "and((event in ['$pageview', '$pageview']), and((toDate(timestamp) in [20699, +Inf)), (team_id in [2, 2])))",
+                       "Search Algorithm": "generic exclusion search",
+                       "Initial Parts": 50,
+                       "Selected Parts": 45,
+                       "Initial Granules": 5515706,
+                       "Selected Granules": 8832
+                      },
+                      {
+                       "Type": "Skip",
+                       "Name": "minmax_sharded_events_timestamp",
+                       "Description": "minmax GRANULARITY 1",
+                       "Condition": "(timestamp in [1788461223, +Inf))",
+                       "Initial Parts": 45,
+                       "Selected Parts": 44,
+                       "Initial Granules": 8832,
+                       "Selected Granules": 8285
+                      }
+                     ]
+                    }
+                   ]
+                  }
+                 ]
+                }
+               ]
+              }
+             ]
+            }
+           ]
+          }
+         ]
+        },
+        {
+         "Node Type": "ReadFromRemote",
+         "Node Id": "ReadFromRemote_124",
+         "Description": "Read from remote replica"
+        }
+       ]
+      }
+     ]
+    }
+   ]
+  }
+ }
+]

--- a/posthog/query_scan/test/fixtures/plan_replay_list_in_subqueries.json
+++ b/posthog/query_scan/test/fixtures/plan_replay_list_in_subqueries.json
@@ -1,0 +1,126 @@
+[
+ {
+  "Plan": {
+   "Node Type": "Expression",
+   "Node Id": "Expression_568",
+   "Description": "(Project names + (Before ORDER BY + Projection) [lifted up part])",
+   "Plans": [
+    {
+     "Node Type": "Limit",
+     "Node Id": "Limit_562",
+     "Description": "preliminary LIMIT",
+     "Plans": [
+      {
+       "Node Type": "Sorting",
+       "Node Id": "Sorting_561",
+       "Description": "Sorting for ORDER BY",
+       "Plans": [
+        {
+         "Node Type": "Expression",
+         "Node Id": "Expression_566",
+         "Description": "(Before ORDER BY + Projection)",
+         "Plans": [
+          {
+           "Node Type": "Filter",
+           "Node Id": "Filter_558",
+           "Description": "HAVING",
+           "Plans": [
+            {
+             "Node Type": "MergingAggregated",
+             "Node Id": "MergingAggregated_557",
+             "Plans": [
+              {
+               "Node Type": "Union",
+               "Node Id": "Union_551",
+               "Plans": [
+                {
+                 "Node Type": "CreatingSets",
+                 "Node Id": "CreatingSets_579",
+                 "Description": "Create sets before main query execution",
+                 "Plans": [
+                  {
+                   "Node Type": "Aggregating",
+                   "Node Id": "Aggregating_511",
+                   "Plans": [
+                    {
+                     "Node Type": "Expression",
+                     "Node Id": "Expression_510",
+                     "Description": "Before GROUP BY",
+                     "Plans": [
+                      {
+                       "Node Type": "Filter",
+                       "Node Id": "Filter_578",
+                       "Description": "(WHERE + Change column names to column identifiers)",
+                       "Plans": [
+                        {
+                         "Node Type": "ReadFromMergeTree",
+                         "Node Id": "ReadFromMergeTree_507",
+                         "Description": "posthog.sharded_session_replay_events",
+                         "Indexes": [
+                          {
+                           "Type": "Min-Max",
+                           "Keys": [
+                            "min_first_timestamp"
+                           ],
+                           "Condition": "and((min_first_timestamp in (-Inf, '1789058701.088805']), (min_first_timestamp in ['1788418800', +Inf)))",
+                           "Initial Parts": 217,
+                           "Selected Parts": 26,
+                           "Initial Granules": 2164629,
+                           "Selected Granules": 59554
+                          },
+                          {
+                           "Type": "Partition",
+                           "Keys": [
+                            "toYYYYMM(min_first_timestamp)"
+                           ],
+                           "Condition": "and((toYYYYMM(min_first_timestamp) in (-Inf, 202609]), (toYYYYMM(min_first_timestamp) in [202609, +Inf)))",
+                           "Initial Parts": 26,
+                           "Selected Parts": 26,
+                           "Initial Granules": 59554,
+                           "Selected Granules": 59554
+                          },
+                          {
+                           "Type": "PrimaryKey",
+                           "Keys": [
+                            "toDate(min_first_timestamp)",
+                            "team_id",
+                            "session_id"
+                           ],
+                           "Condition": "and((session_id notIn 49327-element set), and(and((session_id in 197773-element set), (session_id in 61-element set)), and((toDate(min_first_timestamp) in (-Inf, 20706]), and((toDate(min_first_timestamp) in [20699, +Inf)), (team_id in [2, 2])))))",
+                           "Search Algorithm": "generic exclusion search",
+                           "Initial Parts": 26,
+                           "Selected Parts": 26,
+                           "Initial Granules": 59554,
+                           "Selected Granules": 163
+                          }
+                         ]
+                        }
+                       ]
+                      }
+                     ]
+                    }
+                   ]
+                  }
+                 ]
+                },
+                {
+                 "Node Type": "ReadFromRemote",
+                 "Node Id": "ReadFromRemote_550",
+                 "Description": "Read from remote replica"
+                }
+               ]
+              }
+             ]
+            }
+           ]
+          }
+         ]
+        }
+       ]
+      }
+     ]
+    }
+   ]
+  }
+ }
+]

--- a/posthog/query_scan/test/fixtures/plan_skip_index_pruned.json
+++ b/posthog/query_scan/test/fixtures/plan_skip_index_pruned.json
@@ -1,0 +1,110 @@
+[
+ {
+  "Plan": {
+   "Node Type": "Expression",
+   "Node Id": "Expression_75",
+   "Description": "(Project names + Projection)",
+   "Plans": [
+    {
+     "Node Type": "MergingAggregated",
+     "Node Id": "MergingAggregated_71",
+     "Plans": [
+      {
+       "Node Type": "Union",
+       "Node Id": "Union_65",
+       "Plans": [
+        {
+         "Node Type": "Aggregating",
+         "Node Id": "Aggregating_63",
+         "Plans": [
+          {
+           "Node Type": "Expression",
+           "Node Id": "Expression_62",
+           "Description": "Before GROUP BY",
+           "Plans": [
+            {
+             "Node Type": "Expression",
+             "Node Id": "Expression_76",
+             "Description": "(WHERE + Change column names to column identifiers)",
+             "Plans": [
+              {
+               "Node Type": "ReadFromMergeTree",
+               "Node Id": "ReadFromMergeTree_59",
+               "Description": "posthog.sharded_events",
+               "Indexes": [
+                {
+                 "Type": "Min-Max",
+                 "Keys": [
+                  "timestamp"
+                 ],
+                 "Condition": "(timestamp in [1788461227, +Inf))",
+                 "Initial Parts": 2929,
+                 "Selected Parts": 91,
+                 "Initial Granules": 280507871,
+                 "Selected Granules": 5525235
+                },
+                {
+                 "Type": "Partition",
+                 "Keys": [
+                  "toYYYYMM(timestamp)"
+                 ],
+                 "Condition": "(toYYYYMM(timestamp) in [202609, +Inf))",
+                 "Initial Parts": 91,
+                 "Selected Parts": 91,
+                 "Initial Granules": 5525235,
+                 "Selected Granules": 5525235
+                },
+                {
+                 "Type": "PrimaryKey",
+                 "Keys": [
+                  "team_id",
+                  "toDate(timestamp)"
+                 ],
+                 "Condition": "and((toDate(timestamp) in [20699, +Inf)), (team_id in [2, 2]))",
+                 "Search Algorithm": "binary search",
+                 "Initial Parts": 91,
+                 "Selected Parts": 53,
+                 "Initial Granules": 5525235,
+                 "Selected Granules": 349931
+                },
+                {
+                 "Type": "Skip",
+                 "Name": "minmax_$session_id",
+                 "Description": "minmax GRANULARITY 1",
+                 "Condition": "($session_id in ['019a0000-0000-7000-8000-000000000000', '019a0000-0000-7000-8000-000000000000'])",
+                 "Initial Parts": 53,
+                 "Selected Parts": 53,
+                 "Initial Granules": 349931,
+                 "Selected Granules": 117977
+                },
+                {
+                 "Type": "Skip",
+                 "Name": "minmax_sharded_events_timestamp",
+                 "Description": "minmax GRANULARITY 1",
+                 "Condition": "(timestamp in [1788461227, +Inf))",
+                 "Initial Parts": 53,
+                 "Selected Parts": 52,
+                 "Initial Granules": 117977,
+                 "Selected Granules": 103415
+                }
+               ]
+              }
+             ]
+            }
+           ]
+          }
+         ]
+        },
+        {
+         "Node Type": "ReadFromRemote",
+         "Node Id": "ReadFromRemote_64",
+         "Description": "Read from remote replica"
+        }
+       ]
+      }
+     ]
+    }
+   ]
+  }
+ }
+]

--- a/posthog/query_scan/test/test_analyze.py
+++ b/posthog/query_scan/test/test_analyze.py
@@ -1,0 +1,122 @@
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+
+from posthog.query_scan.analyze import PlanSet, QueryScanResult, analyze
+from posthog.query_scan.explain import QueryPlan, parse_query_plan
+from posthog.query_scan.findings import FindingReason, ScanMeasurements, ScanThresholds
+from posthog.query_scan.test.test_explain import load_plan
+
+MEASUREMENTS = ScanMeasurements(rows_read=3_000_000_000, duration_ms=6_000)
+
+
+def plan(name: str) -> QueryPlan:
+    return parse_query_plan(load_plan(name))
+
+
+def analyze_fixture(
+    outer: str,
+    *,
+    subqueries: tuple[str, ...] = (),
+    team_granules: int | None = None,
+    range_granules: int | None = None,
+    persons_ratio: float = 0.5,
+    query_kind: str = "HogQLQuery",
+    open_filters_placeholder: bool = False,
+) -> QueryScanResult:
+    return analyze(
+        PlanSet(
+            outer=plan(outer),
+            subqueries=tuple(plan(name) for name in subqueries),
+            team_granules=team_granules,
+            range_granules=range_granules,
+        ),
+        ScanThresholds(persons_ratio=persons_ratio),
+        query_kind=query_kind,
+        open_filters_placeholder=open_filters_placeholder,
+        measurements=MEASUREMENTS,
+    )
+
+
+class TestAnalyze(SimpleTestCase):
+    @parameterized.expand(
+        [
+            # event gate: the read is a large share of the range, so the missing event filter is flagged
+            (
+                "no event filter, over the ratio",
+                "plan_no_event_filter",
+                {"range_granules": 1_000_000},
+                ["no_event_filter"],
+            ),
+            # event gate the other way: the read is a small share, so nothing is flagged
+            ("no event filter, under the ratio", "plan_no_event_filter", {"range_granules": 100_000_000}, []),
+            ("event filter in the key stays quiet", "plan_event_filter_used", {}, []),
+            ("event filter inside an OR still used", "plan_event_filter_in_or", {}, []),
+            ("no date bound is flagged", "plan_no_date_bound", {}, ["no_start_date"]),
+            # persons gate: the persons read dwarfs the events read
+            ("persons join over the ratio", "plan_persons_join", {}, ["persons_join"]),
+            # persons gate the other way: raise the ratio past what the plan shows
+            ("persons join under the ratio", "plan_persons_join", {"persons_ratio": 10.0}, []),
+            ("object storage read yields nothing", "plan_object_storage_read", {}, []),
+            ("a replay list query reads no events", "plan_replay_list_in_subqueries", {}, []),
+            # a subquery whose events read pruned nothing is flagged through the skip-step fallback
+            (
+                "a subquery with no event filter is flagged",
+                "plan_event_filter_used",
+                {"subqueries": ("plan_no_event_filter",)},
+                ["no_event_filter"],
+            ),
+            # a subquery a skip index already pruned is not flagged
+            (
+                "a subquery a skip index pruned is not flagged",
+                "plan_event_filter_used",
+                {"subqueries": ("plan_skip_index_pruned",)},
+                [],
+            ),
+        ]
+    )
+    def test_findings_per_gate(
+        self, _name: str, outer: str, kwargs: dict[str, object], expected_kinds: list[str]
+    ) -> None:
+        result = analyze_fixture(outer, **kwargs)  # type: ignore[arg-type]
+
+        self.assertTrue(result.explain_ok)
+        self.assertEqual(result.finding_kinds(), expected_kinds)
+
+    def test_no_outer_plan_fails_closed(self) -> None:
+        result = analyze(
+            PlanSet(outer=None),
+            ScanThresholds(),
+            query_kind="HogQLQuery",
+            open_filters_placeholder=False,
+            measurements=MEASUREMENTS,
+        )
+
+        self.assertFalse(result.explain_ok)
+        self.assertEqual(result.findings, [])
+
+    def test_open_filters_placeholder_sets_the_filters_reason(self) -> None:
+        result = analyze_fixture("plan_no_date_bound", open_filters_placeholder=True)
+
+        self.assertEqual([finding.reason for finding in result.findings], [FindingReason.FILTERS])
+        self.assertIn("No date range is set on this insight or dashboard", result.findings[0].message)
+
+    def test_insight_kind_uses_the_insight_wording(self) -> None:
+        result = analyze_fixture("plan_no_date_bound", query_kind="TrendsQuery")
+
+        self.assertEqual(result.finding_kinds(), ["no_start_date"])
+        self.assertIsNone(result.findings[0].reason)
+        self.assertIn("This insight has no start date", result.findings[0].message)
+
+    def test_shares_are_the_read_over_the_denominators(self) -> None:
+        result = analyze_fixture("plan_no_event_filter", team_granules=10_000_000, range_granules=1_000_000)
+
+        assert result.range_share is not None and result.project_share is not None
+        self.assertAlmostEqual(result.range_share, 0.329267, places=5)
+        self.assertAlmostEqual(result.project_share, 0.0329267, places=6)
+
+    def test_a_subquery_finding_names_the_subquery(self) -> None:
+        result = analyze_fixture("plan_event_filter_used", subqueries=("plan_no_event_filter",))
+
+        assert result.findings[0].evidence is not None
+        self.assertIn("In subquery 1", result.findings[0].evidence)

--- a/posthog/query_scan/test/test_explain.py
+++ b/posthog/query_scan/test/test_explain.py
@@ -1,0 +1,169 @@
+import json
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+
+from posthog.query_scan.explain import parse_query_plan
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def load_plan(name: str) -> object:
+    return json.loads((FIXTURES / f"{name}.json").read_text())
+
+
+def min_max_read(condition: str, keys: list[str]) -> list[dict[str, object]]:
+    return [
+        {
+            "Plan": {
+                "Node Type": "ReadFromMergeTree",
+                "Description": "posthog.sharded_events",
+                "Indexes": [
+                    {
+                        "Type": "Min-Max",
+                        "Keys": keys,
+                        "Condition": condition,
+                        "Initial Granules": 1000,
+                        "Selected Granules": 1000,
+                    }
+                ],
+            }
+        }
+    ]
+
+
+class TestExplainParsing(SimpleTestCase):
+    @parameterized.expand(
+        [
+            # fixture, primary key columns, event in the key, granules after the last step, has a
+            # timestamp key, the lower unix bound the Min-Max step could apply
+            ("plan_event_filter_used", ("team_id", "toDate(timestamp)", "event"), True, 8567, True, 1788461182),
+            ("plan_no_event_filter", ("team_id", "toDate(timestamp)"), False, 329267, True, 1788461215),
+            ("plan_no_date_bound", ("team_id", "event"), True, 412056, False, None),
+            (
+                "plan_event_filter_in_or",
+                ("team_id", "toDate(timestamp)", "event", "cityHash64(distinct_id)"),
+                True,
+                23018,
+                True,
+                1788461220,
+            ),
+            ("plan_skip_index_pruned", ("team_id", "toDate(timestamp)"), False, 103415, True, 1788461227),
+            ("event_filter_usable", ("team_id", "toDate(timestamp)", "event"), True, 750, True, 1700000000),
+            ("no_event_filter", ("team_id", "toDate(timestamp)"), False, 39000, True, 1700000000),
+        ]
+    )
+    def test_events_read_reports_table_keys_granules_and_bounds(
+        self,
+        fixture: str,
+        expected_keys: tuple[str, ...],
+        event_in_key: bool,
+        final_granules: int,
+        has_timestamp_key: bool,
+        lower_bound: int | None,
+    ) -> None:
+        plan = parse_query_plan(load_plan(fixture))
+
+        read = plan.events_read()
+        assert read is not None
+        self.assertEqual(read.table, "posthog.sharded_events")
+        primary_key = read.primary_key()
+        assert primary_key is not None
+        self.assertEqual(primary_key.keys, expected_keys)
+        self.assertEqual("event" in primary_key.keys, event_in_key)
+        self.assertEqual(read.selected_granules(), final_granules)
+        self.assertEqual(read.has_timestamp_key(), has_timestamp_key)
+        bounds = read.timestamp_bounds()
+        self.assertEqual(bounds.lower, lower_bound)
+        self.assertIsNone(bounds.upper)
+
+    def test_steps_are_kept_in_order_and_skip_steps_carry_names(self) -> None:
+        read = parse_query_plan(load_plan("plan_skip_index_pruned")).events_read()
+        assert read is not None
+
+        self.assertEqual([step.type for step in read.indexes], ["Min-Max", "Partition", "PrimaryKey", "Skip", "Skip"])
+        self.assertEqual(
+            [step.name for step in read.skip_steps()],
+            ["minmax_$session_id", "minmax_sharded_events_timestamp"],
+        )
+
+    @parameterized.expand(
+        [
+            ("lower bound only", "(timestamp in [1700000000, +Inf))", ["timestamp"], 1700000000, None),
+            ("upper bound only", "(timestamp in (-Inf, 1800000000])", ["timestamp"], None, 1800000000),
+            ("both bounds", "(timestamp in [1700000000, 1800000000])", ["timestamp"], 1700000000, 1800000000),
+            ("no timestamp key", "true", [], None, None),
+        ]
+    )
+    def test_timestamp_bounds_parse_the_canonical_forms(
+        self, _name: str, condition: str, keys: list[str], lower: int | None, upper: int | None
+    ) -> None:
+        read = parse_query_plan(min_max_read(condition, keys)).events_read()
+        assert read is not None
+
+        bounds = read.timestamp_bounds()
+        self.assertEqual(bounds.lower, lower)
+        self.assertEqual(bounds.upper, upper)
+
+    def test_persons_join_plan_names_both_reads(self) -> None:
+        plan = parse_query_plan(load_plan("plan_persons_join"))
+
+        events_read = plan.events_read()
+        assert events_read is not None
+        self.assertEqual(events_read.table, "posthog.sharded_events")
+        self.assertEqual([read.table for read in plan.person_reads()], ["posthog.person"])
+        self.assertFalse(plan.has_non_mergetree_read)
+
+    @parameterized.expand(
+        [
+            ("object storage read has no events read", "plan_object_storage_read", True),
+            ("a replay list reads its own table, not events", "plan_replay_list_in_subqueries", False),
+        ]
+    )
+    def test_plans_without_an_events_read(self, _name: str, fixture: str, non_mergetree: bool) -> None:
+        plan = parse_query_plan(load_plan(fixture))
+
+        self.assertIsNone(plan.events_read())
+        self.assertEqual(plan.has_non_mergetree_read, non_mergetree)
+
+    @parameterized.expand(
+        [
+            ("the events table with no database qualifier", "events", True, False),
+            ("the native-JSON table", "posthog.sharded_events_json", True, False),
+            ("another table whose name ends in events", "posthog.ai_events", False, False),
+            ("the persons table", "posthog.person", False, True),
+            ("a person override table", "posthog.person_distinct_id_overrides", False, True),
+        ]
+    )
+    def test_table_names_are_classified_by_the_description(
+        self, _name: str, description: str, reads_events: bool, reads_persons: bool
+    ) -> None:
+        plan = parse_query_plan(
+            [{"Plan": {"Node Type": "ReadFromMergeTree", "Description": description, "Indexes": []}}]
+        )
+
+        read = plan.reads[0]
+        self.assertEqual(read.reads_events(), reads_events)
+        self.assertEqual(read.reads_persons(), reads_persons)
+
+    @parameterized.expand(
+        [
+            ("nothing at all", None),
+            ("unparseable text", "not json at all"),
+            ("a read without a description", [{"Plan": {"Node Type": "ReadFromMergeTree", "Indexes": []}}]),
+        ]
+    )
+    def test_unexpected_shape_reports_no_events_read(self, _name: str, payload: object) -> None:
+        plan = parse_query_plan(payload)
+
+        self.assertEqual(plan.reads, ())
+        self.assertIsNone(plan.events_read())
+
+    def test_json_text_is_accepted(self) -> None:
+        raw = (FIXTURES / "plan_event_filter_used.json").read_text()
+
+        read = parse_query_plan(raw).events_read()
+        assert read is not None
+        self.assertEqual(read.table, "posthog.sharded_events")

--- a/posthog/query_scan/test/test_findings.py
+++ b/posthog/query_scan/test/test_findings.py
@@ -1,0 +1,98 @@
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+
+from posthog.query_scan.findings import (
+    FindingKind,
+    FindingReason,
+    ScanMeasurements,
+    build_warning,
+    explain_evidence,
+    format_rows,
+)
+
+MEASUREMENTS = ScanMeasurements(rows_read=8_400_000_000, duration_ms=19_000)
+
+
+class TestFindings(SimpleTestCase):
+    @parameterized.expand([("8.4 billion", 8_400_000_000), ("12,345", 12_345)])
+    def test_row_counts_read_as_words_above_a_million(self, expected: str, rows: int) -> None:
+        self.assertEqual(format_rows(rows), expected)
+
+    @parameterized.expand(
+        [
+            (FindingKind.NO_EVENT_FILTER, None, "HogQLQuery", "add `WHERE event IN", "add an event filter"),
+            (
+                FindingKind.NO_EVENT_FILTER,
+                None,
+                "TrendsQuery",
+                "This insight looks at all events",
+                "instead of All events",
+            ),
+            (FindingKind.NO_START_DATE, None, "HogQLQuery", "add `timestamp >= now()", "relative to now"),
+            (
+                FindingKind.NO_START_DATE,
+                FindingReason.FILTERS,
+                "HogQLQuery",
+                "No date range is set on this insight or dashboard",
+                "The SQL does not need to change",
+            ),
+            (FindingKind.NO_START_DATE, None, "TrendsQuery", "This insight has no start date", "instead of All time"),
+            (FindingKind.PERSONS_JOIN, None, "HogQLQuery", "joins the persons table", "person.properties.email"),
+        ]
+    )
+    def test_copy_switches_between_sql_and_insight_wording(
+        self,
+        kind: FindingKind,
+        reason: FindingReason | None,
+        query_kind: str,
+        message_contains: str,
+        fix_contains: str,
+    ) -> None:
+        warning = build_warning(kind=kind, reason=reason, query_kind=query_kind, measurements=MEASUREMENTS)
+
+        self.assertEqual(warning.type, "query_scan")
+        self.assertEqual(warning.kind, kind)
+        self.assertIn(message_contains, warning.message)
+        self.assertIn(fix_contains, warning.fix)
+        self.assertEqual(warning.rows_read, 8_400_000_000)
+        self.assertEqual(warning.duration_ms, 19_000)
+
+    @parameterized.expand(
+        [
+            (
+                "keys and granule counts",
+                ("team_id", "toDate(timestamp)"),
+                5_582_406,
+                362_907,
+                None,
+                "ClickHouse's index used team_id, toDate(timestamp) and kept 362,907 of 5,582,406 granules.",
+            ),
+            (
+                "no columns used",
+                (),
+                100,
+                100,
+                None,
+                "ClickHouse's index used no columns and kept 100 of 100 granules.",
+            ),
+            (
+                "a subquery finding names the subquery",
+                ("team_id",),
+                9_366_597,
+                79_160,
+                0,
+                "In subquery 1: ClickHouse's index used team_id and kept 79,160 of 9,366,597 granules.",
+            ),
+        ]
+    )
+    def test_evidence_renders_keys_and_granule_counts(
+        self,
+        _name: str,
+        keys: tuple[str, ...],
+        before: int | None,
+        after: int | None,
+        subquery_index: int | None,
+        expected: str,
+    ) -> None:
+        self.assertEqual(explain_evidence(keys, before=before, after=after, subquery_index=subquery_index), expected)

--- a/posthog/query_scan/test/test_stub.py
+++ b/posthog/query_scan/test/test_stub.py
@@ -1,0 +1,91 @@
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+
+from posthog.hogql import ast
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.parser import parse_select
+from posthog.hogql.printer import HogQLPrinter
+
+from posthog.query_scan.stub import stub_in_subqueries
+
+
+def print_hogql(node: ast.Expr) -> str:
+    # HogQLPrinter serializes a parsed tree with no database, so the stub can be checked without one.
+    return HogQLPrinter(context=HogQLContext(team_id=0)).visit(node)
+
+
+class TestStubInSubqueries(SimpleTestCase):
+    @parameterized.expand(
+        [
+            (
+                "IN a subquery",
+                "SELECT count() FROM events WHERE event IN (SELECT event FROM events)",
+                "SELECT count() FROM events WHERE 1",
+                1,
+            ),
+            (
+                "NOT IN a subquery",
+                "SELECT count() FROM events WHERE event NOT IN (SELECT event FROM events)",
+                "SELECT count() FROM events WHERE 1",
+                1,
+            ),
+            (
+                "NOT wrapping an IN subquery folds whole, never NOT 1",
+                "SELECT count() FROM events WHERE NOT (event IN (SELECT event FROM events))",
+                "SELECT count() FROM events WHERE 1",
+                1,
+            ),
+            (
+                "an IN subquery inside a JOIN subquery",
+                "SELECT count() FROM events e "
+                "JOIN (SELECT id FROM persons WHERE id IN (SELECT id FROM cohortpeople)) p ON e.person_id = p.id",
+                "SELECT count() FROM events e JOIN (SELECT id FROM persons WHERE 1) p ON e.person_id = p.id",
+                1,
+            ),
+            (
+                "an IN subquery in the select list",
+                "SELECT event IN (SELECT event FROM events) FROM events",
+                "SELECT 1 FROM events",
+                1,
+            ),
+            (
+                "a literal IN list survives",
+                "SELECT count() FROM events WHERE event IN ('$pageview', '$autocapture')",
+                "SELECT count() FROM events WHERE event IN ('$pageview', '$autocapture')",
+                0,
+            ),
+        ]
+    )
+    def test_stub_replaces_in_subqueries_and_keeps_literal_lists(
+        self, _name: str, source: str, expected: str, expected_subqueries: int
+    ) -> None:
+        result = stub_in_subqueries(parse_select(source))
+
+        self.assertEqual(print_hogql(result.stubbed), print_hogql(parse_select(expected)))
+        self.assertEqual(len(result.subqueries), expected_subqueries)
+
+    def test_global_in_is_stubbed_too(self) -> None:
+        # HogQL has no GLOBAL IN syntax, so build the op the tree carries once it is lowered for a
+        # distributed query.
+        node = parse_select("SELECT count() FROM events WHERE event IN (SELECT event FROM events)")
+        assert isinstance(node, ast.SelectQuery) and isinstance(node.where, ast.CompareOperation)
+        node.where.op = ast.CompareOperationOp.GlobalIn
+
+        result = stub_in_subqueries(node)
+
+        self.assertEqual(len(result.subqueries), 1)
+        self.assertEqual(print_hogql(result.stubbed), print_hogql(parse_select("SELECT count() FROM events WHERE 1")))
+
+    def test_collector_returns_subqueries_in_visit_order(self) -> None:
+        source = (
+            "SELECT count() FROM events "
+            "WHERE event IN (SELECT 'first' FROM events) AND event IN (SELECT 'second' FROM events)"
+        )
+
+        result = stub_in_subqueries(parse_select(source))
+
+        self.assertEqual(len(result.subqueries), 2)
+        printed = [print_hogql(subquery) for subquery in result.subqueries]
+        self.assertIn("'first'", printed[0])
+        self.assertIn("'second'", printed[1])

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -231,6 +231,8 @@ from posthog.schema_enums import (
     PropertyOperator as PropertyOperator,
     PropertyType as PropertyType,
     QueryIndexUsage as QueryIndexUsage,
+    QueryScanFindingKind as QueryScanFindingKind,
+    QueryScanFindingReason as QueryScanFindingReason,
     QueryScanMode as QueryScanMode,
     QueryScanStatus as QueryScanStatus,
     QuickFilterContext as QuickFilterContext,
@@ -6644,11 +6646,54 @@ class QueryScanSummary(BaseModel):
         description=("ClickHouse time for the last fresh run, summed over its ClickHouse queries."),
     )
     mode: QueryScanMode
+    project_share: float | None = Field(
+        default=None,
+        description=(
+            "Share of the granules across all the project's events that the query read,"
+            " 0 to 1, written by the analysis."
+        ),
+    )
+    range_share: float | None = Field(
+        default=None,
+        description=(
+            "Share of the granules in the query's date range that the query read, 0 to 1, written by the analysis."
+        ),
+    )
     rows_read: int = Field(
         ...,
         description="Rows ClickHouse read for the last fresh run, all tables included.",
     )
     status: QueryScanStatus | None = Field(default=None, description="Absent when the run was too fast to analyze.")
+
+
+class QueryScanWarning(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    clause: str | None = Field(
+        default=None,
+        description="The offending condition printed back as HogQL, when there is one",
+    )
+    duration_ms: int
+    evidence: str | None = Field(
+        default=None,
+        description=("What ClickHouse reported did not use the filter, when EXPLAIN was available"),
+    )
+    fix: str = Field(..., description='The instruction handed to "Fix with AI" and to agents')
+    kind: QueryScanFindingKind
+    message: str = Field(
+        ...,
+        description=("Shown to the person. Sentence case, says what happened and what to do."),
+    )
+    reason: QueryScanFindingReason | None = Field(
+        default=None,
+        description=("Why the filter could not be used; only for event_filter_not_used and no_start_date"),
+    )
+    rows_read: int
+    type: Literal["query_scan"] = Field(
+        default="query_scan",
+        description="Tells warning kinds apart in the shared `warnings` list",
+    )
 
 
 class QueryStatus(BaseModel):
@@ -6964,17 +7009,16 @@ class SessionAttributionExplorerQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -7025,17 +7069,16 @@ class SessionBatchEventsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -7077,17 +7120,16 @@ class SessionQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -7197,17 +7239,16 @@ class SessionsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -7246,17 +7287,16 @@ class SessionsTimelineQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -7465,17 +7505,16 @@ class StickinessQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -7757,17 +7796,16 @@ class TestBasicQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -7816,17 +7854,16 @@ class TestCachedBasicQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -7905,17 +7942,16 @@ class TraceQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -7957,17 +7993,16 @@ class TraceSpansAggregationQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -8009,17 +8044,16 @@ class TraceSpansAttributeBreakdownQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -8061,17 +8095,16 @@ class TraceSpansQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -8113,17 +8146,16 @@ class TraceSpansSymbolStatsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -8165,17 +8197,16 @@ class TraceSpansTreeQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -8217,17 +8248,16 @@ class TracesQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -8449,17 +8479,16 @@ class TrendsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -8519,17 +8548,16 @@ class UsageMetricsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -8572,17 +8600,16 @@ class WebAgentAnalyticsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -8658,17 +8685,16 @@ class WebBotsTableQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -8712,17 +8738,16 @@ class WebExternalClicksTableQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -8774,17 +8799,16 @@ class WebGoalsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -8824,17 +8848,16 @@ class WebNotableChangesQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -8883,17 +8906,16 @@ class WebOverviewQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -8934,17 +8956,16 @@ class WebPageURLSearchQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -9003,17 +9024,16 @@ class WebStatsTableQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -9096,17 +9116,16 @@ class AccountsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -9152,17 +9171,16 @@ class AccountsTableQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -9218,17 +9236,16 @@ class ActorsPropertyTaxonomyQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -9272,17 +9289,16 @@ class ActorsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -9320,17 +9336,16 @@ class AnalyticsQueryResponseBase(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -10922,17 +10937,16 @@ class CachedAccountsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -10989,17 +11003,16 @@ class CachedAccountsTableQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -11048,17 +11061,16 @@ class CachedActorsPropertyTaxonomyQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -11113,17 +11125,16 @@ class CachedActorsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -11173,17 +11184,16 @@ class CachedCalendarHeatmapQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -11235,17 +11245,16 @@ class CachedDocumentSimilarityQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -11294,17 +11303,16 @@ class CachedEndpointsUsageOverviewQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -11358,17 +11366,16 @@ class CachedEndpointsUsageTableQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -11417,17 +11424,16 @@ class CachedEndpointsUsageTrendsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -11476,17 +11482,16 @@ class CachedErrorTrackingBreakdownsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -11536,17 +11541,16 @@ class CachedErrorTrackingFingerprintProjectionQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -11622,17 +11626,16 @@ class CachedErrorTrackingReleasesQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -11684,17 +11687,16 @@ class CachedErrorTrackingSimilarIssuesQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -11746,17 +11748,16 @@ class CachedEventTaxonomyQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -11811,17 +11812,16 @@ class CachedEventsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -11907,17 +11907,16 @@ class CachedFunnelCorrelationResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -11973,17 +11972,16 @@ class CachedFunnelsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -12038,17 +12036,16 @@ class CachedGroupsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -12097,17 +12094,16 @@ class CachedLifecycleQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -12161,17 +12157,16 @@ class CachedLogsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -12220,17 +12215,16 @@ class CachedMCPHarnessBreakdownQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -12280,17 +12274,16 @@ class CachedMCPMissingCapabilitiesQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -12339,17 +12332,16 @@ class CachedMCPModelBreakdownQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -12398,17 +12390,16 @@ class CachedMCPToolCallBreakdownQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -12457,17 +12448,16 @@ class CachedMCPToolCallsAndErrorsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -12516,17 +12506,16 @@ class CachedMCPToolCategoriesQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -12575,17 +12564,16 @@ class CachedMCPToolCategoryCountsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -12634,17 +12622,16 @@ class CachedMCPToolCategoryMapQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -12693,17 +12680,16 @@ class CachedMCPToolDailyStatsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -12752,17 +12738,16 @@ class CachedMCPToolDescriptionsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -12811,17 +12796,16 @@ class CachedMCPToolFailureOccurrencesQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -12870,17 +12854,16 @@ class CachedMCPToolFailuresQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -12929,17 +12912,16 @@ class CachedMCPToolNeighborsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -12988,17 +12970,16 @@ class CachedMCPToolQualityDailyStatsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -13051,17 +13032,16 @@ class CachedMCPToolQualityRowsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -13110,17 +13090,16 @@ class CachedMCPToolSampleIntentsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -13172,17 +13151,16 @@ class CachedMCPToolStatsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -13231,17 +13209,16 @@ class CachedMCPToolTopUsersQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -13291,17 +13268,16 @@ class CachedMarketingAnalyticsAggregatedQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -13367,17 +13343,16 @@ class CachedMarketingAnalyticsAttributionPathsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -13449,17 +13424,16 @@ class CachedMarketingAnalyticsAttributionQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -13527,17 +13501,16 @@ class CachedMarketingAnalyticsRetentionQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -13592,17 +13565,16 @@ class CachedMarketingAnalyticsTableQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -13651,17 +13623,16 @@ class CachedMetricsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -13710,17 +13681,16 @@ class CachedPathsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -13769,17 +13739,16 @@ class CachedPropertyValuesQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -13833,17 +13802,16 @@ class CachedRecordingsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -13892,17 +13860,16 @@ class CachedRetentionQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -13956,17 +13923,16 @@ class CachedSessionAttributionExplorerQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -14028,17 +13994,16 @@ class CachedSessionBatchEventsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -14091,17 +14056,16 @@ class CachedSessionQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -14155,17 +14119,16 @@ class CachedSessionsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -14215,17 +14178,16 @@ class CachedSessionsTimelineQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -14274,17 +14236,16 @@ class CachedStickinessQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -14363,17 +14324,16 @@ class CachedTeamTaxonomyQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -14466,17 +14426,16 @@ class CachedTraceQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -14529,17 +14488,16 @@ class CachedTraceSpansAggregationQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -14592,17 +14550,16 @@ class CachedTraceSpansAttributeBreakdownQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -14655,17 +14612,16 @@ class CachedTraceSpansQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -14718,17 +14674,16 @@ class CachedTraceSpansSymbolStatsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -14781,17 +14736,16 @@ class CachedTraceSpansTreeQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -14844,17 +14798,16 @@ class CachedTracesQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -14905,17 +14858,16 @@ class CachedTrendsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -14964,17 +14916,16 @@ class CachedUsageMetricsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -15023,17 +14974,16 @@ class CachedVectorSearchQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -15087,17 +15037,16 @@ class CachedWebAgentAnalyticsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -15151,17 +15100,16 @@ class CachedWebBotsTableQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -15216,17 +15164,16 @@ class CachedWebExternalClicksTableQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -15289,17 +15236,16 @@ class CachedWebGoalsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -15350,17 +15296,16 @@ class CachedWebNotableChangesQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -15420,17 +15365,16 @@ class CachedWebOverviewQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -15482,17 +15426,16 @@ class CachedWebPageURLSearchQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -15562,17 +15505,16 @@ class CachedWebStatsTableQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -15629,17 +15571,16 @@ class CachedWebVitalsPathBreakdownQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -15678,17 +15619,16 @@ class CalendarHeatmapResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -15790,17 +15730,16 @@ class Response(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -15844,17 +15783,16 @@ class Response1(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -15898,17 +15836,16 @@ class Response2(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -15957,17 +15894,16 @@ class Response4(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -16026,17 +15962,16 @@ class Response5(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -16080,17 +16015,16 @@ class Response6(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -16133,17 +16067,16 @@ class Response7(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -16195,17 +16128,16 @@ class Response8(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -16251,17 +16183,16 @@ class Response9(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -16304,17 +16235,16 @@ class Response10(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -16357,17 +16287,16 @@ class Response11(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -16411,17 +16340,16 @@ class Response12(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -16460,17 +16388,16 @@ class Response13(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -16512,17 +16439,16 @@ class Response18(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -16565,17 +16491,16 @@ class Response20(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -16623,17 +16548,16 @@ class Response21(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -16679,17 +16603,16 @@ class Response22(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -16806,17 +16729,16 @@ class DocumentSimilarityQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -16871,17 +16793,16 @@ class EndpointsUsageOverviewQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -16924,17 +16845,16 @@ class EndpointsUsageTableQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -16972,17 +16892,16 @@ class EndpointsUsageTrendsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -17020,17 +16939,16 @@ class ErrorTrackingBreakdownsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -17078,17 +16996,16 @@ class ErrorTrackingFingerprintProjectionQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -17152,17 +17069,16 @@ class ErrorTrackingQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -17242,17 +17158,16 @@ class ErrorTrackingReleasesQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -17293,17 +17208,16 @@ class ErrorTrackingSimilarIssuesQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -17344,17 +17258,16 @@ class EventTaxonomyQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -17398,17 +17311,16 @@ class EventsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -17490,17 +17402,16 @@ class FunnelCorrelationResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -17545,17 +17456,16 @@ class FunnelsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -17617,17 +17527,16 @@ class GroupsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -17709,14 +17618,14 @@ class HogQLQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Also carries"
-            " access control warnings when a system-table query filters out objects"
-            " the user can't access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Also carries access control"
+            " warnings when a system-table query filters out objects the user can't"
+            " access."
         ),
     )
 
@@ -17846,17 +17755,16 @@ class LifecycleQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -17895,17 +17803,16 @@ class LogAttributesQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -17943,17 +17850,16 @@ class LogValuesQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -17996,17 +17902,16 @@ class LogsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -18062,17 +17967,16 @@ class MCPHarnessBreakdownQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -18111,17 +18015,16 @@ class MCPMissingCapabilitiesQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -18159,17 +18062,16 @@ class MCPModelBreakdownQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -18207,17 +18109,16 @@ class MCPToolCallBreakdownQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -18255,17 +18156,16 @@ class MCPToolCallsAndErrorsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -18303,17 +18203,16 @@ class MCPToolCategoriesQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -18351,17 +18250,16 @@ class MCPToolCategoryCountsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -18399,17 +18297,16 @@ class MCPToolCategoryMapQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -18447,17 +18344,16 @@ class MCPToolDailyStatsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -18495,17 +18391,16 @@ class MCPToolDescriptionsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -18543,17 +18438,16 @@ class MCPToolFailureOccurrencesQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -18591,17 +18485,16 @@ class MCPToolFailuresQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -18639,17 +18532,16 @@ class MCPToolNeighborsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -18687,17 +18579,16 @@ class MCPToolQualityDailyStatsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -18739,17 +18630,16 @@ class MCPToolQualityRowsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -18787,17 +18677,16 @@ class MCPToolSampleIntentsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -18838,17 +18727,16 @@ class MCPToolStatsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -18886,17 +18774,16 @@ class MCPToolTopUsersQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -18935,17 +18822,16 @@ class MarketingAnalyticsAggregatedQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -19000,17 +18886,16 @@ class MarketingAnalyticsAttributionPathsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -19071,17 +18956,16 @@ class MarketingAnalyticsAttributionQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -19138,17 +19022,16 @@ class MarketingAnalyticsRetentionQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -19192,17 +19075,16 @@ class MarketingAnalyticsTableQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -19263,17 +19145,16 @@ class MetricsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -19384,17 +19265,16 @@ class PathsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -19460,17 +19340,16 @@ class PropertyValuesQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -19514,17 +19393,16 @@ class QueryResponseAlternative1(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -19567,17 +19445,16 @@ class QueryResponseAlternative2(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -19621,17 +19498,16 @@ class QueryResponseAlternative3(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -19675,17 +19551,16 @@ class QueryResponseAlternative4(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -19741,17 +19616,16 @@ class QueryResponseAlternative6(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -19798,14 +19672,14 @@ class QueryResponseAlternative8(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Also carries"
-            " access control warnings when a system-table query filters out objects"
-            " the user can't access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Also carries access control"
+            " warnings when a system-table query filters out objects the user can't"
+            " access."
         ),
     )
 
@@ -19848,17 +19722,16 @@ class QueryResponseAlternative11(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -19900,17 +19773,16 @@ class QueryResponseAlternative12(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -19951,17 +19823,16 @@ class QueryResponseAlternative13(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -20000,17 +19871,16 @@ class QueryResponseAlternative14(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -20048,17 +19918,16 @@ class QueryResponseAlternative15(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -20123,17 +19992,16 @@ class QueryResponseAlternative16(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -20191,17 +20059,16 @@ class QueryResponseAlternative22(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -20250,17 +20117,16 @@ class QueryResponseAlternative23(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -20319,17 +20185,16 @@ class QueryResponseAlternative24(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -20373,17 +20238,16 @@ class QueryResponseAlternative25(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -20426,17 +20290,16 @@ class QueryResponseAlternative26(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -20488,17 +20351,16 @@ class QueryResponseAlternative28(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -20544,17 +20406,16 @@ class QueryResponseAlternative29(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -20595,17 +20456,16 @@ class QueryResponseAlternative30(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -20645,17 +20505,16 @@ class QueryResponseAlternative32(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -20699,17 +20558,16 @@ class QueryResponseAlternative33(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -20748,17 +20606,16 @@ class QueryResponseAlternative34(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -20819,17 +20676,16 @@ class QueryResponseAlternative35(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -20884,17 +20740,16 @@ class QueryResponseAlternative36(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -20951,17 +20806,16 @@ class QueryResponseAlternative37(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -21005,17 +20859,16 @@ class QueryResponseAlternative38(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -21059,17 +20912,16 @@ class QueryResponseAlternative39(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -21113,17 +20965,16 @@ class QueryResponseAlternative40(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -21170,14 +21021,14 @@ class QueryResponseAlternative41(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Also carries"
-            " access control warnings when a system-table query filters out objects"
-            " the user can't access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Also carries access control"
+            " warnings when a system-table query filters out objects the user can't"
+            " access."
         ),
     )
 
@@ -21226,17 +21077,16 @@ class QueryResponseAlternative42(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -21295,17 +21145,16 @@ class QueryResponseAlternative43(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -21349,17 +21198,16 @@ class QueryResponseAlternative44(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -21402,17 +21250,16 @@ class QueryResponseAlternative45(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -21464,17 +21311,16 @@ class QueryResponseAlternative46(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -21520,17 +21366,16 @@ class QueryResponseAlternative47(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -21573,17 +21418,16 @@ class QueryResponseAlternative48(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -21626,17 +21470,16 @@ class QueryResponseAlternative49(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -21680,17 +21523,16 @@ class QueryResponseAlternative50(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -21729,17 +21571,16 @@ class QueryResponseAlternative51(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -21781,17 +21622,16 @@ class QueryResponseAlternative52(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -21833,17 +21673,16 @@ class QueryResponseAlternative56(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -21886,17 +21725,16 @@ class QueryResponseAlternative58(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -21944,17 +21782,16 @@ class QueryResponseAlternative59(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -22000,17 +21837,16 @@ class QueryResponseAlternative60(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -22050,17 +21886,16 @@ class QueryResponseAlternative61(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -22105,17 +21940,16 @@ class QueryResponseAlternative62(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -22153,17 +21987,16 @@ class QueryResponseAlternative63(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -22201,17 +22034,16 @@ class QueryResponseAlternative64(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -22249,17 +22081,16 @@ class QueryResponseAlternative65(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -22297,17 +22128,16 @@ class QueryResponseAlternative66(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -22350,17 +22180,16 @@ class QueryResponseAlternative68(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -22403,17 +22232,16 @@ class QueryResponseAlternative70(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -22456,17 +22284,16 @@ class QueryResponseAlternative71(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -22505,17 +22332,16 @@ class QueryResponseAlternative72(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -22553,17 +22379,16 @@ class QueryResponseAlternative73(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -22601,17 +22426,16 @@ class QueryResponseAlternative74(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -22653,17 +22477,16 @@ class QueryResponseAlternative75(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -22705,17 +22528,16 @@ class QueryResponseAlternative76(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -22757,17 +22579,16 @@ class QueryResponseAlternative77(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -22809,17 +22630,16 @@ class QueryResponseAlternative78(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -22872,17 +22692,16 @@ class QueryResponseAlternative80(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -22923,17 +22742,16 @@ class QueryResponseAlternative81(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -22971,17 +22789,16 @@ class QueryResponseAlternative82(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -23023,17 +22840,16 @@ class QueryResponseAlternative83(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -23096,17 +22912,16 @@ class QueryResponseAlternative87(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -23144,17 +22959,16 @@ class QueryResponseAlternative88(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -23202,17 +23016,16 @@ class QueryResponseAlternative89(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -23258,17 +23071,16 @@ class QueryResponseAlternative90(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -23306,17 +23118,16 @@ class QueryResponseAlternative91(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -23359,17 +23170,16 @@ class QueryResponseAlternative92(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -23407,17 +23217,16 @@ class QueryResponseAlternative93(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -23455,17 +23264,16 @@ class QueryResponseAlternative94(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -23503,17 +23311,16 @@ class QueryResponseAlternative95(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -23551,17 +23358,16 @@ class QueryResponseAlternative96(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -23599,17 +23405,16 @@ class QueryResponseAlternative97(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -23647,17 +23452,16 @@ class QueryResponseAlternative98(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -23695,17 +23499,16 @@ class QueryResponseAlternative99(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -23743,17 +23546,16 @@ class QueryResponseAlternative100(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -23794,17 +23596,16 @@ class QueryResponseAlternative101(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -23842,17 +23643,16 @@ class QueryResponseAlternative102(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -23894,17 +23694,16 @@ class QueryResponseAlternative103(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -23942,17 +23741,16 @@ class QueryResponseAlternative104(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -23990,17 +23788,16 @@ class QueryResponseAlternative105(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -24038,17 +23835,16 @@ class QueryResponseAlternative106(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -24086,17 +23882,16 @@ class QueryResponseAlternative107(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -24134,17 +23929,16 @@ class QueryResponseAlternative108(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -24182,17 +23976,16 @@ class QueryResponseAlternative109(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -24230,17 +24023,16 @@ class QueryResponseAlternative110(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -24279,17 +24071,16 @@ class QueryResponseAlternative111(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -24327,17 +24118,16 @@ class QueryResponseAlternative112(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -24380,17 +24170,16 @@ class RecordingsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -24428,17 +24217,16 @@ class RetentionQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -24580,17 +24368,16 @@ class TeamTaxonomyQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -24690,17 +24477,16 @@ class VectorSearchQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -25116,17 +24902,16 @@ class WebVitalsPathBreakdownQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -25164,17 +24949,16 @@ class WebVitalsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -25691,17 +25475,16 @@ class CachedErrorTrackingQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -25759,14 +25542,14 @@ class CachedHogQLQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Also carries"
-            " access control warnings when a system-table query filters out objects"
-            " the user can't access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Also carries access control"
+            " warnings when a system-table query filters out objects the user can't"
+            " access."
         ),
     )
 
@@ -25882,17 +25665,16 @@ class CachedPathsV2QueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -25941,17 +25723,16 @@ class CachedWebVitalsQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -26222,14 +26003,14 @@ class Response3(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Also carries"
-            " access control warnings when a system-table query filters out objects"
-            " the user can't access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Also carries access control"
+            " warnings when a system-table query filters out objects the user can't"
+            " access."
         ),
     )
 
@@ -26271,17 +26052,16 @@ class Response14(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -26582,17 +26362,16 @@ class ErrorTrackingIssueCorrelationQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -27886,17 +27665,16 @@ class PathsV2QueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -28017,17 +27795,16 @@ class QueryResponseAlternative17(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -28564,17 +28341,16 @@ class CachedErrorTrackingIssueCorrelationQueryResponse(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 
@@ -28647,17 +28423,16 @@ class Response15(BaseModel):
         default=None,
         description=("Connector-synced data warehouse sources referenced by this query, if any."),
     )
-    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning] | None = Field(
+    warnings: list[DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning] | None = Field(
         default=None,
         description=(
-            "Warnings about data warehouse sources referenced by the query whose"
-            " latest sync failed, is paused, hit a billing limit, or is otherwise"
-            " stale. Results may not reflect current source data. Accumulated"
-            " across every HogQL execution that contributes to this response — so"
-            " insights backed by warehouse tables (Trends, Funnels, etc.) receive"
-            " the same warnings as raw HogQL queries. Also carries access control"
-            " warnings when a system-table query filters out objects the user can't"
-            " access."
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries. Also carries access control warnings when a system-table"
+            " query filters out objects the user can't access."
         ),
     )
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -6648,15 +6648,13 @@ class QueryScanSummary(BaseModel):
     mode: QueryScanMode
     project_share: float | None = Field(
         default=None,
-        description=(
-            "Share of the granules across all the project's events that the query read,"
-            " 0 to 1, written by the analysis."
-        ),
+        description=("How much of all the project's events the query read, 0 to 1. Set once the analysis is done."),
     )
     range_share: float | None = Field(
         default=None,
         description=(
-            "Share of the granules in the query's date range that the query read, 0 to 1, written by the analysis."
+            "How much of the project's events in the query's date range the query read,"
+            " 0 to 1. Set once the analysis is done."
         ),
     )
     rows_read: int = Field(

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -6668,37 +6668,17 @@ class QueryScanWarning(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    clause: str | None = Field(
-        default=None,
-        description="The offending condition printed back as HogQL, when there is one",
-    )
+    clause: str | None = Field(default=None, description="The condition at fault, as HogQL.")
     duration_ms: int
-    evidence: str | None = Field(
-        default=None,
-        description=(
-            "The fact the finding rests on, in one sentence: what the plan reported, or the setting that caused it."
-        ),
-    )
-    fix: str = Field(
-        ...,
-        description=('The instruction "Fix with AI" and the assistant get for this finding.'),
-    )
+    evidence: str | None = Field(default=None, description="The one fact the finding rests on.")
+    fix: str = Field(..., description='What "Fix with AI" and the assistant are told to do.')
     kind: QueryScanFindingKind
-    message: str = Field(
-        ...,
-        description=("Shown to the person. Sentence case, says what happened and what to do."),
-    )
+    message: str = Field(..., description="Shown to the person: what happened and what to do.")
     reason: QueryScanFindingReason | None = Field(
-        default=None,
-        description=(
-            "Why the filter the query has did not narrow the read. Only on no_event_filter and no_start_date."
-        ),
+        default=None, description="Only with `no_event_filter` and `no_start_date`."
     )
     rows_read: int
-    type: Literal["query_scan"] = Field(
-        default="query_scan",
-        description="Tells warning kinds apart in the shared `warnings` list",
-    )
+    type: Literal["query_scan"] = "query_scan"
 
 
 class QueryStatus(BaseModel):
@@ -7023,7 +7003,8 @@ class SessionAttributionExplorerQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -7083,7 +7064,8 @@ class SessionBatchEventsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -7134,7 +7116,8 @@ class SessionQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -7253,7 +7236,8 @@ class SessionsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -7301,7 +7285,8 @@ class SessionsTimelineQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -7519,7 +7504,8 @@ class StickinessQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -7810,7 +7796,8 @@ class TestBasicQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -7868,7 +7855,8 @@ class TestCachedBasicQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -7956,7 +7944,8 @@ class TraceQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -8007,7 +7996,8 @@ class TraceSpansAggregationQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -8058,7 +8048,8 @@ class TraceSpansAttributeBreakdownQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -8109,7 +8100,8 @@ class TraceSpansQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -8160,7 +8152,8 @@ class TraceSpansSymbolStatsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -8211,7 +8204,8 @@ class TraceSpansTreeQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -8262,7 +8256,8 @@ class TracesQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -8493,7 +8488,8 @@ class TrendsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -8562,7 +8558,8 @@ class UsageMetricsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -8614,7 +8611,8 @@ class WebAgentAnalyticsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -8699,7 +8697,8 @@ class WebBotsTableQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -8752,7 +8751,8 @@ class WebExternalClicksTableQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -8813,7 +8813,8 @@ class WebGoalsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -8862,7 +8863,8 @@ class WebNotableChangesQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -8920,7 +8922,8 @@ class WebOverviewQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -8970,7 +8973,8 @@ class WebPageURLSearchQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -9038,7 +9042,8 @@ class WebStatsTableQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -9130,7 +9135,8 @@ class AccountsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -9185,7 +9191,8 @@ class AccountsTableQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -9250,7 +9257,8 @@ class ActorsPropertyTaxonomyQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -9303,7 +9311,8 @@ class ActorsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -9350,7 +9359,8 @@ class AnalyticsQueryResponseBase(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -10951,7 +10961,8 @@ class CachedAccountsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -11017,7 +11028,8 @@ class CachedAccountsTableQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -11075,7 +11087,8 @@ class CachedActorsPropertyTaxonomyQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -11139,7 +11152,8 @@ class CachedActorsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -11198,7 +11212,8 @@ class CachedCalendarHeatmapQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -11259,7 +11274,8 @@ class CachedDocumentSimilarityQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -11317,7 +11333,8 @@ class CachedEndpointsUsageOverviewQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -11380,7 +11397,8 @@ class CachedEndpointsUsageTableQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -11438,7 +11456,8 @@ class CachedEndpointsUsageTrendsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -11496,7 +11515,8 @@ class CachedErrorTrackingBreakdownsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -11555,7 +11575,8 @@ class CachedErrorTrackingFingerprintProjectionQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -11640,7 +11661,8 @@ class CachedErrorTrackingReleasesQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -11701,7 +11723,8 @@ class CachedErrorTrackingSimilarIssuesQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -11762,7 +11785,8 @@ class CachedEventTaxonomyQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -11826,7 +11850,8 @@ class CachedEventsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -11921,7 +11946,8 @@ class CachedFunnelCorrelationResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -11986,7 +12012,8 @@ class CachedFunnelsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -12050,7 +12077,8 @@ class CachedGroupsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -12108,7 +12136,8 @@ class CachedLifecycleQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -12171,7 +12200,8 @@ class CachedLogsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -12229,7 +12259,8 @@ class CachedMCPHarnessBreakdownQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -12288,7 +12319,8 @@ class CachedMCPMissingCapabilitiesQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -12346,7 +12378,8 @@ class CachedMCPModelBreakdownQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -12404,7 +12437,8 @@ class CachedMCPToolCallBreakdownQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -12462,7 +12496,8 @@ class CachedMCPToolCallsAndErrorsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -12520,7 +12555,8 @@ class CachedMCPToolCategoriesQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -12578,7 +12614,8 @@ class CachedMCPToolCategoryCountsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -12636,7 +12673,8 @@ class CachedMCPToolCategoryMapQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -12694,7 +12732,8 @@ class CachedMCPToolDailyStatsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -12752,7 +12791,8 @@ class CachedMCPToolDescriptionsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -12810,7 +12850,8 @@ class CachedMCPToolFailureOccurrencesQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -12868,7 +12909,8 @@ class CachedMCPToolFailuresQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -12926,7 +12968,8 @@ class CachedMCPToolNeighborsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -12984,7 +13027,8 @@ class CachedMCPToolQualityDailyStatsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -13046,7 +13090,8 @@ class CachedMCPToolQualityRowsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -13104,7 +13149,8 @@ class CachedMCPToolSampleIntentsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -13165,7 +13211,8 @@ class CachedMCPToolStatsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -13223,7 +13270,8 @@ class CachedMCPToolTopUsersQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -13282,7 +13330,8 @@ class CachedMarketingAnalyticsAggregatedQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -13357,7 +13406,8 @@ class CachedMarketingAnalyticsAttributionPathsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -13438,7 +13488,8 @@ class CachedMarketingAnalyticsAttributionQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -13515,7 +13566,8 @@ class CachedMarketingAnalyticsRetentionQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -13579,7 +13631,8 @@ class CachedMarketingAnalyticsTableQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -13637,7 +13690,8 @@ class CachedMetricsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -13695,7 +13749,8 @@ class CachedPathsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -13753,7 +13808,8 @@ class CachedPropertyValuesQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -13816,7 +13872,8 @@ class CachedRecordingsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -13874,7 +13931,8 @@ class CachedRetentionQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -13937,7 +13995,8 @@ class CachedSessionAttributionExplorerQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -14008,7 +14067,8 @@ class CachedSessionBatchEventsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -14070,7 +14130,8 @@ class CachedSessionQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -14133,7 +14194,8 @@ class CachedSessionsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -14192,7 +14254,8 @@ class CachedSessionsTimelineQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -14250,7 +14313,8 @@ class CachedStickinessQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -14338,7 +14402,8 @@ class CachedTeamTaxonomyQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -14440,7 +14505,8 @@ class CachedTraceQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -14502,7 +14568,8 @@ class CachedTraceSpansAggregationQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -14564,7 +14631,8 @@ class CachedTraceSpansAttributeBreakdownQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -14626,7 +14694,8 @@ class CachedTraceSpansQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -14688,7 +14757,8 @@ class CachedTraceSpansSymbolStatsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -14750,7 +14820,8 @@ class CachedTraceSpansTreeQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -14812,7 +14883,8 @@ class CachedTracesQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -14872,7 +14944,8 @@ class CachedTrendsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -14930,7 +15003,8 @@ class CachedUsageMetricsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -14988,7 +15062,8 @@ class CachedVectorSearchQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -15051,7 +15126,8 @@ class CachedWebAgentAnalyticsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -15114,7 +15190,8 @@ class CachedWebBotsTableQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -15178,7 +15255,8 @@ class CachedWebExternalClicksTableQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -15250,7 +15328,8 @@ class CachedWebGoalsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -15310,7 +15389,8 @@ class CachedWebNotableChangesQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -15379,7 +15459,8 @@ class CachedWebOverviewQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -15440,7 +15521,8 @@ class CachedWebPageURLSearchQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -15519,7 +15601,8 @@ class CachedWebStatsTableQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -15585,7 +15668,8 @@ class CachedWebVitalsPathBreakdownQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -15633,7 +15717,8 @@ class CalendarHeatmapResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -15744,7 +15829,8 @@ class Response(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -15797,7 +15883,8 @@ class Response1(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -15850,7 +15937,8 @@ class Response2(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -15908,7 +15996,8 @@ class Response4(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -15976,7 +16065,8 @@ class Response5(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -16029,7 +16119,8 @@ class Response6(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -16081,7 +16172,8 @@ class Response7(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -16142,7 +16234,8 @@ class Response8(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -16197,7 +16290,8 @@ class Response9(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -16249,7 +16343,8 @@ class Response10(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -16301,7 +16396,8 @@ class Response11(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -16354,7 +16450,8 @@ class Response12(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -16402,7 +16499,8 @@ class Response13(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -16453,7 +16551,8 @@ class Response18(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -16505,7 +16604,8 @@ class Response20(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -16562,7 +16662,8 @@ class Response21(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -16617,7 +16718,8 @@ class Response22(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -16743,7 +16845,8 @@ class DocumentSimilarityQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -16807,7 +16910,8 @@ class EndpointsUsageOverviewQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -16859,7 +16963,8 @@ class EndpointsUsageTableQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -16906,7 +17011,8 @@ class EndpointsUsageTrendsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -16953,7 +17059,8 @@ class ErrorTrackingBreakdownsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -17010,7 +17117,8 @@ class ErrorTrackingFingerprintProjectionQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -17083,7 +17191,8 @@ class ErrorTrackingQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -17172,7 +17281,8 @@ class ErrorTrackingReleasesQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -17222,7 +17332,8 @@ class ErrorTrackingSimilarIssuesQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -17272,7 +17383,8 @@ class EventTaxonomyQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -17325,7 +17437,8 @@ class EventsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -17416,7 +17529,8 @@ class FunnelCorrelationResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -17470,7 +17584,8 @@ class FunnelsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -17541,7 +17656,8 @@ class GroupsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -17630,7 +17746,7 @@ class HogQLQueryResponse(BaseModel):
             " sync failed, is paused, hit a billing limit, or is otherwise stale."
             " Results may not reflect current source data. Also carries access control"
             " warnings when a system-table query filters out objects the user can't"
-            " access."
+            " access. Also carries query scan findings, see `QueryScanWarning`."
         ),
     )
 
@@ -17769,7 +17885,8 @@ class LifecycleQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -17817,7 +17934,8 @@ class LogAttributesQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -17864,7 +17982,8 @@ class LogValuesQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -17916,7 +18035,8 @@ class LogsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -17981,7 +18101,8 @@ class MCPHarnessBreakdownQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -18029,7 +18150,8 @@ class MCPMissingCapabilitiesQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -18076,7 +18198,8 @@ class MCPModelBreakdownQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -18123,7 +18246,8 @@ class MCPToolCallBreakdownQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -18170,7 +18294,8 @@ class MCPToolCallsAndErrorsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -18217,7 +18342,8 @@ class MCPToolCategoriesQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -18264,7 +18390,8 @@ class MCPToolCategoryCountsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -18311,7 +18438,8 @@ class MCPToolCategoryMapQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -18358,7 +18486,8 @@ class MCPToolDailyStatsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -18405,7 +18534,8 @@ class MCPToolDescriptionsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -18452,7 +18582,8 @@ class MCPToolFailureOccurrencesQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -18499,7 +18630,8 @@ class MCPToolFailuresQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -18546,7 +18678,8 @@ class MCPToolNeighborsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -18593,7 +18726,8 @@ class MCPToolQualityDailyStatsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -18644,7 +18778,8 @@ class MCPToolQualityRowsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -18691,7 +18826,8 @@ class MCPToolSampleIntentsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -18741,7 +18877,8 @@ class MCPToolStatsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -18788,7 +18925,8 @@ class MCPToolTopUsersQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -18836,7 +18974,8 @@ class MarketingAnalyticsAggregatedQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -18900,7 +19039,8 @@ class MarketingAnalyticsAttributionPathsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -18970,7 +19110,8 @@ class MarketingAnalyticsAttributionQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -19036,7 +19177,8 @@ class MarketingAnalyticsRetentionQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -19089,7 +19231,8 @@ class MarketingAnalyticsTableQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -19159,7 +19302,8 @@ class MetricsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -19279,7 +19423,8 @@ class PathsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -19354,7 +19499,8 @@ class PropertyValuesQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -19407,7 +19553,8 @@ class QueryResponseAlternative1(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -19459,7 +19606,8 @@ class QueryResponseAlternative2(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -19512,7 +19660,8 @@ class QueryResponseAlternative3(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -19565,7 +19714,8 @@ class QueryResponseAlternative4(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -19630,7 +19780,8 @@ class QueryResponseAlternative6(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -19684,7 +19835,7 @@ class QueryResponseAlternative8(BaseModel):
             " sync failed, is paused, hit a billing limit, or is otherwise stale."
             " Results may not reflect current source data. Also carries access control"
             " warnings when a system-table query filters out objects the user can't"
-            " access."
+            " access. Also carries query scan findings, see `QueryScanWarning`."
         ),
     )
 
@@ -19736,7 +19887,8 @@ class QueryResponseAlternative11(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -19787,7 +19939,8 @@ class QueryResponseAlternative12(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -19837,7 +19990,8 @@ class QueryResponseAlternative13(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -19885,7 +20039,8 @@ class QueryResponseAlternative14(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -19932,7 +20087,8 @@ class QueryResponseAlternative15(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -20006,7 +20162,8 @@ class QueryResponseAlternative16(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -20073,7 +20230,8 @@ class QueryResponseAlternative22(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -20131,7 +20289,8 @@ class QueryResponseAlternative23(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -20199,7 +20358,8 @@ class QueryResponseAlternative24(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -20252,7 +20412,8 @@ class QueryResponseAlternative25(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -20304,7 +20465,8 @@ class QueryResponseAlternative26(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -20365,7 +20527,8 @@ class QueryResponseAlternative28(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -20420,7 +20583,8 @@ class QueryResponseAlternative29(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -20470,7 +20634,8 @@ class QueryResponseAlternative30(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -20519,7 +20684,8 @@ class QueryResponseAlternative32(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -20572,7 +20738,8 @@ class QueryResponseAlternative33(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -20620,7 +20787,8 @@ class QueryResponseAlternative34(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -20690,7 +20858,8 @@ class QueryResponseAlternative35(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -20754,7 +20923,8 @@ class QueryResponseAlternative36(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -20820,7 +20990,8 @@ class QueryResponseAlternative37(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -20873,7 +21044,8 @@ class QueryResponseAlternative38(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -20926,7 +21098,8 @@ class QueryResponseAlternative39(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -20979,7 +21152,8 @@ class QueryResponseAlternative40(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -21033,7 +21207,7 @@ class QueryResponseAlternative41(BaseModel):
             " sync failed, is paused, hit a billing limit, or is otherwise stale."
             " Results may not reflect current source data. Also carries access control"
             " warnings when a system-table query filters out objects the user can't"
-            " access."
+            " access. Also carries query scan findings, see `QueryScanWarning`."
         ),
     )
 
@@ -21091,7 +21265,8 @@ class QueryResponseAlternative42(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -21159,7 +21334,8 @@ class QueryResponseAlternative43(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -21212,7 +21388,8 @@ class QueryResponseAlternative44(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -21264,7 +21441,8 @@ class QueryResponseAlternative45(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -21325,7 +21503,8 @@ class QueryResponseAlternative46(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -21380,7 +21559,8 @@ class QueryResponseAlternative47(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -21432,7 +21612,8 @@ class QueryResponseAlternative48(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -21484,7 +21665,8 @@ class QueryResponseAlternative49(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -21537,7 +21719,8 @@ class QueryResponseAlternative50(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -21585,7 +21768,8 @@ class QueryResponseAlternative51(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -21636,7 +21820,8 @@ class QueryResponseAlternative52(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -21687,7 +21872,8 @@ class QueryResponseAlternative56(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -21739,7 +21925,8 @@ class QueryResponseAlternative58(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -21796,7 +21983,8 @@ class QueryResponseAlternative59(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -21851,7 +22039,8 @@ class QueryResponseAlternative60(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -21900,7 +22089,8 @@ class QueryResponseAlternative61(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -21954,7 +22144,8 @@ class QueryResponseAlternative62(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -22001,7 +22192,8 @@ class QueryResponseAlternative63(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -22048,7 +22240,8 @@ class QueryResponseAlternative64(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -22095,7 +22288,8 @@ class QueryResponseAlternative65(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -22142,7 +22336,8 @@ class QueryResponseAlternative66(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -22194,7 +22389,8 @@ class QueryResponseAlternative68(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -22246,7 +22442,8 @@ class QueryResponseAlternative70(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -22298,7 +22495,8 @@ class QueryResponseAlternative71(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -22346,7 +22544,8 @@ class QueryResponseAlternative72(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -22393,7 +22592,8 @@ class QueryResponseAlternative73(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -22440,7 +22640,8 @@ class QueryResponseAlternative74(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -22491,7 +22692,8 @@ class QueryResponseAlternative75(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -22542,7 +22744,8 @@ class QueryResponseAlternative76(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -22593,7 +22796,8 @@ class QueryResponseAlternative77(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -22644,7 +22848,8 @@ class QueryResponseAlternative78(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -22706,7 +22911,8 @@ class QueryResponseAlternative80(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -22756,7 +22962,8 @@ class QueryResponseAlternative81(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -22803,7 +23010,8 @@ class QueryResponseAlternative82(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -22854,7 +23062,8 @@ class QueryResponseAlternative83(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -22926,7 +23135,8 @@ class QueryResponseAlternative87(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -22973,7 +23183,8 @@ class QueryResponseAlternative88(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -23030,7 +23241,8 @@ class QueryResponseAlternative89(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -23085,7 +23297,8 @@ class QueryResponseAlternative90(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -23132,7 +23345,8 @@ class QueryResponseAlternative91(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -23184,7 +23398,8 @@ class QueryResponseAlternative92(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -23231,7 +23446,8 @@ class QueryResponseAlternative93(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -23278,7 +23494,8 @@ class QueryResponseAlternative94(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -23325,7 +23542,8 @@ class QueryResponseAlternative95(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -23372,7 +23590,8 @@ class QueryResponseAlternative96(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -23419,7 +23638,8 @@ class QueryResponseAlternative97(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -23466,7 +23686,8 @@ class QueryResponseAlternative98(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -23513,7 +23734,8 @@ class QueryResponseAlternative99(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -23560,7 +23782,8 @@ class QueryResponseAlternative100(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -23610,7 +23833,8 @@ class QueryResponseAlternative101(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -23657,7 +23881,8 @@ class QueryResponseAlternative102(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -23708,7 +23933,8 @@ class QueryResponseAlternative103(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -23755,7 +23981,8 @@ class QueryResponseAlternative104(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -23802,7 +24029,8 @@ class QueryResponseAlternative105(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -23849,7 +24077,8 @@ class QueryResponseAlternative106(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -23896,7 +24125,8 @@ class QueryResponseAlternative107(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -23943,7 +24173,8 @@ class QueryResponseAlternative108(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -23990,7 +24221,8 @@ class QueryResponseAlternative109(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -24037,7 +24269,8 @@ class QueryResponseAlternative110(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -24085,7 +24318,8 @@ class QueryResponseAlternative111(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -24132,7 +24366,8 @@ class QueryResponseAlternative112(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -24184,7 +24419,8 @@ class RecordingsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -24231,7 +24467,8 @@ class RetentionQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -24382,7 +24619,8 @@ class TeamTaxonomyQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -24491,7 +24729,8 @@ class VectorSearchQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -24916,7 +25155,8 @@ class WebVitalsPathBreakdownQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -24963,7 +25203,8 @@ class WebVitalsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -25489,7 +25730,8 @@ class CachedErrorTrackingQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -25554,7 +25796,7 @@ class CachedHogQLQueryResponse(BaseModel):
             " sync failed, is paused, hit a billing limit, or is otherwise stale."
             " Results may not reflect current source data. Also carries access control"
             " warnings when a system-table query filters out objects the user can't"
-            " access."
+            " access. Also carries query scan findings, see `QueryScanWarning`."
         ),
     )
 
@@ -25679,7 +25921,8 @@ class CachedPathsV2QueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -25737,7 +25980,8 @@ class CachedWebVitalsQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -26015,7 +26259,7 @@ class Response3(BaseModel):
             " sync failed, is paused, hit a billing limit, or is otherwise stale."
             " Results may not reflect current source data. Also carries access control"
             " warnings when a system-table query filters out objects the user can't"
-            " access."
+            " access. Also carries query scan findings, see `QueryScanWarning`."
         ),
     )
 
@@ -26066,7 +26310,8 @@ class Response14(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -26376,7 +26621,8 @@ class ErrorTrackingIssueCorrelationQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -27679,7 +27925,8 @@ class PathsV2QueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -27809,7 +28056,8 @@ class QueryResponseAlternative17(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -28355,7 +28603,8 @@ class CachedErrorTrackingIssueCorrelationQueryResponse(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 
@@ -28437,7 +28686,8 @@ class Response15(BaseModel):
             " HogQL execution that contributes to this response — so insights backed by"
             " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
             " HogQL queries. Also carries access control warnings when a system-table"
-            " query filters out objects the user can't access."
+            " query filters out objects the user can't access. Also carries query scan"
+            " findings, see `QueryScanWarning`."
         ),
     )
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -6677,9 +6677,14 @@ class QueryScanWarning(BaseModel):
     duration_ms: int
     evidence: str | None = Field(
         default=None,
-        description=("What ClickHouse reported did not use the filter, when EXPLAIN was available"),
+        description=(
+            "The fact the finding rests on, in one sentence: what the plan reported, or the setting that caused it."
+        ),
     )
-    fix: str = Field(..., description='The instruction handed to "Fix with AI" and to agents')
+    fix: str = Field(
+        ...,
+        description=('The instruction "Fix with AI" and the assistant get for this finding.'),
+    )
     kind: QueryScanFindingKind
     message: str = Field(
         ...,
@@ -6687,7 +6692,9 @@ class QueryScanWarning(BaseModel):
     )
     reason: QueryScanFindingReason | None = Field(
         default=None,
-        description=("Why the filter could not be used; only for event_filter_not_used and no_start_date"),
+        description=(
+            "Why the filter the query has did not narrow the read. Only on no_event_filter and no_start_date."
+        ),
     )
     rows_read: int
     type: Literal["query_scan"] = Field(

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -3872,6 +3872,25 @@ class LimitContext(Enum):
     NONE_TYPE_NONE = None
 
 
+class QueryScanFindingKind(StrEnum):
+    NO_EVENT_FILTER = "no_event_filter"
+    EVENT_FILTER_NOT_USED = "event_filter_not_used"
+    NO_START_DATE = "no_start_date"
+    PERSONS_JOIN = "persons_join"
+    ALL_EVENTS = "all_events"
+    ALL_TIME = "all_time"
+
+
+class QueryScanFindingReason(StrEnum):
+    IN_OR = "in_or"
+    WRAPPED = "wrapped"
+    NEGATED = "negated"
+    DYNAMIC = "dynamic"
+    NOT_PRUNED = "not_pruned"
+    COLUMN = "column"
+    FILTERS = "filters"
+
+
 class QueryScanMode(StrEnum):
     LOG_ONLY = "log_only"
     SHOW = "show"

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -3874,11 +3874,8 @@ class LimitContext(Enum):
 
 class QueryScanFindingKind(StrEnum):
     NO_EVENT_FILTER = "no_event_filter"
-    EVENT_FILTER_NOT_USED = "event_filter_not_used"
     NO_START_DATE = "no_start_date"
     PERSONS_JOIN = "persons_join"
-    ALL_EVENTS = "all_events"
-    ALL_TIME = "all_time"
 
 
 class QueryScanFindingReason(StrEnum):
@@ -3887,7 +3884,6 @@ class QueryScanFindingReason(StrEnum):
     NEGATED = "negated"
     DYNAMIC = "dynamic"
     NOT_PRUNED = "not_pruned"
-    COLUMN = "column"
     FILTERS = "filters"
 
 

--- a/products/customer_analytics/frontend/generated/api.schemas.ts
+++ b/products/customer_analytics/frontend/generated/api.schemas.ts
@@ -1608,11 +1608,8 @@ export type QueryScanFindingKindApi = (typeof QueryScanFindingKindApi)[keyof typ
 
 export const QueryScanFindingKindApi = {
     NoEventFilter: 'no_event_filter',
-    EventFilterNotUsed: 'event_filter_not_used',
     NoStartDate: 'no_start_date',
     PersonsJoin: 'persons_join',
-    AllEvents: 'all_events',
-    AllTime: 'all_time',
 } as const
 
 export type QueryScanFindingReasonApi = (typeof QueryScanFindingReasonApi)[keyof typeof QueryScanFindingReasonApi]
@@ -1623,7 +1620,6 @@ export const QueryScanFindingReasonApi = {
     Negated: 'negated',
     Dynamic: 'dynamic',
     NotPruned: 'not_pruned',
-    Column: 'column',
     Filters: 'filters',
 } as const
 
@@ -1631,14 +1627,14 @@ export interface QueryScanWarningApi {
     /** The offending condition printed back as HogQL, when there is one */
     clause?: string | null
     duration_ms: number
-    /** What ClickHouse reported did not use the filter, when EXPLAIN was available */
+    /** The fact the finding rests on, in one sentence: what the plan reported, or the setting that caused it. */
     evidence?: string | null
-    /** The instruction handed to "Fix with AI" and to agents */
+    /** The instruction "Fix with AI" and the assistant get for this finding. */
     fix: string
     kind: QueryScanFindingKindApi
     /** Shown to the person. Sentence case, says what happened and what to do. */
     message: string
-    /** Why the filter could not be used; only for event_filter_not_used and no_start_date */
+    /** Why the filter the query has did not narrow the read. Only on no_event_filter and no_start_date. */
     reason?: QueryScanFindingReasonApi | null
     rows_read: number
     /** Tells warning kinds apart in the shared `warnings` list */

--- a/products/customer_analytics/frontend/generated/api.schemas.ts
+++ b/products/customer_analytics/frontend/generated/api.schemas.ts
@@ -1465,9 +1465,9 @@ export interface QueryScanSummaryApi {
     duration_ms: number
     /** What clients may show for this response. The server evaluated the flag once for this query; clients and the assistant read this field and never evaluate the flag themselves. */
     mode: QueryScanModeApi
-    /** Share of the granules across all the project's events that the query read, 0 to 1, written by the analysis. */
+    /** How much of all the project's events the query read, 0 to 1. Set once the analysis is done. */
     project_share?: number | null
-    /** Share of the granules in the query's date range that the query read, 0 to 1, written by the analysis. */
+    /** How much of the project's events in the query's date range the query read, 0 to 1. Set once the analysis is done. */
     range_share?: number | null
     /** Rows ClickHouse read for the last fresh run of this query, all tables included. */
     rows_read: number

--- a/products/customer_analytics/frontend/generated/api.schemas.ts
+++ b/products/customer_analytics/frontend/generated/api.schemas.ts
@@ -1461,17 +1461,16 @@ export const QueryScanStatusApi = {
 } as const
 
 export interface QueryScanSummaryApi {
-    /** ClickHouse time for the last fresh run, summed over every ClickHouse query the run made. */
+    /** ClickHouse time for the last fresh run, summed over its ClickHouse queries. */
     duration_ms: number
-    /** What clients may show for this response. The server evaluated the flag once for this query; clients and the assistant read this field and never evaluate the flag themselves. */
     mode: QueryScanModeApi
     /** How much of all the project's events the query read, 0 to 1. Set once the analysis is done. */
     project_share?: number | null
     /** How much of the project's events in the query's date range the query read, 0 to 1. Set once the analysis is done. */
     range_share?: number | null
-    /** Rows ClickHouse read for the last fresh run of this query, all tables included. */
+    /** Rows ClickHouse read for the last fresh run, all tables included. */
     rows_read: number
-    /** Where the analysis of this query stands, see `QueryScanStatus`. The analysis only runs when `duration_ms` is over the threshold in the flag's payload, so the field is absent for a fast query. */
+    /** Absent when the run was too fast to analyze. */
     status?: QueryScanStatusApi | null
 }
 
@@ -1624,20 +1623,19 @@ export const QueryScanFindingReasonApi = {
 } as const
 
 export interface QueryScanWarningApi {
-    /** The offending condition printed back as HogQL, when there is one */
+    /** The condition at fault, as HogQL. */
     clause?: string | null
     duration_ms: number
-    /** The fact the finding rests on, in one sentence: what the plan reported, or the setting that caused it. */
+    /** The one fact the finding rests on. */
     evidence?: string | null
-    /** The instruction "Fix with AI" and the assistant get for this finding. */
+    /** What "Fix with AI" and the assistant are told to do. */
     fix: string
     kind: QueryScanFindingKindApi
-    /** Shown to the person. Sentence case, says what happened and what to do. */
+    /** Shown to the person: what happened and what to do. */
     message: string
-    /** Why the filter the query has did not narrow the read. Only on no_event_filter and no_start_date. */
+    /** Only with `no_event_filter` and `no_start_date`. */
     reason?: QueryScanFindingReasonApi | null
     rows_read: number
-    /** Tells warning kinds apart in the shared `warnings` list */
     type?: 'query_scan'
 }
 
@@ -1666,7 +1664,7 @@ export interface AccountsTableQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 

--- a/products/customer_analytics/frontend/generated/api.schemas.ts
+++ b/products/customer_analytics/frontend/generated/api.schemas.ts
@@ -1465,6 +1465,10 @@ export interface QueryScanSummaryApi {
     duration_ms: number
     /** What clients may show for this response. The server evaluated the flag once for this query; clients and the assistant read this field and never evaluate the flag themselves. */
     mode: QueryScanModeApi
+    /** Share of the granules across all the project's events that the query read, 0 to 1, written by the analysis. */
+    project_share?: number | null
+    /** Share of the granules in the query's date range that the query read, 0 to 1, written by the analysis. */
+    range_share?: number | null
     /** Rows ClickHouse read for the last fresh run of this query, all tables included. */
     rows_read: number
     /** Where the analysis of this query stands, see `QueryScanStatus`. The analysis only runs when `duration_ms` is over the threshold in the flag's payload, so the field is absent for a fast query. */
@@ -1600,6 +1604,47 @@ export interface AccessControlFilterWarningApi {
     type?: 'access_control'
 }
 
+export type QueryScanFindingKindApi = (typeof QueryScanFindingKindApi)[keyof typeof QueryScanFindingKindApi]
+
+export const QueryScanFindingKindApi = {
+    NoEventFilter: 'no_event_filter',
+    EventFilterNotUsed: 'event_filter_not_used',
+    NoStartDate: 'no_start_date',
+    PersonsJoin: 'persons_join',
+    AllEvents: 'all_events',
+    AllTime: 'all_time',
+} as const
+
+export type QueryScanFindingReasonApi = (typeof QueryScanFindingReasonApi)[keyof typeof QueryScanFindingReasonApi]
+
+export const QueryScanFindingReasonApi = {
+    InOr: 'in_or',
+    Wrapped: 'wrapped',
+    Negated: 'negated',
+    Dynamic: 'dynamic',
+    NotPruned: 'not_pruned',
+    Column: 'column',
+    Filters: 'filters',
+} as const
+
+export interface QueryScanWarningApi {
+    /** The offending condition printed back as HogQL, when there is one */
+    clause?: string | null
+    duration_ms: number
+    /** What ClickHouse reported did not use the filter, when EXPLAIN was available */
+    evidence?: string | null
+    /** The instruction handed to "Fix with AI" and to agents */
+    fix: string
+    kind: QueryScanFindingKindApi
+    /** Shown to the person. Sentence case, says what happened and what to do. */
+    message: string
+    /** Why the filter could not be used; only for event_filter_not_used and no_start_date */
+    reason?: QueryScanFindingReasonApi | null
+    rows_read: number
+    /** Tells warning kinds apart in the shared `warnings` list */
+    type?: 'query_scan'
+}
+
 export interface AccountsTableQueryResponseApi {
     /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
     error?: string | null
@@ -1626,7 +1671,7 @@ export interface AccountsTableQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export type AccountsTableSortDirectionApi =

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -1973,9 +1973,9 @@ export interface QueryScanSummaryApi {
     duration_ms: number
     /** What clients may show for this response. The server evaluated the flag once for this query; clients and the assistant read this field and never evaluate the flag themselves. */
     mode: QueryScanModeApi
-    /** Share of the granules across all the project's events that the query read, 0 to 1, written by the analysis. */
+    /** How much of all the project's events the query read, 0 to 1. Set once the analysis is done. */
     project_share?: number | null
-    /** Share of the granules in the query's date range that the query read, 0 to 1, written by the analysis. */
+    /** How much of the project's events in the query's date range the query read, 0 to 1. Set once the analysis is done. */
     range_share?: number | null
     /** Rows ClickHouse read for the last fresh run of this query, all tables included. */
     rows_read: number

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -1973,6 +1973,10 @@ export interface QueryScanSummaryApi {
     duration_ms: number
     /** What clients may show for this response. The server evaluated the flag once for this query; clients and the assistant read this field and never evaluate the flag themselves. */
     mode: QueryScanModeApi
+    /** Share of the granules across all the project's events that the query read, 0 to 1, written by the analysis. */
+    project_share?: number | null
+    /** Share of the granules in the query's date range that the query read, 0 to 1, written by the analysis. */
+    range_share?: number | null
     /** Rows ClickHouse read for the last fresh run of this query, all tables included. */
     rows_read: number
     /** Where the analysis of this query stands, see `QueryScanStatus`. The analysis only runs when `duration_ms` is over the threshold in the flag's payload, so the field is absent for a fast query. */
@@ -2063,6 +2067,47 @@ export interface AccessControlFilterWarningApi {
     type?: 'access_control'
 }
 
+export type QueryScanFindingKindApi = (typeof QueryScanFindingKindApi)[keyof typeof QueryScanFindingKindApi]
+
+export const QueryScanFindingKindApi = {
+    NoEventFilter: 'no_event_filter',
+    EventFilterNotUsed: 'event_filter_not_used',
+    NoStartDate: 'no_start_date',
+    PersonsJoin: 'persons_join',
+    AllEvents: 'all_events',
+    AllTime: 'all_time',
+} as const
+
+export type QueryScanFindingReasonApi = (typeof QueryScanFindingReasonApi)[keyof typeof QueryScanFindingReasonApi]
+
+export const QueryScanFindingReasonApi = {
+    InOr: 'in_or',
+    Wrapped: 'wrapped',
+    Negated: 'negated',
+    Dynamic: 'dynamic',
+    NotPruned: 'not_pruned',
+    Column: 'column',
+    Filters: 'filters',
+} as const
+
+export interface QueryScanWarningApi {
+    /** The offending condition printed back as HogQL, when there is one */
+    clause?: string | null
+    duration_ms: number
+    /** What ClickHouse reported did not use the filter, when EXPLAIN was available */
+    evidence?: string | null
+    /** The instruction handed to "Fix with AI" and to agents */
+    fix: string
+    kind: QueryScanFindingKindApi
+    /** Shown to the person. Sentence case, says what happened and what to do. */
+    message: string
+    /** Why the filter could not be used; only for event_filter_not_used and no_start_date */
+    reason?: QueryScanFindingReasonApi | null
+    rows_read: number
+    /** Tells warning kinds apart in the shared `warnings` list */
+    type?: 'query_scan'
+}
+
 export type TrendsQueryResponseApiResultsItem = { [key: string]: unknown }
 
 export interface TrendsQueryResponseApi {
@@ -2088,7 +2133,7 @@ export interface TrendsQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export type BaseMathTypeApi = (typeof BaseMathTypeApi)[keyof typeof BaseMathTypeApi]
@@ -3310,7 +3355,7 @@ export interface FunnelsQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export type FunnelsDataWarehouseNodeApiResponse = { [key: string]: unknown } | null
@@ -3500,7 +3545,7 @@ export interface RetentionQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export type AggregationPropertyTypeApi = (typeof AggregationPropertyTypeApi)[keyof typeof AggregationPropertyTypeApi]
@@ -3799,7 +3844,7 @@ export interface PathsQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface PathsQueryApi {
@@ -3974,7 +4019,7 @@ export interface PathsV2QueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface PathsV2QueryApi {
@@ -4048,7 +4093,7 @@ export interface StickinessQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export type StickinessComputationModeApi =
@@ -4200,7 +4245,7 @@ export interface LifecycleQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export type LifecycleDataWarehouseNodeApiResponse = { [key: string]: unknown } | null
@@ -4464,7 +4509,7 @@ export interface WebStatsTableQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface WebAnalyticsSamplingApi {
@@ -4558,7 +4603,7 @@ export interface WebOverviewQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface WebOverviewQueryApi {
@@ -4689,7 +4734,7 @@ export interface ResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface Response1Api {
@@ -4718,7 +4763,7 @@ export interface Response1Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface Response2Api {
@@ -4747,7 +4792,7 @@ export interface Response2Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface HogQLNoticeApi {
@@ -4854,7 +4899,7 @@ export interface Response3Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface Response4Api {
@@ -4883,7 +4928,7 @@ export interface Response4Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface Response5Api {
@@ -4917,7 +4962,7 @@ export interface Response5Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface Response6Api {
@@ -4946,7 +4991,7 @@ export interface Response6Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface Response7Api {
@@ -4974,7 +5019,7 @@ export interface Response7Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface Response8Api {
@@ -5006,7 +5051,7 @@ export interface Response8Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface WebVitalsPathBreakdownResultItemApi {
@@ -5047,7 +5092,7 @@ export interface Response9Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface Response10Api {
@@ -5075,7 +5120,7 @@ export interface Response10Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface Response11Api {
@@ -5103,7 +5148,7 @@ export interface Response11Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface MarketingAnalyticsItemApi {
@@ -5142,7 +5187,7 @@ export interface Response12Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export type Response13ApiResults = { [key: string]: MarketingAnalyticsItemApi }
@@ -5168,7 +5213,7 @@ export interface Response13Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface VolumeBucketApi {
@@ -5340,7 +5385,7 @@ export interface Response14Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface PopulationApi {
@@ -5391,7 +5436,7 @@ export interface Response15Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export type ExperimentSignificanceCodeApi =
@@ -5567,7 +5612,7 @@ export interface Response18Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface Response20Api {
@@ -5595,7 +5640,7 @@ export interface Response20Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface Response21Api {
@@ -5626,7 +5671,7 @@ export interface Response21Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface AccountsTableCustomPropertyHistoryPointApi {
@@ -5700,7 +5745,7 @@ export interface Response22Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export type TaxonomicFilterGroupTypeApi = (typeof TaxonomicFilterGroupTypeApi)[keyof typeof TaxonomicFilterGroupTypeApi]
@@ -5862,7 +5907,7 @@ export interface EventsQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export type CompareApi = (typeof CompareApi)[keyof typeof CompareApi]
@@ -5898,7 +5943,7 @@ export interface ActorsQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface InsightActorsQueryApi {
@@ -6185,7 +6230,7 @@ export interface FunnelCorrelationResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface FunnelCorrelationQueryApi {
@@ -6789,7 +6834,7 @@ export interface HogQLQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface HogQLVariableApi {
@@ -6906,7 +6951,7 @@ export interface GroupsQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface GroupsQueryApi {
@@ -6952,7 +6997,7 @@ export interface WebExternalClicksTableQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface WebExternalClicksTableQueryApi {
@@ -7022,7 +7067,7 @@ export interface WebBotsTableQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface WebBotsTableQueryApi {
@@ -7089,7 +7134,7 @@ export interface WebGoalsQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface WebGoalsQueryApi {
@@ -7215,7 +7260,7 @@ export interface WebVitalsPathBreakdownQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface WebVitalsPathBreakdownQueryApi {
@@ -7303,7 +7348,7 @@ export interface SessionAttributionExplorerQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface SessionAttributionExplorerQueryApi {
@@ -7345,7 +7390,7 @@ export interface SessionsQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface SessionsQueryApi {
@@ -7822,7 +7867,7 @@ export interface MarketingAnalyticsTableQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface MarketingAnalyticsTableQueryApi {
@@ -7896,7 +7941,7 @@ export interface MarketingAnalyticsAggregatedQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface MarketingAnalyticsAggregatedQueryApi {
@@ -7996,7 +8041,7 @@ export interface ErrorTrackingQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface ErrorTrackingQueryApi {
@@ -8062,7 +8107,7 @@ export interface ErrorTrackingIssueCorrelationQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface ErrorTrackingIssueCorrelationQueryApi {
@@ -8176,7 +8221,7 @@ export interface TracesQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface TracesQueryApi {
@@ -8257,7 +8302,7 @@ export interface TraceQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface TraceQueryApi {
@@ -8327,7 +8372,7 @@ export interface SessionQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface SessionQueryApi {
@@ -8406,7 +8451,7 @@ export interface EndpointsUsageTableQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface EndpointsUsageTableQueryApi {
@@ -8456,7 +8501,7 @@ export interface AccountsQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface AccountsQueryApi {
@@ -8713,7 +8758,7 @@ export interface AccountsTableQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export type AccountsTableSortDirectionApi =

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -2071,11 +2071,8 @@ export type QueryScanFindingKindApi = (typeof QueryScanFindingKindApi)[keyof typ
 
 export const QueryScanFindingKindApi = {
     NoEventFilter: 'no_event_filter',
-    EventFilterNotUsed: 'event_filter_not_used',
     NoStartDate: 'no_start_date',
     PersonsJoin: 'persons_join',
-    AllEvents: 'all_events',
-    AllTime: 'all_time',
 } as const
 
 export type QueryScanFindingReasonApi = (typeof QueryScanFindingReasonApi)[keyof typeof QueryScanFindingReasonApi]
@@ -2086,7 +2083,6 @@ export const QueryScanFindingReasonApi = {
     Negated: 'negated',
     Dynamic: 'dynamic',
     NotPruned: 'not_pruned',
-    Column: 'column',
     Filters: 'filters',
 } as const
 
@@ -2094,14 +2090,14 @@ export interface QueryScanWarningApi {
     /** The offending condition printed back as HogQL, when there is one */
     clause?: string | null
     duration_ms: number
-    /** What ClickHouse reported did not use the filter, when EXPLAIN was available */
+    /** The fact the finding rests on, in one sentence: what the plan reported, or the setting that caused it. */
     evidence?: string | null
-    /** The instruction handed to "Fix with AI" and to agents */
+    /** The instruction "Fix with AI" and the assistant get for this finding. */
     fix: string
     kind: QueryScanFindingKindApi
     /** Shown to the person. Sentence case, says what happened and what to do. */
     message: string
-    /** Why the filter could not be used; only for event_filter_not_used and no_start_date */
+    /** Why the filter the query has did not narrow the read. Only on no_event_filter and no_start_date. */
     reason?: QueryScanFindingReasonApi | null
     rows_read: number
     /** Tells warning kinds apart in the shared `warnings` list */

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -1969,17 +1969,16 @@ export const QueryScanStatusApi = {
 } as const
 
 export interface QueryScanSummaryApi {
-    /** ClickHouse time for the last fresh run, summed over every ClickHouse query the run made. */
+    /** ClickHouse time for the last fresh run, summed over its ClickHouse queries. */
     duration_ms: number
-    /** What clients may show for this response. The server evaluated the flag once for this query; clients and the assistant read this field and never evaluate the flag themselves. */
     mode: QueryScanModeApi
     /** How much of all the project's events the query read, 0 to 1. Set once the analysis is done. */
     project_share?: number | null
     /** How much of the project's events in the query's date range the query read, 0 to 1. Set once the analysis is done. */
     range_share?: number | null
-    /** Rows ClickHouse read for the last fresh run of this query, all tables included. */
+    /** Rows ClickHouse read for the last fresh run, all tables included. */
     rows_read: number
-    /** Where the analysis of this query stands, see `QueryScanStatus`. The analysis only runs when `duration_ms` is over the threshold in the flag's payload, so the field is absent for a fast query. */
+    /** Absent when the run was too fast to analyze. */
     status?: QueryScanStatusApi | null
 }
 
@@ -2087,20 +2086,19 @@ export const QueryScanFindingReasonApi = {
 } as const
 
 export interface QueryScanWarningApi {
-    /** The offending condition printed back as HogQL, when there is one */
+    /** The condition at fault, as HogQL. */
     clause?: string | null
     duration_ms: number
-    /** The fact the finding rests on, in one sentence: what the plan reported, or the setting that caused it. */
+    /** The one fact the finding rests on. */
     evidence?: string | null
-    /** The instruction "Fix with AI" and the assistant get for this finding. */
+    /** What "Fix with AI" and the assistant are told to do. */
     fix: string
     kind: QueryScanFindingKindApi
-    /** Shown to the person. Sentence case, says what happened and what to do. */
+    /** Shown to the person: what happened and what to do. */
     message: string
-    /** Why the filter the query has did not narrow the read. Only on no_event_filter and no_start_date. */
+    /** Only with `no_event_filter` and `no_start_date`. */
     reason?: QueryScanFindingReasonApi | null
     rows_read: number
-    /** Tells warning kinds apart in the shared `warnings` list */
     type?: 'query_scan'
 }
 
@@ -2128,7 +2126,7 @@ export interface TrendsQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -3350,7 +3348,7 @@ export interface FunnelsQueryResponseApi {
     total_median_conversion_time?: number | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -3540,7 +3538,7 @@ export interface RetentionQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -3839,7 +3837,7 @@ export interface PathsQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -4014,7 +4012,7 @@ export interface PathsV2QueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -4088,7 +4086,7 @@ export interface StickinessQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -4240,7 +4238,7 @@ export interface LifecycleQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -4504,7 +4502,7 @@ export interface WebStatsTableQueryResponseApi {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -4598,7 +4596,7 @@ export interface WebOverviewQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -4729,7 +4727,7 @@ export interface ResponseApi {
     types: string[]
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -4758,7 +4756,7 @@ export interface Response1Api {
     types?: string[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -4787,7 +4785,7 @@ export interface Response2Api {
     types: string[]
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -4894,7 +4892,7 @@ export interface Response3Api {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -4923,7 +4921,7 @@ export interface Response4Api {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -4957,7 +4955,7 @@ export interface Response5Api {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -4986,7 +4984,7 @@ export interface Response6Api {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -5014,7 +5012,7 @@ export interface Response7Api {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -5046,7 +5044,7 @@ export interface Response8Api {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -5087,7 +5085,7 @@ export interface Response9Api {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -5115,7 +5113,7 @@ export interface Response10Api {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -5143,7 +5141,7 @@ export interface Response11Api {
     types: string[]
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -5182,7 +5180,7 @@ export interface Response12Api {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -5208,7 +5206,7 @@ export interface Response13Api {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -5380,7 +5378,7 @@ export interface Response14Api {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -5431,7 +5429,7 @@ export interface Response15Api {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -5607,7 +5605,7 @@ export interface Response18Api {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -5635,7 +5633,7 @@ export interface Response20Api {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -5666,7 +5664,7 @@ export interface Response21Api {
     types: string[]
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -5740,7 +5738,7 @@ export interface Response22Api {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -5902,7 +5900,7 @@ export interface EventsQueryResponseApi {
     types: string[]
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -5938,7 +5936,7 @@ export interface ActorsQueryResponseApi {
     types?: string[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -6225,7 +6223,7 @@ export interface FunnelCorrelationResponseApi {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -6829,7 +6827,7 @@ export interface HogQLQueryResponseApi {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -6946,7 +6944,7 @@ export interface GroupsQueryResponseApi {
     types: string[]
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -6992,7 +6990,7 @@ export interface WebExternalClicksTableQueryResponseApi {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -7062,7 +7060,7 @@ export interface WebBotsTableQueryResponseApi {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -7129,7 +7127,7 @@ export interface WebGoalsQueryResponseApi {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -7255,7 +7253,7 @@ export interface WebVitalsPathBreakdownQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -7343,7 +7341,7 @@ export interface SessionAttributionExplorerQueryResponseApi {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -7385,7 +7383,7 @@ export interface SessionsQueryResponseApi {
     types: string[]
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -7862,7 +7860,7 @@ export interface MarketingAnalyticsTableQueryResponseApi {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -7936,7 +7934,7 @@ export interface MarketingAnalyticsAggregatedQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -8036,7 +8034,7 @@ export interface ErrorTrackingQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -8102,7 +8100,7 @@ export interface ErrorTrackingIssueCorrelationQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -8216,7 +8214,7 @@ export interface TracesQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -8297,7 +8295,7 @@ export interface TraceQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -8367,7 +8365,7 @@ export interface SessionQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -8446,7 +8444,7 @@ export interface EndpointsUsageTableQueryResponseApi {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -8496,7 +8494,7 @@ export interface AccountsQueryResponseApi {
     types: string[]
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -8753,7 +8751,7 @@ export interface AccountsTableQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 

--- a/products/data_quality/frontend/dataQualityCheckEditorLogic.ts
+++ b/products/data_quality/frontend/dataQualityCheckEditorLogic.ts
@@ -495,7 +495,10 @@ export const dataQualityCheckEditorLogic = kea<dataQualityCheckEditorLogicType>(
                         rows: response.results.slice(0, 10) as unknown[][],
                         rowCount: response.results.length,
                         hasMore: !!response.hasMore,
-                        warnings: response.warnings ?? [],
+                        warnings: (response.warnings ?? []).filter(
+                            (warning): warning is DataWarehouseSyncWarning | AccessControlFilterWarning =>
+                                warning.type !== 'query_scan'
+                        ),
                     }
                 },
             },

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -963,17 +963,16 @@ export const QueryScanStatusApi = {
 } as const
 
 export interface QueryScanSummaryApi {
-    /** ClickHouse time for the last fresh run, summed over every ClickHouse query the run made. */
+    /** ClickHouse time for the last fresh run, summed over its ClickHouse queries. */
     duration_ms: number
-    /** What clients may show for this response. The server evaluated the flag once for this query; clients and the assistant read this field and never evaluate the flag themselves. */
     mode: QueryScanModeApi
     /** How much of all the project's events the query read, 0 to 1. Set once the analysis is done. */
     project_share?: number | null
     /** How much of the project's events in the query's date range the query read, 0 to 1. Set once the analysis is done. */
     range_share?: number | null
-    /** Rows ClickHouse read for the last fresh run of this query, all tables included. */
+    /** Rows ClickHouse read for the last fresh run, all tables included. */
     rows_read: number
-    /** Where the analysis of this query stands, see `QueryScanStatus`. The analysis only runs when `duration_ms` is over the threshold in the flag's payload, so the field is absent for a fast query. */
+    /** Absent when the run was too fast to analyze. */
     status?: QueryScanStatusApi | null
 }
 
@@ -1081,20 +1080,19 @@ export const QueryScanFindingReasonApi = {
 } as const
 
 export interface QueryScanWarningApi {
-    /** The offending condition printed back as HogQL, when there is one */
+    /** The condition at fault, as HogQL. */
     clause?: string | null
     duration_ms: number
-    /** The fact the finding rests on, in one sentence: what the plan reported, or the setting that caused it. */
+    /** The one fact the finding rests on. */
     evidence?: string | null
-    /** The instruction "Fix with AI" and the assistant get for this finding. */
+    /** What "Fix with AI" and the assistant are told to do. */
     fix: string
     kind: QueryScanFindingKindApi
-    /** Shown to the person. Sentence case, says what happened and what to do. */
+    /** Shown to the person: what happened and what to do. */
     message: string
-    /** Why the filter the query has did not narrow the read. Only on no_event_filter and no_start_date. */
+    /** Only with `no_event_filter` and `no_start_date`. */
     reason?: QueryScanFindingReasonApi | null
     rows_read: number
-    /** Tells warning kinds apart in the shared `warnings` list */
     type?: 'query_scan'
 }
 
@@ -1122,7 +1120,7 @@ export interface TrendsQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -2344,7 +2342,7 @@ export interface FunnelsQueryResponseApi {
     total_median_conversion_time?: number | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -2534,7 +2532,7 @@ export interface RetentionQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -2833,7 +2831,7 @@ export interface PathsQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -3008,7 +3006,7 @@ export interface PathsV2QueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -3082,7 +3080,7 @@ export interface StickinessQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -3234,7 +3232,7 @@ export interface LifecycleQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -3498,7 +3496,7 @@ export interface WebStatsTableQueryResponseApi {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -3592,7 +3590,7 @@ export interface WebOverviewQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -3723,7 +3721,7 @@ export interface ResponseApi {
     types: string[]
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -3752,7 +3750,7 @@ export interface Response1Api {
     types?: string[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -3781,7 +3779,7 @@ export interface Response2Api {
     types: string[]
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -3888,7 +3886,7 @@ export interface Response3Api {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -3917,7 +3915,7 @@ export interface Response4Api {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -3951,7 +3949,7 @@ export interface Response5Api {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -3980,7 +3978,7 @@ export interface Response6Api {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -4008,7 +4006,7 @@ export interface Response7Api {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -4040,7 +4038,7 @@ export interface Response8Api {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -4081,7 +4079,7 @@ export interface Response9Api {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -4109,7 +4107,7 @@ export interface Response10Api {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -4137,7 +4135,7 @@ export interface Response11Api {
     types: string[]
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -4176,7 +4174,7 @@ export interface Response12Api {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -4202,7 +4200,7 @@ export interface Response13Api {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -4374,7 +4372,7 @@ export interface Response14Api {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -4425,7 +4423,7 @@ export interface Response15Api {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -4601,7 +4599,7 @@ export interface Response18Api {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -4629,7 +4627,7 @@ export interface Response20Api {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -4660,7 +4658,7 @@ export interface Response21Api {
     types: string[]
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -4734,7 +4732,7 @@ export interface Response22Api {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -4896,7 +4894,7 @@ export interface EventsQueryResponseApi {
     types: string[]
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -4932,7 +4930,7 @@ export interface ActorsQueryResponseApi {
     types?: string[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -5219,7 +5217,7 @@ export interface FunnelCorrelationResponseApi {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -5823,7 +5821,7 @@ export interface HogQLQueryResponseApi {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -5940,7 +5938,7 @@ export interface GroupsQueryResponseApi {
     types: string[]
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -5986,7 +5984,7 @@ export interface WebExternalClicksTableQueryResponseApi {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -6056,7 +6054,7 @@ export interface WebBotsTableQueryResponseApi {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -6123,7 +6121,7 @@ export interface WebGoalsQueryResponseApi {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -6249,7 +6247,7 @@ export interface WebVitalsPathBreakdownQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -6337,7 +6335,7 @@ export interface SessionAttributionExplorerQueryResponseApi {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -6379,7 +6377,7 @@ export interface SessionsQueryResponseApi {
     types: string[]
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -6856,7 +6854,7 @@ export interface MarketingAnalyticsTableQueryResponseApi {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -6930,7 +6928,7 @@ export interface MarketingAnalyticsAggregatedQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -7030,7 +7028,7 @@ export interface ErrorTrackingQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -7096,7 +7094,7 @@ export interface ErrorTrackingIssueCorrelationQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -7210,7 +7208,7 @@ export interface TracesQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -7291,7 +7289,7 @@ export interface TraceQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -7361,7 +7359,7 @@ export interface SessionQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -7440,7 +7438,7 @@ export interface EndpointsUsageTableQueryResponseApi {
     types?: unknown[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -7490,7 +7488,7 @@ export interface AccountsQueryResponseApi {
     types: string[]
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
@@ -7747,7 +7745,7 @@ export interface AccountsTableQueryResponseApi {
     timings?: QueryTimingApi[] | null
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
-    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+    /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
     warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -967,9 +967,9 @@ export interface QueryScanSummaryApi {
     duration_ms: number
     /** What clients may show for this response. The server evaluated the flag once for this query; clients and the assistant read this field and never evaluate the flag themselves. */
     mode: QueryScanModeApi
-    /** Share of the granules across all the project's events that the query read, 0 to 1, written by the analysis. */
+    /** How much of all the project's events the query read, 0 to 1. Set once the analysis is done. */
     project_share?: number | null
-    /** Share of the granules in the query's date range that the query read, 0 to 1, written by the analysis. */
+    /** How much of the project's events in the query's date range the query read, 0 to 1. Set once the analysis is done. */
     range_share?: number | null
     /** Rows ClickHouse read for the last fresh run of this query, all tables included. */
     rows_read: number

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -967,6 +967,10 @@ export interface QueryScanSummaryApi {
     duration_ms: number
     /** What clients may show for this response. The server evaluated the flag once for this query; clients and the assistant read this field and never evaluate the flag themselves. */
     mode: QueryScanModeApi
+    /** Share of the granules across all the project's events that the query read, 0 to 1, written by the analysis. */
+    project_share?: number | null
+    /** Share of the granules in the query's date range that the query read, 0 to 1, written by the analysis. */
+    range_share?: number | null
     /** Rows ClickHouse read for the last fresh run of this query, all tables included. */
     rows_read: number
     /** Where the analysis of this query stands, see `QueryScanStatus`. The analysis only runs when `duration_ms` is over the threshold in the flag's payload, so the field is absent for a fast query. */
@@ -1057,6 +1061,47 @@ export interface AccessControlFilterWarningApi {
     type?: 'access_control'
 }
 
+export type QueryScanFindingKindApi = (typeof QueryScanFindingKindApi)[keyof typeof QueryScanFindingKindApi]
+
+export const QueryScanFindingKindApi = {
+    NoEventFilter: 'no_event_filter',
+    EventFilterNotUsed: 'event_filter_not_used',
+    NoStartDate: 'no_start_date',
+    PersonsJoin: 'persons_join',
+    AllEvents: 'all_events',
+    AllTime: 'all_time',
+} as const
+
+export type QueryScanFindingReasonApi = (typeof QueryScanFindingReasonApi)[keyof typeof QueryScanFindingReasonApi]
+
+export const QueryScanFindingReasonApi = {
+    InOr: 'in_or',
+    Wrapped: 'wrapped',
+    Negated: 'negated',
+    Dynamic: 'dynamic',
+    NotPruned: 'not_pruned',
+    Column: 'column',
+    Filters: 'filters',
+} as const
+
+export interface QueryScanWarningApi {
+    /** The offending condition printed back as HogQL, when there is one */
+    clause?: string | null
+    duration_ms: number
+    /** What ClickHouse reported did not use the filter, when EXPLAIN was available */
+    evidence?: string | null
+    /** The instruction handed to "Fix with AI" and to agents */
+    fix: string
+    kind: QueryScanFindingKindApi
+    /** Shown to the person. Sentence case, says what happened and what to do. */
+    message: string
+    /** Why the filter could not be used; only for event_filter_not_used and no_start_date */
+    reason?: QueryScanFindingReasonApi | null
+    rows_read: number
+    /** Tells warning kinds apart in the shared `warnings` list */
+    type?: 'query_scan'
+}
+
 export type TrendsQueryResponseApiResultsItem = { [key: string]: unknown }
 
 export interface TrendsQueryResponseApi {
@@ -1082,7 +1127,7 @@ export interface TrendsQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export type BaseMathTypeApi = (typeof BaseMathTypeApi)[keyof typeof BaseMathTypeApi]
@@ -2304,7 +2349,7 @@ export interface FunnelsQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export type FunnelsDataWarehouseNodeApiResponse = { [key: string]: unknown } | null
@@ -2494,7 +2539,7 @@ export interface RetentionQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export type AggregationPropertyTypeApi = (typeof AggregationPropertyTypeApi)[keyof typeof AggregationPropertyTypeApi]
@@ -2793,7 +2838,7 @@ export interface PathsQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface PathsQueryApi {
@@ -2968,7 +3013,7 @@ export interface PathsV2QueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface PathsV2QueryApi {
@@ -3042,7 +3087,7 @@ export interface StickinessQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export type StickinessComputationModeApi =
@@ -3194,7 +3239,7 @@ export interface LifecycleQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export type LifecycleDataWarehouseNodeApiResponse = { [key: string]: unknown } | null
@@ -3458,7 +3503,7 @@ export interface WebStatsTableQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface WebAnalyticsSamplingApi {
@@ -3552,7 +3597,7 @@ export interface WebOverviewQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface WebOverviewQueryApi {
@@ -3683,7 +3728,7 @@ export interface ResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface Response1Api {
@@ -3712,7 +3757,7 @@ export interface Response1Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface Response2Api {
@@ -3741,7 +3786,7 @@ export interface Response2Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface HogQLNoticeApi {
@@ -3848,7 +3893,7 @@ export interface Response3Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface Response4Api {
@@ -3877,7 +3922,7 @@ export interface Response4Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface Response5Api {
@@ -3911,7 +3956,7 @@ export interface Response5Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface Response6Api {
@@ -3940,7 +3985,7 @@ export interface Response6Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface Response7Api {
@@ -3968,7 +4013,7 @@ export interface Response7Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface Response8Api {
@@ -4000,7 +4045,7 @@ export interface Response8Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface WebVitalsPathBreakdownResultItemApi {
@@ -4041,7 +4086,7 @@ export interface Response9Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface Response10Api {
@@ -4069,7 +4114,7 @@ export interface Response10Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface Response11Api {
@@ -4097,7 +4142,7 @@ export interface Response11Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface MarketingAnalyticsItemApi {
@@ -4136,7 +4181,7 @@ export interface Response12Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export type Response13ApiResults = { [key: string]: MarketingAnalyticsItemApi }
@@ -4162,7 +4207,7 @@ export interface Response13Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface VolumeBucketApi {
@@ -4334,7 +4379,7 @@ export interface Response14Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface PopulationApi {
@@ -4385,7 +4430,7 @@ export interface Response15Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export type ExperimentSignificanceCodeApi =
@@ -4561,7 +4606,7 @@ export interface Response18Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface Response20Api {
@@ -4589,7 +4634,7 @@ export interface Response20Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface Response21Api {
@@ -4620,7 +4665,7 @@ export interface Response21Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface AccountsTableCustomPropertyHistoryPointApi {
@@ -4694,7 +4739,7 @@ export interface Response22Api {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export type TaxonomicFilterGroupTypeApi = (typeof TaxonomicFilterGroupTypeApi)[keyof typeof TaxonomicFilterGroupTypeApi]
@@ -4856,7 +4901,7 @@ export interface EventsQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export type CompareApi = (typeof CompareApi)[keyof typeof CompareApi]
@@ -4892,7 +4937,7 @@ export interface ActorsQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface InsightActorsQueryApi {
@@ -5179,7 +5224,7 @@ export interface FunnelCorrelationResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface FunnelCorrelationQueryApi {
@@ -5783,7 +5828,7 @@ export interface HogQLQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface HogQLVariableApi {
@@ -5900,7 +5945,7 @@ export interface GroupsQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface GroupsQueryApi {
@@ -5946,7 +5991,7 @@ export interface WebExternalClicksTableQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface WebExternalClicksTableQueryApi {
@@ -6016,7 +6061,7 @@ export interface WebBotsTableQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface WebBotsTableQueryApi {
@@ -6083,7 +6128,7 @@ export interface WebGoalsQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface WebGoalsQueryApi {
@@ -6209,7 +6254,7 @@ export interface WebVitalsPathBreakdownQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface WebVitalsPathBreakdownQueryApi {
@@ -6297,7 +6342,7 @@ export interface SessionAttributionExplorerQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface SessionAttributionExplorerQueryApi {
@@ -6339,7 +6384,7 @@ export interface SessionsQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface SessionsQueryApi {
@@ -6816,7 +6861,7 @@ export interface MarketingAnalyticsTableQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface MarketingAnalyticsTableQueryApi {
@@ -6890,7 +6935,7 @@ export interface MarketingAnalyticsAggregatedQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface MarketingAnalyticsAggregatedQueryApi {
@@ -6990,7 +7035,7 @@ export interface ErrorTrackingQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface ErrorTrackingQueryApi {
@@ -7056,7 +7101,7 @@ export interface ErrorTrackingIssueCorrelationQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface ErrorTrackingIssueCorrelationQueryApi {
@@ -7170,7 +7215,7 @@ export interface TracesQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface TracesQueryApi {
@@ -7251,7 +7296,7 @@ export interface TraceQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface TraceQueryApi {
@@ -7321,7 +7366,7 @@ export interface SessionQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface SessionQueryApi {
@@ -7400,7 +7445,7 @@ export interface EndpointsUsageTableQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface EndpointsUsageTableQueryApi {
@@ -7450,7 +7495,7 @@ export interface AccountsQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export interface AccountsQueryApi {
@@ -7707,7 +7752,7 @@ export interface AccountsTableQueryResponseApi {
     /** Connector-synced data warehouse sources referenced by this query, if any. */
     used_data_warehouse_sources?: DataWarehouseSourceUsageApi[] | null
     /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi)[] | null
+    warnings?: (DataWarehouseSyncWarningApi | AccessControlFilterWarningApi | QueryScanWarningApi)[] | null
 }
 
 export type AccountsTableSortDirectionApi =

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -1065,11 +1065,8 @@ export type QueryScanFindingKindApi = (typeof QueryScanFindingKindApi)[keyof typ
 
 export const QueryScanFindingKindApi = {
     NoEventFilter: 'no_event_filter',
-    EventFilterNotUsed: 'event_filter_not_used',
     NoStartDate: 'no_start_date',
     PersonsJoin: 'persons_join',
-    AllEvents: 'all_events',
-    AllTime: 'all_time',
 } as const
 
 export type QueryScanFindingReasonApi = (typeof QueryScanFindingReasonApi)[keyof typeof QueryScanFindingReasonApi]
@@ -1080,7 +1077,6 @@ export const QueryScanFindingReasonApi = {
     Negated: 'negated',
     Dynamic: 'dynamic',
     NotPruned: 'not_pruned',
-    Column: 'column',
     Filters: 'filters',
 } as const
 
@@ -1088,14 +1084,14 @@ export interface QueryScanWarningApi {
     /** The offending condition printed back as HogQL, when there is one */
     clause?: string | null
     duration_ms: number
-    /** What ClickHouse reported did not use the filter, when EXPLAIN was available */
+    /** The fact the finding rests on, in one sentence: what the plan reported, or the setting that caused it. */
     evidence?: string | null
-    /** The instruction handed to "Fix with AI" and to agents */
+    /** The instruction "Fix with AI" and the assistant get for this finding. */
     fix: string
     kind: QueryScanFindingKindApi
     /** Shown to the person. Sentence case, says what happened and what to do. */
     message: string
-    /** Why the filter could not be used; only for event_filter_not_used and no_start_date */
+    /** Why the filter the query has did not narrow the read. Only on no_event_filter and no_start_date. */
     reason?: QueryScanFindingReasonApi | null
     rows_read: number
     /** Tells warning kinds apart in the shared `warnings` list */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -1351,17 +1351,16 @@ export namespace Schemas {
     } as const;
 
     export interface QueryScanSummary {
-      /** ClickHouse time for the last fresh run, summed over every ClickHouse query the run made. */
+      /** ClickHouse time for the last fresh run, summed over its ClickHouse queries. */
       duration_ms: number;
-      /** What clients may show for this response. The server evaluated the flag once for this query; clients and the assistant read this field and never evaluate the flag themselves. */
       mode: QueryScanMode;
       /** How much of all the project's events the query read, 0 to 1. Set once the analysis is done. */
       project_share?: number | null;
       /** How much of the project's events in the query's date range the query read, 0 to 1. Set once the analysis is done. */
       range_share?: number | null;
-      /** Rows ClickHouse read for the last fresh run of this query, all tables included. */
+      /** Rows ClickHouse read for the last fresh run, all tables included. */
       rows_read: number;
-      /** Where the analysis of this query stands, see `QueryScanStatus`. The analysis only runs when `duration_ms` is over the threshold in the flag's payload, so the field is absent for a fast query. */
+      /** Absent when the run was too fast to analyze. */
       status?: QueryScanStatus | null;
     }
 
@@ -1462,20 +1461,19 @@ export namespace Schemas {
     } as const;
 
     export interface QueryScanWarning {
-      /** The offending condition printed back as HogQL, when there is one */
+      /** The condition at fault, as HogQL. */
       clause?: string | null;
       duration_ms: number;
-      /** The fact the finding rests on, in one sentence: what the plan reported, or the setting that caused it. */
+      /** The one fact the finding rests on. */
       evidence?: string | null;
-      /** The instruction "Fix with AI" and the assistant get for this finding. */
+      /** What "Fix with AI" and the assistant are told to do. */
       fix: string;
       kind: QueryScanFindingKind;
-      /** Shown to the person. Sentence case, says what happened and what to do. */
+      /** Shown to the person: what happened and what to do. */
       message: string;
-      /** Why the filter the query has did not narrow the read. Only on no_event_filter and no_start_date. */
+      /** Only with `no_event_filter` and `no_start_date`. */
       reason?: QueryScanFindingReason | null;
       rows_read: number;
-      /** Tells warning kinds apart in the shared `warnings` list */
       type?: 'query_scan';
     }
 
@@ -1506,7 +1504,7 @@ export namespace Schemas {
       types: string[];
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -1819,7 +1817,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -3665,7 +3663,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -3712,7 +3710,7 @@ export namespace Schemas {
       types?: string[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -3809,7 +3807,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -4355,7 +4353,7 @@ export namespace Schemas {
       total_median_conversion_time?: number | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -4454,7 +4452,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -4709,7 +4707,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -4857,7 +4855,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -4903,7 +4901,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -5026,7 +5024,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -5200,7 +5198,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -5290,7 +5288,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -5426,7 +5424,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -5980,7 +5978,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -6659,7 +6657,7 @@ export namespace Schemas {
       types: string[];
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -6688,7 +6686,7 @@ export namespace Schemas {
       types?: string[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -6717,7 +6715,7 @@ export namespace Schemas {
       types: string[];
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -6755,7 +6753,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -6784,7 +6782,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -6818,7 +6816,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -6847,7 +6845,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -6875,7 +6873,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -6907,7 +6905,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -6948,7 +6946,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -6976,7 +6974,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -7004,7 +7002,7 @@ export namespace Schemas {
       types: string[];
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -7043,7 +7041,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -7069,7 +7067,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -7243,7 +7241,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -7294,7 +7292,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -7429,7 +7427,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -7457,7 +7455,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -7488,7 +7486,7 @@ export namespace Schemas {
       types: string[];
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -7517,7 +7515,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -7656,7 +7654,7 @@ export namespace Schemas {
       types: string[];
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -7748,7 +7746,7 @@ export namespace Schemas {
       types: string[];
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -7794,7 +7792,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -7860,7 +7858,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -7922,7 +7920,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -8031,7 +8029,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -8114,7 +8112,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -8156,7 +8154,7 @@ export namespace Schemas {
       types: string[];
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -8361,7 +8359,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -8430,7 +8428,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -8527,7 +8525,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -8593,7 +8591,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -8707,7 +8705,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -8761,7 +8759,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -8804,7 +8802,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -8885,7 +8883,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -15578,7 +15576,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -30370,7 +30368,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -32120,7 +32118,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -32173,7 +32171,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -32629,7 +32627,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -32816,7 +32814,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -33679,7 +33677,7 @@ export namespace Schemas {
       unattributed: ErrorTrackingReleaseSeries | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -33834,7 +33832,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -35083,7 +35081,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -45101,7 +45099,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -45190,7 +45188,7 @@ export namespace Schemas {
       unattributedConversions: number;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -45278,7 +45276,7 @@ export namespace Schemas {
       totalConversions: number;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -45389,7 +45387,7 @@ export namespace Schemas {
       truncatedCohorts: number;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -45476,7 +45474,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -45543,7 +45541,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -45626,7 +45624,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -45692,7 +45690,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -45796,7 +45794,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -45846,7 +45844,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -46023,7 +46021,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -46078,7 +46076,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -46133,7 +46131,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -46192,7 +46190,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -46253,7 +46251,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -46439,7 +46437,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -46547,7 +46545,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -46613,7 +46611,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -46659,7 +46657,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -46704,7 +46702,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -46751,7 +46749,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -46794,7 +46792,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -46842,7 +46840,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -46891,7 +46889,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -46942,7 +46940,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -46994,7 +46992,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -47040,7 +47038,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -47094,7 +47092,7 @@ export namespace Schemas {
       totalCount: number;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -47171,7 +47169,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -47216,7 +47214,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -47254,7 +47252,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -47293,7 +47291,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -47332,7 +47330,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -47377,7 +47375,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -47426,7 +47424,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -47479,7 +47477,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -73308,7 +73306,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -74036,7 +74034,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -74112,7 +74110,7 @@ export namespace Schemas {
       types: string[];
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -74140,7 +74138,7 @@ export namespace Schemas {
       types: string[];
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -74169,7 +74167,7 @@ export namespace Schemas {
       types?: string[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -74198,7 +74196,7 @@ export namespace Schemas {
       types: string[];
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -74234,7 +74232,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -74279,7 +74277,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -74328,7 +74326,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -74355,7 +74353,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -74381,7 +74379,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -74405,7 +74403,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -74430,7 +74428,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -74471,7 +74469,7 @@ export namespace Schemas {
       unattributed: ErrorTrackingReleaseSeries | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -74498,7 +74496,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -74613,7 +74611,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -74642,7 +74640,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -74676,7 +74674,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -74705,7 +74703,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -74733,7 +74731,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -74765,7 +74763,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -74795,7 +74793,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -74821,7 +74819,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -74854,7 +74852,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -74883,7 +74881,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -74909,7 +74907,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -74947,7 +74945,7 @@ export namespace Schemas {
       unattributedConversions: number;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -74981,7 +74979,7 @@ export namespace Schemas {
       totalConversions: number;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75015,7 +75013,7 @@ export namespace Schemas {
       truncatedCohorts: number;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75045,7 +75043,7 @@ export namespace Schemas {
       types: string[];
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75074,7 +75072,7 @@ export namespace Schemas {
       types?: string[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75103,7 +75101,7 @@ export namespace Schemas {
       types: string[];
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75141,7 +75139,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75170,7 +75168,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75204,7 +75202,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75233,7 +75231,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75261,7 +75259,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75293,7 +75291,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75323,7 +75321,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75351,7 +75349,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75379,7 +75377,7 @@ export namespace Schemas {
       types: string[];
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75408,7 +75406,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75434,7 +75432,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75461,7 +75459,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75533,7 +75531,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75561,7 +75559,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75592,7 +75590,7 @@ export namespace Schemas {
       types: string[];
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75621,7 +75619,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75649,7 +75647,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75674,7 +75672,7 @@ export namespace Schemas {
       total_median_conversion_time?: number | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75697,7 +75695,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75720,7 +75718,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75743,7 +75741,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75768,7 +75766,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75796,7 +75794,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75829,7 +75827,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75858,7 +75856,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75882,7 +75880,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75905,7 +75903,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75928,7 +75926,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75956,7 +75954,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -75981,7 +75979,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76006,7 +76004,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76031,7 +76029,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76064,7 +76062,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76090,7 +76088,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76113,7 +76111,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76140,7 +76138,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76179,7 +76177,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76202,7 +76200,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76233,7 +76231,7 @@ export namespace Schemas {
       types: string[];
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76262,7 +76260,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76285,7 +76283,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76313,7 +76311,7 @@ export namespace Schemas {
       types?: unknown[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76338,7 +76336,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76361,7 +76359,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76384,7 +76382,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76407,7 +76405,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76430,7 +76428,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76453,7 +76451,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76476,7 +76474,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76499,7 +76497,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76523,7 +76521,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76546,7 +76544,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76571,7 +76569,7 @@ export namespace Schemas {
       totalCount: number;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76594,7 +76592,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76617,7 +76615,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76640,7 +76638,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76663,7 +76661,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76686,7 +76684,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76709,7 +76707,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76732,7 +76730,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76757,7 +76755,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
@@ -76780,7 +76778,7 @@ export namespace Schemas {
       timings?: QueryTiming[] | null;
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
-      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. Also carries query scan findings, see `QueryScanWarning`. */
       warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -46799,7 +46799,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface MCPModelBreakdownQuery {
@@ -76504,7 +76504,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative101 {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -1355,6 +1355,10 @@ export namespace Schemas {
       duration_ms: number;
       /** What clients may show for this response. The server evaluated the flag once for this query; clients and the assistant read this field and never evaluate the flag themselves. */
       mode: QueryScanMode;
+      /** Share of the granules across all the project's events that the query read, 0 to 1, written by the analysis. */
+      project_share?: number | null;
+      /** Share of the granules in the query's date range that the query read, 0 to 1, written by the analysis. */
+      range_share?: number | null;
       /** Rows ClickHouse read for the last fresh run of this query, all tables included. */
       rows_read: number;
       /** Where the analysis of this query stands, see `QueryScanStatus`. The analysis only runs when `duration_ms` is over the threshold in the flag's payload, so the field is absent for a fast query. */
@@ -1436,6 +1440,49 @@ export namespace Schemas {
       type?: 'warehouse_sync';
     }
 
+    export type QueryScanFindingKind = typeof QueryScanFindingKind[keyof typeof QueryScanFindingKind];
+
+
+    export const QueryScanFindingKind = {
+      NoEventFilter: 'no_event_filter',
+      EventFilterNotUsed: 'event_filter_not_used',
+      NoStartDate: 'no_start_date',
+      PersonsJoin: 'persons_join',
+      AllEvents: 'all_events',
+      AllTime: 'all_time',
+    } as const;
+
+    export type QueryScanFindingReason = typeof QueryScanFindingReason[keyof typeof QueryScanFindingReason];
+
+
+    export const QueryScanFindingReason = {
+      InOr: 'in_or',
+      Wrapped: 'wrapped',
+      Negated: 'negated',
+      Dynamic: 'dynamic',
+      NotPruned: 'not_pruned',
+      Column: 'column',
+      Filters: 'filters',
+    } as const;
+
+    export interface QueryScanWarning {
+      /** The offending condition printed back as HogQL, when there is one */
+      clause?: string | null;
+      duration_ms: number;
+      /** What ClickHouse reported did not use the filter, when EXPLAIN was available */
+      evidence?: string | null;
+      /** The instruction handed to "Fix with AI" and to agents */
+      fix: string;
+      kind: QueryScanFindingKind;
+      /** Shown to the person. Sentence case, says what happened and what to do. */
+      message: string;
+      /** Why the filter could not be used; only for event_filter_not_used and no_start_date */
+      reason?: QueryScanFindingReason | null;
+      rows_read: number;
+      /** Tells warning kinds apart in the shared `warnings` list */
+      type?: 'query_scan';
+    }
+
     export interface AccountsQueryResponse {
       columns: unknown[];
       /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
@@ -1464,7 +1511,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryLogTags {
@@ -1777,7 +1824,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export type AccountsTableSortDirection = typeof AccountsTableSortDirection[keyof typeof AccountsTableSortDirection];
@@ -3623,7 +3670,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface ActorsPropertyTaxonomyQuery {
@@ -3670,7 +3717,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export type Compare = typeof Compare[keyof typeof Compare];
@@ -3767,7 +3814,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export type EventsNodeResponse = { [key: string]: unknown } | null;
@@ -4313,7 +4360,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export type FunnelsDataWarehouseNodeResponse = { [key: string]: unknown } | null;
@@ -4412,7 +4459,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export type AggregationPropertyType = typeof AggregationPropertyType[keyof typeof AggregationPropertyType];
@@ -4667,7 +4714,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface PathsQuery {
@@ -4815,7 +4862,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface PathsV2Query {
@@ -4861,7 +4908,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export type StickinessComputationMode = typeof StickinessComputationMode[keyof typeof StickinessComputationMode];
@@ -4984,7 +5031,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export type LifecycleDataWarehouseNodeResponse = { [key: string]: unknown } | null;
@@ -5158,7 +5205,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface WebAnalyticsSampling {
@@ -5248,7 +5295,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface WebOverviewQuery {
@@ -5384,7 +5431,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface FunnelCorrelationQuery {
@@ -5938,7 +5985,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface HogQLVariable {
@@ -6617,7 +6664,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface Response1 {
@@ -6646,7 +6693,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface Response2 {
@@ -6675,7 +6722,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface Response3 {
@@ -6713,7 +6760,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface Response4 {
@@ -6742,7 +6789,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface Response5 {
@@ -6776,7 +6823,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface Response6 {
@@ -6805,7 +6852,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface Response7 {
@@ -6833,7 +6880,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface Response8 {
@@ -6865,7 +6912,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface WebVitalsPathBreakdownResultItem {
@@ -6906,7 +6953,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface Response10 {
@@ -6934,7 +6981,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface Response11 {
@@ -6962,7 +7009,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface MarketingAnalyticsItem {
@@ -7001,7 +7048,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export type Response13Results = {[key: string]: MarketingAnalyticsItem};
@@ -7027,7 +7074,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface VolumeBucket {
@@ -7201,7 +7248,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface Population {
@@ -7252,7 +7299,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export type Response16CredibleIntervals = {[key: string]: number[]};
@@ -7387,7 +7434,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface Response20 {
@@ -7415,7 +7462,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface Response21 {
@@ -7446,7 +7493,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface Response22 {
@@ -7475,7 +7522,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export type TaxonomicFilterGroupType = typeof TaxonomicFilterGroupType[keyof typeof TaxonomicFilterGroupType];
@@ -7614,7 +7661,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface EventsQuery {
@@ -7706,7 +7753,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface GroupsQuery {
@@ -7752,7 +7799,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface WebExternalClicksTableQuery {
@@ -7818,7 +7865,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface WebBotsTableQuery {
@@ -7880,7 +7927,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface WebGoalsQuery {
@@ -7989,7 +8036,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface WebVitalsPathBreakdownQuery {
@@ -8072,7 +8119,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface SessionAttributionExplorerQuery {
@@ -8114,7 +8161,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface SessionsQuery {
@@ -8319,7 +8366,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface MarketingAnalyticsTableQuery {
@@ -8388,7 +8435,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface MarketingAnalyticsAggregatedQuery {
@@ -8485,7 +8532,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface ErrorTrackingQuery {
@@ -8551,7 +8598,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface ErrorTrackingIssueCorrelationQuery {
@@ -8665,7 +8712,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface TracesQuery {
@@ -8719,7 +8766,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface TraceQuery {
@@ -8762,7 +8809,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface SessionQuery {
@@ -8843,7 +8890,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface EndpointsUsageTableQuery {
@@ -15536,7 +15583,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface CalendarHeatmapQuery {
@@ -30328,7 +30375,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface DocumentSimilarityQuery {
@@ -32078,7 +32125,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface EndpointsUsageOverviewQuery {
@@ -32131,7 +32178,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface EndpointsUsageTrendsQuery {
@@ -32587,7 +32634,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface ErrorTrackingBreakdownsQuery {
@@ -32774,7 +32821,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface ErrorTrackingFingerprintProjectionQuery {
@@ -33637,7 +33684,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface ErrorTrackingReleasesQuery {
@@ -33792,7 +33839,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface ErrorTrackingSimilarIssuesQuery {
@@ -35041,7 +35088,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface EventTaxonomyQuery {
@@ -45059,7 +45106,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface SessionsTimelineQuery {
@@ -45148,7 +45195,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface MarketingAnalyticsAttributionQuery {
@@ -45236,7 +45283,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface MarketingAnalyticsAttributionPathsQuery {
@@ -45347,7 +45394,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface MarketingAnalyticsRetentionQuery {
@@ -45434,7 +45481,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface WebAgentAnalyticsQuery {
@@ -45501,7 +45548,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface WebPageURLSearchQuery {
@@ -45584,7 +45631,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface WebNotableChangesQuery {
@@ -45650,7 +45697,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export type LogSeverityLevel = typeof LogSeverityLevel[keyof typeof LogSeverityLevel];
@@ -45754,7 +45801,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface LogAttributesQuery {
@@ -45804,7 +45851,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface LogValuesQuery {
@@ -45981,7 +46028,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface MetricsQuery {
@@ -46036,7 +46083,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface TraceSpansQuery {
@@ -46091,7 +46138,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface TraceSpansAggregationQuery {
@@ -46150,7 +46197,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface TraceSpansTreeQuery {
@@ -46211,7 +46258,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface TraceSpansAttributeBreakdownQuery {
@@ -46397,7 +46444,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export type RecordingsQueryActions = { [key: string]: unknown }[] | null;
@@ -46505,7 +46552,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface VectorSearchQuery {
@@ -46571,7 +46618,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface UsageMetricsQuery {
@@ -46617,7 +46664,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface MCPToolCallBreakdownQuery {
@@ -46662,7 +46709,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface MCPToolCallsAndErrorsQuery {
@@ -46709,7 +46756,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface MCPHarnessBreakdownQuery {
@@ -46800,7 +46847,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface MCPToolTopUsersQuery {
@@ -46849,7 +46896,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface MCPToolFailuresQuery {
@@ -46900,7 +46947,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface MCPToolFailureOccurrencesQuery {
@@ -46952,7 +46999,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface MCPToolStatsQuery {
@@ -46998,7 +47045,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface MCPToolDailyStatsQuery {
@@ -47052,7 +47099,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export type MCPToolQualitySortColumn = typeof MCPToolQualitySortColumn[keyof typeof MCPToolQualitySortColumn];
@@ -47129,7 +47176,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface MCPToolQualityDailyStatsQuery {
@@ -47174,7 +47221,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface MCPToolCategoryCountsQuery {
@@ -47212,7 +47259,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface MCPToolCategoriesQuery {
@@ -47251,7 +47298,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface MCPToolCategoryMapQuery {
@@ -47290,7 +47337,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface MCPToolDescriptionsQuery {
@@ -47335,7 +47382,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface MCPToolSampleIntentsQuery {
@@ -47384,7 +47431,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface MCPToolNeighborsQuery {
@@ -47437,7 +47484,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface MCPMissingCapabilitiesQuery {
@@ -73266,7 +73313,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface PropertyValuesQuery {
@@ -73994,7 +74041,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface TeamTaxonomyQuery {
@@ -74070,7 +74117,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative2 {
@@ -74098,7 +74145,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative3 {
@@ -74127,7 +74174,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative4 {
@@ -74156,7 +74203,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative5 {
@@ -74192,7 +74239,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative7 {
@@ -74237,7 +74284,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative9 {
@@ -74286,7 +74333,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative12 {
@@ -74313,7 +74360,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative13 {
@@ -74339,7 +74386,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative14 {
@@ -74363,7 +74410,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export type QueryResponseAlternative15Results = {[key: string]: Results};
@@ -74388,7 +74435,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative16 {
@@ -74429,7 +74476,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative17 {
@@ -74456,7 +74503,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export type QueryResponseAlternative18CredibleIntervals = {[key: string]: number[]};
@@ -74571,7 +74618,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative23 {
@@ -74600,7 +74647,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative24 {
@@ -74634,7 +74681,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative25 {
@@ -74663,7 +74710,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative26 {
@@ -74691,7 +74738,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative28 {
@@ -74723,7 +74770,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative29 {
@@ -74753,7 +74800,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative30 {
@@ -74779,7 +74826,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export type QueryResponseAlternative31Data = { [key: string]: unknown };
@@ -74812,7 +74859,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative33 {
@@ -74841,7 +74888,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export type QueryResponseAlternative34Results = {[key: string]: MarketingAnalyticsItem};
@@ -74867,7 +74914,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative35 {
@@ -74905,7 +74952,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative36 {
@@ -74939,7 +74986,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative37 {
@@ -74973,7 +75020,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative38 {
@@ -75003,7 +75050,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative39 {
@@ -75032,7 +75079,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative40 {
@@ -75061,7 +75108,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative41 {
@@ -75099,7 +75146,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative42 {
@@ -75128,7 +75175,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative43 {
@@ -75162,7 +75209,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative44 {
@@ -75191,7 +75238,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative45 {
@@ -75219,7 +75266,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative46 {
@@ -75251,7 +75298,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative47 {
@@ -75281,7 +75328,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative48 {
@@ -75309,7 +75356,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative49 {
@@ -75337,7 +75384,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative50 {
@@ -75366,7 +75413,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export type QueryResponseAlternative51Results = {[key: string]: MarketingAnalyticsItem};
@@ -75392,7 +75439,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative52 {
@@ -75419,7 +75466,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export type QueryResponseAlternative54CredibleIntervals = {[key: string]: number[]};
@@ -75491,7 +75538,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative58 {
@@ -75519,7 +75566,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative59 {
@@ -75550,7 +75597,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative60 {
@@ -75579,7 +75626,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export type QueryResponseAlternative61ResultsItem = { [key: string]: unknown };
@@ -75607,7 +75654,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative62 {
@@ -75632,7 +75679,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative63 {
@@ -75655,7 +75702,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative64 {
@@ -75678,7 +75725,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative65 {
@@ -75701,7 +75748,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export type QueryResponseAlternative66ResultsItem = { [key: string]: unknown };
@@ -75726,7 +75773,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative68 {
@@ -75754,7 +75801,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export type QueryResponseAlternative69Tables = {[key: string]: DatabaseSchemaPostHogTable | DatabaseSchemaSystemTable | DatabaseSchemaDataWarehouseTable | DatabaseSchemaViewTable | DatabaseSchemaManagedViewTable | DatabaseSchemaBatchExportTable | DatabaseSchemaMaterializedViewTable | DatabaseSchemaEndpointTable};
@@ -75787,7 +75834,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative71 {
@@ -75816,7 +75863,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative72 {
@@ -75840,7 +75887,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative73 {
@@ -75863,7 +75910,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative74 {
@@ -75886,7 +75933,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative75 {
@@ -75914,7 +75961,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative76 {
@@ -75939,7 +75986,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative77 {
@@ -75964,7 +76011,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative78 {
@@ -75989,7 +76036,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative79 {
@@ -76022,7 +76069,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative81 {
@@ -76048,7 +76095,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative82 {
@@ -76071,7 +76118,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative83 {
@@ -76098,7 +76145,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative86 {
@@ -76137,7 +76184,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative88 {
@@ -76160,7 +76207,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative89 {
@@ -76191,7 +76238,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative90 {
@@ -76220,7 +76267,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative91 {
@@ -76243,7 +76290,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative92 {
@@ -76271,7 +76318,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export type QueryResponseAlternative93ResultsItem = { [key: string]: unknown };
@@ -76296,7 +76343,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative94 {
@@ -76319,7 +76366,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative95 {
@@ -76342,7 +76389,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative96 {
@@ -76365,7 +76412,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative97 {
@@ -76388,7 +76435,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative98 {
@@ -76411,7 +76458,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative99 {
@@ -76434,7 +76481,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative100 {
@@ -76481,7 +76528,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative102 {
@@ -76504,7 +76551,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative103 {
@@ -76529,7 +76576,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative104 {
@@ -76552,7 +76599,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative105 {
@@ -76575,7 +76622,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative106 {
@@ -76598,7 +76645,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative107 {
@@ -76621,7 +76668,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative108 {
@@ -76644,7 +76691,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative109 {
@@ -76667,7 +76714,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative110 {
@@ -76690,7 +76737,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative111 {
@@ -76715,7 +76762,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export interface QueryResponseAlternative112 {
@@ -76738,7 +76785,7 @@ export namespace Schemas {
       /** Connector-synced data warehouse sources referenced by this query, if any. */
       used_data_warehouse_sources?: DataWarehouseSourceUsage[] | null;
       /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. Also carries access control warnings when a system-table query filters out objects the user can't access. */
-      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning)[] | null;
+      warnings?: (DataWarehouseSyncWarning | AccessControlFilterWarning | QueryScanWarning)[] | null;
     }
 
     export type QueryResponseAlternative = { [key: string]: unknown } | QueryResponseAlternative1 | QueryResponseAlternative2 | QueryResponseAlternative3 | QueryResponseAlternative4 | QueryResponseAlternative5 | QueryResponseAlternative6 | QueryResponseAlternative7 | QueryResponseAlternative8 | QueryResponseAlternative9 | QueryResponseAlternative10 | QueryResponseAlternative11 | QueryResponseAlternative12 | QueryResponseAlternative13 | QueryResponseAlternative14 | QueryResponseAlternative15 | QueryResponseAlternative16 | QueryResponseAlternative17 | QueryResponseAlternative18 | QueryResponseAlternative19 | QueryResponseAlternative20 | QueryResponseAlternative21 | QueryResponseAlternative22 | QueryResponseAlternative23 | QueryResponseAlternative24 | QueryResponseAlternative25 | QueryResponseAlternative26 | QueryResponseAlternative28 | QueryResponseAlternative29 | QueryResponseAlternative30 | QueryResponseAlternative31 | QueryResponseAlternative32 | QueryResponseAlternative33 | QueryResponseAlternative34 | QueryResponseAlternative35 | QueryResponseAlternative36 | QueryResponseAlternative37 | unknown | QueryResponseAlternative38 | QueryResponseAlternative39 | QueryResponseAlternative40 | QueryResponseAlternative41 | QueryResponseAlternative42 | QueryResponseAlternative43 | QueryResponseAlternative44 | QueryResponseAlternative45 | QueryResponseAlternative46 | QueryResponseAlternative47 | QueryResponseAlternative48 | QueryResponseAlternative49 | QueryResponseAlternative50 | QueryResponseAlternative51 | QueryResponseAlternative52 | QueryResponseAlternative54 | QueryResponseAlternative55 | QueryResponseAlternative56 | QueryResponseAlternative58 | QueryResponseAlternative59 | QueryResponseAlternative60 | QueryResponseAlternative61 | QueryResponseAlternative62 | QueryResponseAlternative63 | QueryResponseAlternative64 | QueryResponseAlternative65 | QueryResponseAlternative66 | QueryResponseAlternative68 | QueryResponseAlternative69 | QueryResponseAlternative70 | QueryResponseAlternative71 | QueryResponseAlternative72 | QueryResponseAlternative73 | QueryResponseAlternative74 | QueryResponseAlternative75 | QueryResponseAlternative76 | QueryResponseAlternative77 | QueryResponseAlternative78 | QueryResponseAlternative79 | QueryResponseAlternative80 | QueryResponseAlternative81 | QueryResponseAlternative82 | QueryResponseAlternative83 | QueryResponseAlternative86 | QueryResponseAlternative87 | QueryResponseAlternative88 | QueryResponseAlternative89 | QueryResponseAlternative90 | QueryResponseAlternative91 | QueryResponseAlternative92 | QueryResponseAlternative93 | QueryResponseAlternative94 | QueryResponseAlternative95 | QueryResponseAlternative96 | QueryResponseAlternative97 | QueryResponseAlternative98 | QueryResponseAlternative99 | QueryResponseAlternative100 | QueryResponseAlternative101 | QueryResponseAlternative102 | QueryResponseAlternative103 | QueryResponseAlternative104 | QueryResponseAlternative105 | QueryResponseAlternative106 | QueryResponseAlternative107 | QueryResponseAlternative108 | QueryResponseAlternative109 | QueryResponseAlternative110 | QueryResponseAlternative111 | QueryResponseAlternative112;

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -1355,9 +1355,9 @@ export namespace Schemas {
       duration_ms: number;
       /** What clients may show for this response. The server evaluated the flag once for this query; clients and the assistant read this field and never evaluate the flag themselves. */
       mode: QueryScanMode;
-      /** Share of the granules across all the project's events that the query read, 0 to 1, written by the analysis. */
+      /** How much of all the project's events the query read, 0 to 1. Set once the analysis is done. */
       project_share?: number | null;
-      /** Share of the granules in the query's date range that the query read, 0 to 1, written by the analysis. */
+      /** How much of the project's events in the query's date range the query read, 0 to 1. Set once the analysis is done. */
       range_share?: number | null;
       /** Rows ClickHouse read for the last fresh run of this query, all tables included. */
       rows_read: number;

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -1445,11 +1445,8 @@ export namespace Schemas {
 
     export const QueryScanFindingKind = {
       NoEventFilter: 'no_event_filter',
-      EventFilterNotUsed: 'event_filter_not_used',
       NoStartDate: 'no_start_date',
       PersonsJoin: 'persons_join',
-      AllEvents: 'all_events',
-      AllTime: 'all_time',
     } as const;
 
     export type QueryScanFindingReason = typeof QueryScanFindingReason[keyof typeof QueryScanFindingReason];
@@ -1461,7 +1458,6 @@ export namespace Schemas {
       Negated: 'negated',
       Dynamic: 'dynamic',
       NotPruned: 'not_pruned',
-      Column: 'column',
       Filters: 'filters',
     } as const;
 
@@ -1469,14 +1465,14 @@ export namespace Schemas {
       /** The offending condition printed back as HogQL, when there is one */
       clause?: string | null;
       duration_ms: number;
-      /** What ClickHouse reported did not use the filter, when EXPLAIN was available */
+      /** The fact the finding rests on, in one sentence: what the plan reported, or the setting that caused it. */
       evidence?: string | null;
-      /** The instruction handed to "Fix with AI" and to agents */
+      /** The instruction "Fix with AI" and the assistant get for this finding. */
       fix: string;
       kind: QueryScanFindingKind;
       /** Shown to the person. Sentence case, says what happened and what to do. */
       message: string;
-      /** Why the filter could not be used; only for event_filter_not_used and no_start_date */
+      /** Why the filter the query has did not narrow the read. Only on no_event_filter and no_start_date. */
       reason?: QueryScanFindingReason | null;
       rows_read: number;
       /** Tells warning kinds apart in the shared `warnings` list */


### PR DESCRIPTION
## Problem

#97356 records how much a slow query read. That number says how much, not why. This PR is the reasoning: given how ClickHouse planned the query, it decides which of three things is wrong and how to say it. It is pure functions with no I/O; #97358 calls them from a background job, and #97360 shows the result.

It reads ClickHouse's own plan, from `EXPLAIN`, rather than our query tree, because the plan reports which sort-key columns ClickHouse could use to skip data and how many blocks survived. That is the truth about what was read. The tree can only guess.

## Changes

- Three findings. No start date: no timestamp bound reached the index. No event filter: `event` did not prune, and the query read at least a tenth of the blocks in its date range. Persons join: the read of the persons table is at least half the events read, in rows.
- For "no event filter", the query tree supplies the reason the filter could not prune: it excludes events (`!=`, `NOT IN`), wraps `event` in a function, sits inside an OR, or compares `event` to a column. The reason picks the wording. A plan-only rule missed `event != 'x'`, because ClickHouse lists `event` as a used key for it and then prunes nothing.
- Two shares: the fraction of the date range's blocks and of the project's blocks the query read. Both come from the plan; no events are counted.
- Before EXPLAIN, every `IN (subquery)` is replaced by a constant and each subquery is explained on its own. EXPLAIN runs those subqueries in full to build the set; on one replay query that was 6 seconds and 1.4 billion rows for a plan that should read nothing.
- Blocks are not rows: the persons table packs about five times more rows per block than events, so the persons gate scales each side by its table's rows per block.
- Mechanical: the finding and share types on the response, and their generated copies. Nothing looks different yet.

## How did you test this code?

Pure tests with no database: one case per finding and per gate direction, the plan parser against real production plans (URLs scrubbed), the stub visitor over `IN`, `NOT IN`, `NOT (x IN ...)`, subquery collection order, and printing the stubbed tree as ClickHouse SQL. The last one catches the regression that broke the first dev-stack run, a clone that dropped the tree's types.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Internal analysis code with no surface of its own.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code; Opus 4.8 subagents wrote the first version, Fable 5.1 finished it. Skills invoked: `/writing-dataclasses`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-pr-descriptions`. This layer was rebuilt once: an earlier version analyzed the query tree and counted events in a date range; production measurements showed the plan gives the same answers for free, so the count and the tree checks were dropped, and the one tree check that the plan cannot replace, why an event filter could not prune, was restored afterwards. The plan fixtures are from PostHog's own project and were checked for URLs, emails, IPs and tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018edMgtXf5h4mYbq1pgeH5y
