### PR TITLE
fix(temporal): fail loudly on an unregistered task queue

### DIFF
--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -554,6 +554,18 @@ WORKFLOWS_DICT = _workflows
 ACTIVITIES_DICT = _activities
 
 
+def resolve_queue_registrations(
+    task_queue: str,
+) -> tuple[list[type[PostHogWorkflow]], list[typing.Callable[..., typing.Any]]]:
+    # The dicts are defaultdicts, so a plain lookup silently returns empty lists and Temporal
+    # rejects the worker with an opaque "no activities" error. Fail on an unregistered queue
+    # with the real cause instead.
+    if task_queue not in WORKFLOWS_DICT or task_queue not in ACTIVITIES_DICT:
+        raise ValueError(f'Task queue "{task_queue}" not found in WORKFLOWS_DICT or ACTIVITIES_DICT')
+
+    return list(WORKFLOWS_DICT[task_queue]), list(ACTIVITIES_DICT[task_queue])
+
+
 def workflows_include_data_import_syncs(workflows: collections.abc.Iterable[type]) -> bool:
     """True when this worker runs data-warehouse source syncs and must eagerly load the sources."""
     return any(wf in DATA_SYNC_WORKFLOWS for wf in workflows)
@@ -686,11 +698,7 @@ class Command(BaseCommand):
         health_max_idle_seconds = options.get("health_max_idle_seconds", None)
         disable_combined_metrics_server = options.get("disable_combined_metrics_server", False)
 
-        try:
-            workflows = list(WORKFLOWS_DICT[task_queue])
-            activities = list(ACTIVITIES_DICT[task_queue])
-        except KeyError:
-            raise ValueError(f'Task queue "{task_queue}" not found in WORKFLOWS_DICT or ACTIVITIES_DICT')
+        workflows, activities = resolve_queue_registrations(task_queue)
 
         # Data-import source modules import vendor SDKs (google-ads, etc.) at module scope, and those
         # SDKs register protobuf descriptors into a process-global pool that rejects a second

--- a/posthog/management/commands/test/test_start_temporal_worker.py
+++ b/posthog/management/commands/test/test_start_temporal_worker.py
@@ -8,6 +8,7 @@ from posthog.management.commands.start_temporal_worker import (
     WA_DIGEST_WORKFLOWS,
     WEEKLY_DIGEST_WORKFLOWS,
     _task_queue_specs,
+    resolve_queue_registrations,
     workflows_include_data_import_syncs,
 )
 
@@ -33,6 +34,14 @@ def test_wizard_queue_registers_workflows_and_activities() -> None:
     assert WIZARD_ACTIVITIES
     assert set(WIZARD_WORKFLOWS) <= workflows
     assert set(WIZARD_ACTIVITIES) <= activities
+
+
+def test_unknown_queue_raises_instead_of_registering_an_empty_worker() -> None:
+    # A missing registration must fail loudly at boot. The registry dicts are
+    # defaultdicts, so a silent empty lookup reaches Temporal and surfaces as the
+    # opaque "At least one activity... must be specified" error.
+    with pytest.raises(ValueError, match="not-a-registered-queue"):
+        resolve_queue_registrations("not-a-registered-queue")
 
 
 # Data-import sources import vendor SDKs (google-ads, etc.) that register protobuf descriptors into a


### PR DESCRIPTION
## Problem

When a dedicated Temporal worker polls a queue that has no entry in the registry (for example, a charts deployment sets `TEMPORAL_TASK_QUEUE=wizard-task-queue` but not `WIZARD_TASK_QUEUE`), the worker starts with zero workflows and activities. Temporal then rejects it with the opaque error:

```
ValueError: At least one activity, Nexus service, or workflow must be specified
```

The registry dicts are `defaultdict(set)`, so the existing lookup never raises `KeyError` and the intended `Task queue "..." not found` message was unreachable.

## Changes

- Extracts `resolve_queue_registrations`, which checks membership before lookup and raises the real `ValueError` for an unregistered queue.
- Adds a regression test for the unknown-queue path.

## How did you test this code?

- `uv run pytest posthog/management/commands/test/test_start_temporal_worker.py` — 8 passed.
- `uv run mypy --cache-fine-grained` on both touched files — clean.
- Reproduced the prod failure shape locally: with `WIZARD_TASK_QUEUE` unset, `resolve_queue_registrations("wizard-task-queue")` now raises `Task queue "wizard-task-queue" not found...` instead of building an empty worker.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No doc change needed; `docs/internal/wizard-registry.md` already instructs operators to set both envs.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)