### PR TITLE
chore(alerts): remove schedule overlap test

### DIFF
--- a/posthog/temporal/tests/test_alerts_workflows.py
+++ b/posthog/temporal/tests/test_alerts_workflows.py
@@ -11,7 +11,7 @@ from django.conf import settings
 
 import pytest_asyncio
 from asgiref.sync import sync_to_async
-from temporalio.client import ScheduleOverlapPolicy, WorkflowFailureError
+from temporalio.client import WorkflowFailureError
 from temporalio.exceptions import WorkflowAlreadyStartedError
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
@@ -121,22 +121,6 @@ def test_schedule_is_registered_in_init_schedules():
     from posthog.temporal.schedule import schedules
 
     assert create_schedule_due_alert_checks_schedule in schedules
-
-
-@pytest.mark.asyncio
-async def test_due_alert_schedule_skips_overlapping_runs() -> None:
-    captured: dict = {}
-
-    async def create_schedule(*args, **kwargs) -> None:
-        captured["schedule"] = args[2]
-
-    with (
-        patch("posthog.temporal.alerts.schedule.a_schedule_exists", new=AsyncMock(return_value=False)),
-        patch("posthog.temporal.alerts.schedule.a_create_schedule", new=create_schedule),
-    ):
-        await create_schedule_due_alert_checks_schedule(MagicMock())
-
-    assert captured["schedule"].policy.overlap == ScheduleOverlapPolicy.SKIP
 
 
 def _valid_trends_query() -> dict:


### PR DESCRIPTION
## Problem

Reviewers do not need a test that only restates the schedule overlap configuration.

## Changes

- Removes the direct assertion for the scheduled-alert overlap policy.
- This mechanical cleanup changes no production behavior, API, or user interface.

## How did you test this code?

- Ran `uv run hogli ci:preflight --fix`; it passed with existing complexity advisories.
- Not run: this change removes a narrow test and changes no runtime code.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This removes internal test coverage only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Slack app used `/writing-tests`, `/stacking-prs`, and `/writing-pr-descriptions`. This follow-up depends on [PR #97378](https://github.com/PostHog/posthog/pull/97378). No private source data is in this patch.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0C0PRQA2HJ/p1788954733457789?thread_ts=1788954733.457789&cid=C0C0PRQA2HJ)*