### PR TITLE
fix(alerts): finish scheduled runs after child start

### DIFF
--- a/posthog/temporal/alerts/activities.py
+++ b/posthog/temporal/alerts/activities.py
@@ -3,7 +3,8 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 
 from django.db import transaction
-from django.db.models import Case, F, IntegerField, Q, Value, When
+from django.db.models import Case, F, IntegerField, Q, Value, When, Window
+from django.db.models.functions import RowNumber
 
 import structlog
 import temporalio.activity
@@ -92,7 +93,24 @@ async def retrieve_due_alerts() -> list[AlertInfo]:
             .filter(Q(snoozed_until__isnull=True) | Q(snoozed_until__lt=now))
             .filter(insight__deleted=False)
             .annotate(_interval_order=calculation_interval_order)
-            .order_by("_interval_order", F("next_check_at").asc(nulls_first=True))
+            .annotate(
+                _team_rank=Window(
+                    expression=RowNumber(),
+                    partition_by=[F("team_id")],
+                    order_by=[
+                        F("_interval_order").asc(),
+                        F("next_check_at").asc(nulls_first=True),
+                        F("id").asc(),
+                    ],
+                ),
+            )
+            .order_by(
+                "_team_rank",
+                "_interval_order",
+                F("next_check_at").asc(nulls_first=True),
+                "team_id",
+                "id",
+            )
             .only("id", "team_id", "calculation_interval", "insight_id")[:MAX_DUE_ALERTS_PER_SCHEDULE_RUN]
         )
 

--- a/posthog/temporal/alerts/activities.py
+++ b/posthog/temporal/alerts/activities.py
@@ -67,6 +67,7 @@ from products.notifications.backend.facade.api import (
 logger = structlog.get_logger(__name__)
 
 _NOTIFICATION_DELIVERY_EXECUTOR = ThreadPoolExecutor(max_workers=10, thread_name_prefix="insight-alert-delivery")
+MAX_DUE_ALERTS_PER_SCHEDULE_RUN = 50
 
 
 @temporalio.activity.defn
@@ -92,7 +93,7 @@ async def retrieve_due_alerts() -> list[AlertInfo]:
             .filter(insight__deleted=False)
             .annotate(_interval_order=calculation_interval_order)
             .order_by("_interval_order", F("next_check_at").asc(nulls_first=True))
-            .only("id", "team_id", "calculation_interval", "insight_id")
+            .only("id", "team_id", "calculation_interval", "insight_id")[:MAX_DUE_ALERTS_PER_SCHEDULE_RUN]
         )
 
         return [

--- a/posthog/temporal/alerts/schedule.py
+++ b/posthog/temporal/alerts/schedule.py
@@ -27,7 +27,7 @@ async def create_schedule_due_alert_checks_schedule(client: Client) -> None:
             execution_timeout=dt.timedelta(minutes=10),
         ),
         spec=ScheduleSpec(cron_expressions=["*/1 * * * *"]),
-        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.ALLOW_ALL),
+        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
     )
 
     if await a_schedule_exists(client, SCHEDULE_ID):

--- a/posthog/temporal/alerts/schedule.py
+++ b/posthog/temporal/alerts/schedule.py
@@ -27,7 +27,7 @@ async def create_schedule_due_alert_checks_schedule(client: Client) -> None:
             execution_timeout=dt.timedelta(minutes=10),
         ),
         spec=ScheduleSpec(cron_expressions=["*/1 * * * *"]),
-        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
+        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.ALLOW_ALL),
     )
 
     if await a_schedule_exists(client, SCHEDULE_ID):

--- a/posthog/temporal/alerts/workflows.py
+++ b/posthog/temporal/alerts/workflows.py
@@ -1,11 +1,10 @@
 import json
-import asyncio
 import datetime as dt
 from uuid import UUID
 
 import temporalio.common
 import temporalio.workflow
-from temporalio.exceptions import ApplicationError, WorkflowAlreadyStartedError
+from temporalio.exceptions import WorkflowAlreadyStartedError
 
 from posthog.schema import AlertState
 
@@ -61,64 +60,42 @@ class ScheduleDueAlertChecksWorkflow(PostHogWorkflow):
             ),
         )
 
-        # Fan-out child workflows — one per alert. Deterministic ID prevents
-        # duplicate checks when schedule runs overlap; Temporal guarantees no
-        # two open workflows can share the same ID, so a still-running child
-        # rejects the duplicate start.
-        tasks = []
+        # Fan-out child workflows — one per alert. Deterministic IDs prevent
+        # duplicate checks from retries or concurrent manual triggers. Wait
+        # only for Temporal to accept the start; the children run independently.
         for alert in alerts:
             slo_properties: dict[str, JsonValue] = {
                 "alert_type": "insight",
                 "calculation_interval": alert.calculation_interval,
                 "insight_id": alert.insight_id,
             }
-            task = temporalio.workflow.execute_child_workflow(
-                CheckAlertWorkflow.run,
-                CheckAlertWorkflowInputs(
-                    alert_id=alert.alert_id,
-                    team_id=alert.team_id,
-                    distinct_id=alert.distinct_id,
-                    calculation_interval=alert.calculation_interval,
-                    insight_id=alert.insight_id,
-                    slo=SloConfig(
-                        operation=SloOperation.ALERT_CHECK,
-                        area=SloArea.ANALYTIC_PLATFORM,
+            try:
+                await temporalio.workflow.start_child_workflow(
+                    CheckAlertWorkflow.run,
+                    CheckAlertWorkflowInputs(
+                        alert_id=alert.alert_id,
                         team_id=alert.team_id,
-                        resource_id=alert.alert_id,
                         distinct_id=alert.distinct_id,
-                        start_properties=slo_properties.copy(),
-                        completion_properties=slo_properties.copy(),
+                        calculation_interval=alert.calculation_interval,
+                        insight_id=alert.insight_id,
+                        slo=SloConfig(
+                            operation=SloOperation.ALERT_CHECK,
+                            area=SloArea.ANALYTIC_PLATFORM,
+                            team_id=alert.team_id,
+                            resource_id=alert.alert_id,
+                            distinct_id=alert.distinct_id,
+                            start_properties=slo_properties.copy(),
+                            completion_properties=slo_properties.copy(),
+                        ),
                     ),
-                ),
-                id=f"check-alert-{alert.alert_id}",
-                parent_close_policy=temporalio.workflow.ParentClosePolicy.ABANDON,
-                execution_timeout=alert_timeouts(alert.calculation_interval).workflow_execution,
-            )
-            tasks.append(task)
-
-        if tasks:
-            results = await asyncio.gather(*tasks, return_exceptions=True)
-            failed_ids = []
-            for alert, result in zip(alerts, results):
-                if isinstance(result, BaseException):
-                    if isinstance(result, WorkflowAlreadyStartedError):
-                        # Previous schedule run's child still processing this
-                        # alert — not a failure, just skip it.
-                        temporalio.workflow.logger.info(
-                            "check_alert.already_running",
-                            extra={"alert_id": alert.alert_id},
-                        )
-                    else:
-                        failed_ids.append(alert.alert_id)
-                        temporalio.workflow.logger.warning(
-                            "check_alert.child_workflow_error",
-                            extra={"alert_id": alert.alert_id, "error": str(result)},
-                        )
-
-            if failed_ids:
-                raise ApplicationError(
-                    f"Alert checks failed for IDs: {failed_ids}",
-                    non_retryable=True,
+                    id=f"check-alert-{alert.alert_id}",
+                    parent_close_policy=temporalio.workflow.ParentClosePolicy.ABANDON,
+                    execution_timeout=alert_timeouts(alert.calculation_interval).workflow_execution,
+                )
+            except WorkflowAlreadyStartedError:
+                temporalio.workflow.logger.info(
+                    "check_alert.already_running",
+                    extra={"alert_id": alert.alert_id},
                 )
 
 

--- a/posthog/temporal/alerts/workflows.py
+++ b/posthog/temporal/alerts/workflows.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 import temporalio.common
 import temporalio.workflow
-from temporalio.exceptions import WorkflowAlreadyStartedError
+from temporalio.exceptions import ApplicationError, WorkflowAlreadyStartedError
 
 from posthog.schema import AlertState
 
@@ -63,6 +63,7 @@ class ScheduleDueAlertChecksWorkflow(PostHogWorkflow):
         # Fan-out child workflows — one per alert. Deterministic IDs prevent
         # duplicate checks from retries or concurrent manual triggers. Wait
         # only for Temporal to accept the start; the children run independently.
+        failed_ids: list[str] = []
         for alert in alerts:
             slo_properties: dict[str, JsonValue] = {
                 "alert_type": "insight",
@@ -97,6 +98,18 @@ class ScheduleDueAlertChecksWorkflow(PostHogWorkflow):
                     "check_alert.already_running",
                     extra={"alert_id": alert.alert_id},
                 )
+            except Exception as error:
+                failed_ids.append(alert.alert_id)
+                temporalio.workflow.logger.warning(
+                    "check_alert.start_failed",
+                    extra={"alert_id": alert.alert_id, "error": str(error)},
+                )
+
+        if failed_ids:
+            raise ApplicationError(
+                f"Alert checks failed to start for IDs: {failed_ids}",
+                non_retryable=True,
+            )
 
 
 @temporalio.workflow.defn(name="check-alert")

--- a/posthog/temporal/tests/test_alerts_activities.py
+++ b/posthog/temporal/tests/test_alerts_activities.py
@@ -41,6 +41,7 @@ from posthog.temporal.alerts.activities import (
     notify_alert,
     prepare_alert,
     record_failed_evaluation,
+    retrieve_due_alerts,
 )
 from posthog.temporal.alerts.retry_policy import alert_timeouts
 from posthog.temporal.alerts.types import (
@@ -128,6 +129,17 @@ async def _create_alert(
         return alert
 
     return await _create()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_retrieve_due_alerts_limits_each_schedule_run_to_fifty(ateam) -> None:
+    for _ in range(51):
+        await _create_alert(ateam)
+
+    alerts = await ActivityEnvironment().run(retrieve_due_alerts)
+
+    assert len(alerts) == 50
 
 
 @pytest_asyncio.fixture

--- a/posthog/temporal/tests/test_alerts_activities.py
+++ b/posthog/temporal/tests/test_alerts_activities.py
@@ -28,7 +28,7 @@ from posthog.exceptions import (
     ClickHouseClusterMemoryLimitExceeded,
     ClickHouseQueryMemoryLimitExceeded,
 )
-from posthog.models import User
+from posthog.models import Team, User
 from posthog.slo.types import SloOperation, SloOutcome
 from posthog.tasks.alerts.utils import (
     AlertEvaluationResult,
@@ -83,7 +83,7 @@ def _memory_limit_error() -> ClickHouseQueryMemoryLimitExceeded:
 
 
 async def _create_alert(
-    ateam,
+    ateam: Team,
     *,
     query: dict | None = None,
     enabled: bool = True,
@@ -133,13 +133,23 @@ async def _create_alert(
 
 @pytest.mark.asyncio
 @pytest.mark.django_db
-async def test_retrieve_due_alerts_limits_each_schedule_run_to_fifty(ateam) -> None:
-    for _ in range(51):
-        await _create_alert(ateam)
+async def test_retrieve_due_alerts_limits_each_schedule_run_to_fifty_without_starving_other_teams(
+    ateam: Team,
+) -> None:
+    for _ in range(50):
+        await _create_alert(ateam, calculation_interval=AlertCalculationInterval.REAL_TIME.value)
+
+    other_team = await sync_to_async(Team.objects.create)(
+        organization_id=ateam.organization_id,
+        project_id=ateam.project_id,
+        name="Other team",
+    )
+    other_alert = await _create_alert(other_team)
 
     alerts = await ActivityEnvironment().run(retrieve_due_alerts)
 
     assert len(alerts) == 50
+    assert str(other_alert.id) in {alert.alert_id for alert in alerts}
 
 
 @pytest_asyncio.fixture

--- a/posthog/temporal/tests/test_alerts_workflows.py
+++ b/posthog/temporal/tests/test_alerts_workflows.py
@@ -11,8 +11,8 @@ from django.conf import settings
 
 import pytest_asyncio
 from asgiref.sync import sync_to_async
-from temporalio.client import ScheduleOverlapPolicy, WorkflowFailureError
-from temporalio.exceptions import WorkflowAlreadyStartedError
+from temporalio.client import WorkflowFailureError
+from temporalio.exceptions import ApplicationError, WorkflowAlreadyStartedError
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
@@ -117,26 +117,40 @@ async def test_schedule_due_alert_checks_skips_already_running_children() -> Non
     start_child.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+async def test_schedule_due_alert_checks_attempts_remaining_children_before_reporting_start_failures() -> None:
+    alerts = [
+        AlertInfo(
+            alert_id=f"alert-{index}",
+            team_id=42,
+            distinct_id=f"user-{index}",
+            calculation_interval=AlertCalculationInterval.DAILY.value,
+            insight_id=123,
+        )
+        for index in range(2)
+    ]
+
+    with (
+        patch(
+            "posthog.temporal.alerts.workflows.temporalio.workflow.execute_activity",
+            new=AsyncMock(return_value=alerts),
+        ),
+        patch(
+            "posthog.temporal.alerts.workflows.temporalio.workflow.start_child_workflow",
+            new=AsyncMock(side_effect=[RuntimeError("start failed"), None]),
+        ) as start_child,
+        patch("posthog.temporal.alerts.workflows.temporalio.workflow.logger", new=MagicMock()),
+    ):
+        with pytest.raises(ApplicationError, match="alert-0"):
+            await ScheduleDueAlertChecksWorkflow().run()
+
+    assert start_child.await_count == 2
+
+
 def test_schedule_is_registered_in_init_schedules():
     from posthog.temporal.schedule import schedules
 
     assert create_schedule_due_alert_checks_schedule in schedules
-
-
-@pytest.mark.asyncio
-async def test_due_alert_schedule_skips_overlapping_runs() -> None:
-    captured: dict = {}
-
-    async def create_schedule(*args, **kwargs) -> None:
-        captured["schedule"] = args[2]
-
-    with (
-        patch("posthog.temporal.alerts.schedule.a_schedule_exists", new=AsyncMock(return_value=False)),
-        patch("posthog.temporal.alerts.schedule.a_create_schedule", new=create_schedule),
-    ):
-        await create_schedule_due_alert_checks_schedule(MagicMock())
-
-    assert captured["schedule"].policy.overlap == ScheduleOverlapPolicy.SKIP
 
 
 def _valid_trends_query() -> dict:

--- a/posthog/temporal/tests/test_alerts_workflows.py
+++ b/posthog/temporal/tests/test_alerts_workflows.py
@@ -11,7 +11,8 @@ from django.conf import settings
 
 import pytest_asyncio
 from asgiref.sync import sync_to_async
-from temporalio.client import WorkflowFailureError
+from temporalio.client import ScheduleOverlapPolicy, WorkflowFailureError
+from temporalio.exceptions import WorkflowAlreadyStartedError
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
@@ -49,7 +50,7 @@ CHECK_ALERT_ACTIVITIES: list[Callable[..., Any]] = [
 
 
 @pytest.mark.asyncio
-async def test_schedule_due_alert_checks_adds_shared_slo_context() -> None:
+async def test_schedule_due_alert_checks_starts_child_with_shared_slo_context() -> None:
     alert = AlertInfo(
         alert_id="alert-1",
         team_id=42,
@@ -64,12 +65,14 @@ async def test_schedule_due_alert_checks_adds_shared_slo_context() -> None:
             new=AsyncMock(return_value=[alert]),
         ),
         patch(
-            "posthog.temporal.alerts.workflows.temporalio.workflow.execute_child_workflow", new=AsyncMock()
-        ) as execute_child,
+            "posthog.temporal.alerts.workflows.temporalio.workflow.start_child_workflow", new=AsyncMock()
+        ) as start_child,
     ):
         await ScheduleDueAlertChecksWorkflow().run()
 
-    inputs = execute_child.call_args.args[1]
+    start_child.assert_awaited_once()
+    assert start_child.await_args is not None
+    inputs = start_child.await_args.args[1]
     assert isinstance(inputs, CheckAlertWorkflowInputs)
     assert inputs.slo is not None
     assert inputs.slo.operation == SloOperation.ALERT_CHECK
@@ -88,10 +91,52 @@ async def test_schedule_due_alert_checks_adds_shared_slo_context() -> None:
     assert "alert_state" not in inputs.slo.start_properties
 
 
+@pytest.mark.asyncio
+async def test_schedule_due_alert_checks_skips_already_running_children() -> None:
+    alert = AlertInfo(
+        alert_id="alert-1",
+        team_id=42,
+        distinct_id="user-1",
+        calculation_interval=AlertCalculationInterval.DAILY.value,
+        insight_id=123,
+    )
+
+    with (
+        patch(
+            "posthog.temporal.alerts.workflows.temporalio.workflow.execute_activity",
+            new=AsyncMock(return_value=[alert]),
+        ),
+        patch(
+            "posthog.temporal.alerts.workflows.temporalio.workflow.start_child_workflow",
+            new=AsyncMock(side_effect=WorkflowAlreadyStartedError("check-alert-alert-1", "check-alert")),
+        ) as start_child,
+        patch("posthog.temporal.alerts.workflows.temporalio.workflow.logger", new=MagicMock()),
+    ):
+        await ScheduleDueAlertChecksWorkflow().run()
+
+    start_child.assert_awaited_once()
+
+
 def test_schedule_is_registered_in_init_schedules():
     from posthog.temporal.schedule import schedules
 
     assert create_schedule_due_alert_checks_schedule in schedules
+
+
+@pytest.mark.asyncio
+async def test_due_alert_schedule_skips_overlapping_runs() -> None:
+    captured: dict = {}
+
+    async def create_schedule(*args, **kwargs) -> None:
+        captured["schedule"] = args[2]
+
+    with (
+        patch("posthog.temporal.alerts.schedule.a_schedule_exists", new=AsyncMock(return_value=False)),
+        patch("posthog.temporal.alerts.schedule.a_create_schedule", new=create_schedule),
+    ):
+        await create_schedule_due_alert_checks_schedule(MagicMock())
+
+    assert captured["schedule"].policy.overlap == ScheduleOverlapPolicy.SKIP
 
 
 def _valid_trends_query() -> dict:


### PR DESCRIPTION
## Problem

Scheduled insight alerts can time out before their parent workflow completes, even after child checks start. An unbounded due batch can also exceed Temporal payload limits while the system drains a backlog.

## Changes

- The scheduler starts at most 50 child checks and returns when Temporal accepts each start.
- Due alerts are interleaved across teams before applying the global cap.
- Deterministic child IDs reject duplicate concurrent checks while schedule runs retain `ALLOW_ALL` overlap behavior.
- Child-start failures do not prevent later alerts in the batch from starting, and the parent still reports the failures.

```mermaid
flowchart LR
    Tick{{Scheduler tick}} --> Retrieve[Retrieve due alerts]
    Retrieve --> Start[Start child checks]
    Start --> Wait[Wait for child completion]
    Wait --> Complete{{Parent completes}}
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class Tick,Complete phYellow;
    class Retrieve,Start,Wait phBlue;
```

```mermaid
flowchart LR
    Tick{{Scheduler tick}} --> Retrieve[Retrieve up to 50 due alerts]
    Retrieve --> Start[Start child checks]
    Start --> Complete{{Parent completes}}
    Start --> Children[Child checks continue]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class Tick,Complete phYellow;
    class Retrieve,Start,Children phBlue;
```

## How did you test this code?

- Added focused coverage for the 50-alert cap, cross-team progress, non-blocking child starts, duplicate starts, and start failures.
- The commit hook ran Python formatting and `ty check`. PR CI validates the review-round changes.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This changes internal scheduler behavior only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Slack app used `/writing-tests` and `/writing-pr-descriptions`. The duplicate PR search found no existing retrieval cap. No private source data is in this patch.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0C0PRQA2HJ/p1788954733457789?thread_ts=1788954733.457789&cid=C0C0PRQA2HJ)*
