### PR TITLE
feat(desktop): show current agent work

### DIFF
--- a/products/desktop/packages/agent/src/pi/conversation/translatePiMessage.test.ts
+++ b/products/desktop/packages/agent/src/pi/conversation/translatePiMessage.test.ts
@@ -234,6 +234,58 @@ describe("createPiMessageTranslator", () => {
     ]);
   });
 
+  it("keeps current-work calls out of the conversation", () => {
+    const translator = createPiMessageTranslator();
+    const message = makeAssistant([
+      {
+        id: "current-work-1",
+        type: "toolCall",
+        name: "set_current_work",
+        arguments: { status: "Writing regression tests" },
+      } as never,
+    ]);
+    const result: ToolResultMessage = {
+      role: "toolResult",
+      toolCallId: "current-work-1",
+      toolName: "set_current_work",
+      content: [
+        { type: "text", text: "Current work: Writing regression tests" },
+      ],
+      isError: false,
+      timestamp: 2,
+    };
+
+    expect(translator.translate(message)).toEqual([]);
+    expect(
+      translator.translateToolExecutionStart(
+        "current-work-1",
+        "set_current_work",
+        { status: "Writing regression tests" },
+        1,
+      ),
+    ).toEqual([]);
+    expect(
+      translator.translateToolExecutionUpdate(
+        "current-work-1",
+        "set_current_work",
+        { status: "Writing regression tests" },
+        { content: [] },
+        1,
+      ),
+    ).toEqual([]);
+    expect(
+      translator.translateToolExecutionEnd(
+        "current-work-1",
+        "set_current_work",
+        { content: [] },
+        false,
+        false,
+        2,
+      ),
+    ).toEqual([]);
+    expect(translator.translate(result)).toEqual([]);
+  });
+
   it("classifies ls as a directory listing", () => {
     const translator = createPiMessageTranslator();
     const message = makeAssistant([

--- a/products/desktop/packages/agent/src/pi/conversation/translatePiMessage.ts
+++ b/products/desktop/packages/agent/src/pi/conversation/translatePiMessage.ts
@@ -25,6 +25,8 @@ import { readTranslator } from "./tools/readTranslator";
 import { writeTranslator } from "./tools/writeTranslator";
 import type { PiToolTranslator } from "./toolTranslator";
 
+const HIDDEN_PI_TOOL_NAMES = new Set(["set_current_work"]);
+
 const TRANSLATOR_BY_NAME: Record<PiToolName, PiToolTranslator> = {
   read: readTranslator,
   bash: bashTranslator,
@@ -34,6 +36,10 @@ const TRANSLATOR_BY_NAME: Record<PiToolName, PiToolTranslator> = {
   find: findTranslator,
   ls: lsTranslator,
 };
+
+function isHiddenPiTool(toolName: string): boolean {
+  return HIDDEN_PI_TOOL_NAMES.has(toolName);
+}
 
 interface PendingToolCall {
   name: string;
@@ -190,6 +196,10 @@ export function createPiMessageTranslator(): PiMessageTranslator {
       }
 
       if (block.type === "toolCall") {
+        if (isHiddenPiTool(block.name)) {
+          continue;
+        }
+
         pendingToolCalls.set(block.id, {
           name: block.name,
           arguments: block.arguments,
@@ -230,6 +240,10 @@ export function createPiMessageTranslator(): PiMessageTranslator {
     status: AgentToolCallStatus,
     timestamp: number,
   ): AgentConversationEvent[] {
+    if (isHiddenPiTool(toolName)) {
+      return [];
+    }
+
     const toolCall: Extract<
       AgentConversationEvent,
       { type: "tool_call_updated" }
@@ -319,6 +333,10 @@ export function createPiMessageTranslator(): PiMessageTranslator {
     },
 
     translateToolExecutionStart(toolCallId, toolName, args, timestamp) {
+      if (isHiddenPiTool(toolName)) {
+        return [];
+      }
+
       pendingToolCalls.set(toolCallId, { name: toolName, arguments: args });
 
       return [

--- a/products/desktop/packages/agent/src/server/agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.test.ts
@@ -420,7 +420,7 @@ describe("AgentServer HTTP Mode", () => {
     appendLogCalls = [];
     // Use a unique high port per test to avoid reuse and browser-blocked ports.
     port = getNextTestPort();
-  });
+  }, 30_000);
 
   afterEach(async () => {
     const runningServer = server;
@@ -429,7 +429,7 @@ describe("AgentServer HTTP Mode", () => {
       await runningServer?.stop();
     } finally {
       mswServer.resetHandlers();
-      await repo.cleanup();
+      await repo?.cleanup();
     }
   });
 

--- a/products/desktop/packages/harness/package.json
+++ b/products/desktop/packages/harness/package.json
@@ -48,6 +48,10 @@
       "types": "./dist/extensions/product-engineer/index.d.ts",
       "import": "./dist/extensions/product-engineer/index.js"
     },
+    "./extensions/current-work": {
+      "types": "./dist/extensions/current-work/index.d.ts",
+      "import": "./dist/extensions/current-work/index.js"
+    },
     "./extensions/web-access": {
       "types": "./dist/extensions/web-access/index.d.ts",
       "import": "./dist/extensions/web-access/index.js"

--- a/products/desktop/packages/harness/package.json
+++ b/products/desktop/packages/harness/package.json
@@ -49,8 +49,8 @@
       "import": "./dist/extensions/product-engineer/index.js"
     },
     "./extensions/current-work": {
-      "types": "./dist/extensions/current-work/index.d.ts",
-      "import": "./dist/extensions/current-work/index.js"
+      "types": "./dist/extensions/current-work/extension.d.ts",
+      "import": "./dist/extensions/current-work/extension.js"
     },
     "./extensions/web-access": {
       "types": "./dist/extensions/web-access/index.d.ts",

--- a/products/desktop/packages/harness/src/extensions/README.md
+++ b/products/desktop/packages/harness/src/extensions/README.md
@@ -65,3 +65,8 @@ extension is loaded everywhere with no further wiring:
 The CLI path shows each extension's directory name in Pi's startup banner. The runtime path uses
 named `InlineExtension` values, so those extensions appear as `<inline:name>` rather than anonymous
 `<inline:N>` entries. Both paths use Pi's native extension loader.
+
+## Current work
+
+The `current-work` extension lets the agent update the generating indicator with the current task
+phase. It does not add a conversation-history entry.

--- a/products/desktop/packages/harness/src/extensions/current-work/extension.test.ts
+++ b/products/desktop/packages/harness/src/extensions/current-work/extension.test.ts
@@ -60,12 +60,16 @@ function setup(mode: "rpc" | "tui" = "rpc") {
   } as unknown as ExtensionAPI);
 
   const currentWorkHandler = handlers.get("tool_call") as ToolCallHandler;
+  const beforeAgentStartHandler = handlers.get(
+    "before_agent_start",
+  ) as LifecycleHandler;
   const agentEndHandler = handlers.get("agent_end") as LifecycleHandler;
   const agentStartHandler = handlers.get("agent_start") as LifecycleHandler;
   const settledHandler = handlers.get("agent_settled") as LifecycleHandler;
   if (
     !currentWorkTool ||
     !currentWorkHandler ||
+    !beforeAgentStartHandler ||
     !agentStartHandler ||
     !agentEndHandler ||
     !settledHandler
@@ -76,6 +80,7 @@ function setup(mode: "rpc" | "tui" = "rpc") {
   return {
     agentEndHandler,
     agentStartHandler,
+    beforeAgentStartHandler,
     context,
     currentWorkHandler,
     currentWorkTool,
@@ -86,6 +91,23 @@ function setup(mode: "rpc" | "tui" = "rpc") {
 }
 
 describe("current-work extension", () => {
+  it("injects a set_current_work reminder after the user message at agent start", () => {
+    const extension = setup();
+
+    const result = extension.beforeAgentStartHandler(
+      {} as never,
+      extension.context,
+    ) as {
+      message?: { customType: string; content: string; display: boolean };
+    };
+
+    expect(result.message?.customType).toBe("current-work-reminder");
+    expect(result.message?.content).toBe(
+      "Set the visible current-work status before starting a task phase.",
+    );
+    expect(result.message?.display).toBe(false);
+  });
+
   it("hides current-work calls, lets other tools run, and clears after the agent settles", async () => {
     const extension = setup();
 

--- a/products/desktop/packages/harness/src/extensions/current-work/extension.test.ts
+++ b/products/desktop/packages/harness/src/extensions/current-work/extension.test.ts
@@ -1,0 +1,165 @@
+import type {
+  ExtensionAPI,
+  ExtensionContext,
+  ToolCallEvent,
+} from "@earendil-works/pi-coding-agent";
+import { describe, expect, it, vi } from "vitest";
+import { createCurrentWorkExtension } from "./extension";
+
+type ToolCallHandler = (
+  event: ToolCallEvent,
+  context: ExtensionContext,
+) => unknown;
+
+type LifecycleHandler = (event: unknown, context: ExtensionContext) => unknown;
+
+type EmptyRenderer = () => { render: (width: number) => string[] };
+
+type CurrentWorkTool = {
+  renderCall: EmptyRenderer;
+  renderResult: EmptyRenderer;
+  renderShell: "self";
+  execute: (
+    toolCallId: string,
+    params: { status: string },
+    signal: AbortSignal | undefined,
+    onUpdate: undefined,
+    context: ExtensionContext,
+  ) => Promise<unknown>;
+};
+
+function toolCall(
+  toolName: string,
+  input: Record<string, unknown> = {},
+): ToolCallEvent {
+  return {
+    type: "tool_call",
+    toolCallId: "call-1",
+    toolName,
+    input,
+  } as ToolCallEvent;
+}
+
+function setup(mode: "rpc" | "tui" = "rpc") {
+  const handlers = new Map<string, ToolCallHandler | LifecycleHandler>();
+  const setStatus = vi.fn();
+  const setWorkingMessage = vi.fn();
+  let currentWorkTool: CurrentWorkTool | undefined;
+  const context = {
+    mode,
+    ui: { setStatus, setWorkingMessage },
+  } as unknown as ExtensionContext;
+
+  createCurrentWorkExtension()({
+    on: (event: string, handler: ToolCallHandler | LifecycleHandler) => {
+      handlers.set(event, handler);
+    },
+    registerTool: (tool: CurrentWorkTool) => {
+      currentWorkTool = tool;
+    },
+  } as unknown as ExtensionAPI);
+
+  const currentWorkHandler = handlers.get("tool_call") as ToolCallHandler;
+  const agentEndHandler = handlers.get("agent_end") as LifecycleHandler;
+  const agentStartHandler = handlers.get("agent_start") as LifecycleHandler;
+  const settledHandler = handlers.get("agent_settled") as LifecycleHandler;
+  if (
+    !currentWorkTool ||
+    !currentWorkHandler ||
+    !agentStartHandler ||
+    !agentEndHandler ||
+    !settledHandler
+  ) {
+    throw new Error("Current-work extension was not initialized");
+  }
+
+  return {
+    agentEndHandler,
+    agentStartHandler,
+    context,
+    currentWorkHandler,
+    currentWorkTool,
+    settledHandler,
+    setStatus,
+    setWorkingMessage,
+  };
+}
+
+describe("current-work extension", () => {
+  it("hides current-work calls, lets other tools run, and clears after the agent settles", async () => {
+    const extension = setup();
+
+    expect(
+      await extension.currentWorkHandler(toolCall("read"), extension.context),
+    ).toBeUndefined();
+    expect(extension.currentWorkTool.renderShell).toBe("self");
+    expect(extension.currentWorkTool.renderCall().render(80)).toEqual([]);
+    expect(extension.currentWorkTool.renderResult().render(80)).toEqual([]);
+
+    await extension.currentWorkHandler(
+      toolCall("set_current_work", { status: "Writing regression tests" }),
+      extension.context,
+    );
+    await expect(
+      extension.currentWorkTool.execute(
+        "call-1",
+        { status: "Writing regression tests" },
+        undefined,
+        undefined,
+        extension.context,
+      ),
+    ).resolves.toMatchObject({
+      details: { status: "Writing regression tests" },
+    });
+    expect(
+      await extension.currentWorkHandler(toolCall("read"), extension.context),
+    ).toBeUndefined();
+
+    expect(extension.setStatus).toHaveBeenLastCalledWith(
+      "current-work",
+      "Writing regression tests",
+    );
+    expect(extension.setWorkingMessage).toHaveBeenLastCalledWith(
+      "Writing regression tests... (0s)",
+    );
+
+    await extension.agentEndHandler({}, extension.context);
+
+    expect(extension.setStatus).toHaveBeenLastCalledWith(
+      "current-work",
+      "Writing regression tests",
+    );
+    expect(extension.setWorkingMessage).toHaveBeenLastCalledWith();
+
+    await extension.settledHandler({}, extension.context);
+
+    expect(extension.setStatus).toHaveBeenLastCalledWith(
+      "current-work",
+      undefined,
+    );
+  });
+
+  it("shows elapsed time with the current task phase", async () => {
+    vi.useFakeTimers();
+    try {
+      const extension = setup("tui");
+
+      await extension.agentStartHandler({}, extension.context);
+      await extension.currentWorkHandler(
+        toolCall("set_current_work", { status: "Writing regression tests" }),
+        extension.context,
+      );
+      vi.advanceTimersByTime(2_000);
+
+      expect(extension.setStatus).not.toHaveBeenCalled();
+      expect(extension.setWorkingMessage).toHaveBeenLastCalledWith(
+        "Writing regression tests... (2s)",
+      );
+
+      await extension.agentEndHandler({}, extension.context);
+      expect(extension.setWorkingMessage).toHaveBeenLastCalledWith();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/products/desktop/packages/harness/src/extensions/current-work/extension.ts
+++ b/products/desktop/packages/harness/src/extensions/current-work/extension.ts
@@ -1,0 +1,172 @@
+import type {
+  ExtensionAPI,
+  ExtensionContext,
+  ExtensionFactory,
+  ToolCallEvent,
+} from "@earendil-works/pi-coding-agent";
+import { Container } from "@earendil-works/pi-tui";
+import { Type } from "typebox";
+
+const CURRENT_WORK_STATUS_KEY = "current-work";
+const CURRENT_WORK_TOOL_NAME = "set_current_work";
+const MIN_STATUS_LENGTH = 3;
+const MAX_STATUS_LENGTH = 72;
+
+function normalizeStatus(value: string): string {
+  return value.trim().replace(/\.+$/, "");
+}
+
+function isCurrentWorkToolCall(event: ToolCallEvent): boolean {
+  return event.toolName === CURRENT_WORK_TOOL_NAME;
+}
+
+function currentWorkFromEvent(event: ToolCallEvent): string | null {
+  if (!isCurrentWorkToolCall(event)) {
+    return null;
+  }
+
+  const input = event.input as Record<string, unknown>;
+  if (typeof input.status !== "string") {
+    return null;
+  }
+
+  const status = normalizeStatus(input.status);
+  if (
+    status.length < MIN_STATUS_LENGTH ||
+    status.length > MAX_STATUS_LENGTH ||
+    /[\r\n]/.test(status)
+  ) {
+    return null;
+  }
+
+  return status;
+}
+
+function formatElapsed(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes > 0) {
+    return `${minutes}m ${seconds.toString().padStart(2, "0")}s`;
+  }
+  return `${seconds}s`;
+}
+
+export function createCurrentWorkExtension(): ExtensionFactory {
+  return (pi: ExtensionAPI) => {
+    let currentWork: string | undefined;
+    let startedAt: number | undefined;
+    let interval: ReturnType<typeof setInterval> | undefined;
+
+    const updateWorkingMessage = (
+      context: Pick<ExtensionContext, "ui">,
+    ): void => {
+      const elapsed = startedAt === undefined ? 0 : Date.now() - startedAt;
+      context.ui.setWorkingMessage(
+        `${currentWork ?? "Working"}... (${formatElapsed(elapsed)})`,
+      );
+    };
+
+    const stopTimer = (context: Pick<ExtensionContext, "ui">): void => {
+      if (interval) {
+        clearInterval(interval);
+        interval = undefined;
+      }
+      startedAt = undefined;
+      context.ui.setWorkingMessage();
+    };
+
+    const startTimer = (context: Pick<ExtensionContext, "ui">): void => {
+      if (interval) {
+        clearInterval(interval);
+      }
+      startedAt = Date.now();
+      updateWorkingMessage(context);
+      interval = setInterval(() => updateWorkingMessage(context), 1000);
+    };
+
+    const setCurrentWork = (
+      context: Pick<ExtensionContext, "mode" | "ui">,
+      status: string,
+    ): void => {
+      currentWork = status;
+      if (context.mode === "rpc") {
+        context.ui.setStatus(CURRENT_WORK_STATUS_KEY, status);
+      }
+      updateWorkingMessage(context);
+    };
+
+    const clearCurrentWork = (
+      context: Pick<ExtensionContext, "mode" | "ui">,
+    ): void => {
+      currentWork = undefined;
+      if (context.mode === "rpc") {
+        context.ui.setStatus(CURRENT_WORK_STATUS_KEY, undefined);
+      }
+    };
+
+    pi.registerTool({
+      name: CURRENT_WORK_TOOL_NAME,
+      label: "Set current work",
+      description:
+        "Set the visible current-work status before starting a meaningful tool-use phase.",
+      promptSnippet:
+        "Set the visible current-work status before starting a meaningful tool-use phase",
+      promptGuidelines: [
+        "Use set_current_work before a meaningful new task phase when practical. Use a concise present-participle phrase that names the current phase, such as 'Inspecting the test setup' or 'Writing regression tests'. Keep the phrase at the task-phase level, not per individual tool call.",
+      ],
+      renderShell: "self",
+      renderCall: () => new Container(),
+      renderResult: () => new Container(),
+      parameters: Type.Object({
+        status: Type.String({
+          description:
+            "A concise present-participle phrase for the current task phase, without ending punctuation.",
+          minLength: MIN_STATUS_LENGTH,
+          maxLength: MAX_STATUS_LENGTH,
+        }),
+      }),
+      execute: async (_toolCallId, params, _signal, _onUpdate, context) => {
+        const status = normalizeStatus(params.status);
+        if (!status || /[\r\n]/.test(status)) {
+          throw new Error("Status must be a single-line phrase.");
+        }
+
+        setCurrentWork(context, status);
+
+        return {
+          content: [{ type: "text", text: `Current work: ${status}` }],
+          details: { status },
+        };
+      },
+    });
+
+    pi.on("tool_call", (event, context) => {
+      const status = currentWorkFromEvent(event);
+      if (status) {
+        setCurrentWork(context, status);
+      }
+    });
+
+    pi.on("agent_start", (_event, context) => {
+      startTimer(context);
+    });
+
+    pi.on("agent_end", (_event, context) => {
+      stopTimer(context);
+    });
+
+    pi.on("agent_settled", (_event, context) => {
+      clearCurrentWork(context);
+    });
+
+    pi.on("session_shutdown", (_event, context) => {
+      stopTimer(context);
+      clearCurrentWork(context);
+    });
+  };
+}
+
+export default function currentWork(pi: ExtensionAPI): void {
+  createCurrentWorkExtension()(pi);
+}

--- a/products/desktop/packages/harness/src/extensions/current-work/extension.ts
+++ b/products/desktop/packages/harness/src/extensions/current-work/extension.ts
@@ -109,11 +109,11 @@ export function createCurrentWorkExtension(): ExtensionFactory {
       name: CURRENT_WORK_TOOL_NAME,
       label: "Set current work",
       description:
-        "Set the visible current-work status before starting a meaningful tool-use phase.",
+        "Set the visible current-work status before starting a meaningful task phase.",
       promptSnippet:
-        "Set the visible current-work status before starting a meaningful tool-use phase",
+        "Set the visible current-work status before starting a task phase",
       promptGuidelines: [
-        "Use set_current_work before a meaningful new task phase when practical. Use a concise present-participle phrase that names the current phase, such as 'Inspecting the test setup' or 'Writing regression tests'. Keep the phrase at the task-phase level, not per individual tool call.",
+        "Use set_current_work before a new task phase. Use a concise present-participle phrase that names the current phase, such as 'Inspecting the test setup' or 'Writing regression tests'. Keep the phrase at the task phase level, not per individual tool call.",
       ],
       renderShell: "self",
       renderCall: () => new Container(),

--- a/products/desktop/packages/harness/src/extensions/current-work/extension.ts
+++ b/products/desktop/packages/harness/src/extensions/current-work/extension.ts
@@ -128,8 +128,14 @@ export function createCurrentWorkExtension(): ExtensionFactory {
       }),
       execute: async (_toolCallId, params, _signal, _onUpdate, context) => {
         const status = normalizeStatus(params.status);
-        if (!status || /[\r\n]/.test(status)) {
-          throw new Error("Status must be a single-line phrase.");
+        if (
+          status.length < MIN_STATUS_LENGTH ||
+          status.length > MAX_STATUS_LENGTH ||
+          /[\r\n]/.test(status)
+        ) {
+          throw new Error(
+            `Status must be a single-line phrase of ${MIN_STATUS_LENGTH}-${MAX_STATUS_LENGTH} characters.`,
+          );
         }
 
         setCurrentWork(context, status);

--- a/products/desktop/packages/harness/src/extensions/current-work/extension.ts
+++ b/products/desktop/packages/harness/src/extensions/current-work/extension.ts
@@ -9,6 +9,9 @@ import { Type } from "typebox";
 
 const CURRENT_WORK_STATUS_KEY = "current-work";
 const CURRENT_WORK_TOOL_NAME = "set_current_work";
+const CURRENT_WORK_TOOL_DESCRIPTION =
+  "Set the visible current-work status before starting a task phase.";
+const CURRENT_WORK_REMINDER = CURRENT_WORK_TOOL_DESCRIPTION;
 const MIN_STATUS_LENGTH = 3;
 const MAX_STATUS_LENGTH = 72;
 
@@ -108,12 +111,13 @@ export function createCurrentWorkExtension(): ExtensionFactory {
     pi.registerTool({
       name: CURRENT_WORK_TOOL_NAME,
       label: "Set current work",
-      description:
-        "Set the visible current-work status before starting a meaningful task phase.",
-      promptSnippet:
-        "Set the visible current-work status before starting a task phase",
+      description: CURRENT_WORK_TOOL_DESCRIPTION,
+      promptSnippet: CURRENT_WORK_TOOL_DESCRIPTION,
       promptGuidelines: [
-        "Use set_current_work before a new task phase. Use a concise present-participle phrase that names the current phase, such as 'Inspecting the test setup' or 'Writing regression tests'. Keep the phrase at the task phase level, not per individual tool call.",
+        "Use set_current_work before a new task phase. " +
+          "Use a concise present-participle phrase that names the current phase, such as 'Inspecting the test setup' or 'Writing regression tests'. " +
+          "Keep the phrase at the task phase level, not per individual tool call. " +
+          "Reading and investigations also deserve a named piece of work.",
       ],
       renderShell: "self",
       renderCall: () => new Container(),
@@ -146,6 +150,14 @@ export function createCurrentWorkExtension(): ExtensionFactory {
         };
       },
     });
+
+    pi.on("before_agent_start", () => ({
+      message: {
+        customType: "current-work-reminder",
+        content: CURRENT_WORK_REMINDER,
+        display: false,
+      },
+    }));
 
     pi.on("tool_call", (event, context) => {
       const status = currentWorkFromEvent(event);

--- a/products/desktop/packages/harness/src/extensions/current-work/index.ts
+++ b/products/desktop/packages/harness/src/extensions/current-work/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./extension";

--- a/products/desktop/packages/harness/src/extensions/current-work/index.ts
+++ b/products/desktop/packages/harness/src/extensions/current-work/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./extension";

--- a/products/desktop/packages/harness/src/extensions/entrypoints.ts
+++ b/products/desktop/packages/harness/src/extensions/entrypoints.ts
@@ -2,7 +2,7 @@ export const HARNESS_EXTENSION_ENTRYPOINTS = {
   "hog-branding": "hog-branding/index",
   "posthog-provider": "posthog-provider/index",
   "product-engineer": "product-engineer/index",
-  "current-work": "current-work/index",
+  "current-work": "current-work/extension",
   "background-jobs": "background-jobs/index",
   orchestration: "orchestration/index",
   "web-access": "web-access/index",

--- a/products/desktop/packages/harness/src/extensions/entrypoints.ts
+++ b/products/desktop/packages/harness/src/extensions/entrypoints.ts
@@ -2,6 +2,7 @@ export const HARNESS_EXTENSION_ENTRYPOINTS = {
   "hog-branding": "hog-branding/index",
   "posthog-provider": "posthog-provider/index",
   "product-engineer": "product-engineer/index",
+  "current-work": "current-work/index",
   "background-jobs": "background-jobs/index",
   orchestration: "orchestration/index",
   "web-access": "web-access/index",

--- a/products/desktop/packages/harness/src/extensions/registry.ts
+++ b/products/desktop/packages/harness/src/extensions/registry.ts
@@ -3,6 +3,7 @@ import type {
   ExtensionFactory,
   InlineExtension,
 } from "@earendil-works/pi-coding-agent";
+import { createCurrentWorkExtension } from "./current-work/extension";
 import {
   HARNESS_EXTENSION_ENTRYPOINTS,
   type HarnessExtensionName,
@@ -35,6 +36,7 @@ const EXTENSIONS: HarnessExtension[] = [
   { name: "hog-branding", create: createHogBrandingExtension },
   { name: "posthog-provider", create: createPosthogProviderExtension },
   { name: "product-engineer", create: () => createProductEngineerExtension() },
+  { name: "current-work", create: () => createCurrentWorkExtension() },
   { name: "orchestration", create: () => createOrchestrationExtension() },
   { name: "rtk", create: () => createRtkExtension() },
   { name: "web-access", create: createWebAccessExtension },

--- a/products/desktop/packages/harness/src/runtime.test.ts
+++ b/products/desktop/packages/harness/src/runtime.test.ts
@@ -52,6 +52,7 @@ describe("createHarnessRuntime", () => {
           expect.arrayContaining([
             "<inline:hog-branding>",
             "<inline:posthog-provider>",
+            "<inline:current-work>",
             "<inline:orchestration>",
             "<inline:web-access>",
             "<inline:mcp>",

--- a/products/desktop/packages/ui/src/features/pi-sessions/PiSessionView.tsx
+++ b/products/desktop/packages/ui/src/features/pi-sessions/PiSessionView.tsx
@@ -630,6 +630,8 @@ export function PiSessionView({ task, isCloud }: PiSessionViewProps) {
 
   const currentExtensionState =
     extensionState ?? createEmptyPiExtensionTaskState();
+  const { "current-work": currentWork, ...extensionStatuses } =
+    currentExtensionState.statuses;
   const extensionDialog = currentExtensionState.dialogs[0];
 
   return (
@@ -662,6 +664,7 @@ export function PiSessionView({ task, isCloud }: PiSessionViewProps) {
           repoPath={repoPath}
           promptRecallRef={promptRecallRef}
           hasPendingPermission={Boolean(mcpPermission)}
+          currentWork={currentWork}
         />
       </div>
       <div
@@ -673,7 +676,7 @@ export function PiSessionView({ task, isCloud }: PiSessionViewProps) {
           onEdit={editQueuedMessage}
           onRemove={removeQueuedMessage}
         />
-        <PiExtensionStatuses statuses={currentExtensionState.statuses} />
+        <PiExtensionStatuses statuses={extensionStatuses} />
         <PiExtensionWidgets
           widgets={currentExtensionState.widgets}
           placement="aboveEditor"

--- a/products/desktop/packages/ui/src/features/sessions/components/GeneratingIndicator.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/GeneratingIndicator.tsx
@@ -53,6 +53,7 @@ interface GeneratingIndicatorProps {
    *  behind, the hint adds a ticking "quiet for Ns" so a turn that renders
    *  nothing for minutes still reads as running rather than hung. */
   lastActivityAt?: number | null;
+  currentWork?: string;
 }
 
 export function GeneratingIndicator({
@@ -60,6 +61,7 @@ export function GeneratingIndicator({
   pausedDurationMs,
   activityKey,
   lastActivityAt,
+  currentWork,
 }: GeneratingIndicatorProps) {
   const [elapsed, setElapsed] = useState(0);
   const [quietFor, setQuietFor] = useState(0);
@@ -109,7 +111,7 @@ export function GeneratingIndicator({
     >
       <Brain size={12} className="ph-pulse shrink-0" />
       <Text render={<span />} className="truncate text-[13px] text-accent-11">
-        {activity}...
+        {currentWork ?? activity}...
       </Text>
       {/* The hint shrinks (and truncates) well before the activity word does. */}
       <Text

--- a/products/desktop/packages/ui/src/features/sessions/components/SessionFooter.stories.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SessionFooter.stories.tsx
@@ -53,6 +53,11 @@ export const GeneratingAtNarrowWidths: Story = {
 
 /** A turn that has rendered nothing for a while — one long tool call, or a
  *  thinking block the model kept to itself. */
+export const GeneratingWithCurrentWorkAtNarrowWidths: Story = {
+  args: { ...generatingArgs, currentWork: "Writing regression tests" },
+  render: (args) => <AtWidths args={args} />,
+};
+
 export const GeneratingWhileQuietAtNarrowWidths: Story = {
   args: {
     ...generatingArgs,

--- a/products/desktop/packages/ui/src/features/sessions/components/SessionFooter.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SessionFooter.test.tsx
@@ -22,6 +22,21 @@ describe("SessionFooter", () => {
     expect(screen.queryByText(/Esc to stop/)).not.toBeInTheDocument();
   });
 
+  it("shows the current task phase while generating", () => {
+    render(
+      <Theme>
+        <SessionFooter
+          isPromptPending
+          promptStartedAt={Date.now()}
+          lastGenerationDuration={null}
+          currentWork="Writing regression tests"
+        />
+      </Theme>,
+    );
+
+    expect(screen.getByText("Writing regression tests...")).toBeInTheDocument();
+  });
+
   it("shows the generating footer for a background Codex turn", () => {
     render(
       <Theme>

--- a/products/desktop/packages/ui/src/features/sessions/components/SessionFooter.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SessionFooter.tsx
@@ -30,6 +30,7 @@ interface SessionFooterProps {
   /** Timestamp (ms) of the newest event in the thread; the generating indicator
    *  says how long it has been since one arrived. */
   lastActivityAt?: number | null;
+  currentWork?: string;
 }
 
 export function SessionFooter({
@@ -46,6 +47,7 @@ export function SessionFooter({
   isBackgroundTurnActive = false,
   completedToolCallCount,
   lastActivityAt,
+  currentWork,
 }: SessionFooterProps) {
   const rightSide = (
     <Flex align="center" gap="3" className="ml-auto shrink-0">
@@ -90,6 +92,7 @@ export function SessionFooter({
               pausedDurationMs={pausedDurationMs}
               activityKey={completedToolCallCount}
               lastActivityAt={lastActivityAt}
+              currentWork={currentWork}
             />
             {queuedCount > 0 && (
               <Text className="truncate text-[13px] text-muted-foreground">

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -1220,6 +1220,7 @@ interface SharedChatThreadProps {
   taskId?: string;
   footerState?: Omit<BuildResult, "items">;
   hasPendingPermission?: boolean;
+  currentWork?: string;
   /**
    * Chain index of the oldest loaded entry; 0 means the whole transcript is loaded. Above 0 the
    * thread renders windowed regardless of length, because only that body survives a prepend.
@@ -1328,6 +1329,7 @@ function ChatThreadRenderer({
   taskId,
   footerState,
   hasPendingPermission,
+  currentWork,
   promptRecallRef,
   olderHistoryCursor = 0,
   isLoadingOlderHistory,
@@ -1461,6 +1463,7 @@ function ChatThreadRenderer({
         taskId={taskId}
         footerState={footerState}
         hasPendingPermission={hasPendingPermission}
+        currentWork={currentWork}
       />
     </>
   );

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThreadFooter.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThreadFooter.tsx
@@ -19,6 +19,7 @@ interface ChatThreadFooterProps {
   taskId?: string;
   footerState?: Omit<BuildResult, "items">;
   hasPendingPermission?: boolean;
+  currentWork?: string;
 }
 
 /**
@@ -38,6 +39,7 @@ export function ChatThreadFooter({
   taskId,
   footerState,
   hasPendingPermission,
+  currentWork,
 }: ChatThreadFooterProps) {
   const showDebugLogs = useSettingsStore((s) => s.debugLogsCloudRuns);
   const eventFooterState = useConversationItems(events, isPromptPending, {
@@ -85,6 +87,7 @@ export function ChatThreadFooter({
         isBackgroundTurnActive={isBackgroundTurnActive}
         completedToolCallCount={completedToolCallCount}
         lastActivityAt={lastActivityAt}
+        currentWork={currentWork}
       />
     </div>
   );


### PR DESCRIPTION
## Problem

People using Hog and PostHog Desktop only see generic activity text while an agent works.

## Changes

- People now see an agent-provided task phase, such as "Writing regression tests", in the generating indicator.

<img width="1668" height="582" alt="CleanShot 2026-09-09 at 14 06 32@2x" src="https://github.com/user-attachments/assets/66f1d113-5a10-423f-a72b-790f8d2517be" />

## How did you test this code?

- Added extension tests for timer updates, settled cleanup, and hidden Hog rendering.
- Added translator coverage for suppressing all Desktop conversation events from current-work calls.
- Ran the affected Harness, agent, and UI Vitest tests, plus typechecks and `hogli ci:preflight --fix`.
- Rendered the new Storybook state at narrow widths.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- Updated the Harness extension guide.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent-created change. Skills used: `posthog-desktop`, `writing-tests`, `writing-ui-components`, `writing-user-facing-copy`, `running-ci-preflight`, and `writing-pr-descriptions`.
- The final design keeps the model-callable status tool hidden at the Hog renderer and Desktop translation boundaries.
