### PR TITLE
feat(cdp): add the legacy_destination hog function type

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -7426,6 +7426,7 @@ export type HogFunctionTypeType =
     | 'site_app'
     | 'transformation'
     | 'transformation_log'
+    | 'legacy_destination'
 
 export type HogFunctionType = {
     id: string

--- a/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.test.ts
@@ -9,7 +9,7 @@ import { forSnapshot } from '~/tests/helpers/snapshots'
 import { createTestTeamFixture } from '~/tests/helpers/sql'
 
 import { Hub, Team } from '../../types'
-import { createHogExecutionGlobals } from '../_tests/fixtures'
+import { createHogExecutionGlobals, insertHogFunction } from '../_tests/fixtures'
 import { DESTINATION_PLUGINS_BY_ID } from '../legacy-plugins'
 import { LegacyPluginExecutorService } from '../services/legacy-plugin-executor.service'
 import { HogFunctionInvocationGlobals } from '../types'
@@ -317,7 +317,7 @@ describe('CdpLegacyEventsConsumer', () => {
 
             expect(invocations).toBeTruthy()
             expect(invocations.length).toBeGreaterThan(0)
-            expect(invocations[0].hogFunction.template_id).toBe('plugin-customerio-plugin')
+            expect(invocations[0].invocation.hogFunction.template_id).toBe('plugin-customerio-plugin')
 
             // Check that the loader was called and cached
             const cachedConfigs = consumer['pluginConfigsLoader'].getCache()[team.id.toString()]
@@ -366,7 +366,7 @@ describe('CdpLegacyEventsConsumer', () => {
             expect(invocations.length).toBeGreaterThan(0)
 
             // Check that the attachment was loaded into inputs
-            const hogFunction = invocations[0].hogFunction
+            const hogFunction = invocations[0].invocation.hogFunction
             expect(hogFunction.inputs).toBeTruthy()
             expect(hogFunction.inputs?.mappings).toBeTruthy()
             expect(hogFunction.inputs?.mappings?.value).toEqual({
@@ -408,7 +408,7 @@ describe('CdpLegacyEventsConsumer', () => {
             expect(invocations).toBeTruthy()
             expect(invocations.length).toBeGreaterThan(0)
 
-            const hogFunctionInvocation = invocations[0]
+            const hogFunctionInvocation = invocations[0].invocation
             expect(hogFunctionInvocation.hogFunction.template_id).toBe('plugin-customerio-plugin')
 
             // Verify the invocation structure is correct by executing it manually
@@ -480,7 +480,7 @@ describe('CdpLegacyEventsConsumer', () => {
             expect(invocations.length).toBeGreaterThan(0)
 
             // Verify that the inputs contain the actual object, not "[object Object]"
-            const inputs = invocations[0].state.globals.inputs as Record<string, any>
+            const inputs = invocations[0].invocation.state.globals.inputs as Record<string, any>
 
             expect(inputs.complexMapping).toBeDefined()
             expect(typeof inputs.complexMapping).not.toBe('string')
@@ -522,6 +522,71 @@ describe('CdpLegacyEventsConsumer', () => {
         it('should return empty array for teams with no configs', async () => {
             const hogFunctions = await consumer['pluginConfigsLoader'].get('99999')
             expect(hogFunctions).toEqual([])
+        })
+    })
+
+    describe('migrated legacy_destination hog functions', () => {
+        const migrate = async (overrides: Record<string, any> = {}) =>
+            insertHogFunction(hub.postgres, team.id, {
+                type: 'legacy_destination',
+                template_id: 'plugin-customerio-plugin',
+                name: 'Migrated Customer.io',
+                enabled: true,
+                inputs: {
+                    customerioSiteId: { value: '1234567890' },
+                    customerioToken: { value: 'cio-token' },
+                },
+                ...overrides,
+            })
+
+        it('runs the migrated hog function instead of the plugin config it replaces', async () => {
+            const migrated = await migrate()
+
+            const invocations = await consumer['getLegacyPluginHogFunctionInvocations'](invocation)
+
+            expect(invocations).toHaveLength(1)
+            expect(invocations[0].invocation.hogFunction.id).toBe(migrated.id)
+            expect(invocations[0].pluginConfigId).toBeNull()
+        })
+
+        it('still runs a plugin config whose template has not been migrated', async () => {
+            await migrate({ template_id: 'plugin-hubspot-plugin' })
+
+            const invocations = await consumer['getLegacyPluginHogFunctionInvocations'](invocation)
+            const templateIds = invocations.map((x) => x.invocation.hogFunction.template_id)
+
+            expect(templateIds).toEqual(expect.arrayContaining(['plugin-customerio-plugin', 'plugin-hubspot-plugin']))
+            expect(templateIds).toHaveLength(2)
+        })
+
+        it('invokes the underlying processor exactly once when both representations exist', async () => {
+            await migrate()
+            const onEvent = jest.spyOn(customerIoPlugin, 'onEvent')
+
+            await consumer.processEvent(invocation)
+
+            expect(onEvent).toHaveBeenCalledTimes(1)
+        })
+
+        it('does not run a disabled migrated hog function, and does not let it suppress the plugin config', async () => {
+            await migrate({ enabled: false })
+
+            const invocations = await consumer['getLegacyPluginHogFunctionInvocations'](invocation)
+
+            expect(invocations).toHaveLength(1)
+            expect(invocations[0].pluginConfigId).toBe(pluginConfig.id)
+        })
+
+        it('reports the migrated row against its own hog function id rather than the plugin config', async () => {
+            const migrated = await migrate()
+            const queueAppMetric = jest.spyOn(consumer['hogFunctionMonitoringService'], 'queueAppMetric')
+
+            await consumer.processEvent(invocation)
+
+            expect(queueAppMetric).toHaveBeenCalledWith(
+                expect.objectContaining({ app_source_id: migrated.id, team_id: team.id }),
+                'hog_function'
+            )
         })
     })
 

--- a/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.test.ts
@@ -1,6 +1,7 @@
 import { mockFetch } from '~/tests/helpers/mocks/request.mock'
 
 import { DateTime } from 'luxon'
+import { register } from 'prom-client'
 
 import { closeHub, createHub } from '~/common/utils/db/hub'
 import { PostgresUse } from '~/common/utils/db/postgres'
@@ -600,6 +601,24 @@ describe('CdpLegacyEventsConsumer', () => {
             const invocations = await consumer['getLegacyPluginHogFunctionInvocations'](invocation)
 
             expect(invocations).toHaveLength(1)
+        })
+
+        it('labels the execution with which representation ran it', async () => {
+            const metricName = 'cdp_legacy_event_consumer_execution_result_total'
+            register.getSingleMetric(metricName)?.reset()
+
+            await consumer.processEvent(invocation)
+
+            await migrate()
+            // A fresh consumer stands in for the reload that pubsub triggers in production, which
+            // invalidates the hog function manager's caches as well as this consumer's own
+            const migratedConsumer = new CdpLegacyEventsConsumer(hub, createCdpConsumerDeps(hub))
+            await migratedConsumer.processEvent(invocation)
+
+            const metric = (await register.getMetricsAsJSON()).find((m) => m.name === metricName) as any
+            const sources = metric.values.map((v: any) => v.labels.source)
+
+            expect(sources).toEqual(['plugin_config', 'hog_function'])
         })
 
         it('reports the migrated row against its own hog function id rather than the plugin config', async () => {

--- a/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.test.ts
@@ -577,6 +577,31 @@ describe('CdpLegacyEventsConsumer', () => {
             expect(invocations[0].pluginConfigId).toBe(pluginConfig.id)
         })
 
+        it('passes secrets that live in encrypted_inputs to the processor', async () => {
+            await migrate({
+                inputs: { customerioSiteId: { value: '1234567890' } },
+                encrypted_inputs: hub.encryptedFields.encrypt(
+                    JSON.stringify({ customerioToken: { value: 'cio-token' } })
+                ) as any,
+            })
+
+            const invocations = await consumer['getLegacyPluginHogFunctionInvocations'](invocation)
+
+            expect(invocations[0].invocation.state.globals.inputs).toMatchObject({
+                customerioSiteId: '1234567890',
+                customerioToken: 'cio-token',
+            })
+        })
+
+        it('runs one of two migrated rows sharing a template, not both', async () => {
+            await migrate()
+            await migrate()
+
+            const invocations = await consumer['getLegacyPluginHogFunctionInvocations'](invocation)
+
+            expect(invocations).toHaveLength(1)
+        })
+
         it('reports the migrated row against its own hog function id rather than the plugin config', async () => {
             const migrated = await migrate()
             const queueAppMetric = jest.spyOn(consumer['hogFunctionMonitoringService'], 'queueAppMetric')

--- a/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.ts
@@ -50,16 +50,12 @@ type PluginConfigHogFunction = {
     hogFunction: HogFunctionType
 }
 
-const supersededPluginConfigCounter = new Counter({
-    name: 'cdp_legacy_event_consumer_superseded_plugin_config_total',
-    help: 'Plugin configs skipped because a migrated legacy_destination hog function covers the same template',
-    labelNames: ['template_id'],
-})
-
 const legacyPluginExecutionResultCounter = new Counter({
     name: 'cdp_legacy_event_consumer_execution_result_total',
     help: 'The number of times we have executed a legacy plugin',
-    labelNames: ['result', 'template_id'],
+    // `source` says which representation the consumer picked, so a migration can be watched as the
+    // share moving from plugin_config to hog_function while result stays where it was
+    labelNames: ['result', 'template_id', 'source'],
 })
 
 export type CdpLegacyEventsConsumerConfig = CdpConsumerBaseConfig &
@@ -260,11 +256,6 @@ export class CdpLegacyEventsConsumer extends CdpConsumerBase<CdpLegacyEventsCons
             const migrated = [...byTemplate.values()]
             const migratedTemplateIds = new Set(migrated.map((fn) => fn.template_id))
 
-            const superseded = pluginConfigFns.filter((x) => migratedTemplateIds.has(x.hogFunction.template_id))
-            for (const { hogFunction } of superseded) {
-                supersededPluginConfigCounter.labels({ template_id: hogFunction.template_id ?? 'unknown' }).inc()
-            }
-
             results[teamId] = [
                 ...pluginConfigFns.filter((x) => !migratedTemplateIds.has(x.hogFunction.template_id)),
                 ...migrated.map((hogFunction) => ({ pluginConfigId: null, hogFunction })),
@@ -352,6 +343,7 @@ export class CdpLegacyEventsConsumer extends CdpConsumerBase<CdpLegacyEventsCons
                 .labels({
                     result: error ? 'error' : 'success',
                     template_id: result.invocation.hogFunction.template_id,
+                    source: pluginConfigId !== null ? 'plugin_config' : 'hog_function',
                 })
                 .inc()
 

--- a/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.ts
@@ -100,6 +100,13 @@ export class CdpLegacyEventsConsumer extends CdpConsumerBase<CdpLegacyEventsCons
             refreshBackgroundAgeMs: 300000, // 5 minutes
             bufferMs: 10, // 10ms buffer for batching
         })
+
+        // This loader caches the combined plugin-config and migrated-function view, so the manager
+        // invalidating its own copy is not enough: enabling or deleting a migrated row has to change
+        // which of the two runs straight away, not at the next refresh.
+        deps.pubSub.on<{ teamId: number }>('reload-hog-functions', ({ teamId }) => {
+            this.pluginConfigsLoader.markForRefresh(teamId.toString())
+        })
     }
 
     private async loadAndBuildHogFunctions(teamIds: string[]): Promise<Record<string, PluginConfigHogFunction[]>> {
@@ -240,7 +247,17 @@ export class CdpLegacyEventsConsumer extends CdpConsumerBase<CdpLegacyEventsCons
         const results: Record<string, PluginConfigHogFunction[]> = {}
 
         for (const [teamId, pluginConfigFns] of Object.entries(fromPluginConfigs)) {
-            const migrated = fromHogFunctions[teamId] ?? []
+            // Nothing in the database stops two migrated rows sharing a template, and running both
+            // would send every event twice. Keep the oldest and ignore the rest.
+            const byTemplate = new Map<string, HogFunctionType>()
+            for (const fn of [...(fromHogFunctions[teamId] ?? [])].sort((a, b) => a.id.localeCompare(b.id))) {
+                const templateId = fn.template_id ?? ''
+                if (!byTemplate.has(templateId)) {
+                    byTemplate.set(templateId, fn)
+                }
+            }
+
+            const migrated = [...byTemplate.values()]
             const migratedTemplateIds = new Set(migrated.map((fn) => fn.template_id))
 
             const superseded = pluginConfigFns.filter((x) => migratedTemplateIds.has(x.hogFunction.template_id))
@@ -409,8 +426,9 @@ export class CdpLegacyEventsConsumer extends CdpConsumerBase<CdpLegacyEventsCons
         }
 
         return pluginConfigHogFunctions.map(({ hogFunction, pluginConfigId }) => {
-            // Plugin configs are always static { value: any } so we can just convert to a record of strings
-            const inputs = Object.entries(hogFunction.inputs || {}).reduce(
+            // Plugin configs are always static { value: any } so we can just convert to a record of strings.
+            // A migrated row keeps its secrets in encrypted_inputs, which the manager decrypts separately.
+            const inputs = Object.entries({ ...hogFunction.inputs, ...hogFunction.encrypted_inputs }).reduce(
                 (acc, [key, value]) => {
                     acc[key] = value?.value
                     return acc

--- a/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.ts
@@ -45,9 +45,16 @@ export type LightweightPluginConfig = {
 }
 
 type PluginConfigHogFunction = {
-    pluginConfigId: number
+    /** Null once the plugin config has been migrated and the hog function row is the source of truth */
+    pluginConfigId: number | null
     hogFunction: HogFunctionType
 }
+
+const supersededPluginConfigCounter = new Counter({
+    name: 'cdp_legacy_event_consumer_superseded_plugin_config_total',
+    help: 'Plugin configs skipped because a migrated legacy_destination hog function covers the same template',
+    labelNames: ['template_id'],
+})
 
 const legacyPluginExecutionResultCounter = new Counter({
     name: 'cdp_legacy_event_consumer_execution_result_total',
@@ -212,6 +219,41 @@ export class CdpLegacyEventsConsumer extends CdpConsumerBase<CdpLegacyEventsCons
             }
         }
 
+        return this.preferMigratedHogFunctions(results, await this.loadMigratedHogFunctions(teamIds))
+    }
+
+    private async loadMigratedHogFunctions(teamIds: string[]): Promise<Record<string, HogFunctionType[]>> {
+        const byTeam = await this.hogFunctionManager.getHogFunctionsForTeams(
+            teamIds.map((id) => parseInt(id)),
+            ['legacy_destination']
+        )
+
+        return Object.fromEntries(Object.entries(byTeam).map(([teamId, fns]) => [teamId, fns]))
+    }
+
+    // Both representations would run the same processor. Production has at most one enabled onEvent
+    // plugin config per team and plugin, so the template id identifies the pair and the migrated row wins.
+    private preferMigratedHogFunctions(
+        fromPluginConfigs: Record<string, PluginConfigHogFunction[]>,
+        fromHogFunctions: Record<string, HogFunctionType[]>
+    ): Record<string, PluginConfigHogFunction[]> {
+        const results: Record<string, PluginConfigHogFunction[]> = {}
+
+        for (const [teamId, pluginConfigFns] of Object.entries(fromPluginConfigs)) {
+            const migrated = fromHogFunctions[teamId] ?? []
+            const migratedTemplateIds = new Set(migrated.map((fn) => fn.template_id))
+
+            const superseded = pluginConfigFns.filter((x) => migratedTemplateIds.has(x.hogFunction.template_id))
+            for (const { hogFunction } of superseded) {
+                supersededPluginConfigCounter.labels({ template_id: hogFunction.template_id ?? 'unknown' }).inc()
+            }
+
+            results[teamId] = [
+                ...pluginConfigFns.filter((x) => !migratedTemplateIds.has(x.hogFunction.template_id)),
+                ...migrated.map((hogFunction) => ({ pluginConfigId: null, hogFunction })),
+            ]
+        }
+
         return results
     }
 
@@ -281,11 +323,12 @@ export class CdpLegacyEventsConsumer extends CdpConsumerBase<CdpLegacyEventsCons
         const invocations = await this.getLegacyPluginHogFunctionInvocations(invocation)
 
         const results = await Promise.all(
-            invocations.map(async (invocation) => this.legacyPluginExecutor.execute(invocation))
+            invocations.map(async ({ invocation, pluginConfigId }) =>
+                this.legacyPluginExecutor.execute(invocation).then((result) => ({ result, pluginConfigId }))
+            )
         )
 
-        for (const result of results) {
-            const pluginConfigId = parseInt(result.invocation.hogFunction.id.replace('legacy-', ''))
+        for (const { result, pluginConfigId } of results) {
             const error = result.error
 
             legacyPluginExecutionResultCounter
@@ -298,12 +341,12 @@ export class CdpLegacyEventsConsumer extends CdpConsumerBase<CdpLegacyEventsCons
             this.hogFunctionMonitoringService.queueAppMetric(
                 {
                     team_id: event.teamId,
-                    app_source_id: String(pluginConfigId),
+                    app_source_id: pluginConfigId !== null ? String(pluginConfigId) : result.invocation.hogFunction.id,
                     metric_kind: error ? 'failure' : 'success',
                     metric_name: error ? 'failed' : 'succeeded',
                     count: 1,
                 },
-                'legacy_plugin'
+                pluginConfigId !== null ? 'legacy_plugin' : 'hog_function'
             )
         }
     }
@@ -358,14 +401,14 @@ export class CdpLegacyEventsConsumer extends CdpConsumerBase<CdpLegacyEventsCons
 
     private async getLegacyPluginHogFunctionInvocations(
         invocation: HogFunctionInvocationGlobals
-    ): Promise<CyclotronJobInvocationHogFunction[]> {
+    ): Promise<{ invocation: CyclotronJobInvocationHogFunction; pluginConfigId: number | null }[]> {
         const pluginConfigHogFunctions = await this.pluginConfigsLoader.get(invocation.project.id.toString())
 
         if (!pluginConfigHogFunctions) {
             return []
         }
 
-        return pluginConfigHogFunctions.map(({ hogFunction }) => {
+        return pluginConfigHogFunctions.map(({ hogFunction, pluginConfigId }) => {
             // Plugin configs are always static { value: any } so we can just convert to a record of strings
             const inputs = Object.entries(hogFunction.inputs || {}).reduce(
                 (acc, [key, value]) => {
@@ -375,13 +418,16 @@ export class CdpLegacyEventsConsumer extends CdpConsumerBase<CdpLegacyEventsCons
                 {} as Record<string, string>
             )
 
-            return createInvocation(
-                {
-                    ...invocation,
-                    inputs,
-                },
-                hogFunction
-            )
+            return {
+                pluginConfigId,
+                invocation: createInvocation(
+                    {
+                        ...invocation,
+                        inputs,
+                    },
+                    hogFunction
+                ),
+            }
         })
     }
 

--- a/nodejs/src/cdp/types.ts
+++ b/nodejs/src/cdp/types.ts
@@ -564,6 +564,7 @@ export type HogFunctionTypeType =
     | 'source_webhook'
     | 'warehouse_source_webhook'
     | 'site_destination'
+    | 'legacy_destination'
 
 // Function types a cyclotron worker actually executes, so a rerun can safely re-enqueue
 // the stored invocation onto the cyclotron hog queue and have it run. Every other type

--- a/posthog/cdp/legacy_destination_migration.py
+++ b/posthog/cdp/legacy_destination_migration.py
@@ -191,3 +191,41 @@ def migrate_legacy_destinations(
             created.append(row["id"])
 
     return MigrationResult(created=created, skipped=skipped, dropped_inputs=dropped_inputs)
+
+
+def disable_migrated_plugin_configs(
+    *,
+    dry_run: bool = True,
+    team_ids: list[int] | None = None,
+) -> list[int]:
+    """Disable each enabled onEvent plugin config that a migrated hog function already covers.
+
+    Run this only once the migrated rows are known good. Until then the plugin config stays enabled
+    as the rollback: the consumer prefers the hog function, so only one of the pair ever runs, and
+    deleting the hog function hands the work straight back.
+
+    A config is left alone unless an enabled legacy_destination exists for its team and template.
+    """
+    candidates = PluginConfig.objects.filter(
+        enabled=True, deleted=False, plugin__capabilities__methods__contains=["onEvent"]
+    )
+    if team_ids:
+        candidates = candidates.filter(team_id__in=team_ids)
+
+    covered_pairs = set(
+        HogFunction.objects.filter(type=HogFunctionType.LEGACY_DESTINATION, enabled=True, deleted=False).values_list(
+            "team_id", "template_id"
+        )
+    )
+
+    to_disable = [
+        row["id"]
+        for row in candidates.values("id", "team_id", "plugin__url")
+        if (row["team_id"], f"plugin-{plugin_id_from_url(row['plugin__url'] or '')}") in covered_pairs
+    ]
+
+    if to_disable and not dry_run:
+        # nosemgrep: idor-lookup-without-team (internal migration; ids come from the team-scoped query above)
+        PluginConfig.objects.filter(id__in=to_disable).update(enabled=False)
+
+    return to_disable

--- a/posthog/cdp/legacy_destination_migration.py
+++ b/posthog/cdp/legacy_destination_migration.py
@@ -22,6 +22,14 @@ PLUGIN_ID_OVERRIDES = {
 class MigrationResult:
     created: list[int] = field(default_factory=list)
     skipped: dict[int, str] = field(default_factory=dict)
+    dropped_inputs: dict[int, list[str]] = field(default_factory=dict)
+
+
+@frozen
+class _BuildOutcome:
+    hog_function: HogFunction | None = None
+    skip_reason: str | None = None
+    dropped_inputs: list[str] = field(default_factory=list)
 
 
 def plugin_id_from_url(url: str) -> str:
@@ -48,17 +56,17 @@ def build_inputs(plugin_config: Mapping[str, Any], plugin_id: str) -> dict[str, 
     return inputs
 
 
-def _build_hog_function(plugin_config: Mapping[str, Any]) -> tuple[HogFunction | None, str | None]:
+def _build_hog_function(plugin_config: Mapping[str, Any], drop_unmapped_inputs: bool) -> _BuildOutcome:
     url: str = plugin_config["plugin__url"] or ""
 
     if not url:
-        return None, "plugin has no url"
+        return _BuildOutcome(skip_reason="plugin has no url")
 
     plugin_id = plugin_id_from_url(url)
     template = HogFunctionTemplate.get_template(f"plugin-{plugin_id}")
 
     if not template:
-        return None, f"no bundled template for plugin-{plugin_id}"
+        return _BuildOutcome(skip_reason=f"no bundled template for plugin-{plugin_id}")
 
     team_id = plugin_config["team_id"]
 
@@ -70,18 +78,22 @@ def _build_hog_function(plugin_config: Mapping[str, Any]) -> tuple[HogFunction |
         template_id=template.template_id,
         deleted=False,
     ).exists():
-        return None, "already migrated"
+        return _BuildOutcome(skip_reason="already migrated")
 
     inputs = build_inputs(plugin_config, plugin_id)
 
     # HogFunction.save() drops any key the template schema does not declare, without a trace
     schema_keys = {entry["key"] for entry in template.inputs_schema or []}
     unmapped = sorted(set(inputs) - schema_keys)
-    if unmapped:
-        return None, f"inputs not in the template schema: {', '.join(unmapped)}"
+    if unmapped and not drop_unmapped_inputs:
+        return _BuildOutcome(skip_reason=f"inputs not in the template schema: {', '.join(unmapped)}")
 
-    return (
-        HogFunction(
+    for key in unmapped:
+        del inputs[key]
+
+    return _BuildOutcome(
+        dropped_inputs=unmapped,
+        hog_function=HogFunction(
             team_id=team_id,
             type=HogFunctionType.LEGACY_DESTINATION,
             template_id=template.template_id,
@@ -96,7 +108,6 @@ def _build_hog_function(plugin_config: Mapping[str, Any]) -> tuple[HogFunction |
             enabled=True,
             deleted=False,
         ),
-        None,
     )
 
 
@@ -105,6 +116,7 @@ def migrate_legacy_destinations(
     dry_run: bool = True,
     team_ids: list[int] | None = None,
     plugin_config_ids: list[int] | None = None,
+    drop_unmapped_inputs: bool = False,
     batch_size: int = 100,
     limit: int | None = None,
 ) -> MigrationResult:
@@ -112,6 +124,10 @@ def migrate_legacy_destinations(
 
     The plugin config is left enabled. The consumer prefers the hog function for a matching template, so
     rolling back means deleting the hog function rather than restoring the plugin config.
+
+    A config carrying inputs the template schema does not declare is refused, because saving it would
+    drop them silently. Read them off a dry run, confirm the bundled processor ignores them, then pass
+    drop_unmapped_inputs to migrate anyway.
     """
     candidates = (
         PluginConfig.objects.values("id")
@@ -129,6 +145,7 @@ def migrate_legacy_destinations(
     candidate_ids = [row["id"] for row in candidates]
     created: list[int] = []
     skipped: dict[int, str] = {}
+    dropped_inputs: dict[int, list[str]] = {}
 
     for start in range(0, len(candidate_ids), batch_size):
         # nosemgrep: idor-lookup-without-team (internal migration; ids come from the team-scoped query above)
@@ -137,16 +154,19 @@ def migrate_legacy_destinations(
         )
 
         for row in batch:
-            hog_function, skip_reason = _build_hog_function(row)
+            outcome = _build_hog_function(row, drop_unmapped_inputs)
 
-            if hog_function is None:
-                skipped[row["id"]] = skip_reason or "unknown"
+            if outcome.hog_function is None:
+                skipped[row["id"]] = outcome.skip_reason or "unknown"
                 continue
+
+            if outcome.dropped_inputs:
+                dropped_inputs[row["id"]] = outcome.dropped_inputs
 
             if not dry_run:
                 # Saved one at a time rather than bulk, so each row fires the worker reload signal
-                hog_function.save()
+                outcome.hog_function.save()
 
             created.append(row["id"])
 
-    return MigrationResult(created=created, skipped=skipped)
+    return MigrationResult(created=created, skipped=skipped, dropped_inputs=dropped_inputs)

--- a/posthog/cdp/legacy_destination_migration.py
+++ b/posthog/cdp/legacy_destination_migration.py
@@ -37,21 +37,34 @@ def plugin_id_from_url(url: str) -> str:
     return PLUGIN_ID_OVERRIDES.get(plugin_id, plugin_id)
 
 
+def _as_consumer_value(value: Any) -> str:
+    """Mirror how CdpLegacyEventsConsumer builds inputs from a plugin config, so a migrated row hands
+    the processor exactly what it gets today. See `value?.toString() ?? ''` in that consumer."""
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return value if isinstance(value, str) else json.dumps(value, separators=(",", ":"))
+
+
 def build_inputs(plugin_config: Mapping[str, Any], plugin_id: str) -> dict[str, Any]:
-    inputs: dict[str, Any] = {key: {"value": value} for key, value in plugin_config["config"].items()}
+    inputs: dict[str, Any] = {
+        key: {"value": _as_consumer_value(value)} for key, value in plugin_config["config"].items()
+    }
 
     if plugin_id in STORAGE_BACKED_PLUGIN_IDS:
         inputs["legacy_plugin_config_id"] = {"value": str(plugin_config["id"])}
 
-    if plugin_config["config"]:
-        for attachment in PluginAttachment.objects.filter(plugin_config_id=plugin_config["id"]):
-            contents: Any = attachment.parse_contents()
-            try:
-                contents = json.loads(contents)
-            except Exception:
-                pass
-            if contents:
-                inputs[attachment.key] = {"value": contents}
+    # The consumer only folds attachments in when the config is non-empty. That drops the credential
+    # for a config that carries nothing else, so migrate the attachment either way.
+    for attachment in PluginAttachment.objects.filter(plugin_config_id=plugin_config["id"]):
+        contents: Any = attachment.parse_contents()
+        try:
+            contents = json.loads(contents)
+        except Exception:
+            pass
+        if contents:
+            inputs[attachment.key] = {"value": contents}
 
     return inputs
 
@@ -81,6 +94,15 @@ def _build_hog_function(plugin_config: Mapping[str, Any], drop_unmapped_inputs: 
         return _BuildOutcome(skip_reason="already migrated")
 
     inputs = build_inputs(plugin_config, plugin_id)
+
+    # A required input with nothing behind it saves cleanly and then fails at runtime with no credentials
+    missing = sorted(
+        entry["key"]
+        for entry in template.inputs_schema or []
+        if entry.get("required") and not inputs.get(entry["key"], {}).get("value")
+    )
+    if missing:
+        return _BuildOutcome(skip_reason=f"required inputs with no value: {', '.join(missing)}")
 
     # HogFunction.save() drops any key the template schema does not declare, without a trace
     schema_keys = {entry["key"] for entry in template.inputs_schema or []}

--- a/posthog/cdp/legacy_destination_migration.py
+++ b/posthog/cdp/legacy_destination_migration.py
@@ -1,0 +1,152 @@
+import json
+from collections.abc import Mapping
+from dataclasses import field
+from typing import Any
+
+from posthog.dataclasses import frozen
+
+from products.cdp.backend.models.hog_function_template import HogFunctionTemplate
+from products.cdp.backend.models.hog_functions.hog_function import HogFunction, HogFunctionType
+from products.cdp.backend.models.plugin import PluginAttachment, PluginConfig
+
+# Migrating one of these without its numeric plugin config id would reset its PluginStorage state
+STORAGE_BACKED_PLUGIN_IDS = {"first-time-event-tracker"}
+
+PLUGIN_ID_OVERRIDES = {
+    "semver-flattener": "semver-flattener-plugin",
+    "user-agent": "user-agent-plugin",
+}
+
+
+@frozen
+class MigrationResult:
+    created: list[int] = field(default_factory=list)
+    skipped: dict[int, str] = field(default_factory=dict)
+
+
+def plugin_id_from_url(url: str) -> str:
+    plugin_id = url.replace("inline://", "").replace("https://github.com/PostHog/", "")
+    return PLUGIN_ID_OVERRIDES.get(plugin_id, plugin_id)
+
+
+def build_inputs(plugin_config: Mapping[str, Any], plugin_id: str) -> dict[str, Any]:
+    inputs: dict[str, Any] = {key: {"value": value} for key, value in plugin_config["config"].items()}
+
+    if plugin_id in STORAGE_BACKED_PLUGIN_IDS:
+        inputs["legacy_plugin_config_id"] = {"value": str(plugin_config["id"])}
+
+    if plugin_config["config"]:
+        for attachment in PluginAttachment.objects.filter(plugin_config_id=plugin_config["id"]):
+            contents: Any = attachment.parse_contents()
+            try:
+                contents = json.loads(contents)
+            except Exception:
+                pass
+            if contents:
+                inputs[attachment.key] = {"value": contents}
+
+    return inputs
+
+
+def _build_hog_function(plugin_config: Mapping[str, Any]) -> tuple[HogFunction | None, str | None]:
+    url: str = plugin_config["plugin__url"] or ""
+
+    if not url:
+        return None, "plugin has no url"
+
+    plugin_id = plugin_id_from_url(url)
+    template = HogFunctionTemplate.get_template(f"plugin-{plugin_id}")
+
+    if not template:
+        return None, f"no bundled template for plugin-{plugin_id}"
+
+    team_id = plugin_config["team_id"]
+
+    # The consumer dedupes a plugin config against a migrated hog function by template id, so a second
+    # row for the same pair would leave the outcome dependent on load order.
+    if HogFunction.objects.filter(
+        team_id=team_id,
+        type=HogFunctionType.LEGACY_DESTINATION,
+        template_id=template.template_id,
+        deleted=False,
+    ).exists():
+        return None, "already migrated"
+
+    inputs = build_inputs(plugin_config, plugin_id)
+
+    # HogFunction.save() drops any key the template schema does not declare, without a trace
+    schema_keys = {entry["key"] for entry in template.inputs_schema or []}
+    unmapped = sorted(set(inputs) - schema_keys)
+    if unmapped:
+        return None, f"inputs not in the template schema: {', '.join(unmapped)}"
+
+    return (
+        HogFunction(
+            team_id=team_id,
+            type=HogFunctionType.LEGACY_DESTINATION,
+            template_id=template.template_id,
+            name=plugin_config["plugin__name"],
+            description=template.description or "",
+            icon_url=template.icon_url,
+            hog="",
+            bytecode=[],
+            inputs_schema=template.inputs_schema,
+            inputs=inputs,
+            filters=None,
+            enabled=True,
+            deleted=False,
+        ),
+        None,
+    )
+
+
+def migrate_legacy_destinations(
+    *,
+    dry_run: bool = True,
+    team_ids: list[int] | None = None,
+    plugin_config_ids: list[int] | None = None,
+    batch_size: int = 100,
+    limit: int | None = None,
+) -> MigrationResult:
+    """Move enabled onEvent plugin configs onto legacy_destination hog functions running the same bundled code.
+
+    The plugin config is left enabled. The consumer prefers the hog function for a matching template, so
+    rolling back means deleting the hog function rather than restoring the plugin config.
+    """
+    candidates = (
+        PluginConfig.objects.values("id")
+        .filter(enabled=True, deleted=False, plugin__capabilities__methods__contains=["onEvent"])
+        .order_by("id")
+    )
+
+    if team_ids:
+        candidates = candidates.filter(team_id__in=team_ids)
+    if plugin_config_ids:
+        candidates = candidates.filter(id__in=plugin_config_ids)
+    if limit:
+        candidates = candidates[:limit]
+
+    candidate_ids = [row["id"] for row in candidates]
+    created: list[int] = []
+    skipped: dict[int, str] = {}
+
+    for start in range(0, len(candidate_ids), batch_size):
+        # nosemgrep: idor-lookup-without-team (internal migration; ids come from the team-scoped query above)
+        batch = PluginConfig.objects.values("id", "config", "team_id", "plugin__name", "plugin__url").filter(
+            id__in=candidate_ids[start : start + batch_size]
+        )
+
+        for row in batch:
+            hog_function, skip_reason = _build_hog_function(row)
+
+            if hog_function is None:
+                skipped[row["id"]] = skip_reason or "unknown"
+                continue
+
+            if not dry_run:
+                # Saved one at a time rather than bulk, so each row fires the worker reload signal
+                hog_function.save()
+
+            created.append(row["id"])
+
+    return MigrationResult(created=created, skipped=skipped)

--- a/posthog/cdp/legacy_destination_migration.py
+++ b/posthog/cdp/legacy_destination_migration.py
@@ -138,7 +138,7 @@ def migrate_legacy_destinations(
     dry_run: bool = True,
     team_ids: list[int] | None = None,
     plugin_config_ids: list[int] | None = None,
-    drop_unmapped_inputs: bool = False,
+    drop_unmapped_inputs: bool = True,
     batch_size: int = 100,
     limit: int | None = None,
 ) -> MigrationResult:
@@ -147,9 +147,8 @@ def migrate_legacy_destinations(
     The plugin config is left enabled. The consumer prefers the hog function for a matching template, so
     rolling back means deleting the hog function rather than restoring the plugin config.
 
-    A config carrying inputs the template schema does not declare is refused, because saving it would
-    drop them silently. Read them off a dry run, confirm the bundled processor ignores them, then pass
-    drop_unmapped_inputs to migrate anyway.
+    Inputs the template schema does not declare are dropped, and every one is reported, because no
+    bundled processor reads them. Pass drop_unmapped_inputs=False to refuse those configs instead.
     """
     candidates = (
         PluginConfig.objects.values("id")

--- a/posthog/cdp/test/test_legacy_destination_migration.py
+++ b/posthog/cdp/test/test_legacy_destination_migration.py
@@ -1,6 +1,6 @@
 from posthog.test.base import BaseTest
 
-from posthog.cdp.legacy_destination_migration import migrate_legacy_destinations
+from posthog.cdp.legacy_destination_migration import disable_migrated_plugin_configs, migrate_legacy_destinations
 
 from products.cdp.backend.models.hog_function_template import HogFunctionTemplate
 from products.cdp.backend.models.hog_functions.hog_function import HogFunction, HogFunctionType
@@ -179,3 +179,45 @@ class TestLegacyDestinationMigration(BaseTest):
         result = migrate_legacy_destinations(dry_run=False, team_ids=[self.team.id + 1])
 
         assert result.created == []
+
+
+class TestDisableMigratedPluginConfigs(TestLegacyDestinationMigration):
+    def _disable(self, dry_run=False):
+        return disable_migrated_plugin_configs(dry_run=dry_run, team_ids=[self.team.id])
+
+    def test_disables_only_a_config_a_migrated_hog_function_covers(self):
+        covered = self._plugin_config()
+        uncovered = self._plugin_config(plugin=self._plugin(url="https://github.com/PostHog/not-bundled"))
+
+        self._migrate()
+        disabled = self._disable()
+
+        assert disabled == [covered.id]
+        covered.refresh_from_db()
+        uncovered.refresh_from_db()
+        assert covered.enabled is False
+        assert uncovered.enabled is True
+
+    def test_leaves_everything_enabled_before_the_migration_runs(self):
+        plugin_config = self._plugin_config()
+
+        assert self._disable() == []
+        plugin_config.refresh_from_db()
+        assert plugin_config.enabled is True
+
+    def test_dry_run_reports_without_disabling(self):
+        plugin_config = self._plugin_config()
+        self._migrate()
+
+        assert self._disable(dry_run=True) == [plugin_config.id]
+        plugin_config.refresh_from_db()
+        assert plugin_config.enabled is True
+
+    def test_ignores_a_migrated_row_that_is_disabled(self):
+        plugin_config = self._plugin_config()
+        self._migrate()
+        self._hog_functions().update(enabled=False)
+
+        assert self._disable() == []
+        plugin_config.refresh_from_db()
+        assert plugin_config.enabled is True

--- a/posthog/cdp/test/test_legacy_destination_migration.py
+++ b/posthog/cdp/test/test_legacy_destination_migration.py
@@ -36,7 +36,7 @@ class TestLegacyDestinationMigration(BaseTest):
         plugin.save()
         return plugin
 
-    def _migrate(self, dry_run=False, drop_unmapped_inputs=False):
+    def _migrate(self, dry_run=False, drop_unmapped_inputs=True):
         return migrate_legacy_destinations(
             dry_run=dry_run, team_ids=[self.team.id], drop_unmapped_inputs=drop_unmapped_inputs
         )
@@ -139,16 +139,16 @@ class TestLegacyDestinationMigration(BaseTest):
     def test_refuses_a_config_whose_inputs_the_template_schema_does_not_cover(self):
         plugin_config = self._plugin_config(config={"customerioSiteId": "site-1", "removedOption": "x"})
 
-        result = self._migrate()
+        result = self._migrate(drop_unmapped_inputs=False)
 
         assert result.created == []
         assert result.skipped == {plugin_config.id: "inputs not in the template schema: removedOption"}
         assert not self._hog_functions().exists()
 
-    def test_drops_unmapped_inputs_when_asked_and_reports_what_went(self):
+    def test_drops_unmapped_inputs_by_default_and_reports_what_went(self):
         plugin_config = self._plugin_config(config={"customerioSiteId": "site-1", "removedOption": "x"})
 
-        result = self._migrate(drop_unmapped_inputs=True)
+        result = self._migrate()
 
         assert result.created == [plugin_config.id]
         assert result.dropped_inputs == {plugin_config.id: ["removedOption"]}

--- a/posthog/cdp/test/test_legacy_destination_migration.py
+++ b/posthog/cdp/test/test_legacy_destination_migration.py
@@ -36,8 +36,10 @@ class TestLegacyDestinationMigration(BaseTest):
         plugin.save()
         return plugin
 
-    def _migrate(self, dry_run=False):
-        return migrate_legacy_destinations(dry_run=dry_run, team_ids=[self.team.id])
+    def _migrate(self, dry_run=False, drop_unmapped_inputs=False):
+        return migrate_legacy_destinations(
+            dry_run=dry_run, team_ids=[self.team.id], drop_unmapped_inputs=drop_unmapped_inputs
+        )
 
     def _hog_functions(self):
         return HogFunction.objects.filter(team=self.team, type=HogFunctionType.LEGACY_DESTINATION)
@@ -142,6 +144,17 @@ class TestLegacyDestinationMigration(BaseTest):
         assert result.created == []
         assert result.skipped == {plugin_config.id: "inputs not in the template schema: removedOption"}
         assert not self._hog_functions().exists()
+
+    def test_drops_unmapped_inputs_when_asked_and_reports_what_went(self):
+        plugin_config = self._plugin_config(config={"customerioSiteId": "site-1", "removedOption": "x"})
+
+        result = self._migrate(drop_unmapped_inputs=True)
+
+        assert result.created == [plugin_config.id]
+        assert result.dropped_inputs == {plugin_config.id: ["removedOption"]}
+        hog_function = self._hog_functions().get()
+        assert hog_function.inputs["customerioSiteId"] == {"value": "site-1"}
+        assert "removedOption" not in hog_function.inputs
 
     def test_moves_attachments_into_inputs(self):
         plugin_config = self._plugin_config()

--- a/posthog/cdp/test/test_legacy_destination_migration.py
+++ b/posthog/cdp/test/test_legacy_destination_migration.py
@@ -1,0 +1,168 @@
+from posthog.test.base import BaseTest
+
+from posthog.cdp.legacy_destination_migration import migrate_legacy_destinations
+
+from products.cdp.backend.models.hog_function_template import HogFunctionTemplate
+from products.cdp.backend.models.hog_functions.hog_function import HogFunction, HogFunctionType
+from products.cdp.backend.models.plugin import Plugin, PluginAttachment, PluginConfig
+
+
+class TestLegacyDestinationMigration(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.template = HogFunctionTemplate.objects.create(
+            template_id="plugin-customerio-plugin",
+            sha="1",
+            name="Customer.io",
+            description="Legacy Customer.io",
+            code="",
+            inputs_schema=[
+                {"key": "customerioSiteId", "type": "string"},
+                {"key": "mappings", "type": "json"},
+            ],
+            type="legacy_destination",
+        )
+
+    def _plugin(self, url="https://github.com/PostHog/customerio-plugin", methods=None):
+        plugin, _ = Plugin.objects.get_or_create(
+            url=url,
+            defaults={
+                "organization": self.organization,
+                "name": "Customer.io",
+                "plugin_type": "custom",
+            },
+        )
+        plugin.capabilities = {"methods": methods if methods is not None else ["onEvent"]}
+        plugin.save()
+        return plugin
+
+    def _migrate(self, dry_run=False):
+        return migrate_legacy_destinations(dry_run=dry_run, team_ids=[self.team.id])
+
+    def _hog_functions(self):
+        return HogFunction.objects.filter(team=self.team, type=HogFunctionType.LEGACY_DESTINATION)
+
+    def _plugin_config(self, plugin=None, config=None, **kwargs):
+        return PluginConfig.objects.create(
+            **{
+                "team": self.team,
+                "plugin": plugin or self._plugin(),
+                "enabled": True,
+                "order": 0,
+                "config": config if config is not None else {"customerioSiteId": "site-1"},
+                **kwargs,
+            }
+        )
+
+    def test_creates_one_enabled_hog_function_carrying_the_config(self):
+        plugin_config = self._plugin_config()
+
+        result = self._migrate()
+
+        assert result.created == [plugin_config.id]
+        hog_function = self._hog_functions().get()
+        assert hog_function.template_id == "plugin-customerio-plugin"
+        assert hog_function.enabled is True
+        assert hog_function.inputs["customerioSiteId"] == {"value": "site-1"}
+
+    def test_dry_run_reports_without_writing(self):
+        plugin_config = self._plugin_config()
+
+        result = self._migrate(dry_run=True)
+
+        assert result.created == [plugin_config.id]
+        assert not self._hog_functions().exists()
+
+    def test_rerunning_does_not_create_a_second_row_for_the_same_template(self):
+        self._plugin_config()
+
+        self._migrate()
+        second = self._migrate()
+
+        assert second.created == []
+        assert list(second.skipped.values()) == ["already migrated"]
+        assert self._hog_functions().count() == 1
+
+    def test_leaves_the_plugin_config_enabled_so_rollback_is_deleting_the_hog_function(self):
+        plugin_config = self._plugin_config()
+
+        self._migrate()
+
+        plugin_config.refresh_from_db()
+        assert plugin_config.enabled is True
+
+    def test_skips_plugins_without_a_bundled_template(self):
+        plugin_config = self._plugin_config(plugin=self._plugin(url="https://github.com/PostHog/not-bundled"))
+
+        result = self._migrate()
+
+        assert result.created == []
+        assert result.skipped == {plugin_config.id: "no bundled template for plugin-not-bundled"}
+
+    def test_ignores_configs_that_the_legacy_consumer_never_runs(self):
+        self._plugin_config(plugin=self._plugin(url="https://github.com/PostHog/geoip", methods=["processEvent"]))
+        self._plugin_config(enabled=False)
+        self._plugin_config(deleted=True)
+
+        result = self._migrate()
+
+        assert result.created == []
+        assert not self._hog_functions().exists()
+
+    def test_carries_the_plugin_config_id_only_for_storage_backed_plugins(self):
+        HogFunctionTemplate.objects.create(
+            template_id="plugin-first-time-event-tracker",
+            sha="1",
+            name="First time event tracker",
+            code="",
+            inputs_schema=[
+                {"key": "events", "type": "string"},
+                {"key": "legacy_plugin_config_id", "type": "string"},
+            ],
+            type="legacy_destination",
+        )
+        storage_backed = self._plugin_config(
+            plugin=self._plugin(url="https://github.com/PostHog/first-time-event-tracker"),
+            config={"events": "$pageview"},
+        )
+        self._plugin_config()
+
+        self._migrate()
+
+        tracker = self._hog_functions().get(template_id="plugin-first-time-event-tracker")
+        assert tracker.inputs["legacy_plugin_config_id"] == {"value": str(storage_backed.id)}
+        customerio = self._hog_functions().get(template_id="plugin-customerio-plugin")
+        assert "legacy_plugin_config_id" not in customerio.inputs
+
+    def test_refuses_a_config_whose_inputs_the_template_schema_does_not_cover(self):
+        plugin_config = self._plugin_config(config={"customerioSiteId": "site-1", "removedOption": "x"})
+
+        result = self._migrate()
+
+        assert result.created == []
+        assert result.skipped == {plugin_config.id: "inputs not in the template schema: removedOption"}
+        assert not self._hog_functions().exists()
+
+    def test_moves_attachments_into_inputs(self):
+        plugin_config = self._plugin_config()
+        PluginAttachment.objects.create(
+            team=self.team,
+            plugin_config=plugin_config,
+            key="mappings",
+            content_type="application/json",
+            file_name="mappings.json",
+            file_size=2,
+            contents=b'{"a": 1}',
+        )
+
+        self._migrate()
+
+        hog_function = self._hog_functions().get(template_id="plugin-customerio-plugin")
+        assert hog_function.inputs["mappings"] == {"value": {"a": 1}}
+
+    def test_limits_to_the_requested_team(self):
+        self._plugin_config()
+
+        result = migrate_legacy_destinations(dry_run=False, team_ids=[self.team.id + 1])
+
+        assert result.created == []

--- a/posthog/management/commands/migrate_legacy_destinations_to_hog_functions.py
+++ b/posthog/management/commands/migrate_legacy_destinations_to_hog_functions.py
@@ -16,6 +16,11 @@ class Command(BaseCommand):
         parser.add_argument("--dry-run", action="store_true", help="Report what would be migrated, and change nothing")
         parser.add_argument("--team-ids", type=str, help="Comma separated team ids to limit the migration to")
         parser.add_argument("--plugin-config-ids", type=str, help="Comma separated plugin config ids to migrate")
+        parser.add_argument(
+            "--drop-unmapped-inputs",
+            action="store_true",
+            help="Migrate configs carrying inputs the template schema does not declare, dropping those inputs",
+        )
         parser.add_argument("--batch-size", type=int, default=100, help="Plugin configs to load per batch")
         parser.add_argument("--limit", type=int, default=None, help="Stop after this many plugin configs")
 
@@ -24,6 +29,7 @@ class Command(BaseCommand):
             dry_run=options["dry_run"],
             team_ids=_int_list(options["team_ids"]),
             plugin_config_ids=_int_list(options["plugin_config_ids"]),
+            drop_unmapped_inputs=options["drop_unmapped_inputs"],
             batch_size=options["batch_size"],
             limit=options["limit"],
         )
@@ -33,3 +39,6 @@ class Command(BaseCommand):
 
         for plugin_config_id, reason in result.skipped.items():
             self.stdout.write(f"  skipped {plugin_config_id}: {reason}")
+
+        for plugin_config_id, keys in result.dropped_inputs.items():
+            self.stdout.write(f"  dropped inputs on {plugin_config_id}: {', '.join(keys)}")

--- a/posthog/management/commands/migrate_legacy_destinations_to_hog_functions.py
+++ b/posthog/management/commands/migrate_legacy_destinations_to_hog_functions.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from django.core.management.base import BaseCommand
 
-from posthog.cdp.legacy_destination_migration import migrate_legacy_destinations
+from posthog.cdp.legacy_destination_migration import disable_migrated_plugin_configs, migrate_legacy_destinations
 
 
 def _int_list(value: str | None) -> list[int] | None:
@@ -21,10 +21,23 @@ class Command(BaseCommand):
             action="store_true",
             help="Skip a config carrying inputs the template schema does not declare, rather than dropping them",
         )
+        parser.add_argument(
+            "--disable-migrated",
+            action="store_true",
+            help="Disable plugin configs a migrated hog function already covers, instead of migrating",
+        )
         parser.add_argument("--batch-size", type=int, default=100, help="Plugin configs to load per batch")
         parser.add_argument("--limit", type=int, default=None, help="Stop after this many plugin configs")
 
     def handle(self, *args: Any, **options: Any) -> None:
+        if options["disable_migrated"]:
+            disabled = disable_migrated_plugin_configs(
+                dry_run=options["dry_run"], team_ids=_int_list(options["team_ids"])
+            )
+            prefix = "Would disable" if options["dry_run"] else "Disabled"
+            self.stdout.write(f"{prefix} {len(disabled)} plugin config(s) already covered by a hog function")
+            return
+
         result = migrate_legacy_destinations(
             dry_run=options["dry_run"],
             team_ids=_int_list(options["team_ids"]),

--- a/posthog/management/commands/migrate_legacy_destinations_to_hog_functions.py
+++ b/posthog/management/commands/migrate_legacy_destinations_to_hog_functions.py
@@ -1,0 +1,35 @@
+from typing import Any
+
+from django.core.management.base import BaseCommand
+
+from posthog.cdp.legacy_destination_migration import migrate_legacy_destinations
+
+
+def _int_list(value: str | None) -> list[int] | None:
+    return [int(part) for part in value.split(",")] if value else None
+
+
+class Command(BaseCommand):
+    help = "Migrate enabled onEvent plugin configs to legacy_destination hog functions"
+
+    def add_arguments(self, parser: Any) -> None:
+        parser.add_argument("--dry-run", action="store_true", help="Report what would be migrated, and change nothing")
+        parser.add_argument("--team-ids", type=str, help="Comma separated team ids to limit the migration to")
+        parser.add_argument("--plugin-config-ids", type=str, help="Comma separated plugin config ids to migrate")
+        parser.add_argument("--batch-size", type=int, default=100, help="Plugin configs to load per batch")
+        parser.add_argument("--limit", type=int, default=None, help="Stop after this many plugin configs")
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        result = migrate_legacy_destinations(
+            dry_run=options["dry_run"],
+            team_ids=_int_list(options["team_ids"]),
+            plugin_config_ids=_int_list(options["plugin_config_ids"]),
+            batch_size=options["batch_size"],
+            limit=options["limit"],
+        )
+
+        prefix = "Would migrate" if options["dry_run"] else "Migrated"
+        self.stdout.write(f"{prefix} {len(result.created)} plugin config(s), skipped {len(result.skipped)}")
+
+        for plugin_config_id, reason in result.skipped.items():
+            self.stdout.write(f"  skipped {plugin_config_id}: {reason}")

--- a/posthog/management/commands/migrate_legacy_destinations_to_hog_functions.py
+++ b/posthog/management/commands/migrate_legacy_destinations_to_hog_functions.py
@@ -17,9 +17,9 @@ class Command(BaseCommand):
         parser.add_argument("--team-ids", type=str, help="Comma separated team ids to limit the migration to")
         parser.add_argument("--plugin-config-ids", type=str, help="Comma separated plugin config ids to migrate")
         parser.add_argument(
-            "--drop-unmapped-inputs",
+            "--strict-inputs",
             action="store_true",
-            help="Migrate configs carrying inputs the template schema does not declare, dropping those inputs",
+            help="Skip a config carrying inputs the template schema does not declare, rather than dropping them",
         )
         parser.add_argument("--batch-size", type=int, default=100, help="Plugin configs to load per batch")
         parser.add_argument("--limit", type=int, default=None, help="Stop after this many plugin configs")
@@ -29,7 +29,7 @@ class Command(BaseCommand):
             dry_run=options["dry_run"],
             team_ids=_int_list(options["team_ids"]),
             plugin_config_ids=_int_list(options["plugin_config_ids"]),
-            drop_unmapped_inputs=options["drop_unmapped_inputs"],
+            drop_unmapped_inputs=not options["strict_inputs"],
             batch_size=options["batch_size"],
             limit=options["limit"],
         )

--- a/products/cdp/backend/api/hog_function.py
+++ b/products/cdp/backend/api/hog_function.py
@@ -594,11 +594,16 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
 
         return super().to_internal_value(data)
 
+    API_MANAGED_TYPE_ERRORS = {
+        HogFunctionType.WAREHOUSE_SOURCE_WEBHOOK.value: "Cannot create or modify warehouse source webhook functions via this API.",
+        # A legacy destination is only ever written by the plugin config migration. One created here
+        # would supersede the plugin config it shares a template with, silently replacing it.
+        HogFunctionType.LEGACY_DESTINATION.value: "Cannot create or modify legacy destination functions via this API.",
+    }
+
     def validate_type(self, value):
-        if value == HogFunctionType.WAREHOUSE_SOURCE_WEBHOOK.value:
-            raise serializers.ValidationError(
-                "Cannot create or modify warehouse source webhook functions via this API."
-            )
+        if value in self.API_MANAGED_TYPE_ERRORS:
+            raise serializers.ValidationError(self.API_MANAGED_TYPE_ERRORS[value])
 
         # Ensure it is only set when creating a new function
         if self.context.get("view") and self.context["view"].action == "create":

--- a/products/cdp/backend/api/hog_function.py
+++ b/products/cdp/backend/api/hog_function.py
@@ -594,23 +594,27 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
 
         return super().to_internal_value(data)
 
-    API_MANAGED_TYPE_ERRORS = {
+    # A legacy destination is only ever written by the plugin config migration. One created here would
+    # supersede the plugin config it shares a template with, silently replacing it.
+    UNCREATABLE_TYPE_ERRORS = {
         HogFunctionType.WAREHOUSE_SOURCE_WEBHOOK.value: "Cannot create or modify warehouse source webhook functions via this API.",
-        # A legacy destination is only ever written by the plugin config migration. One created here
-        # would supersede the plugin config it shares a template with, silently replacing it.
-        HogFunctionType.LEGACY_DESTINATION.value: "Cannot create or modify legacy destination functions via this API.",
+        HogFunctionType.LEGACY_DESTINATION.value: "Cannot create legacy destination functions via this API.",
     }
+    # A migrated legacy destination stays editable, so a person can disable one that misbehaves
+    UNEDITABLE_TYPES = {HogFunctionType.WAREHOUSE_SOURCE_WEBHOOK.value}
 
     def validate_type(self, value):
-        if value in self.API_MANAGED_TYPE_ERRORS:
-            raise serializers.ValidationError(self.API_MANAGED_TYPE_ERRORS[value])
+        is_create = bool(self.context.get("view")) and self.context["view"].action == "create"
+        instance = cast(Optional[HogFunction], self.context.get("instance", self.instance))
+        changing_type = instance is not None and instance.type != value
 
-        # Ensure it is only set when creating a new function
-        if self.context.get("view") and self.context["view"].action == "create":
+        if value in self.UNCREATABLE_TYPE_ERRORS and (is_create or changing_type or value in self.UNEDITABLE_TYPES):
+            raise serializers.ValidationError(self.UNCREATABLE_TYPE_ERRORS[value])
+
+        if is_create:
             return value
 
-        instance = cast(Optional[HogFunction], self.context.get("instance", self.instance))
-        if instance and instance.type != value:
+        if changing_type:
             raise serializers.ValidationError("Cannot modify the type of an existing function")
         return value
 

--- a/products/cdp/backend/api/test/test_hog_function.py
+++ b/products/cdp/backend/api/test/test_hog_function.py
@@ -1867,10 +1867,30 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
         assert response.json() == {
             "attr": "type",
-            "detail": "Cannot create or modify legacy destination functions via this API.",
+            "detail": "Cannot create legacy destination functions via this API.",
             "code": "invalid_input",
             "type": "validation_error",
         }
+
+    def test_can_disable_a_migrated_legacy_destination(self):
+        hog_function = HogFunction.objects.create(
+            team=self.team,
+            name="Migrated",
+            type="legacy_destination",
+            template_id="plugin-customerio-plugin",
+            enabled=True,
+            inputs_schema=[{"key": "customerioSiteId", "type": "string"}],
+            inputs={"customerioSiteId": {"value": "site-1"}},
+        )
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/hog_functions/{hog_function.id}/",
+            data={"enabled": False},
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        hog_function.refresh_from_db()
+        assert hog_function.enabled is False
 
     def test_transpiled_field_not_populated_for_other_types(self):
         response = self.client.post(

--- a/products/cdp/backend/api/test/test_hog_function.py
+++ b/products/cdp/backend/api/test/test_hog_function.py
@@ -1873,6 +1873,15 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         }
 
     def test_can_disable_a_migrated_legacy_destination(self):
+        # The serializer resolves template_id on update, so the row has to exist
+        HogFunctionTemplate.objects.create(
+            template_id="plugin-customerio-plugin",
+            sha="1",
+            name="Customer.io",
+            code="",
+            inputs_schema=[{"key": "customerioSiteId", "type": "string"}],
+            type="legacy_destination",
+        )
         hog_function = HogFunction.objects.create(
             team=self.team,
             name="Migrated",

--- a/products/cdp/backend/api/test/test_hog_function.py
+++ b/products/cdp/backend/api/test/test_hog_function.py
@@ -1856,6 +1856,22 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             "type": "validation_error",
         }
 
+    def test_cannot_create_legacy_destination_via_api(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/hog_functions/",
+            data={
+                **EXAMPLE_FULL,
+                "type": "legacy_destination",
+            },
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+        assert response.json() == {
+            "attr": "type",
+            "detail": "Cannot create or modify legacy destination functions via this API.",
+            "code": "invalid_input",
+            "type": "validation_error",
+        }
+
     def test_transpiled_field_not_populated_for_other_types(self):
         response = self.client.post(
             f"/api/projects/{self.team.id}/hog_functions/",

--- a/products/cdp/backend/models/hog_functions/hog_function.py
+++ b/products/cdp/backend/models/hog_functions/hog_function.py
@@ -62,6 +62,8 @@ class HogFunctionType(models.TextChoices):
     SITE_APP = "site_app"
     TRANSFORMATION = "transformation"
     TRANSFORMATION_LOG = "transformation_log"
+    # Run inline by CdpLegacyEventsConsumer, never by a cyclotron worker
+    LEGACY_DESTINATION = "legacy_destination"
 
 
 TYPES_THAT_RELOAD_PLUGIN_SERVER = (
@@ -71,6 +73,7 @@ TYPES_THAT_RELOAD_PLUGIN_SERVER = (
     HogFunctionType.INTERNAL_DESTINATION,
     HogFunctionType.SOURCE_WEBHOOK,
     HogFunctionType.WAREHOUSE_SOURCE_WEBHOOK,
+    HogFunctionType.LEGACY_DESTINATION,
 )
 TYPES_WITH_TRANSPILED_FILTERS = (HogFunctionType.SITE_DESTINATION, HogFunctionType.SITE_APP)
 TYPES_WITH_JAVASCRIPT_SOURCE = (HogFunctionType.SITE_DESTINATION, HogFunctionType.SITE_APP)

--- a/products/cdp/frontend/generated/api.schemas.ts
+++ b/products/cdp/frontend/generated/api.schemas.ts
@@ -249,6 +249,7 @@ export type HogFunctionApiInputs = { [key: string]: InputsItemApi }
  * * `site_app` - Site App
  * * `transformation` - Transformation
  * * `transformation_log` - Transformation Log
+ * * `legacy_destination` - Legacy Destination
  */
 export type HogFunctionTypeEnumApi = (typeof HogFunctionTypeEnumApi)[keyof typeof HogFunctionTypeEnumApi]
 
@@ -261,6 +262,7 @@ export const HogFunctionTypeEnumApi = {
     SiteApp: 'site_app',
     Transformation: 'transformation',
     TransformationLog: 'transformation_log',
+    LegacyDestination: 'legacy_destination',
 } as const
 
 /**
@@ -411,7 +413,8 @@ export interface HogFunctionApi {
      * * `warehouse_source_webhook` - Warehouse Source Webhook
      * * `site_app` - Site App
      * * `transformation` - Transformation
-     * * `transformation_log` - Transformation Log */
+     * * `transformation_log` - Transformation Log
+     * * `legacy_destination` - Legacy Destination */
     type?: HogFunctionTypeEnumApi | null
     /**
      * Display name for the function.
@@ -500,7 +503,8 @@ export interface PatchedHogFunctionApi {
      * * `warehouse_source_webhook` - Warehouse Source Webhook
      * * `site_app` - Site App
      * * `transformation` - Transformation
-     * * `transformation_log` - Transformation Log */
+     * * `transformation_log` - Transformation Log
+     * * `legacy_destination` - Legacy Destination */
     type?: HogFunctionTypeEnumApi | null
     /**
      * Display name for the function.

--- a/products/cdp/frontend/generated/api.zod.ts
+++ b/products/cdp/frontend/generated/api.zod.ts
@@ -40,15 +40,16 @@ export const HogFunctionsCreateBody = /* @__PURE__ */ zod.object({
                     'site_app',
                     'transformation',
                     'transformation_log',
+                    'legacy_destination',
                 ])
                 .describe(
-                    '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
+                    '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log\n\* `legacy_destination` - Legacy Destination'
                 ),
             zod.null(),
         ])
         .optional()
         .describe(
-            'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
+            'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log\n\* `legacy_destination` - Legacy Destination'
         ),
     name: zod.string().max(hogFunctionsCreateBodyNameMax).nullish().describe('Display name for the function.'),
     description: zod.string().optional().describe('Human-readable description of what this function does.'),
@@ -313,15 +314,16 @@ export const HogFunctionsUpdateBody = /* @__PURE__ */ zod.object({
                     'site_app',
                     'transformation',
                     'transformation_log',
+                    'legacy_destination',
                 ])
                 .describe(
-                    '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
+                    '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log\n\* `legacy_destination` - Legacy Destination'
                 ),
             zod.null(),
         ])
         .optional()
         .describe(
-            'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
+            'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log\n\* `legacy_destination` - Legacy Destination'
         ),
     name: zod.string().max(hogFunctionsUpdateBodyNameMax).nullish().describe('Display name for the function.'),
     description: zod.string().optional().describe('Human-readable description of what this function does.'),
@@ -586,15 +588,16 @@ export const HogFunctionsPartialUpdateBody = /* @__PURE__ */ zod.object({
                     'site_app',
                     'transformation',
                     'transformation_log',
+                    'legacy_destination',
                 ])
                 .describe(
-                    '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
+                    '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log\n\* `legacy_destination` - Legacy Destination'
                 ),
             zod.null(),
         ])
         .optional()
         .describe(
-            'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
+            'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log\n\* `legacy_destination` - Legacy Destination'
         ),
     name: zod.string().max(hogFunctionsPartialUpdateBodyNameMax).nullish().describe('Display name for the function.'),
     description: zod.string().optional().describe('Human-readable description of what this function does.'),
@@ -859,15 +862,16 @@ export const HogFunctionsEnableBackfillsCreateBody = /* @__PURE__ */ zod.object(
                     'site_app',
                     'transformation',
                     'transformation_log',
+                    'legacy_destination',
                 ])
                 .describe(
-                    '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
+                    '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log\n\* `legacy_destination` - Legacy Destination'
                 ),
             zod.null(),
         ])
         .optional()
         .describe(
-            'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
+            'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log\n\* `legacy_destination` - Legacy Destination'
         ),
     name: zod
         .string()
@@ -1164,15 +1168,16 @@ export const HogFunctionsInvocationsCreateBody = /* @__PURE__ */ zod.object({
                             'site_app',
                             'transformation',
                             'transformation_log',
+                            'legacy_destination',
                         ])
                         .describe(
-                            '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
+                            '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log\n\* `legacy_destination` - Legacy Destination'
                         ),
                     zod.null(),
                 ])
                 .optional()
                 .describe(
-                    'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
+                    'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log\n\* `legacy_destination` - Legacy Destination'
                 ),
             name: zod
                 .string()

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -44186,6 +44186,7 @@ export namespace Schemas {
      * * `site_app` - Site App
      * * `transformation` - Transformation
      * * `transformation_log` - Transformation Log
+     * * `legacy_destination` - Legacy Destination
      */
     export type HogFunctionTypeEnum = typeof HogFunctionTypeEnum[keyof typeof HogFunctionTypeEnum];
 
@@ -44199,6 +44200,7 @@ export namespace Schemas {
       SiteApp: 'site_app',
       Transformation: 'transformation',
       TransformationLog: 'transformation_log',
+      LegacyDestination: 'legacy_destination',
     } as const;
 
     /**
@@ -44410,7 +44412,8 @@ export namespace Schemas {
        * * `warehouse_source_webhook` - Warehouse Source Webhook
        * * `site_app` - Site App
        * * `transformation` - Transformation
-       * * `transformation_log` - Transformation Log */
+       * * `transformation_log` - Transformation Log
+       * * `legacy_destination` - Legacy Destination */
       type?: HogFunctionTypeEnum | null;
       /**
          * Display name for the function.
@@ -65535,7 +65538,8 @@ export namespace Schemas {
        * * `warehouse_source_webhook` - Warehouse Source Webhook
        * * `site_app` - Site App
        * * `transformation` - Transformation
-       * * `transformation_log` - Transformation Log */
+       * * `transformation_log` - Transformation Log
+       * * `legacy_destination` - Legacy Destination */
       type?: HogFunctionTypeEnum | null;
       /**
          * Display name for the function.

--- a/services/mcp/src/generated/cdp_functions/api.ts
+++ b/services/mcp/src/generated/cdp_functions/api.ts
@@ -66,15 +66,16 @@ export const HogFunctionsCreateBody = () => zod.object({
                     'site_app',
                     'transformation',
                     'transformation_log',
+                    'legacy_destination',
                 ])
                 .describe(
-                    '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
+                    '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log\n\* `legacy_destination` - Legacy Destination'
                 ),
             zod.null(),
         ])
         .optional()
         .describe(
-            'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
+            'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log\n\* `legacy_destination` - Legacy Destination'
         ),
     name: zod.string().max(hogFunctionsCreateBodyNameMax).nullish().describe('Display name for the function.'),
     description: zod.string().optional().describe('Human-readable description of what this function does.'),
@@ -329,15 +330,16 @@ export const HogFunctionsPartialUpdateBody = () => zod.object({
                     'site_app',
                     'transformation',
                     'transformation_log',
+                    'legacy_destination',
                 ])
                 .describe(
-                    '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
+                    '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log\n\* `legacy_destination` - Legacy Destination'
                 ),
             zod.null(),
         ])
         .optional()
         .describe(
-            'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
+            'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log\n\* `legacy_destination` - Legacy Destination'
         ),
     name: zod.string().max(hogFunctionsPartialUpdateBodyNameMax).nullish().describe('Display name for the function.'),
     description: zod.string().optional().describe('Human-readable description of what this function does.'),
@@ -632,15 +634,16 @@ export const HogFunctionsInvocationsCreateBody = () => zod.object({
                             'site_app',
                             'transformation',
                             'transformation_log',
+                            'legacy_destination',
                         ])
                         .describe(
-                            '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
+                            '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log\n\* `legacy_destination` - Legacy Destination'
                         ),
                     zod.null(),
                 ])
                 .optional()
                 .describe(
-                    'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
+                    'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log\n\* `legacy_destination` - Legacy Destination'
                 ),
             name: zod
                 .string()

--- a/services/mcp/src/generated/error_tracking_alerts/api.ts
+++ b/services/mcp/src/generated/error_tracking_alerts/api.ts
@@ -66,15 +66,16 @@ export const HogFunctionsCreateBody = () => zod.object({
                     'site_app',
                     'transformation',
                     'transformation_log',
+                    'legacy_destination',
                 ])
                 .describe(
-                    '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
+                    '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log\n\* `legacy_destination` - Legacy Destination'
                 ),
             zod.null(),
         ])
         .optional()
         .describe(
-            'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
+            'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log\n\* `legacy_destination` - Legacy Destination'
         ),
     name: zod.string().max(hogFunctionsCreateBodyNameMax).nullish().describe('Display name for the function.'),
     description: zod.string().optional().describe('Human-readable description of what this function does.'),
@@ -320,15 +321,16 @@ export const HogFunctionsPartialUpdateBody = () => zod.object({
                     'site_app',
                     'transformation',
                     'transformation_log',
+                    'legacy_destination',
                 ])
                 .describe(
-                    '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
+                    '\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log\n\* `legacy_destination` - Legacy Destination'
                 ),
             zod.null(),
         ])
         .optional()
         .describe(
-            'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log'
+            'Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n\* `destination` - Destination\n\* `site_destination` - Site Destination\n\* `internal_destination` - Internal Destination\n\* `source_webhook` - Source Webhook\n\* `warehouse_source_webhook` - Warehouse Source Webhook\n\* `site_app` - Site App\n\* `transformation` - Transformation\n\* `transformation_log` - Transformation Log\n\* `legacy_destination` - Legacy Destination'
         ),
     name: zod.string().max(hogFunctionsPartialUpdateBodyNameMax).nullish().describe('Display name for the function.'),
     description: zod.string().optional().describe('Human-readable description of what this function does.'),

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-create.json
@@ -457,7 +457,7 @@
         "type": {
             "anyOf": [
                 {
-                    "description": "* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log",
+                    "description": "* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log\n* `legacy_destination` - Legacy Destination",
                     "enum": [
                         "destination",
                         "site_destination",
@@ -466,7 +466,8 @@
                         "warehouse_source_webhook",
                         "site_app",
                         "transformation",
-                        "transformation_log"
+                        "transformation_log",
+                        "legacy_destination"
                     ],
                     "type": "string"
                 },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-invocations-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-invocations-create.json
@@ -837,7 +837,7 @@
                 "type": {
                     "anyOf": [
                         {
-                            "description": "* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log",
+                            "description": "* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log\n* `legacy_destination` - Legacy Destination",
                             "enum": [
                                 "destination",
                                 "site_destination",
@@ -846,7 +846,8 @@
                                 "warehouse_source_webhook",
                                 "site_app",
                                 "transformation",
-                                "transformation_log"
+                                "transformation_log",
+                                "legacy_destination"
                             ],
                             "type": "string"
                         },
@@ -854,7 +855,7 @@
                             "type": "null"
                         }
                     ],
-                    "description": "Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log"
+                    "description": "Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log\n* `legacy_destination` - Legacy Destination"
                 },
                 "updated_at": {
                     "format": "date-time",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-partial-update.json
@@ -467,7 +467,7 @@
         "type": {
             "anyOf": [
                 {
-                    "description": "* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log",
+                    "description": "* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log\n* `legacy_destination` - Legacy Destination",
                     "enum": [
                         "destination",
                         "site_destination",
@@ -476,7 +476,8 @@
                         "warehouse_source_webhook",
                         "site_app",
                         "transformation",
-                        "transformation_log"
+                        "transformation_log",
+                        "legacy_destination"
                     ],
                     "type": "string"
                 },
@@ -484,7 +485,7 @@
                     "type": "null"
                 }
             ],
-            "description": "Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log"
+            "description": "Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log\n* `legacy_destination` - Legacy Destination"
         }
     },
     "required": ["id"],

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-alerts-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-alerts-create.json
@@ -457,7 +457,7 @@
         "type": {
             "anyOf": [
                 {
-                    "description": "* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log",
+                    "description": "* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log\n* `legacy_destination` - Legacy Destination",
                     "enum": [
                         "destination",
                         "site_destination",
@@ -466,7 +466,8 @@
                         "warehouse_source_webhook",
                         "site_app",
                         "transformation",
-                        "transformation_log"
+                        "transformation_log",
+                        "legacy_destination"
                     ],
                     "type": "string"
                 },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-alerts-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-alerts-partial-update.json
@@ -467,7 +467,7 @@
         "type": {
             "anyOf": [
                 {
-                    "description": "* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log",
+                    "description": "* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log\n* `legacy_destination` - Legacy Destination",
                     "enum": [
                         "destination",
                         "site_destination",
@@ -476,7 +476,8 @@
                         "warehouse_source_webhook",
                         "site_app",
                         "transformation",
-                        "transformation_log"
+                        "transformation_log",
+                        "legacy_destination"
                     ],
                     "type": "string"
                 },
@@ -484,7 +485,7 @@
                     "type": "null"
                 }
             ],
-            "description": "Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log"
+            "description": "Function type: destination, site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation, or transformation_log.\n\n* `destination` - Destination\n* `site_destination` - Site Destination\n* `internal_destination` - Internal Destination\n* `source_webhook` - Source Webhook\n* `warehouse_source_webhook` - Warehouse Source Webhook\n* `site_app` - Site App\n* `transformation` - Transformation\n* `transformation_log` - Transformation Log\n* `legacy_destination` - Legacy Destination"
         }
     },
     "required": ["id"],


### PR DESCRIPTION
Stacked on #97309.

## Problem

Legacy onEvent destinations still run from `PluginConfig` rows. `CdpLegacyEventsConsumer` reads those rows and synthesises a throwaway hog function for each one, so the destinations have no real row, no UI, and no path off the plugin tables.

Transformations already made this move: every `plugin-*` hog function in production is a transformation, and the bundled code runs unchanged through `LegacyPluginExecutorService`. No destination has followed.

## Changes

- Adds the `legacy_destination` hog function type. It runs the same bundled processor as the plugin config it replaces, inline in `CdpLegacyEventsConsumer`, never on a cyclotron worker.
- `CdpLegacyEventsConsumer` reads both representations. A migrated hog function supersedes the plugin config with the same `(team, template_id)`, so the processor still runs once per event.
- `migrate_legacy_destinations_to_hog_functions` creates one enabled hog function per plugin config and leaves the plugin config alone. Rollback is deleting the hog function, not restoring anything.
- A migrated row reports metrics under its own hog function id and `app_source = hog_function`. An unmigrated one keeps `legacy_plugin` and the numeric id, so existing metrics do not move until a config is migrated.
- `cdp_legacy_event_consumer_superseded_plugin_config_total` counts plugin configs skipped because a hog function covers them.

The type stays out of the cyclotron destination selection, the rerun allowlist, and the transformation execution-order set. It is in `TYPES_THAT_RELOAD_PLUGIN_SERVER`, so an edit invalidates the consumer cache.

### Why the template id is enough to dedupe

Both representations carry the bundled `template_id`, and the plugin config has no stable identifier on the hog function once storage is gone. A production check found exactly one enabled onEvent plugin config for every `(team, plugin)` pair across both regions, with no duplicates, so the pair is unambiguous.

The migration enforces the same rule going forward: it refuses to create a second `legacy_destination` for a `(team, template_id)` that already has one.

### Unmapped and missing inputs

`HogFunction.save()` keeps only the input keys the template schema declares and silently drops the rest. The migration compares the built inputs against the schema and reports every key it drops, per config. In production those keys are dead config that no bundled processor reads: `filters`, and hubspot's `postHogUrl`, `posthogApiKey`, `posthogProjectKey` and `syncMode`. `--strict-inputs` skips those configs instead of dropping the keys.

The opposite case is the dangerous one. A required input with nothing behind it saves cleanly and then fails at runtime with no credentials, so the migration refuses it. One production GCS config supplies its credential only as an attachment, and would have migrated silently broken without this.

## How did you test this code?

Five cases in `cdp-legacy-event.consumer.test.ts` cover the takeover, each against a real Postgres row rather than a mock:

- The migrated hog function runs and the plugin config it replaces does not.
- A plugin config whose template has no migrated row still runs.
- With both present, the bundled processor is invoked exactly once for one event.
- A disabled migrated row neither runs nor suppresses its plugin config.
- The migrated row reports metrics against its own id.

Ten cases in `test_legacy_destination_migration.py` cover the command: idempotency, dry run, attachments, team scoping, the storage-backed input, the unmapped-input refusal, and that the plugin config stays enabled.

Both suites were run locally against Postgres. Two production bugs surfaced that way and are fixed here: a NOT NULL violation on `description` when a template has none, and `.filter(template_id=...).first()` picking an arbitrary sha instead of `get_template`'s latest.

Not run: the full node and Django suites.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: `/querying-production-databases-via-metabase`, `/writing-dataclasses`, `/writing-tests`, `/stacking-prs`, `/writing-pr-descriptions`.

The dedupe key was the open question. Production data settled it: one enabled onEvent config per team and plugin, so the template id is unique per pair and no new column on `HogFunction` is needed. The migration originally reused the existing `migrate_legacy_plugins` helper, which creates `destination` rows and disables the plugin config; that path puts the work on the cyclotron destination consumer, which carries no `plugin-*` traffic today, so this adds a separate command instead.

No customer data, tenant identifiers, or operational figures are in this PR.

