### PR TITLE
feat(subscriptions): add Pulse creation workflow

### DIFF
--- a/docs/published/docs/mcp-analytics/notifications.mdx
+++ b/docs/published/docs/mcp-analytics/notifications.mdx
@@ -34,6 +34,9 @@ An early-alpha AI report can also prepare up to three cited recommendations afte
 off by default. API and MCP clients enable it with `proactive_config.enabled`; public web research is then allowed by
 default and can be disabled with `proactive_config.allow_public_web_research: false`.
 
+When the Pulse preview is enabled, the AI subscription wizard includes an **Actions** step for these optional settings.
+The same controls are available when you edit an existing AI subscription.
+
 To allow a recommendation to prepare a draft pull request, set `proactive_config.create_draft_pr: true` and select a
 repository with `proactive_config.repository`. You can select a specific GitHub installation with
 `proactive_config.repository_integration_id`. The report checks the creator's current repository access before it

--- a/ee/api/subscription.py
+++ b/ee/api/subscription.py
@@ -805,6 +805,10 @@ class SubscriptionWriteSerializer(serializers.ModelSerializer):
                 raise ValidationError(
                     {"proactive_config": ["Repository settings require create_draft_pr to be enabled."]}
                 )
+            if create_draft_pr and (not repository or repository_integration_id is None):
+                raise ValidationError(
+                    {"proactive_config": ["Draft pull request preparation requires a repository and integration."]}
+                )
         if "contexts" in attrs:
             if resource_type != Subscription.ResourceType.AI_PROMPT:
                 raise ValidationError({"contexts": ["Context only applies to AI subscriptions."]})

--- a/ee/api/test/test_subscription.py
+++ b/ee/api/test/test_subscription.py
@@ -3863,6 +3863,17 @@ class TestAISubscriptionAPI(APILicensedTest):
         assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
         assert "create_draft_pr" in str(response.json())
 
+    def test_ai_subscription_rejects_draft_pr_config_without_a_repository(self, mock_is_cloud, mock_flag, mock_sync):
+        self._enable_ai()
+        self._mock_temporal(mock_sync)
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/subscriptions",
+            self._make_ai_payload(proactive_config={"create_draft_pr": True}),
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+        assert "repository" in str(response.json()).lower()
+
     def test_proactive_config_is_rejected_on_an_insight_subscription(self, mock_is_cloud, mock_flag, mock_sync):
         self._mock_temporal(mock_sync)
         payload = self._insight_payload()

--- a/products/subscriptions/backend/facade/proactive.py
+++ b/products/subscriptions/backend/facade/proactive.py
@@ -10,6 +10,7 @@ from decimal import Decimal
 from typing import cast
 from uuid import UUID
 
+from django.conf import settings
 from django.db import IntegrityError, transaction
 from django.utils import timezone
 
@@ -47,6 +48,20 @@ class ProactiveConfigDTO:
     create_draft_pr: bool
     repository: str | None
     repository_integration_id: int | None
+
+
+@frozen
+class ProactiveRepositoryOptionDTO:
+    repository: str
+    repository_integration_id: int
+
+
+@frozen
+class ProactiveConfigurationOptionsDTO:
+    proactive_available: bool
+    public_web_research_available: bool
+    draft_pr_available: bool
+    repositories: tuple[ProactiveRepositoryOptionDTO, ...]
 
 
 @frozen
@@ -139,6 +154,28 @@ def update_proactive_config(
         create_draft_pr=config.create_draft_pr,
         repository=config.repository,
         repository_integration_id=config.repository_integration_id,
+    )
+
+
+def get_proactive_configuration_options(*, team_id: int, actor_id: int) -> ProactiveConfigurationOptionsDTO:
+    proactive_available = bool(settings.PULSE_PROACTIVE_ENABLED)
+    draft_pr_available = proactive_available and bool(settings.PULSE_ARTIFACT_PREPARATION_ENABLED)
+    repositories = (
+        tuple(
+            ProactiveRepositoryOptionDTO(
+                repository=repository.repository,
+                repository_integration_id=repository.github_integration_id,
+            )
+            for repository in list_authorizable_repositories(team_id=team_id, actor_id=actor_id)
+        )
+        if draft_pr_available
+        else ()
+    )
+    return ProactiveConfigurationOptionsDTO(
+        proactive_available=proactive_available,
+        public_web_research_available=proactive_available and bool(settings.PULSE_PUBLIC_RESEARCH_ENABLED),
+        draft_pr_available=draft_pr_available,
+        repositories=repositories,
     )
 
 

--- a/products/subscriptions/backend/presentation/serializers.py
+++ b/products/subscriptions/backend/presentation/serializers.py
@@ -1,3 +1,4 @@
+from drf_spectacular.utils import extend_schema_serializer
 from rest_framework import serializers
 
 
@@ -22,4 +23,37 @@ class PulseResearchResponseSerializer(serializers.Serializer):
         allow_null=True,
         required=False,
         help_text="Why public research was unavailable, when it could not run.",
+    )
+
+
+class ProactiveRepositoryOptionSerializer(serializers.Serializer):
+    repository = serializers.CharField(
+        read_only=True,
+        help_text="Repository currently authorized for the requesting user, in owner/repository format.",
+    )
+    repository_integration_id = serializers.IntegerField(
+        read_only=True,
+        min_value=1,
+        help_text="GitHub integration that currently authorizes this repository.",
+    )
+
+
+@extend_schema_serializer(many=False)
+class ProactiveConfigurationOptionsSerializer(serializers.Serializer):
+    proactive_available = serializers.BooleanField(
+        read_only=True,
+        help_text="Whether this PostHog instance is configured to generate proactive recommendations.",
+    )
+    public_web_research_available = serializers.BooleanField(
+        read_only=True,
+        help_text="Whether this PostHog instance is configured to use public web research for proactive recommendations.",
+    )
+    draft_pr_available = serializers.BooleanField(
+        read_only=True,
+        help_text="Whether this PostHog instance is configured to prepare draft pull requests for proactive recommendations.",
+    )
+    repositories = ProactiveRepositoryOptionSerializer(
+        many=True,
+        read_only=True,
+        help_text="Repositories currently authorized for the requesting user to use for draft pull request preparation.",
     )

--- a/products/subscriptions/backend/presentation/views.py
+++ b/products/subscriptions/backend/presentation/views.py
@@ -18,10 +18,26 @@ from posthog.temporal.oauth import PULSE_RESEARCH_INTERNAL_SCOPE
 
 from products.subscriptions.backend.facade.api import run_public_research
 from products.subscriptions.backend.facade.contracts import PublicResearchResult
+from products.subscriptions.backend.facade.proactive import get_proactive_configuration_options
 from products.subscriptions.backend.presentation.serializers import (
+    ProactiveConfigurationOptionsSerializer,
     PulseResearchRequestSerializer,
     PulseResearchResponseSerializer,
 )
+
+
+@extend_schema(tags=["subscriptions"])
+class ProactiveConfigurationOptionsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
+    scope_object = "subscription"
+    serializer_class = ProactiveConfigurationOptionsSerializer
+    pagination_class = None
+
+    @extend_schema(responses={200: ProactiveConfigurationOptionsSerializer})
+    def list(self, request: Request, parent_lookup_team_id: int) -> Response:
+        actor_id = request.user.id
+        assert actor_id is not None
+        options = get_proactive_configuration_options(team_id=parent_lookup_team_id, actor_id=actor_id)
+        return Response(ProactiveConfigurationOptionsSerializer(options).data, status=status.HTTP_200_OK)
 
 
 @extend_schema(tags=["subscriptions"])

--- a/products/subscriptions/backend/routes.py
+++ b/products/subscriptions/backend/routes.py
@@ -1,9 +1,15 @@
 from posthog.api.routing import RouterRegistry
 
-from products.subscriptions.backend.presentation.views import PulseResearchViewSet
+from products.subscriptions.backend.presentation.views import ProactiveConfigurationOptionsViewSet, PulseResearchViewSet
 
 
 def register_routes(routers: RouterRegistry) -> None:
+    routers.projects.register(
+        r"subscriptions/proactive_options",
+        ProactiveConfigurationOptionsViewSet,
+        "project_subscription_proactive_options",
+        ["team_id"],
+    )
     routers.projects.register(
         r"subscriptions/pulse_research", PulseResearchViewSet, "project_subscription_pulse_research", ["team_id"]
     )

--- a/products/subscriptions/backend/tests/test_presentation.py
+++ b/products/subscriptions/backend/tests/test_presentation.py
@@ -6,6 +6,9 @@ from typing import cast
 from uuid import uuid4
 
 import pytest
+from posthog.test.base import APIBaseTest
+
+from django.test import override_settings
 
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.parsers import JSONParser
@@ -62,3 +65,21 @@ def test_runtime_kill_switch_blocks_an_existing_research_token(disabled_setting:
     search = cast(Callable[..., Response], PulseResearchViewSet().search)
     with pytest.raises(PermissionDenied):
         search(request, team_id=1)
+
+
+class TestProactiveConfigurationOptionsView(APIBaseTest):
+    @override_settings(
+        PULSE_PROACTIVE_ENABLED=True,
+        PULSE_PUBLIC_RESEARCH_ENABLED=False,
+        PULSE_ARTIFACT_PREPARATION_ENABLED=False,
+    )
+    def test_returns_instance_availability_for_the_current_project(self) -> None:
+        response = self.client.get(f"/api/projects/{self.team.pk}/subscriptions/proactive_options/")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "proactive_available": True,
+            "public_web_research_available": False,
+            "draft_pr_available": False,
+            "repositories": [],
+        }

--- a/products/subscriptions/backend/tests/test_proactive_recommendations.py
+++ b/products/subscriptions/backend/tests/test_proactive_recommendations.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 import pytest
 
 from django.apps import apps
+from django.test import override_settings
 from django.utils import timezone
 
 from posthog.models import Team
@@ -23,6 +24,7 @@ from products.subscriptions.backend.facade.proactive import (
     claim_recommendation_run,
     finalize_recommendation_run,
     get_proactive_config,
+    get_proactive_configuration_options,
     read_recommendation_appendix,
     recent_recommendation_memory,
 )
@@ -107,6 +109,37 @@ def test_proactive_subscription_config_is_a_team_scoped_record(team) -> None:
 
     other_team = Team.objects.create(organization=team.organization, name="Other project")
     assert get_proactive_config(team_id=other_team.id, subscription_id=123).enabled is False
+
+
+@override_settings(
+    PULSE_PROACTIVE_ENABLED=True,
+    PULSE_PUBLIC_RESEARCH_ENABLED=False,
+    PULSE_ARTIFACT_PREPARATION_ENABLED=True,
+)
+@pytest.mark.django_db
+def test_proactive_configuration_options_only_expose_currently_authorizable_repositories(team, monkeypatch) -> None:
+    user_integration_id = uuid4()
+    monkeypatch.setattr(
+        proactive,
+        "list_authorizable_repositories",
+        lambda **_kwargs: (
+            AuthorizableRepository(
+                repository="posthog/posthog",
+                github_integration_id=123,
+                github_user_integration_id=user_integration_id,
+                github_installation_id="456",
+            ),
+        ),
+    )
+
+    options = get_proactive_configuration_options(team_id=team.id, actor_id=456)
+
+    assert options.proactive_available is True
+    assert options.public_web_research_available is False
+    assert options.draft_pr_available is True
+    assert options.repositories == (
+        proactive.ProactiveRepositoryOptionDTO(repository="posthog/posthog", repository_integration_id=123),
+    )
 
 
 @pytest.mark.django_db

--- a/products/subscriptions/frontend/components/Subscriptions/AiPromptFields.tsx
+++ b/products/subscriptions/frontend/components/Subscriptions/AiPromptFields.tsx
@@ -24,23 +24,28 @@ export function AiPromptSubscriptionIntroduction(): JSX.Element {
 const AI_PROMPT_EXAMPLES: { icon: ReactElement; label: string; prompt: string }[] = [
     {
         icon: <IconLineGraph />,
-        label: 'Top events',
-        prompt: 'Top 5 events by volume, with counts and unique users for each.',
+        label: 'Improve activation',
+        prompt: 'Investigate where new users drop off before activation and identify the highest-impact next step.',
     },
     {
         icon: <IconTrending />,
-        label: 'Period-over-period growth',
-        prompt: 'For the top 10 events by volume, compare the current period vs the previous one and rank by growth rate. Flag any event that more than doubled or halved.',
+        label: 'Grow feature adoption',
+        prompt: 'Investigate which important features are gaining or losing adoption and recommend where to focus.',
     },
     {
         icon: <IconPulse />,
-        label: 'Health check',
-        prompt: 'Health check: total event volume and unique active users, and how each compares to the previous period.',
+        label: 'Increase conversion',
+        prompt: 'Investigate the conversion funnel, identify the largest drop-off, and recommend a next step.',
     },
     {
         icon: <IconWarning />,
-        label: 'Tracking gaps',
-        prompt: 'Which events we normally track received no data? List them so I can catch broken instrumentation.',
+        label: 'Improve retention',
+        prompt: 'Investigate which users are least likely to return and identify an opportunity to improve retention.',
+    },
+    {
+        icon: <IconWarning />,
+        label: 'Catch regressions',
+        prompt: 'Investigate meaningful recent regressions in product usage and identify what needs attention first.',
     },
 ]
 
@@ -112,18 +117,18 @@ export function AiPromptFields({
             ) : null}
             <LemonField
                 name="prompt"
-                label="What do you want to know?"
-                help="We'll use this question to surface the right information in each report."
+                label="What should this report investigate?"
+                help="Describe the question or goal for each report."
             >
                 <LemonTextArea
-                    placeholder="e.g. Which events grew the most week-over-week? Highlight any unusual spikes."
+                    placeholder="e.g. Which events grew the most week-over-week? Highlight unusual spikes."
                     minRows={4}
                     maxLength={SubscriptionAIPromptMaxLength.CHARACTERS}
                 />
             </LemonField>
             {showExamples ? (
                 <div className="flex flex-col gap-1">
-                    <span className="text-xs text-secondary">Try one of these questions:</span>
+                    <span className="text-xs text-secondary">Try a suggested goal:</span>
                     <div className="flex flex-wrap gap-1">
                         {AI_PROMPT_EXAMPLES.map((example) => (
                             <LemonButton

--- a/products/subscriptions/frontend/components/Subscriptions/ProactiveSubscriptionFields.test.tsx
+++ b/products/subscriptions/frontend/components/Subscriptions/ProactiveSubscriptionFields.test.tsx
@@ -1,0 +1,53 @@
+import '@testing-library/jest-dom'
+
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+
+import { ProactiveSubscriptionFields } from './ProactiveSubscriptionFields'
+
+jest.mock('lib/hooks/useFeatureFlag', () => ({
+    useFeatureFlag: () => true,
+}))
+
+jest.mock('lib/lemon-ui/LemonField', () => ({
+    LemonField: ({
+        children,
+        name,
+    }: {
+        children?: ReactNode | ((field: { onChange: () => void; value: boolean }) => ReactNode)
+        name?: string | string[]
+    }) => {
+        if (typeof children !== 'function') {
+            return children
+        }
+        const field = Array.isArray(name) ? name.at(-1) : name
+        return children({ onChange: jest.fn(), value: field === 'enabled' || field === 'allow_public_web_research' })
+    },
+}))
+
+describe('ProactiveSubscriptionFields', () => {
+    it('explains experiment drafts when proactive follow-up is enabled without a draft pull request', () => {
+        render(
+            <ProactiveSubscriptionFields
+                proactiveConfig={{ enabled: true, create_draft_pr: false }}
+                options={{
+                    proactive_available: true,
+                    public_web_research_available: true,
+                    draft_pr_available: true,
+                    repositories: [],
+                }}
+                optionsLoading={false}
+                optionsLoadFailed={false}
+                show
+                onSelectRepository={jest.fn()}
+                onRetry={jest.fn()}
+            />
+        )
+
+        expect(
+            screen.getByText(
+                'When eligible, PostHog may also prepare an experiment draft. It stays inactive until someone starts it.'
+            )
+        ).toBeInTheDocument()
+    })
+})

--- a/products/subscriptions/frontend/components/Subscriptions/ProactiveSubscriptionFields.tsx
+++ b/products/subscriptions/frontend/components/Subscriptions/ProactiveSubscriptionFields.tsx
@@ -1,0 +1,193 @@
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonField } from 'lib/lemon-ui/LemonField'
+import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
+import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
+import { LemonSwitch } from 'lib/lemon-ui/LemonSwitch'
+
+import type {
+    ProactiveConfigApi,
+    ProactiveConfigurationOptionsApi,
+} from 'products/subscriptions/frontend/generated/api.schemas'
+
+interface ProactiveSubscriptionFieldsProps {
+    proactiveConfig?: ProactiveConfigApi | null
+    options: ProactiveConfigurationOptionsApi | null
+    optionsLoading: boolean
+    optionsLoadFailed: boolean
+    show: boolean
+    onSelectRepository: (repository: string, repositoryIntegrationId: number) => void
+    onRetry: () => void
+}
+
+function repositoryOptionKey(repository: string, repositoryIntegrationId: number): string {
+    return JSON.stringify([repositoryIntegrationId, repository])
+}
+
+export function ProactiveSubscriptionFields({
+    proactiveConfig,
+    options,
+    optionsLoading,
+    optionsLoadFailed,
+    show,
+    onSelectRepository,
+    onRetry,
+}: ProactiveSubscriptionFieldsProps): JSX.Element | null {
+    const pulseEnabled = useFeatureFlag('PULSE')
+
+    if (!show || !pulseEnabled) {
+        return null
+    }
+
+    if (optionsLoading) {
+        return <LemonSkeleton.Row />
+    }
+
+    if (optionsLoadFailed) {
+        return (
+            <LemonBanner type="error">
+                Couldn&apos;t load proactive settings.{' '}
+                <LemonButton type="secondary" size="xsmall" onClick={onRetry}>
+                    Try again
+                </LemonButton>
+            </LemonBanner>
+        )
+    }
+
+    if (!options) {
+        return null
+    }
+
+    const proactiveEnabled = proactiveConfig?.enabled === true
+    const createDraftPullRequest = proactiveConfig?.create_draft_pr === true
+    const selectedRepository =
+        proactiveConfig?.repository && proactiveConfig.repository_integration_id
+            ? repositoryOptionKey(proactiveConfig.repository, proactiveConfig.repository_integration_id)
+            : null
+    const draftPullRequestDisabledReason = !options.draft_pr_available
+        ? 'Draft pull request preparation isn’t configured for this PostHog instance.'
+        : !options.repositories.length
+          ? 'No repositories are available. Connect GitHub with write access.'
+          : undefined
+
+    return (
+        <div className="flex flex-col gap-3">
+            <LemonField name={['proactive_config', 'enabled']}>
+                {({ value, onChange }) => (
+                    <LemonSwitch
+                        checked={Boolean(value)}
+                        onChange={onChange}
+                        disabledReason={
+                            options.proactive_available
+                                ? undefined
+                                : 'Proactive recommendations aren’t configured for this PostHog instance.'
+                        }
+                        bordered
+                        fullWidth
+                        data-attr="subscription-proactive-enabled"
+                        label={
+                            <div className="flex flex-col gap-1 py-1">
+                                <div className="leading-tight">Look for follow-up recommendations</div>
+                                <div className="text-xs text-secondary font-normal leading-tight">
+                                    After each report, investigate changes and suggest a next step.
+                                </div>
+                            </div>
+                        }
+                    />
+                )}
+            </LemonField>
+            {proactiveEnabled ? (
+                <div className="flex flex-col gap-3 pl-2">
+                    <LemonField name={['proactive_config', 'allow_public_web_research']}>
+                        {({ value, onChange }) => (
+                            <LemonSwitch
+                                checked={value !== false}
+                                onChange={onChange}
+                                disabledReason={
+                                    options.public_web_research_available
+                                        ? undefined
+                                        : 'Public web research isn’t configured for this PostHog instance.'
+                                }
+                                bordered
+                                fullWidth
+                                data-attr="subscription-proactive-public-research"
+                                label={
+                                    <div className="flex flex-col gap-1 py-1">
+                                        <div className="leading-tight">Use public web research</div>
+                                        <div className="text-xs text-secondary font-normal leading-tight">
+                                            Search public webpages only when they help investigate a recommendation.
+                                        </div>
+                                    </div>
+                                }
+                            />
+                        )}
+                    </LemonField>
+                    <LemonField name={['proactive_config', 'create_draft_pr']}>
+                        {({ value, onChange }) => (
+                            <LemonSwitch
+                                checked={Boolean(value)}
+                                onChange={onChange}
+                                disabledReason={draftPullRequestDisabledReason}
+                                bordered
+                                fullWidth
+                                data-attr="subscription-proactive-draft-pr"
+                                label={
+                                    <div className="flex flex-col gap-1 py-1">
+                                        <div className="leading-tight">Prepare a draft pull request</div>
+                                        <div className="text-xs text-secondary font-normal leading-tight">
+                                            Build and test in an isolated sandbox before automatically opening a draft
+                                            pull request.
+                                        </div>
+                                    </div>
+                                }
+                            />
+                        )}
+                    </LemonField>
+                    <div className="text-xs text-secondary">
+                        When eligible, PostHog may also prepare an experiment draft. It stays inactive until someone
+                        starts it.
+                    </div>
+                    {createDraftPullRequest && options.draft_pr_available ? (
+                        options.repositories.length ? (
+                            <LemonField name={['proactive_config', 'repository']} label="Repository">
+                                <LemonSelect
+                                    value={selectedRepository}
+                                    onChange={(value) => {
+                                        const repository = options.repositories.find(
+                                            (option) =>
+                                                repositoryOptionKey(
+                                                    option.repository,
+                                                    option.repository_integration_id
+                                                ) === value
+                                        )
+                                        if (repository) {
+                                            onSelectRepository(
+                                                repository.repository,
+                                                repository.repository_integration_id
+                                            )
+                                        }
+                                    }}
+                                    options={options.repositories.map((repository) => ({
+                                        label: repository.repository,
+                                        value: repositoryOptionKey(
+                                            repository.repository,
+                                            repository.repository_integration_id
+                                        ),
+                                    }))}
+                                    placeholder="Select a repository"
+                                    data-attr="subscription-proactive-repository"
+                                />
+                            </LemonField>
+                        ) : (
+                            <LemonBanner type="info">
+                                No repositories are currently available. Connect GitHub with write access, then refresh
+                                this form.
+                            </LemonBanner>
+                        )
+                    ) : null}
+                </div>
+            ) : null}
+        </div>
+    )
+}

--- a/products/subscriptions/frontend/components/Subscriptions/ProactiveSubscriptionFields.tsx
+++ b/products/subscriptions/frontend/components/Subscriptions/ProactiveSubscriptionFields.tsx
@@ -90,7 +90,7 @@ export function ProactiveSubscriptionFields({
                             <div className="flex flex-col gap-1 py-1">
                                 <div className="leading-tight">Look for follow-up recommendations</div>
                                 <div className="text-xs text-secondary font-normal leading-tight">
-                                    After each report, investigate changes and suggest a next step.
+                                    After each report, PostHog investigates changes and suggests a next step.
                                 </div>
                             </div>
                         }

--- a/products/subscriptions/frontend/components/Subscriptions/SubscriptionActionsStep.tsx
+++ b/products/subscriptions/frontend/components/Subscriptions/SubscriptionActionsStep.tsx
@@ -1,0 +1,31 @@
+import { useActions, useValues } from 'kea'
+
+import { ProactiveSubscriptionFields } from './ProactiveSubscriptionFields'
+import { subscriptionLogic } from './subscriptionLogic'
+import type { SubscriptionForm, SubscriptionLogicProps } from './subscriptionLogic'
+
+interface SubscriptionActionsStepProps {
+    logicProps: SubscriptionLogicProps
+    subscription: SubscriptionForm
+}
+
+export function SubscriptionActionsStep({ logicProps, subscription }: SubscriptionActionsStepProps): JSX.Element {
+    const {
+        proactiveConfigurationOptions,
+        proactiveConfigurationOptionsLoading,
+        proactiveConfigurationOptionsLoadFailed,
+    } = useValues(subscriptionLogic(logicProps))
+    const { loadProactiveConfigurationOptions, selectProactiveRepository } = useActions(subscriptionLogic(logicProps))
+
+    return (
+        <ProactiveSubscriptionFields
+            proactiveConfig={subscription.proactive_config}
+            options={proactiveConfigurationOptions}
+            optionsLoading={proactiveConfigurationOptionsLoading}
+            optionsLoadFailed={proactiveConfigurationOptionsLoadFailed}
+            show={Boolean(logicProps.proactiveSettingsEnabled)}
+            onSelectRepository={selectProactiveRepository}
+            onRetry={loadProactiveConfigurationOptions}
+        />
+    )
+}

--- a/products/subscriptions/frontend/components/Subscriptions/SubscriptionWizard.test.tsx
+++ b/products/subscriptions/frontend/components/Subscriptions/SubscriptionWizard.test.tsx
@@ -1,0 +1,100 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { useValues } from 'kea'
+
+import { SubscriptionResourceTypes } from '~/types'
+
+import type { SubscriptionForm } from './subscriptionLogic'
+import { SubscriptionReviewStep } from './SubscriptionWizard'
+
+jest.mock('kea', () => ({
+    ...jest.requireActual('kea'),
+    useActions: () => ({ generatePreview: jest.fn() }),
+    useValues: jest.fn(() => ({
+        previewError: null,
+        previewImageUrl: null,
+        previewLoading: false,
+        proactiveConfigurationOptions: {
+            proactive_available: true,
+            public_web_research_available: true,
+            draft_pr_available: true,
+            repositories: [],
+        },
+    })),
+}))
+
+describe('SubscriptionReviewStep', () => {
+    afterEach(cleanup)
+
+    const subscription = {
+        id: 0,
+        resource_type: SubscriptionResourceTypes.AiPrompt,
+        title: 'Activation review',
+        prompt: 'Find the biggest activation drop-off.',
+        ai_prompt_config: { window: { mode: 'since_last_sent' } },
+        proactive_config: {
+            enabled: true,
+            allow_public_web_research: true,
+            create_draft_pr: true,
+            repository: 'PostHog/posthog',
+            repository_integration_id: 42,
+        },
+        target_value: 'product@example.com',
+        target_type: 'email',
+        frequency: 'weekly',
+        interval: 1,
+        start_date: '2026-08-31T09:00:00Z',
+        byweekday: ['monday'],
+        bysetpos: null,
+        summary: 'sent every week',
+        next_delivery_date: '2026-09-07T09:00:00Z',
+        created_at: '2026-08-31T09:00:00Z',
+        send_test_now: false,
+    } satisfies SubscriptionForm
+
+    it('shows the follow-up actions that will run after an AI report', () => {
+        render(
+            <SubscriptionReviewStep
+                logicProps={{ id: 'new', proactiveSettingsEnabled: true }}
+                subscription={subscription}
+                dashboard={null}
+            />
+        )
+
+        expect(screen.getByText('Actions')).toBeInTheDocument()
+        expect(
+            screen.getByText('Follow-up recommendations · Public web research · Draft pull request: PostHog/posthog')
+        ).toBeInTheDocument()
+    })
+
+    it('omits actions if the feature is disabled before review', () => {
+        render(<SubscriptionReviewStep logicProps={{ id: 'new' }} subscription={subscription} dashboard={null} />)
+
+        expect(screen.queryByText('Actions')).not.toBeInTheDocument()
+    })
+
+    it('omits unavailable public research from the review', () => {
+        jest.mocked(useValues).mockReturnValueOnce({
+            previewError: null,
+            previewImageUrl: null,
+            previewLoading: false,
+            proactiveConfigurationOptions: {
+                proactive_available: true,
+                public_web_research_available: false,
+                draft_pr_available: true,
+                repositories: [],
+            },
+        })
+
+        render(
+            <SubscriptionReviewStep
+                logicProps={{ id: 'new', proactiveSettingsEnabled: true }}
+                subscription={subscription}
+                dashboard={null}
+            />
+        )
+
+        expect(screen.getByText('Follow-up recommendations · Draft pull request: PostHog/posthog')).toBeInTheDocument()
+    })
+})

--- a/products/subscriptions/frontend/components/Subscriptions/SubscriptionWizard.tsx
+++ b/products/subscriptions/frontend/components/Subscriptions/SubscriptionWizard.tsx
@@ -1,6 +1,5 @@
 import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
-import { useState } from 'react'
 
 import { IconChevronLeft, IconGraph } from '@posthog/icons'
 import { LemonInput, LemonTextArea, Link } from '@posthog/lemon-ui'
@@ -35,8 +34,9 @@ import { DashboardType, InsightShortId, SubscriptionResourceTypes, SubscriptionT
 
 import { AiPromptFields, AiPromptSubscriptionIntroduction } from './AiPromptFields'
 import { InsightSelector } from './InsightSelector'
+import { SubscriptionActionsStep } from './SubscriptionActionsStep'
 import { SubscriptionDayPicker } from './SubscriptionDayPicker'
-import { subscriptionLogic } from './subscriptionLogic'
+import { subscriptionLogic, SubscriptionWizardStep } from './subscriptionLogic'
 import type { SubscriptionLogicProps } from './subscriptionLogic'
 import { SubscriptionTimePicker } from './SubscriptionTimePicker'
 import {
@@ -64,23 +64,21 @@ interface SubscriptionWizardProps {
     onCancel: () => void
 }
 
-enum SubscriptionWizardStep {
-    Content = 'content',
-    Delivery = 'delivery',
-    Schedule = 'schedule',
-    Review = 'review',
-}
-
-const steps = [
+const baseSteps = [
     { key: SubscriptionWizardStep.Content, label: 'What to send' },
     { key: SubscriptionWizardStep.Delivery, label: 'Notify' },
     { key: SubscriptionWizardStep.Schedule, label: 'Schedule' },
     { key: SubscriptionWizardStep.Review, label: 'Review' },
 ]
 
+const actionsStep = { key: SubscriptionWizardStep.Actions, label: 'Actions' }
+
 function wizardStepDescription(step: SubscriptionWizardStep): string {
     if (step === SubscriptionWizardStep.Content) {
         return 'Choose the report content to include.'
+    }
+    if (step === SubscriptionWizardStep.Actions) {
+        return 'Choose optional follow-up actions for this report.'
     }
     if (step === SubscriptionWizardStep.Delivery) {
         return 'Choose who to notify about this subscription.'
@@ -97,6 +95,9 @@ export function SubscriptionWizard({
     dashboard,
     onCancel,
 }: SubscriptionWizardProps): JSX.Element {
+    const aiSubscriptionsEnabled = useFeatureFlag('SUBSCRIPTION_AI_PROMPT')
+    const pulseEnabled = useFeatureFlag('PULSE')
+    const proactiveSettingsEnabled = Boolean(aiSubscriptionsEnabled && pulseEnabled)
     const logicProps = {
         id: 'new' as const,
         insightShortId,
@@ -104,20 +105,20 @@ export function SubscriptionWizard({
         dashboardName: dashboard?.name,
         insightName,
         creationSource: 'wizard' as const,
+        proactiveSettingsEnabled,
     }
     const subscriptionFormLogic = subscriptionLogic(logicProps)
-    const [currentStep, setStep] = useState<SubscriptionWizardStep>(SubscriptionWizardStep.Content)
     const {
+        currentWizardStep,
         subscription,
         subscriptionLoading,
         subscriptionInitialized,
         isSubscriptionSubmitting,
         subscriptionChanged,
     } = useValues(subscriptionFormLogic)
-    const { generatePreview, resetSubscription } = useActions(subscriptionFormLogic)
+    const { generatePreview, resetSubscription, selectWizardStep } = useActions(subscriptionFormLogic)
     const { preflight } = useValues(preflightLogic)
     const { currentOrganization } = useValues(organizationLogic)
-    const aiSubscriptionsEnabled = useFeatureFlag('SUBSCRIPTION_AI_PROMPT')
 
     if (subscriptionLoading || !subscriptionInitialized) {
         return <SubscriptionFormSkeleton />
@@ -136,6 +137,11 @@ export function SubscriptionWizard({
         isDebug: Boolean(preflight?.is_debug),
         aiFlagEnabled: Boolean(aiSubscriptionsEnabled),
     })
+    const showActionsStep = isAiPrompt && proactiveSettingsEnabled && !aiGate.submitBlocked
+    const wizardSteps = showActionsStep ? [baseSteps[0], actionsStep, ...baseSteps.slice(1)] : baseSteps
+    const currentStep = wizardSteps.some((step) => step.key === currentWizardStep)
+        ? currentWizardStep
+        : SubscriptionWizardStep.Content
     const selectedInsightsReady = !dashboard || Boolean(subscription.dashboard_export_insights?.length)
     const contentDetailReady = isAiPrompt ? Boolean(subscription.prompt?.trim()) : selectedInsightsReady
     const contentReady = Boolean(subscription.title?.trim()) && contentDetailReady
@@ -169,12 +175,12 @@ export function SubscriptionWizard({
             ? 'Choose a destination and recipient'
             : 'Email delivery is not configured for this PostHog instance'
     }
-    const currentStepIndex = steps.findIndex((step) => step.key === currentStep)
+    const currentStepIndex = wizardSteps.findIndex((step) => step.key === currentStep)
     const goToStep = (step: SubscriptionWizardStep): void => {
         if (step === SubscriptionWizardStep.Review && insightShortId && !isAiPrompt) {
             generatePreview()
         }
-        setStep(step)
+        selectWizardStep(step)
     }
     const requestCancel = (): void =>
         requestSubscriptionWizardCancellation({ onCancel, resetSubscription, subscriptionChanged })
@@ -190,6 +196,9 @@ export function SubscriptionWizard({
                     aiSubscriptionBlocked={aiGate.submitBlocked}
                 />
             )
+            break
+        case SubscriptionWizardStep.Actions:
+            stepContent = <SubscriptionActionsStep logicProps={logicProps} subscription={subscription} />
             break
         case SubscriptionWizardStep.Delivery:
             stepContent = <SubscriptionDeliveryStep subscription={subscription} logicProps={logicProps} />
@@ -210,7 +219,7 @@ export function SubscriptionWizard({
         default:
             stepContent = <></>
     }
-    const nextStep = steps[currentStepIndex + 1]?.key
+    const nextStep = wizardSteps[currentStepIndex + 1]?.key
     let continueDisabledReason: string | undefined
     if (currentStep === SubscriptionWizardStep.Content) {
         continueDisabledReason = contentReady ? undefined : contentDisabledReason
@@ -264,7 +273,7 @@ export function SubscriptionWizard({
                         </div>
                         <nav aria-label="Subscription setup progress" className="mt-3">
                             <ol className="flex flex-wrap items-center gap-x-1 gap-y-2">
-                                {steps.map((step, index) => {
+                                {wizardSteps.map((step, index) => {
                                     const isCurrent = index === currentStepIndex
                                     const isComplete = index < currentStepIndex
                                     const canAccess = index <= currentStepIndex
@@ -300,7 +309,9 @@ export function SubscriptionWizard({
                                                 </span>
                                                 <span>{step.label}</span>
                                             </button>
-                                            {index < steps.length - 1 ? <span className="text-border">→</span> : null}
+                                            {index < wizardSteps.length - 1 ? (
+                                                <span className="text-border">→</span>
+                                            ) : null}
                                         </li>
                                     )
                                 })}
@@ -309,7 +320,7 @@ export function SubscriptionWizard({
                     </header>
                     <section className="p-4 min-h-0 flex-1 overflow-y-auto">
                         <div className="space-y-1 mb-3">
-                            <h3 className="text-base font-semibold m-0">{steps[currentStepIndex].label}</h3>
+                            <h3 className="text-base font-semibold m-0">{wizardSteps[currentStepIndex].label}</h3>
                             <p className="text-xs text-secondary m-0">{wizardStepDescription(currentStep)}</p>
                         </div>
                         {stepContent}
@@ -326,7 +337,7 @@ export function SubscriptionWizard({
                                     type="secondary"
                                     htmlType="button"
                                     icon={<IconChevronLeft className="size-4" />}
-                                    onClick={() => setStep(steps[currentStepIndex - 1].key)}
+                                    onClick={() => selectWizardStep(wizardSteps[currentStepIndex - 1].key)}
                                     disabled={isSubscriptionSubmitting}
                                 >
                                     Back

--- a/products/subscriptions/frontend/components/Subscriptions/SubscriptionWizard.tsx
+++ b/products/subscriptions/frontend/components/Subscriptions/SubscriptionWizard.tsx
@@ -32,12 +32,14 @@ import { urls } from 'scenes/urls'
 
 import { DashboardType, InsightShortId, SubscriptionResourceTypes, SubscriptionType } from '~/types'
 
+import type { ProactiveConfigurationOptionsApi } from 'products/subscriptions/frontend/generated/api.schemas'
+
 import { AiPromptFields, AiPromptSubscriptionIntroduction } from './AiPromptFields'
 import { InsightSelector } from './InsightSelector'
 import { SubscriptionActionsStep } from './SubscriptionActionsStep'
 import { SubscriptionDayPicker } from './SubscriptionDayPicker'
 import { subscriptionLogic, SubscriptionWizardStep } from './subscriptionLogic'
-import type { SubscriptionLogicProps } from './subscriptionLogic'
+import type { SubscriptionForm, SubscriptionLogicProps } from './subscriptionLogic'
 import { SubscriptionTimePicker } from './SubscriptionTimePicker'
 import {
     frequencyOptionsPlural,
@@ -677,23 +679,49 @@ function formatAiAnalysisWindow(subscription: SubscriptionType): string {
     return 'Since last report'
 }
 
-function SubscriptionReviewStep({
+function formatProactiveActions(
+    subscription: SubscriptionForm,
+    options: ProactiveConfigurationOptionsApi | null
+): string | null {
+    const config = subscription.proactive_config
+
+    if (!config?.enabled || !options?.proactive_available) {
+        return null
+    }
+
+    const actions = ['Follow-up recommendations']
+    if (config.allow_public_web_research && options.public_web_research_available) {
+        actions.push('Public web research')
+    }
+    if (config.create_draft_pr && options.draft_pr_available) {
+        actions.push(config.repository ? `Draft pull request: ${config.repository}` : 'Draft pull request')
+    }
+    return actions.join(' · ')
+}
+
+export function SubscriptionReviewStep({
     logicProps,
     subscription,
     dashboard,
     insightShortId,
 }: {
     logicProps: SubscriptionLogicProps
-    subscription: SubscriptionType
+    subscription: SubscriptionForm
     dashboard?: DashboardType<any> | null
     insightShortId?: InsightShortId
 }): JSX.Element {
-    const { previewLoading, previewError, previewImageUrl } = useValues(subscriptionLogic(logicProps))
+    const { previewLoading, previewError, previewImageUrl, proactiveConfigurationOptions } = useValues(
+        subscriptionLogic(logicProps)
+    )
     const { generatePreview } = useActions(subscriptionLogic(logicProps))
     const selectedInsightsCount = subscription.dashboard_export_insights?.length ?? 0
     const advancedSettings = getSubscriptionAdvancedSettings(subscription)
     const nextDeliveryDate = getNextDeliveryDate(subscription)
     const isAiPrompt = subscription.resource_type === SubscriptionResourceTypes.AiPrompt
+    const proactiveActions =
+        isAiPrompt && logicProps.proactiveSettingsEnabled
+            ? formatProactiveActions(subscription, proactiveConfigurationOptions)
+            : null
     let reviewNotice: JSX.Element
 
     if (subscription.send_test_now) {
@@ -720,6 +748,7 @@ function SubscriptionReviewStep({
             ? [
                   { label: 'Prompt', value: subscription.prompt ?? '' },
                   { label: 'Analysis window', value: formatAiAnalysisWindow(subscription) },
+                  ...(proactiveActions ? [{ label: 'Actions', value: proactiveActions }] : []),
               ]
             : []),
         { label: 'Sends to', value: subscription.target_value },

--- a/products/subscriptions/frontend/components/Subscriptions/subscriptionLogic.test.ts
+++ b/products/subscriptions/frontend/components/Subscriptions/subscriptionLogic.test.ts
@@ -328,6 +328,41 @@ describe('subscriptionLogic', () => {
         pulseLogic.unmount()
     })
 
+    it('loads proactive settings when Pulse becomes enabled after the AI subscription loads', async () => {
+        let proactiveOptionsRequests = 0
+        useMocks({
+            get: {
+                '/api/projects/:team/subscriptions/proactive_options/': () => {
+                    proactiveOptionsRequests += 1
+                    return [
+                        200,
+                        {
+                            proactive_available: true,
+                            public_web_research_available: true,
+                            draft_pr_available: true,
+                            repositories: [],
+                        },
+                    ]
+                },
+            },
+        })
+        const props = { id: 'new' as const, proactiveSettingsEnabled: false }
+        const pulseLogic = subscriptionLogic(props)
+        pulseLogic.mount()
+
+        router.actions.push('/subscriptions/new')
+        await expectLogic(pulseLogic).toFinishAllListeners()
+        expect(pulseLogic.values.subscription.resource_type).toBe('ai_prompt')
+        expect(proactiveOptionsRequests).toBe(0)
+
+        subscriptionLogic({ ...props, proactiveSettingsEnabled: true })
+        await expectLogic(pulseLogic).toFinishAllListeners()
+
+        expect(proactiveOptionsRequests).toBe(1)
+        expect(pulseLogic.values.proactiveConfigurationOptions).toMatchObject({ proactive_available: true })
+        pulseLogic.unmount()
+    })
+
     it('requires a repository before saving draft pull request preparation', async () => {
         const pulseLogic = subscriptionLogic({
             insightShortId: '4' as InsightShortId,

--- a/products/subscriptions/frontend/components/Subscriptions/subscriptionLogic.test.ts
+++ b/products/subscriptions/frontend/components/Subscriptions/subscriptionLogic.test.ts
@@ -279,6 +279,74 @@ describe('subscriptionLogic', () => {
         expect(newLogic.values.subscription.resource_type).toBe('ai_prompt')
     })
 
+    it('omits proactive settings when the Pulse feature is off', async () => {
+        let savedPayload: Record<string, unknown> | undefined
+        useMocks({
+            post: {
+                '/api/environments/:team/subscriptions': async ({ request }) => {
+                    savedPayload = (await request.json()) as Record<string, unknown>
+                    return [200, { id: 42, ...savedPayload }]
+                },
+            },
+        })
+        const flagOffLogic = subscriptionLogic({
+            insightShortId: '2' as InsightShortId,
+            id: 'new',
+            proactiveSettingsEnabled: false,
+        })
+        flagOffLogic.mount()
+        await expectLogic(flagOffLogic).toFinishListeners()
+
+        flagOffLogic.actions.setSubscriptionValues({
+            resource_type: 'ai_prompt',
+            title: 'Weekly report',
+            target_type: 'email',
+            target_value: 'ben@posthog.com',
+            prompt: 'Summarize important changes.',
+        })
+        flagOffLogic.actions.submitSubscription()
+        await expectLogic(flagOffLogic).toFinishListeners().toDispatchActions(['submitSubscriptionSuccess'])
+
+        expect(savedPayload).not.toHaveProperty('proactive_config')
+        flagOffLogic.unmount()
+    })
+
+    it('defaults public web research on for Pulse-enabled forms', async () => {
+        const pulseLogic = subscriptionLogic({
+            insightShortId: '3' as InsightShortId,
+            id: 'new',
+            proactiveSettingsEnabled: true,
+        })
+        pulseLogic.mount()
+        await expectLogic(pulseLogic).toFinishListeners()
+
+        expect(pulseLogic.values.subscription.proactive_config).toMatchObject({
+            enabled: false,
+            allow_public_web_research: true,
+            create_draft_pr: false,
+        })
+        pulseLogic.unmount()
+    })
+
+    it('requires a repository before saving draft pull request preparation', async () => {
+        const pulseLogic = subscriptionLogic({
+            insightShortId: '4' as InsightShortId,
+            id: 'new',
+            proactiveSettingsEnabled: true,
+        })
+        pulseLogic.mount()
+        await expectLogic(pulseLogic).toFinishListeners()
+
+        pulseLogic.actions.setSubscriptionValues({
+            proactive_config: { create_draft_pr: true, repository: null, repository_integration_id: null },
+        })
+        pulseLogic.actions.submitSubscription()
+        await expectLogic(pulseLogic).toFinishListeners()
+
+        expect(pulseLogic.values.subscriptionErrors.proactive_config?.repository).toBe('Select a repository')
+        pulseLogic.unmount()
+    })
+
     it('keeps the analysis window when selecting an example question', async () => {
         router.actions.push('/insights/123/subscriptions/new?resource_type=ai_prompt')
         await expectLogic(newLogic).toFinishListeners()

--- a/products/subscriptions/frontend/components/Subscriptions/subscriptionLogic.ts
+++ b/products/subscriptions/frontend/components/Subscriptions/subscriptionLogic.ts
@@ -22,20 +22,20 @@ import { ExportedAssetType, ExporterFormat, SubscriptionResourceTypes, Subscript
 
 import {
     subscriptionsDeliveriesList,
+    subscriptionsProactiveOptionsList,
     subscriptionsTestDeliveryCreate,
 } from 'products/subscriptions/frontend/generated/api'
 import {
     SubscriptionTargetEnumApi,
     type AIWindowConfigApi,
+    type ProactiveConfigurationOptionsApi,
     type SubscriptionApi,
     type SubscriptionDeliveryApi,
 } from 'products/subscriptions/frontend/generated/api.schemas'
 
-import type { SubscriptionResourceType, UserBasicType, WeekdayType } from '../../../../../frontend/src/types'
+import type { WeekdayType } from '../../../../../frontend/src/types'
 import type { OrganizationType, UserType } from '../../../../../frontend/src/types'
-import type { AIPromptConfigApi } from '../../generated/api.schemas'
 import type { SubscriptionAIWindowModeEnumApi } from '../../generated/api.schemas'
-import type { DeliveryConfigApi } from '../../generated/api.schemas'
 import { newSubscriptionTargetLogic } from '../../scenes/newSubscriptionTargetLogic'
 import { runSubscriptionTestDelivery } from './runSubscriptionTestDelivery'
 import { SUBSCRIPTION_PREFILL_PARAMS } from './subscriptionNudge'
@@ -74,7 +74,17 @@ function validatePrompt(
 
 const AI_WINDOW_MAX_DAYS = 365
 
-function validateAiWindow(subscription: Partial<SubscriptionType>): {
+export type SubscriptionForm = SubscriptionType & Pick<SubscriptionApi, 'proactive_config'>
+
+export enum SubscriptionWizardStep {
+    Content = 'content',
+    Actions = 'actions',
+    Delivery = 'delivery',
+    Schedule = 'schedule',
+    Review = 'review',
+}
+
+function validateAiWindow(subscription: Partial<SubscriptionForm>): {
     ai_prompt_config?: { window: { start_days_ago?: any; end_days_ago?: any } }
 } {
     if (subscription.resource_type !== SubscriptionResourceTypes.AiPrompt) {
@@ -158,7 +168,7 @@ function validateTargetValue(
 }
 
 function validateDashboardExportInsights(
-    subscription: Partial<SubscriptionType>,
+    subscription: Partial<SubscriptionForm>,
     dashboardId: number | undefined
 ): any {
     if (subscription.resource_type === SubscriptionResourceTypes.AiPrompt || !dashboardId) {
@@ -167,7 +177,7 @@ function validateDashboardExportInsights(
     return subscription.dashboard_export_insights?.length ? undefined : 'Select at least one insight'
 }
 
-function validateWeekdaySchedule(subscription: Partial<SubscriptionType>): string | null {
+function validateWeekdaySchedule(subscription: Partial<SubscriptionForm>): string | null {
     if (
         (subscription.frequency === 'daily' || subscription.frequency === 'weekly') &&
         !subscription.byweekday?.length
@@ -189,11 +199,26 @@ function validateWeekdaySchedule(subscription: Partial<SubscriptionType>): strin
         : 'Select the delivery day matching the start date for this interval'
 }
 
-function validateFrequency(subscription: Partial<SubscriptionType>): string | null {
+function validateFrequency(subscription: Partial<SubscriptionForm>): string | null {
     if (!subscription.frequency) {
         return 'You need to set a schedule frequency'
     }
     return validateWeekdaySchedule(subscription)
+}
+
+function validateProactiveConfig(
+    subscription: Partial<SubscriptionForm>,
+    proactiveSettingsEnabled: boolean
+): { proactive_config?: { repository: string } } {
+    const proactiveConfig = subscription.proactive_config
+    if (
+        !proactiveSettingsEnabled ||
+        !proactiveConfig?.create_draft_pr ||
+        (proactiveConfig.repository && proactiveConfig.repository_integration_id)
+    ) {
+        return {}
+    }
+    return { proactive_config: { repository: 'Select a repository' } }
 }
 
 function subscriptionSaveErrorMessage(error: unknown): string {
@@ -210,7 +235,7 @@ function subscriptionSaveErrorMessage(error: unknown): string {
 // Frequencies a deep link may prefill. Anything else is ignored rather than trusted into the form.
 const FREQUENCY_PREFILL_VALUES: SubscriptionType['frequency'][] = ['daily', 'weekly', 'monthly']
 
-const NEW_SUBSCRIPTION: Partial<SubscriptionType> = {
+const NEW_SUBSCRIPTION: Partial<SubscriptionForm> = {
     resource_type: SubscriptionResourceTypes.Insight,
     frequency: 'weekly',
     interval: 1,
@@ -224,8 +249,19 @@ const NEW_SUBSCRIPTION: Partial<SubscriptionType> = {
     summary_enabled: false,
     summary_prompt_guide: '',
     ai_prompt_config: { window: { mode: 'since_last_sent' } },
+    proactive_config: {
+        enabled: false,
+        allow_public_web_research: true,
+        create_draft_pr: false,
+        repository: null,
+        repository_integration_id: null,
+    },
     delivery_config: { post_all_insights_in_main_message: false },
     send_test_now: true,
+}
+
+function newSubscriptionForm(overrides: Partial<SubscriptionForm> = {}): SubscriptionForm {
+    return { ...NEW_SUBSCRIPTION, ...overrides } as SubscriptionForm
 }
 
 export interface SubscriptionLogicProps extends SubscriptionBaseProps {
@@ -234,11 +270,13 @@ export interface SubscriptionLogicProps extends SubscriptionBaseProps {
     dashboardName?: string | null
     insightName?: string
     creationSource?: 'editor' | 'wizard'
+    proactiveSettingsEnabled?: boolean
 }
 // Generated by kea-typegen. Update if you're an agent, ignore if you're human.
 export interface subscriptionLogicValues {
     currentOrganization: OrganizationType | null // organizationLogic
     user: UserType | null // userLogic
+    currentWizardStep: SubscriptionWizardStep
     isSubscriptionSubmitting: boolean
     isSubscriptionValid: boolean
     lastDelivery: SubscriptionDeliveryApi | null
@@ -248,19 +286,22 @@ export interface subscriptionLogicValues {
     previewError: string | null
     previewImageUrl: string | null
     previewLoading: boolean
+    proactiveConfigurationOptions: ProactiveConfigurationOptionsApi | null
+    proactiveConfigurationOptionsLoadFailed: boolean
+    proactiveConfigurationOptionsLoading: boolean
     showSubscriptionErrors: boolean
     storedTeamsWebhookHost: string | null
-    subscription: SubscriptionType
+    subscription: SubscriptionForm
     subscriptionAllErrors: Record<string, any>
     subscriptionChanged: boolean
-    subscriptionErrors: DeepPartialMap<SubscriptionType, ValidationErrorType>
+    subscriptionErrors: DeepPartialMap<SubscriptionForm, ValidationErrorType>
     subscriptionHasErrors: boolean
     subscriptionInitialized: boolean
     subscriptionLoading: boolean
     subscriptionManualErrors: Record<string, any>
     subscriptionTouched: boolean
     subscriptionTouches: Record<string, boolean>
-    subscriptionValidationErrors: DeepPartialMap<SubscriptionType, ValidationErrorType>
+    subscriptionValidationErrors: DeepPartialMap<SubscriptionForm, ValidationErrorType>
     summaryQuota: {
         active_count: number
         at_limit: boolean
@@ -293,6 +334,21 @@ export interface subscriptionLogicActions {
         lastDelivery: SubscriptionDeliveryApi | null
         payload?: any
     }
+    loadProactiveConfigurationOptions: () => any
+    loadProactiveConfigurationOptionsFailure: (
+        error: string,
+        errorObject?: any
+    ) => {
+        error: string
+        errorObject?: any
+    }
+    loadProactiveConfigurationOptionsSuccess: (
+        proactiveConfigurationOptions: ProactiveConfigurationOptionsApi,
+        payload?: any
+    ) => {
+        proactiveConfigurationOptions: ProactiveConfigurationOptionsApi
+        payload?: any
+    }
     loadSubscription: () => any
     loadSubscriptionFailure: (
         error: string,
@@ -302,70 +358,10 @@ export interface subscriptionLogicActions {
         errorObject?: any
     }
     loadSubscriptionSuccess: (
-        subscription: {
-            ai_prompt_config?: AIPromptConfigApi | null | undefined
-            bysetpos?: number | null | undefined
-            byweekday?: WeekdayType[] | null | undefined
-            created_at?: string | undefined
-            created_by?: UserBasicType | null | undefined
-            dashboard?: number | undefined
-            dashboard_export_insights?: number[] | undefined
-            deleted?: boolean | undefined
-            delivery_config?: DeliveryConfigApi | undefined
-            enabled?: boolean | undefined
-            frequency?: 'daily' | 'monthly' | 'weekly' | 'yearly' | undefined
-            id?: number | undefined
-            insight?: number | undefined
-            insight_short_id?: string | null | undefined
-            integration_id?: number | null | undefined
-            interval?: number | undefined
-            next_delivery_date?: string | null | undefined
-            prompt?: string | null | undefined
-            resource_name?: string | null | undefined
-            resource_type?: SubscriptionResourceType | undefined
-            send_test_now?: boolean | undefined
-            start_date?: string | undefined
-            summary?: string | undefined
-            summary_enabled?: boolean | undefined
-            summary_prompt_guide?: string | undefined
-            target_type?: string | undefined
-            target_value?: string | undefined
-            title?: string | undefined
-            until_date?: string | undefined
-        },
+        subscription: SubscriptionForm,
         payload?: any
     ) => {
-        subscription: {
-            ai_prompt_config?: AIPromptConfigApi | null | undefined
-            bysetpos?: number | null | undefined
-            byweekday?: WeekdayType[] | null | undefined
-            created_at?: string | undefined
-            created_by?: UserBasicType | null | undefined
-            dashboard?: number | undefined
-            dashboard_export_insights?: number[] | undefined
-            deleted?: boolean | undefined
-            delivery_config?: DeliveryConfigApi | undefined
-            enabled?: boolean | undefined
-            frequency?: 'daily' | 'monthly' | 'weekly' | 'yearly' | undefined
-            id?: number | undefined
-            insight?: number | undefined
-            insight_short_id?: string | null | undefined
-            integration_id?: number | null | undefined
-            interval?: number | undefined
-            next_delivery_date?: string | null | undefined
-            prompt?: string | null | undefined
-            resource_name?: string | null | undefined
-            resource_type?: SubscriptionResourceType | undefined
-            send_test_now?: boolean | undefined
-            start_date?: string | undefined
-            summary?: string | undefined
-            summary_enabled?: boolean | undefined
-            summary_prompt_guide?: string | undefined
-            target_type?: string | undefined
-            target_value?: string | undefined
-            title?: string | undefined
-            until_date?: string | undefined
-        }
+        subscription: SubscriptionForm
         payload?: any
     }
     loadSummaryQuota: () => any
@@ -394,8 +390,8 @@ export interface subscriptionLogicActions {
     replaceTeamsWebhook: () => {
         value: true
     }
-    resetSubscription: (values?: SubscriptionType) => {
-        values?: SubscriptionType
+    resetSubscription: (values?: SubscriptionForm) => {
+        values?: SubscriptionForm
     }
     selectAiAnalysisWindow: (mode: AIWindowConfigApi['mode']) => {
         mode: SubscriptionAIWindowModeEnumApi | undefined
@@ -406,6 +402,16 @@ export interface subscriptionLogicActions {
     ) => {
         label: string
         prompt: string
+    }
+    selectProactiveRepository: (
+        repository: string,
+        repositoryIntegrationId: number
+    ) => {
+        repository: string
+        repositoryIntegrationId: number
+    }
+    selectWizardStep: (step: SubscriptionWizardStep) => {
+        step: SubscriptionWizardStep
     }
     sendTestDelivery: () => {
         value: true
@@ -438,8 +444,8 @@ export interface subscriptionLogicActions {
         name: FieldName
         value: any
     }
-    setSubscriptionValues: (values: DeepPartial<SubscriptionType>) => {
-        values: DeepPartial<SubscriptionType>
+    setSubscriptionValues: (values: DeepPartial<SubscriptionForm>) => {
+        values: DeepPartial<SubscriptionForm>
     }
     submitSubscription: () => {
         value: boolean
@@ -451,11 +457,11 @@ export interface subscriptionLogicActions {
         error: Error
         errors: Record<string, any>
     }
-    submitSubscriptionRequest: (subscription: SubscriptionType) => {
-        subscription: SubscriptionType
+    submitSubscriptionRequest: (subscription: SubscriptionForm) => {
+        subscription: SubscriptionForm
     }
-    submitSubscriptionSuccess: (subscription: SubscriptionType) => {
-        subscription: SubscriptionType
+    submitSubscriptionSuccess: (subscription: SubscriptionForm) => {
+        subscription: SubscriptionForm
     }
     touchSubscriptionField: (key: string) => {
         key: string
@@ -499,9 +505,20 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
             label,
         }),
         selectAiAnalysisWindow: (mode: AIWindowConfigApi['mode']) => ({ mode }),
+        selectProactiveRepository: (repository: string, repositoryIntegrationId: number) => ({
+            repository,
+            repositoryIntegrationId,
+        }),
+        selectWizardStep: (step: SubscriptionWizardStep) => ({ step }),
     }),
 
     reducers({
+        currentWizardStep: [
+            SubscriptionWizardStep.Content as SubscriptionWizardStep,
+            {
+                selectWizardStep: (_, { step }) => step,
+            },
+        ],
         // The host the API returned for a saved Teams subscription. Null once the user chooses to
         // replace the URL, which is what puts the input back on screen and the validation back on.
         storedTeamsWebhookHost: [
@@ -520,6 +537,14 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
                 loadLastDelivery: () => false,
                 loadLastDeliveryFailure: () => true,
                 loadLastDeliverySuccess: () => false,
+            },
+        ],
+        proactiveConfigurationOptionsLoadFailed: [
+            false,
+            {
+                loadProactiveConfigurationOptions: () => false,
+                loadProactiveConfigurationOptionsFailure: () => true,
+                loadProactiveConfigurationOptionsSuccess: () => false,
             },
         ],
         testDeliveryLoading: [
@@ -563,6 +588,12 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
     }),
 
     loaders(({ props }) => ({
+        proactiveConfigurationOptions: {
+            __default: null as ProactiveConfigurationOptionsApi | null,
+            loadProactiveConfigurationOptions: async () => {
+                return await subscriptionsProactiveOptionsList(String(getCurrentTeamId()))
+            },
+        },
         lastDelivery: {
             __default: null as SubscriptionDeliveryApi | null,
             loadLastDelivery: async () => {
@@ -574,7 +605,7 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
             },
         },
         subscription: {
-            __default: undefined as unknown as SubscriptionType,
+            __default: undefined as unknown as SubscriptionForm,
             loadSubscription: async () => {
                 if (props.id && props.id !== 'new') {
                     const subscription = await api.subscriptions.get(props.id)
@@ -604,7 +635,7 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
                         },
                     }
                 }
-                return { ...NEW_SUBSCRIPTION }
+                return newSubscriptionForm()
             },
         },
         summaryQuota: {
@@ -617,7 +648,7 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
 
     forms(({ props, actions, cache, values }) => ({
         subscription: {
-            defaults: { enabled: NEW_SUBSCRIPTION.enabled } as unknown as SubscriptionType,
+            defaults: { enabled: NEW_SUBSCRIPTION.enabled } as unknown as SubscriptionForm,
             errors: (subscription) => ({
                 frequency: validateFrequency(subscription),
                 title: !subscription.title ? 'You need to give your subscription a name' : undefined,
@@ -634,6 +665,7 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
                     isTeamsWebhookKept(subscription.target_type, values.storedTeamsWebhookHost)
                 ),
                 dashboard_export_insights: validateDashboardExportInsights(subscription, props.dashboardId),
+                ...validateProactiveConfig(subscription, Boolean(props.proactiveSettingsEnabled)),
             }),
             submit: async (subscription, breakpoint) => {
                 const isAi = subscription.resource_type === SubscriptionResourceTypes.AiPrompt
@@ -659,11 +691,13 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
                     // toggling resource_type back) would be rejected by the backend, so drop it.
                     prompt: isAi ? subscription.prompt?.trim() : undefined,
                     ai_prompt_config: isAi ? subscription.ai_prompt_config : undefined,
+                    proactive_config:
+                        isAi && props.proactiveSettingsEnabled ? subscription.proactive_config : undefined,
                 }
 
                 breakpoint()
 
-                const updatedSub: SubscriptionType =
+                const updatedSub: SubscriptionForm =
                     props.id === 'new'
                         ? await api.subscriptions.create(payload)
                         : await api.subscriptions.update(props.id, payload)
@@ -728,6 +762,12 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
             }
             if (props.id !== 'new') {
                 actions.loadLastDelivery()
+            }
+            if (
+                props.proactiveSettingsEnabled &&
+                initialSubscription.resource_type === SubscriptionResourceTypes.AiPrompt
+            ) {
+                actions.loadProactiveConfigurationOptions()
             }
         },
         sendTestDelivery: async () => {
@@ -816,6 +856,16 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
             }
             actions.setSubscriptionValues({ ai_prompt_config: { ...config, window } })
         },
+        selectProactiveRepository: ({ repository, repositoryIntegrationId }) => {
+            actions.setSubscriptionValues({
+                proactive_config: {
+                    ...values.subscription.proactive_config,
+                    create_draft_pr: true,
+                    repository,
+                    repository_integration_id: repositoryIntegrationId,
+                },
+            })
+        },
         submitSubscriptionFailure: ({ error }) => {
             // Kea-forms emits this when client validation fails; fields already show errors.
             if (error instanceof Error && error.message === 'Validation Failed') {
@@ -830,6 +880,7 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
 
         setSubscriptionValue: ({ name, value }, _breakpoint, _action, previousState) => {
             const key = Array.isArray(name) ? name[0] : name
+            const path = Array.isArray(name) ? name.join('.') : name
             if (key === 'frequency') {
                 if (value === 'daily') {
                     actions.setSubscriptionValues({
@@ -865,7 +916,28 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
                 })
             }
 
-            const path = Array.isArray(name) ? name.join('.') : name
+            if (
+                path === 'proactive_config.create_draft_pr' &&
+                !value &&
+                (values.subscription.proactive_config?.repository ||
+                    values.subscription.proactive_config?.repository_integration_id)
+            ) {
+                actions.setSubscriptionValues({
+                    proactive_config: {
+                        ...values.subscription.proactive_config,
+                        create_draft_pr: false,
+                        repository: null,
+                        repository_integration_id: null,
+                    },
+                })
+            }
+            if (
+                key === 'resource_type' &&
+                value === SubscriptionResourceTypes.AiPrompt &&
+                props.proactiveSettingsEnabled
+            ) {
+                actions.loadProactiveConfigurationOptions()
+            }
             if (path === 'ai_prompt_config.window.mode') {
                 // Reducers run before listeners, so previousState tells a real mode switch (reset the
                 // day bounds) apart from a same-mode re-select (keep them).
@@ -945,7 +1017,7 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
     events(({ actions, values, props }) => ({
         afterMount: () => {
             if (props.id === 'new' && !values.subscriptionInitialized) {
-                actions.loadSubscriptionSuccess({ ...NEW_SUBSCRIPTION })
+                actions.loadSubscriptionSuccess(newSubscriptionForm())
             }
             // Load the org-wide AI summary quota once per logic mount so
             // the paywall conditional in EditSubscription has data to react
@@ -977,7 +1049,7 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
 
     urlToAction(({ actions, props, cache, values }) => ({
         '/*/*/subscriptions/new': (_, searchParams) => {
-            actions.loadSubscriptionSuccess({ ...NEW_SUBSCRIPTION })
+            actions.loadSubscriptionSuccess(newSubscriptionForm())
             if (searchParams.resource_type === SubscriptionResourceTypes.AiPrompt) {
                 actions.setSubscriptionValue('resource_type', SubscriptionResourceTypes.AiPrompt)
             }
@@ -1042,10 +1114,9 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
             // arrives as props. Without one there is nothing to snapshot, so the only thing
             // this route can create is a report from a prompt.
             const isParentless = !props.insightShortId && !props.dashboardId
-            actions.loadSubscriptionSuccess({
-                ...NEW_SUBSCRIPTION,
-                ...(isParentless ? { resource_type: SubscriptionResourceTypes.AiPrompt } : {}),
-            })
+            actions.loadSubscriptionSuccess(
+                newSubscriptionForm(isParentless ? { resource_type: SubscriptionResourceTypes.AiPrompt } : {})
+            )
             if (searchParams.target_type) {
                 actions.setSubscriptionValue('target_type', searchParams.target_type)
             }

--- a/products/subscriptions/frontend/components/Subscriptions/subscriptionLogic.ts
+++ b/products/subscriptions/frontend/components/Subscriptions/subscriptionLogic.ts
@@ -1,4 +1,4 @@
-import { MakeLogicType, actions, connect, events, kea, key, listeners, path, props, reducers } from 'kea'
+import { MakeLogicType, actions, connect, events, kea, key, listeners, path, props, propsChanged, reducers } from 'kea'
 import { forms } from 'kea-forms'
 import type { DeepPartial, DeepPartialMap, FieldName, ValidationErrorType } from 'kea-forms'
 import { loaders } from 'kea-loaders'
@@ -1013,6 +1013,16 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
             }
         },
     })),
+
+    propsChanged(({ actions, props, values }, oldProps) => {
+        if (
+            !oldProps.proactiveSettingsEnabled &&
+            props.proactiveSettingsEnabled &&
+            values.subscription?.resource_type === SubscriptionResourceTypes.AiPrompt
+        ) {
+            actions.loadProactiveConfigurationOptions()
+        }
+    }),
 
     events(({ actions, values, props }) => ({
         afterMount: () => {

--- a/products/subscriptions/frontend/components/Subscriptions/views/EditSubscription.tsx
+++ b/products/subscriptions/frontend/components/Subscriptions/views/EditSubscription.tsx
@@ -42,6 +42,7 @@ import type { SubscriptionDeliveryApi } from 'products/subscriptions/frontend/ge
 
 import { AiPromptFields, AiPromptSubscriptionIntroduction } from '../AiPromptFields'
 import { InsightSelector } from '../InsightSelector'
+import { ProactiveSubscriptionFields } from '../ProactiveSubscriptionFields'
 import { subscriptionCountLogic } from '../subscriptionCountLogic'
 import { SubscriptionDayPicker } from '../SubscriptionDayPicker'
 import { subscriptionLogic } from '../subscriptionLogic'
@@ -247,11 +248,15 @@ function EditSubscriptionForm({
     onDelete,
 }: EditSubscriptionProps): JSX.Element {
     const dashboardId = dashboard?.id
+    const aiSubscriptionsEnabled = useFeatureFlag('SUBSCRIPTION_AI_PROMPT')
+    const pulseEnabled = useFeatureFlag('PULSE')
+    const proactiveSettingsEnabled = Boolean(aiSubscriptionsEnabled && pulseEnabled)
     const logicProps = {
         id,
         insightShortId,
         dashboardId,
         dashboardName: dashboard?.name,
+        proactiveSettingsEnabled,
     }
     const logic = subscriptionLogic(logicProps)
     const subscriptionslogic = subscriptionsLogic({
@@ -271,15 +276,24 @@ function EditSubscriptionForm({
         summaryQuota,
         testDeliveryLoading,
         storedTeamsWebhookHost,
+        proactiveConfigurationOptions,
+        proactiveConfigurationOptionsLoading,
+        proactiveConfigurationOptionsLoadFailed,
     } = useValues(logic)
     const { previewLoading, previewError, previewImageUrl } = useValues(logic)
-    const { applyDefaultSelectedInsights, generatePreview, sendTestDelivery, replaceTeamsWebhook } = useActions(logic)
+    const {
+        applyDefaultSelectedInsights,
+        generatePreview,
+        loadProactiveConfigurationOptions,
+        replaceTeamsWebhook,
+        selectProactiveRepository,
+        sendTestDelivery,
+    } = useActions(logic)
     const { preflight, siteUrlMisconfigured } = useValues(preflightLogic)
     const { currentOrganization } = useValues(organizationLogic)
     const { deleteSubscription } = useActions(subscriptionslogic)
     const { slackIntegrations, integrations } = useValues(integrationsLogic)
     const { dataProcessingAccepted } = useValues(maxGlobalLogic)
-    const aiSubscriptionsEnabled = useFeatureFlag('SUBSCRIPTION_AI_PROMPT')
     const slackGalleryEnabled = useFeatureFlag('SUBSCRIPTION_SLACK_GALLERY')
     const slackReconnectRestriction = useIntegrationManagementRestriction()
 
@@ -460,6 +474,20 @@ function EditSubscriptionForm({
                                     onSelectAnalysisWindow={logic.actions.selectAiAnalysisWindow}
                                     onSelectExample={logic.actions.selectAiExamplePrompt}
                                 />
+                                {proactiveSettingsEnabled && !aiGate.submitBlocked ? (
+                                    <div className="flex flex-col gap-2 rounded border p-3">
+                                        <h3 className="text-sm font-semibold m-0">Actions</h3>
+                                        <ProactiveSubscriptionFields
+                                            proactiveConfig={subscription.proactive_config}
+                                            options={proactiveConfigurationOptions}
+                                            optionsLoading={proactiveConfigurationOptionsLoading}
+                                            optionsLoadFailed={proactiveConfigurationOptionsLoadFailed}
+                                            show={proactiveSettingsEnabled}
+                                            onSelectRepository={selectProactiveRepository}
+                                            onRetry={loadProactiveConfigurationOptions}
+                                        />
+                                    </div>
+                                ) : null}
                             </>
                         ) : null}
 

--- a/products/subscriptions/frontend/generated/api.schemas.ts
+++ b/products/subscriptions/frontend/generated/api.schemas.ts
@@ -803,6 +803,27 @@ export interface PaginatedSubscriptionDeliveryListApi {
     results: SubscriptionDeliveryApi[]
 }
 
+export interface ProactiveRepositoryOptionApi {
+    /** Repository currently authorized for the requesting user, in owner/repository format. */
+    readonly repository: string
+    /**
+     * GitHub integration that currently authorizes this repository.
+     * @minimum 1
+     */
+    readonly repository_integration_id: number
+}
+
+export interface ProactiveConfigurationOptionsApi {
+    /** Whether this PostHog instance is configured to generate proactive recommendations. */
+    readonly proactive_available: boolean
+    /** Whether this PostHog instance is configured to use public web research for proactive recommendations. */
+    readonly public_web_research_available: boolean
+    /** Whether this PostHog instance is configured to prepare draft pull requests for proactive recommendations. */
+    readonly draft_pr_available: boolean
+    /** Repositories currently authorized for the requesting user to use for draft pull request preparation. */
+    readonly repositories: readonly ProactiveRepositoryOptionApi[]
+}
+
 export interface PulseResearchRequestApi {
     /**
      * A public-web research query. It is searched once and only public results are considered.

--- a/products/subscriptions/frontend/generated/api.ts
+++ b/products/subscriptions/frontend/generated/api.ts
@@ -12,6 +12,7 @@ import type {
     PaginatedSubscriptionDeliveryListApi,
     PaginatedSubscriptionListApi,
     PatchedSubscriptionWriteApi,
+    ProactiveConfigurationOptionsApi,
     PulseResearchRequestApi,
     PulseResearchResponseApi,
     SubscriptionApi,
@@ -217,6 +218,20 @@ export const subscriptionsDeliveriesRetrieve = async (
     options?: RequestInit
 ): Promise<SubscriptionDeliveryApi> => {
     return apiMutator<SubscriptionDeliveryApi>(getSubscriptionsDeliveriesRetrieveUrl(projectId, subscriptionId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getSubscriptionsProactiveOptionsListUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/subscriptions/proactive_options/`
+}
+
+export const subscriptionsProactiveOptionsList = async (
+    projectId: string,
+    options?: RequestInit
+): Promise<ProactiveConfigurationOptionsApi> => {
+    return apiMutator<ProactiveConfigurationOptionsApi>(getSubscriptionsProactiveOptionsListUrl(projectId), {
         ...options,
         method: 'GET',
     })

--- a/products/subscriptions/mcp/tools.yaml
+++ b/products/subscriptions/mcp/tools.yaml
@@ -208,6 +208,9 @@ tools:
             - insight_short_id
             - invite_message
             - send_test_now
+    subscriptions-proactive-options-list:
+        operation: subscriptions_proactive_options_list
+        enabled: false
     subscriptions-retrieve:
         operation: subscriptions_retrieve
         enabled: true

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -70190,6 +70190,27 @@ export namespace Schemas {
       primary_properties: PrimaryPropertiesResponsePrimaryProperties;
     }
 
+    export interface ProactiveRepositoryOption {
+      /** Repository currently authorized for the requesting user, in owner/repository format. */
+      readonly repository: string;
+      /**
+         * GitHub integration that currently authorizes this repository.
+         * @minimum 1
+         */
+      readonly repository_integration_id: number;
+    }
+
+    export interface ProactiveConfigurationOptions {
+      /** Whether this PostHog instance is configured to generate proactive recommendations. */
+      readonly proactive_available: boolean;
+      /** Whether this PostHog instance is configured to use public web research for proactive recommendations. */
+      readonly public_web_research_available: boolean;
+      /** Whether this PostHog instance is configured to prepare draft pull requests for proactive recommendations. */
+      readonly draft_pr_available: boolean;
+      /** Repositories currently authorized for the requesting user to use for draft pull request preparation. */
+      readonly repositories: readonly ProactiveRepositoryOption[];
+    }
+
     export type ProblemTypeEnum = typeof ProblemTypeEnum[keyof typeof ProblemTypeEnum];
 
 


### PR DESCRIPTION
## Problem

The AI subscription form is too long, and proactive actions are difficult to discover or understand before scheduling a report.

## Changes

- Replaces the long form with five focused steps: Report, Actions, Notify, Schedule, and Review.
- Reworks suggested goals as editable prompt starters.
- Adds clear controls for investigation, public web research, repository selection, and automatic draft pull requests.
- Explains unavailable capabilities in place and summarizes only actions the server can perform.
- Keeps the workflow behind the existing Pulse and AI subscription gates.

```mermaid
flowchart LR
    A[Report] --> B[Actions]
    B --> C[Notify]
    C --> D[Schedule]
    D --> E[Review]
```

Screenshots: synthetic local visual QA is complete. A public-safe asset will be attached before this draft is marked ready.

## How did you test this code?

- Five Pulse frontend suites passed with 80 tests after the final restack.
- The full frontend type check passed.
- The five-step create and edit flow was exercised locally with synthetic project data, including unavailable capability states.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the AI subscription notification documentation with Pulse setup, web research, repository, and action behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented this layer using /qa-team, /stacking-prs, /running-ci-preflight, and /writing-pr-descriptions. No existing Pulse v2 PR matched the duplicate search.

Adversarial review removed unavailable action summaries and deployment-skew ambiguity before publication.