### PR TITLE
perf(cohorts): share stage-2 person inputs across their cohorts

### DIFF
--- a/rust/cohort-stream-processor/clippy.toml
+++ b/rust/cohort-stream-processor/clippy.toml
@@ -10,6 +10,7 @@ disallowed-methods = [
     { path = "cohort_stream_processor::store::rocks::CohortStore::multi_get_behavioral", reason = "async code must read through StoreHandle; sync contexts need a module-level allow — see store/handle.rs" },
     { path = "cohort_stream_processor::store::rocks::CohortStore::get_person_record", reason = "async code must read through StoreHandle; sync contexts need a module-level allow — see store/handle.rs" },
     { path = "cohort_stream_processor::store::rocks::CohortStore::multi_get_person_records", reason = "async code must read through StoreHandle; sync contexts need a module-level allow — see store/handle.rs" },
+    { path = "cohort_stream_processor::store::rocks::CohortStore::read_event_snapshot", reason = "async code must read through StoreHandle; sync contexts need a module-level allow — see store/handle.rs" },
     { path = "cohort_stream_processor::store::rocks::CohortStore::get_stage2", reason = "async code must read through StoreHandle; sync contexts need a module-level allow — see store/handle.rs" },
     { path = "cohort_stream_processor::store::rocks::CohortStore::multi_get_stage2", reason = "async code must read through StoreHandle; sync contexts need a module-level allow — see store/handle.rs" },
     { path = "cohort_stream_processor::store::rocks::CohortStore::write_batch", reason = "async code must write through StoreHandle::commit; sync contexts need a module-level allow — see store/handle.rs" },

--- a/rust/cohort-stream-processor/clippy.toml
+++ b/rust/cohort-stream-processor/clippy.toml
@@ -8,6 +8,8 @@ disallowed-methods = [
     { path = "cohort_stream_processor::store::rocks::CohortStore::get", reason = "async code must read through StoreHandle; sync contexts need a module-level allow — see store/handle.rs" },
     { path = "cohort_stream_processor::store::rocks::CohortStore::get_behavioral", reason = "async code must read through StoreHandle; sync contexts need a module-level allow — see store/handle.rs" },
     { path = "cohort_stream_processor::store::rocks::CohortStore::multi_get_behavioral", reason = "async code must read through StoreHandle; sync contexts need a module-level allow — see store/handle.rs" },
+    { path = "cohort_stream_processor::store::rocks::CohortStore::get_person_record", reason = "async code must read through StoreHandle; sync contexts need a module-level allow — see store/handle.rs" },
+    { path = "cohort_stream_processor::store::rocks::CohortStore::multi_get_person_records", reason = "async code must read through StoreHandle; sync contexts need a module-level allow — see store/handle.rs" },
     { path = "cohort_stream_processor::store::rocks::CohortStore::get_stage2", reason = "async code must read through StoreHandle; sync contexts need a module-level allow — see store/handle.rs" },
     { path = "cohort_stream_processor::store::rocks::CohortStore::multi_get_stage2", reason = "async code must read through StoreHandle; sync contexts need a module-level allow — see store/handle.rs" },
     { path = "cohort_stream_processor::store::rocks::CohortStore::write_batch", reason = "async code must write through StoreHandle::commit; sync contexts need a module-level allow — see store/handle.rs" },

--- a/rust/cohort-stream-processor/src/observability/metrics.rs
+++ b/rust/cohort-stream-processor/src/observability/metrics.rs
@@ -554,6 +554,27 @@ pub const PERSON_SEED_REKEY_PRODUCE_FAILURE_TOTAL: &str =
 /// produce-failure counters before concluding produces are failing.**
 pub const SEED_REGISTER_REPAIRS_TOTAL: &str = "cohort_seed_register_repairs_total";
 
+/// Persons whose Stage 2 inputs a seed apply read as one store section (counter).
+///
+/// Attempt-based, like everything a run *found*: a held run counts its persons, and so does the
+/// redelivery that replays it. **Do not divide [`STAGE2_COHORTS_EVALUATED`] by this.** That counter
+/// is settled-based — it is recorded only once the run's stage-2 writes commit — so the ratio
+/// under-reports the sharing during exactly the incidents that produce holds. Read keys per person
+/// off [`SEED_RECOMPUTE_KEYS_FETCHED_TOTAL`] instead, which is attempt-based on both sides.
+pub const SEED_RECOMPUTE_PERSONS_TOTAL: &str = "cohort_seed_recompute_persons_total";
+/// Store keys those sections fetched, labelled by `source` (`behavioral`|`person_record`|`stage2`)
+/// (counter). Against [`SEED_RECOMPUTE_PERSONS_TOTAL`] this is keys per person, by state source, and
+/// it is the sharing win: `person_record` holds at one per person however many cohorts that person
+/// reaches.
+pub const SEED_RECOMPUTE_KEYS_FETCHED_TOTAL: &str = "cohort_seed_recompute_keys_fetched_total";
+/// Raw value bytes one batched read returned, labelled by the same `source` (histogram, bytes). A
+/// section decodes and releases each batch before reading the next, so this is its raw-buffer peak.
+/// **A key limit does not bound bytes** — behavioral values grow with window length — so read this
+/// before concluding the read plan has a memory ceiling. A miss records a real `0`: on
+/// `source="person_record"` a dormant person the seed found nothing for is a zero sample, so read
+/// the upper quantiles rather than the median while a backfill sweeps non-matchers.
+pub const SEED_RECOMPUTE_CHUNK_BYTES: &str = "cohort_seed_recompute_chunk_bytes";
+
 /// Seeds applied as one run, labelled by `kind` (histogram). The p50 is the batching win: `1` means
 /// every seed still pays its own produce round trip.
 pub const SEED_APPLY_RUN_SIZE: &str = "cohort_seed_apply_run_size";
@@ -939,6 +960,18 @@ mod tests {
         assert_eq!(
             SEED_REGISTER_REPAIRS_TOTAL,
             "cohort_seed_register_repairs_total"
+        );
+        assert_eq!(
+            SEED_RECOMPUTE_PERSONS_TOTAL,
+            "cohort_seed_recompute_persons_total"
+        );
+        assert_eq!(
+            SEED_RECOMPUTE_KEYS_FETCHED_TOTAL,
+            "cohort_seed_recompute_keys_fetched_total",
+        );
+        assert_eq!(
+            SEED_RECOMPUTE_CHUNK_BYTES,
+            "cohort_seed_recompute_chunk_bytes"
         );
         assert_eq!(SEED_APPLY_RUN_SIZE, "cohort_seed_apply_run_size");
         assert_eq!(

--- a/rust/cohort-stream-processor/src/observability/metrics.rs
+++ b/rust/cohort-stream-processor/src/observability/metrics.rs
@@ -557,24 +557,19 @@ pub const PERSON_SEED_REKEY_PRODUCE_FAILURE_TOTAL: &str =
 pub const SEED_REGISTER_REPAIRS_TOTAL: &str = "cohort_seed_register_repairs_total";
 
 /// Persons whose Stage 2 inputs a seed apply read through shared store sections (counter).
-///
-/// Attempt-based, like everything a run *found*: a held run counts its persons, and so does the
-/// redelivery that replays it. **Do not divide [`STAGE2_COHORTS_EVALUATED`] by this.** That counter
-/// is settled-based — it is recorded only once the run's stage-2 writes commit — so the ratio
-/// under-reports the sharing during exactly the incidents that produce holds. Read keys per person
-/// off [`SEED_RECOMPUTE_KEYS_FETCHED_TOTAL`] instead, which is attempt-based on both sides.
+/// Attempt-based: a held run counts its persons, and so does the redelivery that replays it.
+/// **Do not divide [`STAGE2_COHORTS_EVALUATED`] by this**, because that counter is settled-based and
+/// the ratio then under-reports the sharing on exactly the runs that hold. Read keys per person off
+/// [`SEED_RECOMPUTE_KEYS_FETCHED_TOTAL`], which is attempt-based on both sides.
 pub const SEED_RECOMPUTE_PERSONS_TOTAL: &str = "cohort_seed_recompute_persons_total";
 /// Store keys those sections fetched, labelled by `source` (`behavioral`|`person_record`|`stage2`)
-/// (counter). Against [`SEED_RECOMPUTE_PERSONS_TOTAL`] this is keys per person, by state source, and
-/// it is the sharing win: `person_record` holds at one per person however many cohorts that person
-/// reaches.
+/// (counter). Over [`SEED_RECOMPUTE_PERSONS_TOTAL`] this is the sharing win: `person_record` holds
+/// at one per person however many cohorts that person reaches.
 pub const SEED_RECOMPUTE_KEYS_FETCHED_TOTAL: &str = "cohort_seed_recompute_keys_fetched_total";
-/// Raw value bytes one batched read returned, labelled by the same `source` (histogram, bytes). A
-/// section decodes and releases each batch before reading the next, so this is its raw-buffer peak.
-/// **A key limit does not bound bytes** — behavioral values grow with window length — so read this
-/// before concluding the read plan has a memory ceiling. A miss records a real `0`: on
-/// `source="person_record"` a dormant person the seed found nothing for is a zero sample, so read
-/// the upper quantiles rather than the median while a backfill sweeps non-matchers.
+/// Raw value bytes one batched read returned, labelled by the same `source` (histogram, bytes).
+/// **A key limit does not bound bytes**, because behavioral values grow with window length, so read
+/// this before assuming the read plan has a memory ceiling. A miss records a real `0`, so prefer the
+/// upper quantiles while a backfill sweeps persons it finds nothing for.
 pub const SEED_RECOMPUTE_CHUNK_BYTES: &str = "cohort_seed_recompute_chunk_bytes";
 
 /// Seeds applied as one run, labelled by `kind` (histogram). The p50 is the batching win: `1` means

--- a/rust/cohort-stream-processor/src/observability/metrics.rs
+++ b/rust/cohort-stream-processor/src/observability/metrics.rs
@@ -148,9 +148,11 @@ pub const STORE_OFFLOAD_QUEUE_WAIT_DURATION_SECONDS: &str =
 /// Execution time of the offloaded op inside the blocking closure, labelled by `op` (histogram,
 /// seconds) — excludes permit and queue waits, so it is the pure on-thread store cost.
 pub const STORE_OFFLOAD_EXEC_DURATION_SECONDS: &str = "store_offload_exec_duration_seconds";
-/// Store ops currently executing inside a blocking closure, labelled by `lane`
-/// (`event`|`maintenance`|`write`|`section`) (gauge). Maintained inside the closure so it stays
-/// correct even if the caller future is dropped mid-flight.
+/// Store ops currently executing inside a blocking closure, labelled by `lane` (gauge). The label is
+/// the permit lane the op holds (`event`|`maintenance`), or `write` and `section` for the permit-free
+/// write and stats-snapshot offloads, so `lane="maintenance"` is the maintenance permits in use,
+/// sections included. Maintained inside the closure so it stays correct even if the caller future
+/// is dropped mid-flight.
 pub const STORE_OFFLOAD_INFLIGHT: &str = "store_offload_inflight";
 
 /// Latency of a RocksDB read, labelled by `op` (histogram, seconds). `op=get` is sampled 1-in-N
@@ -554,7 +556,7 @@ pub const PERSON_SEED_REKEY_PRODUCE_FAILURE_TOTAL: &str =
 /// produce-failure counters before concluding produces are failing.**
 pub const SEED_REGISTER_REPAIRS_TOTAL: &str = "cohort_seed_register_repairs_total";
 
-/// Persons whose Stage 2 inputs a seed apply read as one store section (counter).
+/// Persons whose Stage 2 inputs a seed apply read through shared store sections (counter).
 ///
 /// Attempt-based, like everything a run *found*: a held run counts its persons, and so does the
 /// redelivery that replays it. **Do not divide [`STAGE2_COHORTS_EVALUATED`] by this.** That counter

--- a/rust/cohort-stream-processor/src/store/handle.rs
+++ b/rust/cohort-stream-processor/src/store/handle.rs
@@ -181,14 +181,17 @@ impl StoreHandle {
         self.offload(op, LANE_WRITE, None, f).await
     }
 
-    /// Run a whole infallible sync section (reads + writes mixed) under the [`LANE_SECTION`] label:
-    /// offloads under Maintenance and All, inline under Off. `permits` is the lane the section draws
-    /// from — the maintenance lane for [`Self::run_section`], `None` for the permit-free
-    /// observability snapshot ([`Self::stats_snapshot`]). Keeping stats on this executor is what lets
-    /// `mode` stay matched in exactly the three executors (`read`, `write`, `section`).
+    /// Run a whole infallible sync section (reads + writes mixed): offloads under Maintenance and
+    /// All, inline under Off. `permits` is the lane the section draws from, and `lane_label` is how
+    /// the in-flight gauge names it: the maintenance lane for [`Self::run_section`], `None` under
+    /// [`LANE_SECTION`] for the permit-free observability snapshot ([`Self::stats_snapshot`]). The
+    /// label follows the permit so that `store_offload_inflight{lane="maintenance"}` counts every
+    /// holder of a maintenance permit, sections included. Keeping stats on this executor is what
+    /// lets `mode` stay matched in exactly the three executors (`read`, `write`, `section`).
     async fn section<T, F>(
         &self,
         op: &'static str,
+        lane_label: &'static str,
         permits: Option<Arc<Semaphore>>,
         f: F,
     ) -> Result<T, StoreError>
@@ -201,7 +204,7 @@ impl StoreHandle {
         }
         // A section's closure is infallible (it returns `T`, not `Result`); wrap it so it shares the
         // one offload path. Only teardown cancellation can then make the outer result an `Err`.
-        self.offload(op, LANE_SECTION, permits, move |store| Ok(f(store)))
+        self.offload(op, lane_label, permits, move |store| Ok(f(store)))
             .await
     }
 
@@ -503,8 +506,8 @@ impl StoreHandle {
 
     /// Run a self-contained sync store state machine (mixed reads and writes) on the blocking pool:
     /// the sanctioned context for merge drain/apply and GC, whose deep sync cores are not worth
-    /// async-ifying. Draws a maintenance permit. The result is `Err` only on runtime-teardown
-    /// cancellation ([`StoreError::OffloadCancelled`]).
+    /// async-ifying. Draws a maintenance permit, and counts on the in-flight gauge under that lane.
+    /// The result is `Err` only on runtime-teardown cancellation ([`StoreError::OffloadCancelled`]).
     ///
     /// Keep each section individually short: a started blocking task cannot be cancelled, and
     /// shutdown joins started tasks — a long section extends the effective drain time.
@@ -513,7 +516,8 @@ impl StoreHandle {
         T: Send + 'static,
         F: FnOnce(&CohortStore) -> T + Send + 'static,
     {
-        self.section(op, self.maintenance_permits.clone(), f).await
+        self.section(op, LANE_MAINTENANCE, self.maintenance_permits.clone(), f)
+            .await
     }
 
     /// Snapshot the store's cache tickers and per-CF sizes. No permit — observability must not queue
@@ -523,8 +527,10 @@ impl StoreHandle {
     pub async fn stats_snapshot(&self) -> Result<StoreStats, StoreError> {
         // Routed through `section` with the `None` lane (no permit) so the mode match stays in the
         // three executors rather than being open-coded here.
-        self.section("stats_snapshot", None, |store| store.stats_snapshot())
-            .await
+        self.section("stats_snapshot", LANE_SECTION, None, |store| {
+            store.stats_snapshot()
+        })
+        .await
     }
 
     /// SYNCHRONOUS escape hatch: delete one partition's state on the caller's thread, bypassing the

--- a/rust/cohort-stream-processor/src/workers/mod.rs
+++ b/rust/cohort-stream-processor/src/workers/mod.rs
@@ -11,6 +11,7 @@ pub mod seed_path;
 pub mod seed_run;
 pub mod stage2_gc;
 pub mod stage2_path;
+pub mod stage2_person_inputs;
 pub mod sweep_callback;
 pub mod worker;
 

--- a/rust/cohort-stream-processor/src/workers/seed_apply.rs
+++ b/rust/cohort-stream-processor/src/workers/seed_apply.rs
@@ -844,8 +844,7 @@ struct Scheduled {
 
 impl Scheduled {
     /// One recompute per `(team, run)`, folded into the register diff's half so one produce and
-    /// one commit cover both. Each group shares every person's reads across the cohorts that person
-    /// reaches; the live path composes cohort by cohort instead.
+    /// one commit cover both.
     async fn recompute(
         mut self,
         deps: ApplyDeps<'_>,

--- a/rust/cohort-stream-processor/src/workers/seed_apply.rs
+++ b/rust/cohort-stream-processor/src/workers/seed_apply.rs
@@ -49,9 +49,9 @@ use crate::workers::merge_path::MergeWorkerDeps;
 use crate::workers::reconcile::{ReconcileQueue, SupersedeOutcome};
 use crate::workers::seed_run::{Admitted, OffsetSpan, SeedGroup, SeedKind, SeedOffset, SeedRun};
 use crate::workers::stage2_path::{
-    commit_stage2_writes, diff_single_leaf_registers, recompute_stage2, FoldedLeaf, RegisterDiff,
-    Stage2Recompute,
+    commit_stage2_writes, diff_single_leaf_registers, FoldedLeaf, RegisterDiff, Stage2Recompute,
 };
+use crate::workers::stage2_person_inputs::recompute_stage2_by_person;
 use crate::workers::worker::{
     first_cascades, produce_cascades, produce_membership, transition_metric_label,
 };
@@ -844,7 +844,8 @@ struct Scheduled {
 
 impl Scheduled {
     /// One recompute per `(team, run)`, folded into the register diff's half so one produce and
-    /// one commit cover both.
+    /// one commit cover both. Each group shares every person's reads across the cohorts that person
+    /// reaches; the live path composes cohort by cohort instead.
     async fn recompute(
         mut self,
         deps: ApplyDeps<'_>,
@@ -855,14 +856,14 @@ impl Scheduled {
                 let Some(filters) = deps.team(team_id) else {
                     continue;
                 };
-                let mut composed = recompute_stage2(
+                let mut composed = recompute_stage2_by_person(
                     deps.partition_id,
                     deps.handle,
+                    team_id,
                     filters,
                     &leaves,
                     stamp.now_ms,
                     &stamp.last_updated,
-                    ReadLane::Maintenance,
                 )
                 .await
                 .map_err(SeedHold::store(ApplyStage::Recompute))?;

--- a/rust/cohort-stream-processor/src/workers/seed_path.rs
+++ b/rust/cohort-stream-processor/src/workers/seed_path.rs
@@ -9,7 +9,8 @@
 //! after the produce acks. A failed produce is therefore re-derived while replay still folds the
 //! leaf. If the leaf expires before replay and the fold drops it, this repair no longer applies;
 //! eviction and reconcile remain its recovery paths. Composed bits come from
-//! [`recompute_stage2`](crate::workers::stage2_path::recompute_stage2); single-leaf ones from
+//! [`recompute_stage2_by_person`](crate::workers::stage2_person_inputs::recompute_stage2_by_person),
+//! which reads each person once for all their cohorts; single-leaf ones from
 //! [`diff_single_leaf_registers`](crate::workers::stage2_path::diff_single_leaf_registers), which
 //! is why `Unchanged` leaves still take part. The replay mints no transition, so the persisted
 //! register is the only record of what downstream was told. Store and produce failures hold the

--- a/rust/cohort-stream-processor/src/workers/seed_run.rs
+++ b/rust/cohort-stream-processor/src/workers/seed_run.rs
@@ -164,9 +164,8 @@ impl Default for RunBudget {
 ///
 /// It is a ceiling on what a run retains and emits, not on the reads inside each composed
 /// evaluation: those scale with the trees of every cohort a person is in. The maintenance lane
-/// still meters them, but a whole person now reads under one permit rather than one per evaluation
-/// (see [`stage2_person_inputs`](crate::workers::stage2_person_inputs)), so the lane bounds
-/// concurrent persons, not concurrent reads.
+/// still meters them, one permit per bounded section of a person's reads rather than one per
+/// evaluation (see [`stage2_person_inputs`](crate::workers::stage2_person_inputs)).
 ///
 /// A seed the catalog cannot place weighs one, so a run of them is still bounded by the seed cap
 /// rather than by nothing. Control and skip seeds weigh nothing: they are always their own group.

--- a/rust/cohort-stream-processor/src/workers/seed_run.rs
+++ b/rust/cohort-stream-processor/src/workers/seed_run.rs
@@ -163,8 +163,10 @@ impl Default for RunBudget {
 /// full run of leaves that can emit nothing slip under the ceiling.
 ///
 /// It is a ceiling on what a run retains and emits, not on the reads inside each composed
-/// evaluation: those scale with that cohort's tree exactly as under the per-seed apply, and the
-/// maintenance lane's permits are what meter them.
+/// evaluation: those scale with the trees of every cohort a person is in. The maintenance lane
+/// still meters them, but a whole person now reads under one permit rather than one per evaluation
+/// (see [`stage2_person_inputs`](crate::workers::stage2_person_inputs)), so the lane bounds
+/// concurrent persons, not concurrent reads.
 ///
 /// A seed the catalog cannot place weighs one, so a run of them is still bounded by the seed cap
 /// rather than by nothing. Control and skip seeds weigh nothing: they are always their own group.

--- a/rust/cohort-stream-processor/src/workers/stage2_path.rs
+++ b/rust/cohort-stream-processor/src/workers/stage2_path.rs
@@ -89,8 +89,6 @@ impl Stage2Recompute {
         self.repairs.add(other.repairs);
     }
 
-    /// Record one recomputed pair: the flip it emits, if any, and the `cf_stage2` write it owes.
-    ///
     /// Both recompute orders call this, so what a composed evaluation emits cannot depend on
     /// whether the caller walked cohorts or persons.
     pub(super) fn record_pair(
@@ -130,15 +128,13 @@ impl Stage2Recompute {
 
 #[cfg(test)]
 impl Stage2Recompute {
-    /// Pairs this recompute composed, which is what `STAGE2_COHORTS_EVALUATED` reports. Read by the
-    /// tests that hold the two recompute orders to the same work, including on pairs that flip
-    /// nothing and so leave no trace in `changes` or `writes`.
+    /// Pairs composed, which is what `STAGE2_COHORTS_EVALUATED` reports. A pair that flips nothing
+    /// leaves no other trace for a test to compare.
     pub(super) fn evaluated(&self) -> u64 {
         self.evaluated
     }
 }
 
-/// One recomputed `(cohort, person)` as the emitted change names it.
 pub(super) struct RecomputedPair {
     pub team_id: i32,
     pub cohort_id: CohortId,
@@ -218,9 +214,8 @@ impl RepairCounts {
 }
 
 /// The read-only half of [`compose_stage2`]: one cohort at a time, in `(cohort, person)` order.
-///
-/// The seed paths use [`recompute_stage2_by_person`](super::stage2_person_inputs::recompute_stage2_by_person)
-/// instead, which shares each person's reads across their cohorts.
+/// The seed paths use
+/// [`recompute_stage2_by_person`](super::stage2_person_inputs::recompute_stage2_by_person) instead.
 pub(super) async fn recompute_stage2(
     partition_id: u16,
     handle: &StoreHandle,
@@ -806,8 +801,8 @@ pub(super) fn decode_stage1_state(bytes: Option<Vec<u8>>) -> Option<Stage1State>
     }
 }
 
-/// One stored `cf_stage2` row as composition reads it. [`Default`] is the fail-closed reading an
-/// absent or corrupt row gets: a non-member row nobody has transferred.
+/// One stored `cf_stage2` row as composition reads it. [`Default`] is the fail-closed reading for
+/// an absent or corrupt row.
 #[derive(Debug, Clone, Copy, Default)]
 pub(super) struct PriorStage2State {
     pub in_cohort: bool,
@@ -2057,17 +2052,13 @@ mod tests {
 
     // ---- Sharing one person's inputs across their cohorts ----
     //
-    // `recompute_stage2_by_person` is the seed paths' recompute. It reads each person once instead
-    // of once per affected cohort, so every test below holds it to this module's cohort-ordered
-    // path as an oracle over the same store, and then asserts what the shared read had to get right
-    // for the two to agree.
+    // Every test below holds `recompute_stage2_by_person` to the cohort-ordered path as an oracle
+    // over the same store, then asserts what the shared read had to get right for the two to agree.
 
     use crate::workers::stage2_person_inputs::recompute_stage2_by_person;
 
-    /// Run both recompute orders over the same store and return the agreed result.
-    ///
-    /// Neither commits — both hand their `cf_stage2` writes back for the caller to commit after its
-    /// produce — so running them back to back reads the same durable state twice.
+    /// Run both recompute orders over the same store and return the agreed result. Neither commits,
+    /// so running them back to back reads the same durable state twice.
     async fn recompute_both_ways(
         store: &CohortStore,
         filters: &TeamFilters,
@@ -2141,8 +2132,6 @@ mod tests {
             .collect()
     }
 
-    /// A second person condition, which the stored record does not match. Sharing one record across
-    /// a person's cohorts must still answer each condition separately.
     fn other_person_leaf() -> Value {
         json!({
             "type": "person", "key": "email", "value": "someone@example.com", "operator": "exact",
@@ -2151,13 +2140,8 @@ mod tests {
         })
     }
 
-    /// One person, four cohorts, one shared behavioral leaf and one shared person leaf, and every
-    /// behavioral variant in the mix. The shared read must serve all four cohorts from one person
-    /// record and one behavioral batch without changing any verdict.
-    ///
-    /// Cohort 4 names a second person condition the record does not match, so a read that collapsed
-    /// the record into one bit — "matched anything" rather than "matched this hash" — would enter it.
-    /// That is the mistake sharing the record invites.
+    /// Cohort 4 names a second person condition the record does not match, so a read that answered
+    /// the record as one bit rather than per condition would enter it.
     #[tokio::test]
     async fn shared_inputs_compose_every_leaf_variant_from_one_read() {
         let (_dir, store) = temp_store();
@@ -2193,8 +2177,7 @@ mod tests {
         write_behavioral(&store, compressed_lsk, alice, compressed_state(2));
         write_person_record(&store, alice, &[PERSON_HASH]);
 
-        // Both leaves, so cohort 4 is reached too: it hangs off the shared behavioral leaf, not off
-        // the person condition the other three share.
+        // Cohort 4 hangs off the shared behavioral leaf, not the person condition.
         let affected = [(single_lsk, alice), (per_lsk, alice)];
         let entered = recompute_both_ways(&store, &filters, TEAM as i32, &affected).await;
         assert_eq!(
@@ -2207,8 +2190,8 @@ mod tests {
             "each variant's comparator still decides its own leaf, and the unmatched person \
              condition keeps cohort 4 out of the same record's answers",
         );
-        // Absolute, not against the oracle: both orders build the change through one shared
-        // `record_pair`, so only a literal pins which team the shared read stamped on it.
+        // Both orders build the change through one shared `record_pair`, so only a literal pins
+        // which team the shared read stamped on it.
         assert!(entered
             .changes
             .iter()
@@ -2223,9 +2206,8 @@ mod tests {
         assert_eq!(statuses(&left), vec![(2, MembershipStatus::Left)]);
     }
 
-    /// A referent and its referrer recompute in the same call. The referrer must read the referent's
-    /// *stored* bit, not the one this run is about to write, or it emits a cascade nothing has
-    /// acknowledged.
+    /// The referrer must read the referent's *stored* bit, not the one this run is about to write,
+    /// or it emits a cascade nothing has acknowledged.
     #[tokio::test]
     async fn a_referent_recomputed_in_the_same_call_is_still_read_from_the_store() {
         let (_dir, store) = temp_store();
@@ -2255,10 +2237,9 @@ mod tests {
         );
     }
 
-    /// The one reference kind whose bit comes back through the *behavioral* batch rather than the
-    /// `cf_stage2` batch. A single-leaf referent is resolved from its own leaf state through its own
-    /// comparator, so resolving it from a stored membership row instead would read every referrer of
-    /// a single-leaf cohort as a non-member — and no other test here would notice.
+    /// The one reference kind whose bit comes back through the behavioral batch. Resolving it from
+    /// a stored membership row instead would read every referrer of a single-leaf cohort as a
+    /// non-member.
     #[tokio::test]
     async fn a_single_leaf_referent_resolves_through_its_own_leaf_and_comparator() {
         let (_dir, store) = temp_store();
@@ -2295,8 +2276,7 @@ mod tests {
         assert_eq!(statuses(&above), vec![(1, MembershipStatus::Entered)]);
     }
 
-    /// A referent read as stored, then referenced twice in one tree with opposite negation, is one
-    /// row and two consistent answers.
+    /// One referent named twice with opposite negation is one row and two consistent answers.
     #[tokio::test]
     async fn a_referent_named_twice_with_opposite_negation_reads_one_row() {
         let (_dir, store) = temp_store();
@@ -2321,8 +2301,7 @@ mod tests {
         );
     }
 
-    /// Absent and corrupt rows read as non-member on the shared path exactly as they do per cohort,
-    /// and a transferred fallback is still settled on a pair that does not flip.
+    /// A transferred fallback is still settled on a pair that does not flip.
     #[tokio::test]
     async fn corrupt_rows_stay_non_member_and_a_transferred_fallback_still_settles() {
         let (_dir, store) = temp_store();
@@ -2379,8 +2358,7 @@ mod tests {
         );
     }
 
-    /// Two persons in one call, with opposite state. Sharing is per person, so neither may see the
-    /// other's record or leaves.
+    /// Sharing is per person, so neither may see the other's record or leaves.
     #[tokio::test]
     async fn two_persons_in_one_call_keep_their_own_inputs() {
         let (_dir, store) = temp_store();
@@ -2453,7 +2431,6 @@ mod tests {
         );
     }
 
-    /// Distinct condition hashes, so a fixture can build a cohort wider than one read chunk.
     fn wide_behavioral_leaf(index: usize) -> Value {
         json!({
             "type": "behavioral", "value": "performed_event", "key": "$pageview",
@@ -2467,8 +2444,8 @@ mod tests {
         format!("beh{index:013}").as_bytes().try_into().unwrap()
     }
 
-    /// More behavioral leaves than fit one chunk. A chunk the read skipped would leave its leaves
-    /// non-member and break the AND, so the entry proves every chunk landed.
+    /// A chunk the read skipped would leave its leaves non-member and break the AND, so the entry
+    /// proves every chunk landed.
     #[tokio::test]
     async fn a_cohort_wider_than_one_chunk_reads_every_leaf() {
         const LEAVES: usize = 70;
@@ -2486,8 +2463,8 @@ mod tests {
         let entered = recompute_both_ways(&store, &filters, TEAM as i32, &[(lsks[0], alice)]).await;
         assert_eq!(statuses(&entered), vec![(1, MembershipStatus::Entered)]);
 
-        // Drop one leaf in the second chunk. The `Entered` above is what proves every chunk landed;
-        // this half pins that the far leaf's value is the one being read, not just its key.
+        // The `Entered` above proves every chunk landed. This half pins that the far leaf's value
+        // is read, not just its key.
         write_behavioral(
             &store,
             lsks[LEAVES - 1],
@@ -2503,8 +2480,8 @@ mod tests {
         assert_eq!(statuses(&left), vec![(1, MembershipStatus::Left)]);
     }
 
-    /// One person in more composable cohorts than fit one `cf_stage2` chunk. The pair whose prior
-    /// row already agrees sits in the second chunk, so only a read that reached it stays silent.
+    /// The pair whose prior row already agrees sits past the first chunk, so only a read that
+    /// reached it stays silent.
     #[tokio::test]
     async fn a_person_in_more_cohorts_than_one_chunk_reads_every_prior_row() {
         const COHORTS: i32 = 70;
@@ -2544,10 +2521,8 @@ mod tests {
         );
     }
 
-    /// Invented fixture: `persons` persons, each in `cohorts` composable cohorts that share one
-    /// behavioral leaf and one person leaf, and each cohort also owning a leaf whose compressed
-    /// history spans a year. That is the shape the sharing is for — wide fanout over mostly shared
-    /// state, with values big enough that re-reading them is not free.
+    /// Wide fanout over mostly shared state, with per-cohort leaves big enough that re-reading them
+    /// is not free.
     fn wide_fixture(
         store: &CohortStore,
         cohorts: usize,
@@ -2599,7 +2574,7 @@ mod tests {
         format!("cmp{index:013}").as_bytes().try_into().unwrap()
     }
 
-    /// One entry per day of the window, so each behavioral value is kilobytes rather than bytes.
+    /// One entry per day of the window, so each value is kilobytes rather than bytes.
     fn year_long_compressed_state() -> Stage1State {
         Stage1State::BehavioralCompressedHistory {
             entries: (0..365).map(|day| (20_600 + day, 1)).collect(),
@@ -2616,10 +2591,8 @@ mod tests {
     ///     recompute_orders_benchmark -- --ignored --nocapture
     /// ```
     ///
-    /// Both orders run over one store in one process, so the comparison needs no second checkout and
-    /// no second build. It asserts agreement only: a wall-time threshold in a test is a flake
-    /// waiting for a slower box, and reads per state source and memory belong to
-    /// `cohort_seed_recompute_*` under real load, not here.
+    /// Asserts agreement only. A wall-time threshold here would be a flake waiting for a slower
+    /// box, and reads per source and memory belong to `cohort_seed_recompute_*` under real load.
     #[tokio::test]
     #[ignore = "benchmark; run in release with --ignored --nocapture"]
     async fn recompute_orders_benchmark() {
@@ -2658,8 +2631,8 @@ mod tests {
                 )
             };
 
-            // Warm the block cache first, so the timed pass measures the read shape and not the
-            // first touch of every SST.
+            // Warm the block cache, so the timed pass measures the read shape and not the first
+            // touch of every SST.
             let warm_by_cohort = run_by_cohort().await.unwrap();
             let warm_by_person = run_by_person().await.unwrap();
             assert_eq!(warm_by_person.changes, warm_by_cohort.changes);

--- a/rust/cohort-stream-processor/src/workers/stage2_path.rs
+++ b/rust/cohort-stream-processor/src/workers/stage2_path.rs
@@ -32,7 +32,7 @@ use crate::store::{
 /// `affected_leaves` is the touched `(leaf, person)` set; `lane` is the read lane every recompute
 /// read runs on. Every caller passes `Event`: the seed paths, which read on `Maintenance`, go
 /// through [`recompute_stage2_by_person`](super::stage2_person_inputs::recompute_stage2_by_person)
-/// instead, whose store section draws the maintenance permit.
+/// instead, whose store sections draw the maintenance permit.
 pub async fn compose_stage2(
     partition_id: u16,
     handle: &StoreHandle,

--- a/rust/cohort-stream-processor/src/workers/stage2_path.rs
+++ b/rust/cohort-stream-processor/src/workers/stage2_path.rs
@@ -24,10 +24,10 @@ use crate::stage1::person_record::PersonRecord;
 use crate::stage1::state::{Stage1State, StateVariant, StatefulRecord};
 use crate::stage2::evaluator::{evaluate_tree, leaf_membership};
 use crate::stage2::state::{Stage2Ownership, Stage2State};
-use crate::stage2::CohortEligibility;
 use crate::store::{
     BehavioralKey, PersonRecordKey, ReadLane, Stage2Key, StagedBatch, StoreError, StoreHandle,
 };
+use crate::workers::stage2_person_inputs::ReferenceSource;
 
 /// `affected_leaves` is the touched `(leaf, person)` set; `lane` is the read lane every recompute
 /// read runs on. Every caller passes `Event`: the seed paths, which read on `Maintenance`, go
@@ -748,11 +748,10 @@ async fn resolve_ref_membership(
     let mut single_leaf_refs: Vec<(CohortId, LeafStateKey)> = Vec::new();
     let mut composable_refs: Vec<CohortId> = Vec::new();
     for ref_id in ref_ids {
-        match filters.eligibility.get(&ref_id) {
-            Some(CohortEligibility::SingleLeaf(lsk)) => single_leaf_refs.push((ref_id, *lsk)),
-            Some(elig) if elig.writes_cf_stage2() => composable_refs.push(ref_id),
-            // Excluded, cyclic, or absent from the catalog: non-member.
-            _ => {
+        match ReferenceSource::classify(filters, ref_id) {
+            ReferenceSource::Leaf(lsk) => single_leaf_refs.push((ref_id, lsk)),
+            ReferenceSource::Stored => composable_refs.push(ref_id),
+            ReferenceSource::NonMember => {
                 ref_membership.insert(ref_id, false);
             }
         }
@@ -806,7 +805,7 @@ pub(super) fn decode_stage1_state(bytes: Option<Vec<u8>>) -> Option<Stage1State>
 #[derive(Debug, Clone, Copy, Default)]
 pub(super) struct PriorStage2State {
     pub in_cohort: bool,
-    pub ownership: Stage2Ownership,
+    ownership: Stage2Ownership,
 }
 
 /// Decode both the logical prior bit and its ownership. Missing or corrupt rows keep the existing
@@ -2055,7 +2054,7 @@ mod tests {
     // Every test below holds `recompute_stage2_by_person` to the cohort-ordered path as an oracle
     // over the same store, then asserts what the shared read had to get right for the two to agree.
 
-    use crate::workers::stage2_person_inputs::recompute_stage2_by_person;
+    use crate::workers::stage2_person_inputs::{recompute_stage2_by_person, READ_CHUNK_KEYS};
 
     /// Run both recompute orders over the same store and return the agreed result. Neither commits,
     /// so running them back to back reads the same durable state twice.
@@ -2299,6 +2298,11 @@ mod tests {
             !recompute.changes.iter().any(|change| change.cohort_id == 1),
             "`ref AND NOT ref` over one bit cannot be satisfied",
         );
+        assert_eq!(
+            recompute.evaluated(),
+            2,
+            "both cohorts composed; cohort 1 just could not satisfy `ref AND NOT ref`",
+        );
     }
 
     /// A transferred fallback is still settled on a pair that does not flip.
@@ -2444,106 +2448,133 @@ mod tests {
         format!("beh{index:013}").as_bytes().try_into().unwrap()
     }
 
+    /// Widths derived from the chunk size, so the tests sit on the boundary wherever it moves:
+    /// exactly one chunk catches a `<` for `<=` slip, and one past it makes the second section run.
+    const CHUNK_BOUNDARY_WIDTHS: [usize; 2] = [READ_CHUNK_KEYS, READ_CHUNK_KEYS + 1];
+
     /// A chunk the read skipped would leave its leaves non-member and break the AND, so the entry
     /// proves every chunk landed.
     #[tokio::test]
     async fn a_cohort_wider_than_one_chunk_reads_every_leaf() {
-        const LEAVES: usize = 70;
+        for leaves in CHUNK_BOUNDARY_WIDTHS {
+            let (_dir, store) = temp_store();
+            let filters = freeze((0..leaves).map(wide_behavioral_leaf).collect());
+            let lsks: Vec<LeafStateKey> = (0..leaves)
+                .map(|index| filters.by_condition_to_lsk[&wide_behavioral_hash(index)][0])
+                .collect();
+            let alice = person(1);
+            for &lsk in &lsks {
+                write_behavioral(&store, lsk, alice, behavioral_match());
+            }
 
-        let (_dir, store) = temp_store();
-        let filters = freeze((0..LEAVES).map(wide_behavioral_leaf).collect());
-        let lsks: Vec<LeafStateKey> = (0..LEAVES)
-            .map(|index| filters.by_condition_to_lsk[&wide_behavioral_hash(index)][0])
-            .collect();
-        let alice = person(1);
-        for &lsk in &lsks {
-            write_behavioral(&store, lsk, alice, behavioral_match());
+            let entered =
+                recompute_both_ways(&store, &filters, TEAM as i32, &[(lsks[0], alice)]).await;
+            assert_eq!(
+                statuses(&entered),
+                vec![(1, MembershipStatus::Entered)],
+                "{leaves} leaves",
+            );
+
+            // The `Entered` above proves every chunk landed. This half pins that the last leaf's
+            // value is read, not just its key.
+            write_behavioral(
+                &store,
+                lsks[leaves - 1],
+                alice,
+                Stage1State::BehavioralSingle {
+                    has_match: false,
+                    last_event_at_ms: EVENT_MS,
+                    earliest_eviction_at_ms: i64::MAX,
+                },
+            );
+            write_stage2(&store, 1, alice, true);
+            let left =
+                recompute_both_ways(&store, &filters, TEAM as i32, &[(lsks[0], alice)]).await;
+            assert_eq!(
+                statuses(&left),
+                vec![(1, MembershipStatus::Left)],
+                "{leaves} leaves",
+            );
         }
-
-        let entered = recompute_both_ways(&store, &filters, TEAM as i32, &[(lsks[0], alice)]).await;
-        assert_eq!(statuses(&entered), vec![(1, MembershipStatus::Entered)]);
-
-        // The `Entered` above proves every chunk landed. This half pins that the far leaf's value
-        // is read, not just its key.
-        write_behavioral(
-            &store,
-            lsks[LEAVES - 1],
-            alice,
-            Stage1State::BehavioralSingle {
-                has_match: false,
-                last_event_at_ms: EVENT_MS,
-                earliest_eviction_at_ms: i64::MAX,
-            },
-        );
-        write_stage2(&store, 1, alice, true);
-        let left = recompute_both_ways(&store, &filters, TEAM as i32, &[(lsks[0], alice)]).await;
-        assert_eq!(statuses(&left), vec![(1, MembershipStatus::Left)]);
     }
 
-    /// The pair whose prior row already agrees sits past the first chunk, so only a read that
-    /// reached it stays silent.
+    /// The pair whose prior row already agrees is the last one, so only a read that reached the end
+    /// of the key set stays silent.
     #[tokio::test]
     async fn a_person_in_more_cohorts_than_one_chunk_reads_every_prior_row() {
-        const COHORTS: i32 = 70;
+        for cohorts in CHUNK_BOUNDARY_WIDTHS {
+            let last = cohorts as i32;
+            let (_dir, store) = temp_store();
+            let filters = freeze_cascade(
+                (1..=last)
+                    .map(|id| (id, vec![behavioral_leaf(7), person_leaf()]))
+                    .collect(),
+                false,
+            );
+            let beh_lsk = filters.by_condition_to_lsk[&HASH][0];
+            let alice = person(1);
+            write_behavioral(&store, beh_lsk, alice, behavioral_match());
+            write_person_record(&store, alice, &[PERSON_HASH]);
+            write_stage2(&store, last as u64, alice, true);
 
-        let (_dir, store) = temp_store();
-        let filters = freeze_cascade(
-            (1..=COHORTS)
-                .map(|id| (id, vec![behavioral_leaf(7), person_leaf()]))
-                .collect(),
-            false,
-        );
-        let beh_lsk = filters.by_condition_to_lsk[&HASH][0];
-        let alice = person(1);
-        write_behavioral(&store, beh_lsk, alice, behavioral_match());
-        write_person_record(&store, alice, &[PERSON_HASH]);
-        write_stage2(&store, COHORTS as u64, alice, true);
+            let recompute =
+                recompute_both_ways(&store, &filters, TEAM as i32, &[(beh_lsk, alice)]).await;
 
-        let recompute =
-            recompute_both_ways(&store, &filters, TEAM as i32, &[(beh_lsk, alice)]).await;
-
-        assert_eq!(
-            recompute.evaluated(),
-            COHORTS as u64,
-            "every cohort on the leaf composed",
-        );
-        assert_eq!(
-            recompute.changes.len(),
-            COHORTS as usize - 1,
-            "the one cohort whose stored bit already said `true` did not flip",
-        );
-        assert!(
-            !recompute
-                .changes
-                .iter()
-                .any(|change| change.cohort_id == COHORTS),
-            "and it is the cohort whose row sits past the first chunk",
-        );
+            assert_eq!(
+                recompute.evaluated(),
+                cohorts as u64,
+                "every cohort on the leaf composed ({cohorts} cohorts)",
+            );
+            assert_eq!(
+                recompute.changes.len(),
+                cohorts - 1,
+                "the one cohort whose stored bit already said `true` did not flip ({cohorts} cohorts)",
+            );
+            assert!(
+                !recompute
+                    .changes
+                    .iter()
+                    .any(|change| change.cohort_id == last),
+                "and it is the last cohort, whose row sits at the end of the key set",
+            );
+        }
     }
 
     /// Wide fanout over mostly shared state, with per-cohort leaves big enough that re-reading them
-    /// is not free.
+    /// is not free. With `referencing`, every cohort also names two referents off the seeded leaf:
+    /// a single-leaf cohort, resolved through the behavioral batch, and a composable one, resolved
+    /// from its stored row. Those are the reads the cohort-ordered path pays extra offloads for.
     fn wide_fixture(
         store: &CohortStore,
         cohorts: usize,
         persons: usize,
+        referencing: bool,
     ) -> (TeamFilters, Vec<(LeafStateKey, Uuid)>) {
         let shared = 0;
-        let filters = freeze_cascade(
-            (0..cohorts)
-                .map(|index| {
-                    (
-                        index as i32 + 1,
-                        vec![
-                            wide_behavioral_leaf(shared),
-                            wide_compressed_leaf(index + 1),
-                            person_leaf(),
-                        ],
-                    )
-                })
-                .collect(),
-            false,
-        );
+        let single_leaf_referent = cohorts as i32 + 1;
+        let composable_referent = cohorts as i32 + 2;
+        let mut definitions: Vec<(i32, Vec<Value>)> = (0..cohorts)
+            .map(|index| {
+                let mut leaves = vec![
+                    wide_behavioral_leaf(shared),
+                    wide_compressed_leaf(index + 1),
+                    person_leaf(),
+                ];
+                if referencing {
+                    leaves.push(cohort_ref(single_leaf_referent));
+                    leaves.push(cohort_ref(composable_referent));
+                }
+                (index as i32 + 1, leaves)
+            })
+            .collect();
+        if referencing {
+            definitions.push((single_leaf_referent, vec![wide_compressed_leaf(0)]));
+            definitions.push((
+                composable_referent,
+                vec![wide_compressed_leaf(0), person_leaf()],
+            ));
+        }
+        let filters = freeze_cascade(definitions, referencing);
         let shared_lsk = filters.by_condition_to_lsk[&wide_behavioral_hash(shared)][0];
 
         let mut affected = Vec::with_capacity(persons);
@@ -2553,6 +2584,11 @@ mod tests {
             for cohort in 0..cohorts {
                 let own = filters.by_condition_to_lsk[&wide_compressed_hash(cohort + 1)][0];
                 write_behavioral(store, own, who, year_long_compressed_state());
+            }
+            if referencing {
+                let referent = filters.by_condition_to_lsk[&wide_compressed_hash(0)][0];
+                write_behavioral(store, referent, who, year_long_compressed_state());
+                write_stage2(store, composable_referent as u64, who, true);
             }
             write_person_record(store, who, &[PERSON_HASH]);
             affected.push((shared_lsk, who));
@@ -2591,8 +2627,8 @@ mod tests {
     ///     recompute_orders_benchmark -- --ignored --nocapture
     /// ```
     ///
-    /// Asserts agreement only. A wall-time threshold here would be a flake waiting for a slower
-    /// box, and reads per source and memory belong to `cohort_seed_recompute_*` under real load.
+    /// It asserts agreement only, because a wall-time threshold would flake on a slower box. Reads
+    /// per source and memory come from `cohort_seed_recompute_*` under real load.
     #[tokio::test]
     #[ignore = "benchmark; run in release with --ignored --nocapture"]
     async fn recompute_orders_benchmark() {
@@ -2601,12 +2637,15 @@ mod tests {
         const PERSONS: usize = 500;
 
         println!(
-            "{:>8}  {:>8}  {:>12}  {:>12}  {:>7}",
-            "cohorts", "pairs", "by-cohort", "by-person", "ratio"
+            "{:>8}  {:>5}  {:>8}  {:>12}  {:>12}  {:>7}",
+            "cohorts", "refs", "pairs", "by-cohort", "by-person", "ratio"
         );
-        for cohorts in [1, 4, 14] {
+        let shapes = [1, 4, 14]
+            .into_iter()
+            .flat_map(|cohorts| [(cohorts, false), (cohorts, true)]);
+        for (cohorts, referencing) in shapes {
             let (_dir, store) = temp_store();
-            let (filters, affected) = wide_fixture(&store, cohorts, PERSONS);
+            let (filters, affected) = wide_fixture(&store, cohorts, PERSONS, referencing);
             let handle = handle(&store);
             let run_by_cohort = || {
                 recompute_stage2(
@@ -2647,8 +2686,9 @@ mod tests {
             let by_person = started.elapsed();
 
             println!(
-                "{:>8}  {:>8}  {:>10.1?}  {:>10.1?}  {:>6.2}x",
+                "{:>8}  {:>5}  {:>8}  {:>10.1?}  {:>10.1?}  {:>6.2}x",
                 cohorts,
+                if referencing { "yes" } else { "no" },
                 cohorts * PERSONS,
                 by_cohort,
                 by_person,

--- a/rust/cohort-stream-processor/src/workers/stage2_path.rs
+++ b/rust/cohort-stream-processor/src/workers/stage2_path.rs
@@ -30,7 +30,9 @@ use crate::store::{
 };
 
 /// `affected_leaves` is the touched `(leaf, person)` set; `lane` is the read lane every recompute
-/// read runs on (`Maintenance` on the seed path, so backfill never contends with live reads).
+/// read runs on. Every caller passes `Event`: the seed paths, which read on `Maintenance`, go
+/// through [`recompute_stage2_by_person`](super::stage2_person_inputs::recompute_stage2_by_person)
+/// instead, whose store section draws the maintenance permit.
 pub async fn compose_stage2(
     partition_id: u16,
     handle: &StoreHandle,
@@ -86,6 +88,61 @@ impl Stage2Recompute {
         self.composed.add(other.composed);
         self.repairs.add(other.repairs);
     }
+
+    /// Record one recomputed pair: the flip it emits, if any, and the `cf_stage2` write it owes.
+    ///
+    /// Both recompute orders call this, so what a composed evaluation emits cannot depend on
+    /// whether the caller walked cohorts or persons.
+    pub(super) fn record_pair(
+        &mut self,
+        pair: RecomputedPair,
+        diff: &RecomputeDiff,
+        event_ms: i64,
+        last_updated: &str,
+    ) {
+        self.evaluated += 1;
+        if diff.flipped() {
+            self.composed.count(diff.status());
+            self.changes.push(CohortMembershipChange {
+                team_id: pair.team_id,
+                cohort_id: pair.cohort_id.0,
+                person_id: pair.person_id.to_string(),
+                last_updated: last_updated.to_string(),
+                status: diff.status(),
+                origin: None,
+                run_id: None,
+            });
+        }
+        if diff.requires_write() {
+            // Write `false` rather than deleting so the retracted pair stays enumerable by the
+            // reconcile scan. A no-flip transferred fallback is rewritten once so receiver
+            // evaluation claims ownership.
+            self.writes.push((
+                diff.stage2_key,
+                Stage2State {
+                    in_cohort: diff.new_bit,
+                    last_evaluated_at_ms: event_ms,
+                },
+            ));
+        }
+    }
+}
+
+#[cfg(test)]
+impl Stage2Recompute {
+    /// Pairs this recompute composed, which is what `STAGE2_COHORTS_EVALUATED` reports. Read by the
+    /// tests that hold the two recompute orders to the same work, including on pairs that flip
+    /// nothing and so leave no trace in `changes` or `writes`.
+    pub(super) fn evaluated(&self) -> u64 {
+        self.evaluated
+    }
+}
+
+/// One recomputed `(cohort, person)` as the emitted change names it.
+pub(super) struct RecomputedPair {
+    pub team_id: i32,
+    pub cohort_id: CohortId,
+    pub person_id: Uuid,
 }
 
 /// Per-status flip counts, kept so [`Stage2Recompute::record_metrics`] can attribute each half of a
@@ -160,8 +217,11 @@ impl RepairCounts {
     }
 }
 
-/// The read-only half of [`compose_stage2`].
-pub(crate) async fn recompute_stage2(
+/// The read-only half of [`compose_stage2`]: one cohort at a time, in `(cohort, person)` order.
+///
+/// The seed paths use [`recompute_stage2_by_person`](super::stage2_person_inputs::recompute_stage2_by_person)
+/// instead, which shares each person's reads across their cohorts.
+pub(super) async fn recompute_stage2(
     partition_id: u16,
     handle: &StoreHandle,
     filters: &TeamFilters,
@@ -179,51 +239,26 @@ pub(crate) async fn recompute_stage2(
         }
     }
 
-    let mut changes = Vec::new();
-    let mut writes: Vec<(Stage2Key, Stage2State)> = Vec::new();
-    let mut evaluated: u64 = 0;
-    let mut composed = StatusCounts::default();
-
+    let mut recompute = Stage2Recompute::default();
     for (cohort_id, person_id) in affected {
         let Some(tree) = filters.cohorts.get(&cohort_id) else {
             continue;
         };
 
         let diff = recompute_and_diff(partition_id, person_id, tree, filters, handle, lane).await?;
-        evaluated += 1;
-        if diff.flipped() {
-            composed.count(diff.status());
-            changes.push(CohortMembershipChange {
+        recompute.record_pair(
+            RecomputedPair {
                 team_id: tree.team_id.0,
-                cohort_id: cohort_id.0,
-                person_id: person_id.to_string(),
-                last_updated: last_updated.to_string(),
-                status: diff.status(),
-                origin: None,
-                run_id: None,
-            });
-        }
-        if diff.requires_write() {
-            // Write `false` rather than deleting so the retracted pair stays enumerable by the
-            // reconcile scan. A no-flip transferred fallback is rewritten once so receiver
-            // evaluation claims ownership.
-            writes.push((
-                diff.stage2_key,
-                Stage2State {
-                    in_cohort: diff.new_bit,
-                    last_evaluated_at_ms: event_ms,
-                },
-            ));
-        }
+                cohort_id,
+                person_id,
+            },
+            &diff,
+            event_ms,
+            last_updated,
+        );
     }
 
-    Ok(Stage2Recompute {
-        changes,
-        writes,
-        evaluated,
-        composed,
-        ..Default::default()
-    })
+    Ok(recompute)
 }
 
 /// One leaf a seed run folded, with the membership its resulting state implies. The caller holds
@@ -483,6 +518,15 @@ pub(crate) struct RecomputeDiff {
 }
 
 impl RecomputeDiff {
+    pub(super) fn new(new_bit: bool, prior: PriorStage2State, stage2_key: Stage2Key) -> Self {
+        Self {
+            new_bit,
+            prior_bit: prior.in_cohort,
+            stage2_key,
+            settles_transfer_fallback: prior.ownership == Stage2Ownership::TransferredFallback,
+        }
+    }
+
     pub fn flipped(&self) -> bool {
         self.new_bit != self.prior_bit
     }
@@ -529,13 +573,8 @@ pub(crate) async fn recompute_and_diff(
         cohort_id: tree.cohort_id.0 as u64,
         person_id,
     };
-    let prior = read_prior_stage2_state(handle, &stage2_key, lane).await?;
-    Ok(RecomputeDiff {
-        new_bit,
-        prior_bit: prior.in_cohort,
-        stage2_key,
-        settles_transfer_fallback: prior.ownership == Stage2Ownership::TransferredFallback,
-    })
+    let prior = read_prior_stage2(handle.get_stage2(&stage2_key, lane).await?);
+    Ok(RecomputeDiff::new(new_bit, prior, stage2_key))
 }
 
 /// Compose one cohort for one person. A leaf with absent or undecodable state reads as non-member;
@@ -756,7 +795,7 @@ async fn resolve_ref_membership(
 }
 
 /// Decode a `cf_behavioral` value, or [`None`] for absent/undecodable rows.
-fn decode_stage1_state(bytes: Option<Vec<u8>>) -> Option<Stage1State> {
+pub(super) fn decode_stage1_state(bytes: Option<Vec<u8>>) -> Option<Stage1State> {
     let bytes = bytes?;
     match StatefulRecord::decode(&bytes) {
         Ok(record) => Some(record.state),
@@ -767,36 +806,28 @@ fn decode_stage1_state(bytes: Option<Vec<u8>>) -> Option<Stage1State> {
     }
 }
 
-#[derive(Clone, Copy)]
-struct PriorStage2State {
-    in_cohort: bool,
-    ownership: Stage2Ownership,
+/// One stored `cf_stage2` row as composition reads it. [`Default`] is the fail-closed reading an
+/// absent or corrupt row gets: a non-member row nobody has transferred.
+#[derive(Debug, Clone, Copy, Default)]
+pub(super) struct PriorStage2State {
+    pub in_cohort: bool,
+    pub ownership: Stage2Ownership,
 }
 
 /// Decode both the logical prior bit and its ownership. Missing or corrupt rows keep the existing
 /// fail-closed `false` behavior and are never mistaken for a transferred fallback.
-async fn read_prior_stage2_state(
-    handle: &StoreHandle,
-    key: &Stage2Key,
-    lane: ReadLane,
-) -> Result<PriorStage2State, StoreError> {
-    let Some(bytes) = handle.get_stage2(key, lane).await? else {
-        return Ok(PriorStage2State {
-            in_cohort: false,
-            ownership: Stage2Ownership::Local,
-        });
+pub(super) fn read_prior_stage2(bytes: Option<Vec<u8>>) -> PriorStage2State {
+    let Some(bytes) = bytes else {
+        return PriorStage2State::default();
     };
     match Stage2State::decode_with_ownership(&bytes) {
-        Ok((state, ownership)) => Ok(PriorStage2State {
+        Ok((state, ownership)) => PriorStage2State {
             in_cohort: state.in_cohort,
             ownership,
-        }),
+        },
         Err(_) => {
             counter!(STAGE2_STATE_DECODE_ERROR).increment(1);
-            Ok(PriorStage2State {
-                in_cohort: false,
-                ownership: Stage2Ownership::Local,
-            })
+            PriorStage2State::default()
         }
     }
 }
@@ -816,7 +847,7 @@ fn decode_stage2_bit(bytes: Option<Vec<u8>>) -> bool {
 }
 
 /// Collect every state-keyed leaf's [`LeafStateKey`] in pre-order.
-fn collect_leaf_state_keys(node: &FilterNode, out: &mut Vec<LeafStateKey>) {
+pub(super) fn collect_leaf_state_keys(node: &FilterNode, out: &mut Vec<LeafStateKey>) {
     match node {
         FilterNode::Group { children, .. } => {
             for child in children {
@@ -833,7 +864,7 @@ fn collect_leaf_state_keys(node: &FilterNode, out: &mut Vec<LeafStateKey>) {
 
 /// Collect referenced cohort ids (with duplicates; the caller dedups). Negation is left to
 /// `evaluate_tree`, so a referent referenced twice with opposite negation reads one bit.
-fn collect_cohort_refs(node: &FilterNode, out: &mut Vec<CohortId>) {
+pub(super) fn collect_cohort_refs(node: &FilterNode, out: &mut Vec<CohortId>) {
     match node {
         FilterNode::Group { children, .. } => {
             for child in children {
@@ -932,10 +963,15 @@ mod tests {
     }
 
     fn freeze(values: Vec<Value>) -> TeamFilters {
+        freeze_for_team(TEAM as i32, values)
+    }
+
+    /// Freeze one cohort under an explicit team, so a test can prove state is keyed by team.
+    fn freeze_for_team(team_id: i32, values: Vec<Value>) -> TeamFilters {
         let cohort = json!({ "properties": { "type": "AND", "values": values } });
         let mut builder = TeamFiltersBuilder::default();
         builder
-            .add_cohort(CohortId(1), TeamId(TEAM as i32), &cohort)
+            .add_cohort(CohortId(1), TeamId(team_id), &cohort)
             .unwrap();
         builder.freeze(UTC)
     }
@@ -2017,5 +2053,634 @@ mod tests {
             "cohort 1's register was already true; the unbacked leaf contributes nothing",
         );
         assert_eq!(diff.stage1_writes.len(), 1, "only cohort 2 had no row");
+    }
+
+    // ---- Sharing one person's inputs across their cohorts ----
+    //
+    // `recompute_stage2_by_person` is the seed paths' recompute. It reads each person once instead
+    // of once per affected cohort, so every test below holds it to this module's cohort-ordered
+    // path as an oracle over the same store, and then asserts what the shared read had to get right
+    // for the two to agree.
+
+    use crate::workers::stage2_person_inputs::recompute_stage2_by_person;
+
+    /// Run both recompute orders over the same store and return the agreed result.
+    ///
+    /// Neither commits — both hand their `cf_stage2` writes back for the caller to commit after its
+    /// produce — so running them back to back reads the same durable state twice.
+    async fn recompute_both_ways(
+        store: &CohortStore,
+        filters: &TeamFilters,
+        team_id: i32,
+        affected: &[(LeafStateKey, Uuid)],
+    ) -> Stage2Recompute {
+        let handle = handle(store);
+        let cohort_ordered = recompute_stage2(
+            PARTITION,
+            &handle,
+            filters,
+            affected,
+            EVENT_MS,
+            TS,
+            ReadLane::Maintenance,
+        )
+        .await
+        .unwrap();
+        let by_person = recompute_stage2_by_person(
+            PARTITION,
+            &handle,
+            TeamId(team_id),
+            filters,
+            affected,
+            EVENT_MS,
+            TS,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            by_person.changes, cohort_ordered.changes,
+            "sharing a person's inputs changed which flips the run emits",
+        );
+        assert_eq!(
+            by_person.writes, cohort_ordered.writes,
+            "sharing a person's inputs changed which cf_stage2 rows the run owes",
+        );
+        assert_eq!(
+            by_person.evaluated(),
+            cohort_ordered.evaluated(),
+            "sharing a person's inputs changed how many pairs the run composed",
+        );
+        by_person
+    }
+
+    fn compressed_leaf(op: &str, value: i64) -> Value {
+        json!({
+            "type": "behavioral", "value": "performed_event_multiple", "key": "$pageview",
+            "time_value": 1, "time_interval": "year",
+            "operator": op, "operator_value": value,
+            "conditionHash": "0123456789abcdef",
+            "bytecode": ["_H", 1, 32, "$pageview", 32, "event", 1, 1, 11],
+        })
+    }
+
+    fn compressed_state(count: u32) -> Stage1State {
+        Stage1State::BehavioralCompressedHistory {
+            entries: vec![(20_607, count)],
+            window_start_day: 20_600,
+            last_event_at_ms: EVENT_MS,
+            earliest_eviction_at_ms: i64::MAX,
+        }
+    }
+
+    fn statuses(recompute: &Stage2Recompute) -> Vec<(i32, MembershipStatus)> {
+        recompute
+            .changes
+            .iter()
+            .map(|change| (change.cohort_id, change.status))
+            .collect()
+    }
+
+    /// A second person condition, which the stored record does not match. Sharing one record across
+    /// a person's cohorts must still answer each condition separately.
+    fn other_person_leaf() -> Value {
+        json!({
+            "type": "person", "key": "email", "value": "someone@example.com", "operator": "exact",
+            "conditionHash": "0f0f0f0f0f0f0f0f",
+            "bytecode": ["_H", 1, 32, "someone@example.com", 32, "email", 32, "properties", 32, "person", 1, 3, 11],
+        })
+    }
+
+    /// One person, four cohorts, one shared behavioral leaf and one shared person leaf, and every
+    /// behavioral variant in the mix. The shared read must serve all four cohorts from one person
+    /// record and one behavioral batch without changing any verdict.
+    ///
+    /// Cohort 4 names a second person condition the record does not match, so a read that collapsed
+    /// the record into one bit — "matched anything" rather than "matched this hash" — would enter it.
+    /// That is the mistake sharing the record invites.
+    #[tokio::test]
+    async fn shared_inputs_compose_every_leaf_variant_from_one_read() {
+        let (_dir, store) = temp_store();
+        let filters = freeze_cascade(
+            vec![
+                (1, vec![behavioral_leaf(7), person_leaf()]),
+                (2, vec![daily_leaf(7, "gte", 2), person_leaf()]),
+                (3, vec![compressed_leaf("gte", 2), person_leaf()]),
+                (4, vec![behavioral_leaf(7), other_person_leaf()]),
+            ],
+            false,
+        );
+        let single_lsk = filters.by_condition_to_lsk[&HASH]
+            .iter()
+            .copied()
+            .find(|lsk| filters.by_lsk[lsk].variant == StateVariant::BehavioralSingle)
+            .unwrap();
+        let daily_lsk = filters.by_condition_to_lsk[&HASH]
+            .iter()
+            .copied()
+            .find(|lsk| filters.by_lsk[lsk].variant == StateVariant::BehavioralDailyBuckets)
+            .unwrap();
+        let compressed_lsk = filters.by_condition_to_lsk[&HASH]
+            .iter()
+            .copied()
+            .find(|lsk| filters.by_lsk[lsk].variant == StateVariant::BehavioralCompressedHistory)
+            .unwrap();
+        let per_lsk = LeafStateKey::for_person_property(&PERSON_HASH);
+        let alice = person(1);
+
+        write_behavioral(&store, single_lsk, alice, behavioral_match());
+        write_behavioral(&store, daily_lsk, alice, daily_state(2));
+        write_behavioral(&store, compressed_lsk, alice, compressed_state(2));
+        write_person_record(&store, alice, &[PERSON_HASH]);
+
+        // Both leaves, so cohort 4 is reached too: it hangs off the shared behavioral leaf, not off
+        // the person condition the other three share.
+        let affected = [(single_lsk, alice), (per_lsk, alice)];
+        let entered = recompute_both_ways(&store, &filters, TEAM as i32, &affected).await;
+        assert_eq!(
+            statuses(&entered),
+            vec![
+                (1, MembershipStatus::Entered),
+                (2, MembershipStatus::Entered),
+                (3, MembershipStatus::Entered),
+            ],
+            "each variant's comparator still decides its own leaf, and the unmatched person \
+             condition keeps cohort 4 out of the same record's answers",
+        );
+        // Absolute, not against the oracle: both orders build the change through one shared
+        // `record_pair`, so only a literal pins which team the shared read stamped on it.
+        assert!(entered
+            .changes
+            .iter()
+            .all(|change| change.team_id == TEAM as i32));
+
+        // The daily leaf now misses its threshold, and only that cohort may leave.
+        write_behavioral(&store, daily_lsk, alice, daily_state(1));
+        for cohort in [1, 2, 3] {
+            write_stage2(&store, cohort, alice, true);
+        }
+        let left = recompute_both_ways(&store, &filters, TEAM as i32, &affected).await;
+        assert_eq!(statuses(&left), vec![(2, MembershipStatus::Left)]);
+    }
+
+    /// A referent and its referrer recompute in the same call. The referrer must read the referent's
+    /// *stored* bit, not the one this run is about to write, or it emits a cascade nothing has
+    /// acknowledged.
+    #[tokio::test]
+    async fn a_referent_recomputed_in_the_same_call_is_still_read_from_the_store() {
+        let (_dir, store) = temp_store();
+        let filters = freeze_cascade(
+            vec![
+                (1, vec![person_leaf(), cohort_ref(2)]),
+                (2, vec![behavioral_leaf(7), person_leaf()]),
+            ],
+            true,
+        );
+        let beh_lsk = filters.by_condition_to_lsk[&HASH][0];
+        let per_lsk = LeafStateKey::for_person_property(&PERSON_HASH);
+        let alice = person(1);
+
+        write_behavioral(&store, beh_lsk, alice, behavioral_match());
+        write_person_record(&store, alice, &[PERSON_HASH]);
+        // Cohort 2 will recompute to `true` in this same call; the store still says `false`.
+        write_stage2(&store, 2, alice, false);
+
+        let recompute =
+            recompute_both_ways(&store, &filters, TEAM as i32, &[(per_lsk, alice)]).await;
+
+        assert_eq!(
+            statuses(&recompute),
+            vec![(2, MembershipStatus::Entered)],
+            "cohort 1 read the stored `false` for its referent and did not enter",
+        );
+    }
+
+    /// The one reference kind whose bit comes back through the *behavioral* batch rather than the
+    /// `cf_stage2` batch. A single-leaf referent is resolved from its own leaf state through its own
+    /// comparator, so resolving it from a stored membership row instead would read every referrer of
+    /// a single-leaf cohort as a non-member — and no other test here would notice.
+    #[tokio::test]
+    async fn a_single_leaf_referent_resolves_through_its_own_leaf_and_comparator() {
+        let (_dir, store) = temp_store();
+        let filters = freeze_cascade(
+            vec![
+                (1, vec![person_leaf(), cohort_ref(3)]),
+                (3, vec![daily_leaf(7, "gte", 2)]),
+            ],
+            true,
+        );
+        assert!(
+            matches!(
+                filters.eligibility[&CohortId(3)],
+                CohortEligibility::SingleLeaf(_)
+            ),
+            "cohort 3 has to be the single-leaf kind for this to be the case under test",
+        );
+        let referent_lsk = single_leaf_lsk(&filters, 3);
+        let per_lsk = LeafStateKey::for_person_property(&PERSON_HASH);
+        let alice = person(1);
+        write_person_record(&store, alice, &[PERSON_HASH]);
+
+        // Below the referent's threshold: the referrer must not enter, even though the referent has
+        // behavioral state and no cf_stage2 row of its own to read.
+        write_behavioral(&store, referent_lsk, alice, daily_state(1));
+        let below = recompute_both_ways(&store, &filters, TEAM as i32, &[(per_lsk, alice)]).await;
+        assert!(
+            below.changes.is_empty(),
+            "the referent's own comparator says it is not a member",
+        );
+
+        write_behavioral(&store, referent_lsk, alice, daily_state(2));
+        let above = recompute_both_ways(&store, &filters, TEAM as i32, &[(per_lsk, alice)]).await;
+        assert_eq!(statuses(&above), vec![(1, MembershipStatus::Entered)]);
+    }
+
+    /// A referent read as stored, then referenced twice in one tree with opposite negation, is one
+    /// row and two consistent answers.
+    #[tokio::test]
+    async fn a_referent_named_twice_with_opposite_negation_reads_one_row() {
+        let (_dir, store) = temp_store();
+        let filters = freeze_cascade(
+            vec![
+                (1, vec![person_leaf(), cohort_ref(2), negated_cohort_ref(2)]),
+                (2, vec![behavioral_leaf(7), person_leaf()]),
+            ],
+            true,
+        );
+        let per_lsk = LeafStateKey::for_person_property(&PERSON_HASH);
+        let alice = person(1);
+
+        write_person_record(&store, alice, &[PERSON_HASH]);
+        write_stage2(&store, 2, alice, true);
+
+        let recompute =
+            recompute_both_ways(&store, &filters, TEAM as i32, &[(per_lsk, alice)]).await;
+        assert!(
+            !recompute.changes.iter().any(|change| change.cohort_id == 1),
+            "`ref AND NOT ref` over one bit cannot be satisfied",
+        );
+    }
+
+    /// Absent and corrupt rows read as non-member on the shared path exactly as they do per cohort,
+    /// and a transferred fallback is still settled on a pair that does not flip.
+    #[tokio::test]
+    async fn corrupt_rows_stay_non_member_and_a_transferred_fallback_still_settles() {
+        let (_dir, store) = temp_store();
+        let filters = freeze_cascade(
+            vec![
+                (1, vec![behavioral_leaf(7), person_leaf()]),
+                (2, vec![daily_leaf(7, "gte", 2), person_leaf()]),
+            ],
+            false,
+        );
+        let beh_lsk = filters.by_condition_to_lsk[&HASH]
+            .iter()
+            .copied()
+            .find(|lsk| filters.by_lsk[lsk].variant == StateVariant::BehavioralSingle)
+            .unwrap();
+        let per_lsk = LeafStateKey::for_person_property(&PERSON_HASH);
+        let alice = person(1);
+
+        write_behavioral(&store, beh_lsk, alice, behavioral_match());
+        write_corrupt_person_record(&store, alice);
+        // Cohort 1's row is already `false` and carries a transfer fallback, so the receiver has to
+        // claim it even though the bit does not move.
+        let key = Stage2Key {
+            partition_id: PARTITION,
+            team_id: TEAM,
+            cohort_id: 1,
+            person_id: alice,
+        };
+        let fallback = Stage2State {
+            in_cohort: false,
+            last_evaluated_at_ms: EVENT_MS,
+        };
+        store
+            .write_batch(|b| b.put_stage2(&key, &fallback.encode_transferred_fallback()))
+            .unwrap();
+
+        let recompute =
+            recompute_both_ways(&store, &filters, TEAM as i32, &[(per_lsk, alice)]).await;
+
+        assert!(
+            recompute.changes.is_empty(),
+            "a corrupt person record reads every person leaf as a non-member",
+        );
+        assert_eq!(
+            recompute.writes,
+            vec![(
+                key,
+                Stage2State {
+                    in_cohort: false,
+                    last_evaluated_at_ms: EVENT_MS,
+                }
+            )],
+            "the fallback row is rewritten once, and the ordinary no-flip row is left alone",
+        );
+    }
+
+    /// Two persons in one call, with opposite state. Sharing is per person, so neither may see the
+    /// other's record or leaves.
+    #[tokio::test]
+    async fn two_persons_in_one_call_keep_their_own_inputs() {
+        let (_dir, store) = temp_store();
+        let filters = freeze_cascade(
+            vec![
+                (1, vec![behavioral_leaf(7), person_leaf()]),
+                (2, vec![behavioral_leaf(7), person_leaf()]),
+            ],
+            false,
+        );
+        let beh_lsk = filters.by_condition_to_lsk[&HASH][0];
+        let per_lsk = LeafStateKey::for_person_property(&PERSON_HASH);
+        let (alice, bob) = (person(1), person(2));
+
+        write_behavioral(&store, beh_lsk, alice, behavioral_match());
+        write_person_record(&store, alice, &[PERSON_HASH]);
+        // Bob matches the person condition but has no behavioral state.
+        write_person_record(&store, bob, &[PERSON_HASH]);
+
+        let recompute = recompute_both_ways(
+            &store,
+            &filters,
+            TEAM as i32,
+            &[(per_lsk, alice), (per_lsk, bob)],
+        )
+        .await;
+
+        assert_eq!(
+            recompute
+                .changes
+                .iter()
+                .map(|change| (change.cohort_id, change.person_id.clone()))
+                .collect::<Vec<_>>(),
+            vec![(1, alice.to_string()), (2, alice.to_string()),],
+            "changes stay in (cohort, person) order and Bob's missing leaf keeps him out",
+        );
+        assert_eq!(
+            recompute.evaluated(),
+            4,
+            "both persons composed both cohorts"
+        );
+    }
+
+    /// The same person and the same leaf under a different team must not see the first team's rows.
+    #[tokio::test]
+    async fn state_written_for_one_team_is_invisible_to_another() {
+        let (_dir, store) = temp_store();
+        let leaves = vec![behavioral_leaf(7), person_leaf()];
+        let ours = freeze_for_team(TEAM as i32, leaves.clone());
+        let theirs = freeze_for_team(TEAM as i32 + 1, leaves);
+        let beh_lsk = ours.by_condition_to_lsk[&HASH][0];
+        let per_lsk = LeafStateKey::for_person_property(&PERSON_HASH);
+        let alice = person(1);
+
+        write_behavioral(&store, beh_lsk, alice, behavioral_match());
+        write_person_record(&store, alice, &[PERSON_HASH]);
+
+        let ours_recompute =
+            recompute_both_ways(&store, &ours, TEAM as i32, &[(per_lsk, alice)]).await;
+        assert_eq!(
+            statuses(&ours_recompute),
+            vec![(1, MembershipStatus::Entered)]
+        );
+
+        let theirs_recompute =
+            recompute_both_ways(&store, &theirs, TEAM as i32 + 1, &[(per_lsk, alice)]).await;
+        assert!(
+            theirs_recompute.changes.is_empty(),
+            "the neighbouring team's keyspace holds none of this state",
+        );
+    }
+
+    /// Distinct condition hashes, so a fixture can build a cohort wider than one read chunk.
+    fn wide_behavioral_leaf(index: usize) -> Value {
+        json!({
+            "type": "behavioral", "value": "performed_event", "key": "$pageview",
+            "time_value": 7, "time_interval": "day",
+            "conditionHash": format!("beh{index:013}"),
+            "bytecode": ["_H", 1, 32, "$pageview", 32, "event", 1, 1, 11],
+        })
+    }
+
+    fn wide_behavioral_hash(index: usize) -> [u8; 16] {
+        format!("beh{index:013}").as_bytes().try_into().unwrap()
+    }
+
+    /// More behavioral leaves than fit one chunk. A chunk the read skipped would leave its leaves
+    /// non-member and break the AND, so the entry proves every chunk landed.
+    #[tokio::test]
+    async fn a_cohort_wider_than_one_chunk_reads_every_leaf() {
+        const LEAVES: usize = 70;
+
+        let (_dir, store) = temp_store();
+        let filters = freeze((0..LEAVES).map(wide_behavioral_leaf).collect());
+        let lsks: Vec<LeafStateKey> = (0..LEAVES)
+            .map(|index| filters.by_condition_to_lsk[&wide_behavioral_hash(index)][0])
+            .collect();
+        let alice = person(1);
+        for &lsk in &lsks {
+            write_behavioral(&store, lsk, alice, behavioral_match());
+        }
+
+        let entered = recompute_both_ways(&store, &filters, TEAM as i32, &[(lsks[0], alice)]).await;
+        assert_eq!(statuses(&entered), vec![(1, MembershipStatus::Entered)]);
+
+        // Drop one leaf in the second chunk. The `Entered` above is what proves every chunk landed;
+        // this half pins that the far leaf's value is the one being read, not just its key.
+        write_behavioral(
+            &store,
+            lsks[LEAVES - 1],
+            alice,
+            Stage1State::BehavioralSingle {
+                has_match: false,
+                last_event_at_ms: EVENT_MS,
+                earliest_eviction_at_ms: i64::MAX,
+            },
+        );
+        write_stage2(&store, 1, alice, true);
+        let left = recompute_both_ways(&store, &filters, TEAM as i32, &[(lsks[0], alice)]).await;
+        assert_eq!(statuses(&left), vec![(1, MembershipStatus::Left)]);
+    }
+
+    /// One person in more composable cohorts than fit one `cf_stage2` chunk. The pair whose prior
+    /// row already agrees sits in the second chunk, so only a read that reached it stays silent.
+    #[tokio::test]
+    async fn a_person_in_more_cohorts_than_one_chunk_reads_every_prior_row() {
+        const COHORTS: i32 = 70;
+
+        let (_dir, store) = temp_store();
+        let filters = freeze_cascade(
+            (1..=COHORTS)
+                .map(|id| (id, vec![behavioral_leaf(7), person_leaf()]))
+                .collect(),
+            false,
+        );
+        let beh_lsk = filters.by_condition_to_lsk[&HASH][0];
+        let alice = person(1);
+        write_behavioral(&store, beh_lsk, alice, behavioral_match());
+        write_person_record(&store, alice, &[PERSON_HASH]);
+        write_stage2(&store, COHORTS as u64, alice, true);
+
+        let recompute =
+            recompute_both_ways(&store, &filters, TEAM as i32, &[(beh_lsk, alice)]).await;
+
+        assert_eq!(
+            recompute.evaluated(),
+            COHORTS as u64,
+            "every cohort on the leaf composed",
+        );
+        assert_eq!(
+            recompute.changes.len(),
+            COHORTS as usize - 1,
+            "the one cohort whose stored bit already said `true` did not flip",
+        );
+        assert!(
+            !recompute
+                .changes
+                .iter()
+                .any(|change| change.cohort_id == COHORTS),
+            "and it is the cohort whose row sits past the first chunk",
+        );
+    }
+
+    /// Invented fixture: `persons` persons, each in `cohorts` composable cohorts that share one
+    /// behavioral leaf and one person leaf, and each cohort also owning a leaf whose compressed
+    /// history spans a year. That is the shape the sharing is for — wide fanout over mostly shared
+    /// state, with values big enough that re-reading them is not free.
+    fn wide_fixture(
+        store: &CohortStore,
+        cohorts: usize,
+        persons: usize,
+    ) -> (TeamFilters, Vec<(LeafStateKey, Uuid)>) {
+        let shared = 0;
+        let filters = freeze_cascade(
+            (0..cohorts)
+                .map(|index| {
+                    (
+                        index as i32 + 1,
+                        vec![
+                            wide_behavioral_leaf(shared),
+                            wide_compressed_leaf(index + 1),
+                            person_leaf(),
+                        ],
+                    )
+                })
+                .collect(),
+            false,
+        );
+        let shared_lsk = filters.by_condition_to_lsk[&wide_behavioral_hash(shared)][0];
+
+        let mut affected = Vec::with_capacity(persons);
+        for index in 0..persons {
+            let who = person(index as u128 + 1);
+            write_behavioral(store, shared_lsk, who, behavioral_match());
+            for cohort in 0..cohorts {
+                let own = filters.by_condition_to_lsk[&wide_compressed_hash(cohort + 1)][0];
+                write_behavioral(store, own, who, year_long_compressed_state());
+            }
+            write_person_record(store, who, &[PERSON_HASH]);
+            affected.push((shared_lsk, who));
+        }
+        (filters, affected)
+    }
+
+    fn wide_compressed_leaf(index: usize) -> Value {
+        json!({
+            "type": "behavioral", "value": "performed_event_multiple", "key": "$pageview",
+            "time_value": 1, "time_interval": "year",
+            "operator": "gte", "operator_value": 1,
+            "conditionHash": format!("cmp{index:013}"),
+            "bytecode": ["_H", 1, 32, "$pageview", 32, "event", 1, 1, 11],
+        })
+    }
+
+    fn wide_compressed_hash(index: usize) -> [u8; 16] {
+        format!("cmp{index:013}").as_bytes().try_into().unwrap()
+    }
+
+    /// One entry per day of the window, so each behavioral value is kilobytes rather than bytes.
+    fn year_long_compressed_state() -> Stage1State {
+        Stage1State::BehavioralCompressedHistory {
+            entries: (0..365).map(|day| (20_600 + day, 1)).collect(),
+            window_start_day: 20_600,
+            last_event_at_ms: EVENT_MS,
+            earliest_eviction_at_ms: i64::MAX,
+        }
+    }
+
+    /// Benchmark, not a test. Run it in release:
+    ///
+    /// ```text
+    /// cargo test -p cohort-stream-processor --release --lib \
+    ///     recompute_orders_benchmark -- --ignored --nocapture
+    /// ```
+    ///
+    /// Both orders run over one store in one process, so the comparison needs no second checkout and
+    /// no second build. It asserts agreement only: a wall-time threshold in a test is a flake
+    /// waiting for a slower box, and reads per state source and memory belong to
+    /// `cohort_seed_recompute_*` under real load, not here.
+    #[tokio::test]
+    #[ignore = "benchmark; run in release with --ignored --nocapture"]
+    async fn recompute_orders_benchmark() {
+        use std::time::Instant;
+
+        const PERSONS: usize = 500;
+
+        println!(
+            "{:>8}  {:>8}  {:>12}  {:>12}  {:>7}",
+            "cohorts", "pairs", "by-cohort", "by-person", "ratio"
+        );
+        for cohorts in [1, 4, 14] {
+            let (_dir, store) = temp_store();
+            let (filters, affected) = wide_fixture(&store, cohorts, PERSONS);
+            let handle = handle(&store);
+            let run_by_cohort = || {
+                recompute_stage2(
+                    PARTITION,
+                    &handle,
+                    &filters,
+                    &affected,
+                    EVENT_MS,
+                    TS,
+                    ReadLane::Maintenance,
+                )
+            };
+            let run_by_person = || {
+                recompute_stage2_by_person(
+                    PARTITION,
+                    &handle,
+                    TeamId(TEAM as i32),
+                    &filters,
+                    &affected,
+                    EVENT_MS,
+                    TS,
+                )
+            };
+
+            // Warm the block cache first, so the timed pass measures the read shape and not the
+            // first touch of every SST.
+            let warm_by_cohort = run_by_cohort().await.unwrap();
+            let warm_by_person = run_by_person().await.unwrap();
+            assert_eq!(warm_by_person.changes, warm_by_cohort.changes);
+            assert_eq!(warm_by_person.writes, warm_by_cohort.writes);
+
+            let started = Instant::now();
+            run_by_cohort().await.unwrap();
+            let by_cohort = started.elapsed();
+
+            let started = Instant::now();
+            run_by_person().await.unwrap();
+            let by_person = started.elapsed();
+
+            println!(
+                "{:>8}  {:>8}  {:>10.1?}  {:>10.1?}  {:>6.2}x",
+                cohorts,
+                cohorts * PERSONS,
+                by_cohort,
+                by_person,
+                by_cohort.as_secs_f64() / by_person.as_secs_f64(),
+            );
+        }
     }
 }

--- a/rust/cohort-stream-processor/src/workers/stage2_person_inputs.rs
+++ b/rust/cohort-stream-processor/src/workers/stage2_person_inputs.rs
@@ -1,0 +1,652 @@
+//! Stage 2 recomputation for a seed run, sharing each person's store inputs across their cohorts.
+//!
+//! [`recompute_stage2_by_person`] answers exactly what
+//! [`recompute_stage2`](super::stage2_path::recompute_stage2) answers over the same store — the same
+//! pairs, the same flips, the same `cf_stage2` rows owed — but reaches it person by person. The
+//! cohort-ordered path re-reads a person's record, their behavioral leaves, and their prior
+//! membership once per affected cohort; a wide person seed touching a dozen composable cohorts pays
+//! that a dozen times over, and each read is its own blocking-pool handoff.
+//!
+//! Here a [`PersonReadPlan`] resolves each person's needs from the frozen catalog first, then one
+//! [`PersonInputReader`] fetches them in a single store section: one person record, each distinct
+//! behavioral key once, and one `cf_stage2` key set covering both the pairs' own prior rows and
+//! every composed referent.
+//!
+//! Two boundaries the sharing must not cross:
+//!
+//! - **Stored, not pending.** A composed referent resolves from the bit the store holds, even when
+//!   that referent recomputes in this same group. Substituting a freshly computed bit would emit a
+//!   cascade the referent has not acknowledged.
+//! - **One chunk at a time.** Behavioral values carry whole event histories, so the union is read in
+//!   bounded chunks and each chunk's raw buffers are decoded and dropped before the next is read.
+//!   The person's residue is their decoded membership bits, not their rows.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+use metrics::{counter, histogram};
+use uuid::Uuid;
+
+use crate::filters::reverse_index::{LeafStateMeta, TeamFilters};
+use crate::filters::{CohortId, TeamId};
+use crate::observability::metrics::{
+    SEED_RECOMPUTE_CHUNK_BYTES, SEED_RECOMPUTE_KEYS_FETCHED_TOTAL, SEED_RECOMPUTE_PERSONS_TOTAL,
+    STAGE2_STATE_DECODE_ERROR,
+};
+use crate::stage1::key::LeafStateKey;
+use crate::stage1::person_record::PersonRecord;
+use crate::stage1::state::StateVariant;
+use crate::stage2::evaluator::{evaluate_tree, leaf_membership};
+use crate::stage2::CohortEligibility;
+use crate::store::{
+    BehavioralKey, CohortStore, PersonRecordKey, Stage2Key, StoreError, StoreHandle,
+};
+use crate::workers::stage2_path::{
+    collect_cohort_refs, collect_leaf_state_keys, decode_stage1_state, read_prior_stage2,
+    PriorStage2State, RecomputeDiff, RecomputedPair, Stage2Recompute,
+};
+
+/// Keys per batched read. A key count is not a byte bound — a behavioral value holds a window's
+/// history, and a person's leaves vary widely in size — so this caps the raw buffers held at once
+/// without promising a fixed footprint. [`SEED_RECOMPUTE_CHUNK_BYTES`] measures what it cost.
+const READ_CHUNK_KEYS: usize = 64;
+
+/// The `op` label these sections report their offload timings under.
+const SECTION_OP: &str = "stage2_person_inputs";
+
+/// Recompute one seed group's composable cohorts, sharing each person's reads across their cohorts.
+///
+/// `team_id` is the group's team, which is also the key its `filters` sit under in the frozen
+/// catalog, so every cohort reached here composes from that team's keyspace.
+///
+/// Changes and writes come back in `(cohort, person)` order, matching the cohort-ordered path, so a
+/// caller cannot tell the two apart by the shape of what it produces.
+///
+/// One store read failure holds the whole run: the error propagates before any output exists, so the
+/// caller has nothing partial to publish.
+pub(crate) async fn recompute_stage2_by_person(
+    partition_id: u16,
+    handle: &StoreHandle,
+    team_id: TeamId,
+    filters: &TeamFilters,
+    affected_leaves: &[(LeafStateKey, Uuid)],
+    event_ms: i64,
+    last_updated: &str,
+) -> Result<Stage2Recompute, StoreError> {
+    let mut affected: BTreeMap<Uuid, BTreeSet<CohortId>> = BTreeMap::new();
+    for &(leaf_state_key, person_id) in affected_leaves {
+        if let Some(cohorts) = filters.by_lsk_to_composable_cohorts.get(&leaf_state_key) {
+            affected
+                .entry(person_id)
+                .or_default()
+                .extend(cohorts.iter().copied());
+        }
+    }
+
+    // Collected before emitting, so the pairs come out in cohort order however they were grouped
+    // for reading.
+    let mut pairs: BTreeMap<(CohortId, Uuid), RecomputeDiff> = BTreeMap::new();
+    for (person_id, cohorts) in affected {
+        let plan = PersonReadPlan::build(partition_id, team_id, person_id, &cohorts, filters);
+        if plan.is_empty() {
+            continue;
+        }
+
+        let (plan, inputs) = handle
+            .run_section(SECTION_OP, move |store| {
+                // Counted here, not after the await, so it lands on the same thread as the key
+                // counters below it. A started blocking task runs to completion even if the caller
+                // future is dropped, so counting outside would let a cancelled offload record keys
+                // for a person it never recorded — skewing keys-per-person by exactly the reads
+                // that went missing.
+                counter!(SEED_RECOMPUTE_PERSONS_TOTAL).increment(1);
+                let inputs = PersonInputReader::new(store, &plan).read()?;
+                Ok((plan, inputs))
+            })
+            .await??;
+
+        let references = plan.reference_membership(&inputs);
+        for &cohort_id in &plan.cohorts {
+            let tree = filters
+                .cohorts
+                .get(&cohort_id)
+                .expect("the plan keeps only cohorts this frozen catalog has a tree for");
+            // The cohort-ordered path stamps changes from the tree; this one from the group. The
+            // catalog keys one `TeamFilters` per team and stamps its trees with that same id, so
+            // they agree — and this is the only thing still saying so.
+            debug_assert_eq!(
+                tree.team_id, team_id,
+                "a team's catalog holds only that team's cohorts",
+            );
+            let new_bit = evaluate_tree(&tree.root, &inputs.membership, &references);
+            pairs.insert(
+                (cohort_id, person_id),
+                RecomputeDiff::new(
+                    new_bit,
+                    inputs.prior_stage2(cohort_id),
+                    plan.stage2_key(cohort_id),
+                ),
+            );
+        }
+    }
+
+    let mut recompute = Stage2Recompute::default();
+    for ((cohort_id, person_id), diff) in pairs {
+        recompute.record_pair(
+            RecomputedPair {
+                team_id: team_id.0,
+                cohort_id,
+                person_id,
+            },
+            &diff,
+            event_ms,
+            last_updated,
+        );
+    }
+    Ok(recompute)
+}
+
+// ---- What one person's cohorts read ----
+
+/// How one referenced cohort resolves for a person.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReferenceSource {
+    /// A single-leaf referent: its membership is that leaf's own bit, read through the same
+    /// comparator the referrer's own leaves use.
+    Leaf(LeafStateKey),
+    /// A referent that composes its own row: read the membership the store holds.
+    Stored,
+    /// Excluded, cyclic, or absent from the frozen catalog.
+    NonMember,
+}
+
+/// Everything one person's affected cohorts read from the store, resolved from the frozen catalog
+/// before any I/O and owned, so the whole read runs as one blocking section.
+#[derive(Debug)]
+struct PersonReadPlan {
+    partition_id: u16,
+    team_id: u64,
+    person_id: Uuid,
+    /// The pairs to recompute, ascending. Every id here has a tree in the frozen catalog.
+    cohorts: Vec<CohortId>,
+    /// The distinct behavioral leaves the cohorts read, each with the metadata its comparator needs.
+    behavioral: Vec<(LeafStateKey, LeafStateMeta)>,
+    /// The distinct person-property leaves, which all resolve from the one person record.
+    person_leaves: Vec<LeafStateKey>,
+    /// The cohorts whose stored membership row is read: each recomputed pair's own prior row, plus
+    /// every composed referent. One row serves both when a referent also recomputes here.
+    stage2_cohorts: Vec<CohortId>,
+    /// Every cohort the trees reference, and how each resolves.
+    references: BTreeMap<CohortId, ReferenceSource>,
+}
+
+impl PersonReadPlan {
+    /// Walk one person's affected cohort trees once and collect what they read. Pure: it consults
+    /// the frozen catalog only, so the plan is settled before the run holds a store permit.
+    fn build(
+        partition_id: u16,
+        team_id: TeamId,
+        person_id: Uuid,
+        cohorts: &BTreeSet<CohortId>,
+        filters: &TeamFilters,
+    ) -> Self {
+        let mut plan = Self {
+            partition_id,
+            team_id: team_id.0 as u64,
+            person_id,
+            cohorts: Vec::with_capacity(cohorts.len()),
+            behavioral: Vec::new(),
+            person_leaves: Vec::new(),
+            stage2_cohorts: Vec::with_capacity(cohorts.len()),
+            references: BTreeMap::new(),
+        };
+
+        let mut lsks = Vec::new();
+        let mut refs = Vec::new();
+        for &cohort_id in cohorts {
+            let Some(tree) = filters.cohorts.get(&cohort_id) else {
+                continue;
+            };
+            plan.cohorts.push(cohort_id);
+            // The pair's own prior row, which the diff needs whether or not the cohort flips.
+            plan.stage2_cohorts.push(cohort_id);
+
+            lsks.clear();
+            collect_leaf_state_keys(&tree.root, &mut lsks);
+            for &lsk in &lsks {
+                plan.route_leaf(lsk, filters);
+            }
+
+            refs.clear();
+            collect_cohort_refs(&tree.root, &mut refs);
+            for &ref_id in &refs {
+                plan.route_reference(ref_id, filters);
+            }
+        }
+
+        plan.dedup_read_sets();
+        plan
+    }
+
+    /// Route one leaf to the state source its variant reads from. A key the frozen catalog does not
+    /// carry is routed nowhere, so composition reads it as a non-member.
+    fn route_leaf(&mut self, lsk: LeafStateKey, filters: &TeamFilters) {
+        let Some(meta) = filters.by_lsk.get(&lsk) else {
+            return;
+        };
+        match meta.variant {
+            StateVariant::PersonProperty => self.person_leaves.push(lsk),
+            // Exhaustive (no wildcard) so a future membership source resolving from another store
+            // fails to compile here instead of being silently misrouted into `cf_behavioral`.
+            StateVariant::BehavioralSingle
+            | StateVariant::BehavioralDailyBuckets
+            | StateVariant::BehavioralCompressedHistory => self.behavioral.push((lsk, *meta)),
+        }
+    }
+
+    /// Classify one referenced cohort, and add whatever resolving it will need. Repeats are free:
+    /// a referent named by several of the person's cohorts, or twice in one tree, is classified and
+    /// read once.
+    fn route_reference(&mut self, ref_id: CohortId, filters: &TeamFilters) {
+        if self.references.contains_key(&ref_id) {
+            return;
+        }
+        let source = match filters.eligibility.get(&ref_id) {
+            Some(CohortEligibility::SingleLeaf(lsk)) => ReferenceSource::Leaf(*lsk),
+            Some(eligibility) if eligibility.writes_cf_stage2() => ReferenceSource::Stored,
+            _ => ReferenceSource::NonMember,
+        };
+        match source {
+            ReferenceSource::Leaf(lsk) => self.route_leaf(lsk, filters),
+            ReferenceSource::Stored => self.stage2_cohorts.push(ref_id),
+            ReferenceSource::NonMember => {}
+        }
+        self.references.insert(ref_id, source);
+    }
+
+    /// Cohorts sharing a leaf route it once each, so the read sets arrive with duplicates. Order and
+    /// deduplicate them once here, which is what makes the read one key per distinct row.
+    fn dedup_read_sets(&mut self) {
+        self.behavioral.sort_unstable_by_key(|(lsk, _)| *lsk);
+        self.behavioral.dedup_by_key(|(lsk, _)| *lsk);
+        self.person_leaves.sort_unstable();
+        self.person_leaves.dedup();
+        self.stage2_cohorts.sort_unstable();
+        self.stage2_cohorts.dedup();
+    }
+
+    /// No cohort of this person survived the frozen catalog, so there is nothing to read.
+    fn is_empty(&self) -> bool {
+        self.cohorts.is_empty()
+    }
+
+    fn person_record_key(&self) -> PersonRecordKey {
+        PersonRecordKey::new(self.partition_id, self.team_id, self.person_id)
+    }
+
+    fn behavioral_key(&self, lsk: LeafStateKey) -> BehavioralKey {
+        BehavioralKey::new(self.partition_id, self.team_id, self.person_id, lsk)
+    }
+
+    fn stage2_key(&self, cohort_id: CohortId) -> Stage2Key {
+        Stage2Key {
+            partition_id: self.partition_id,
+            team_id: self.team_id,
+            cohort_id: cohort_id.0 as u64,
+            person_id: self.person_id,
+        }
+    }
+
+    /// Resolve each referenced cohort to one bit, shared by every cohort of this person that names
+    /// it. Entries a given tree does not reference are inert: `evaluate_tree` reads only the ids its
+    /// own leaves carry.
+    fn reference_membership(&self, inputs: &ResolvedPersonInputs) -> HashMap<CohortId, bool> {
+        self.references
+            .iter()
+            .map(|(&ref_id, source)| {
+                let member = match source {
+                    ReferenceSource::Leaf(lsk) => inputs.leaf_membership(*lsk),
+                    ReferenceSource::Stored => inputs.prior_stage2(ref_id).in_cohort,
+                    ReferenceSource::NonMember => false,
+                };
+                (ref_id, member)
+            })
+            .collect()
+    }
+}
+
+// ---- Reading them ----
+
+/// One person's decoded inputs. Compact enough to outlive the section that produced them: the raw
+/// values behind them were dropped chunk by chunk as they were decoded.
+#[derive(Debug, Default)]
+struct ResolvedPersonInputs {
+    membership: HashMap<LeafStateKey, bool>,
+    stage2: HashMap<CohortId, PriorStage2State>,
+}
+
+impl ResolvedPersonInputs {
+    /// A leaf the frozen catalog did not back was never read, and reads as a non-member.
+    fn leaf_membership(&self, lsk: LeafStateKey) -> bool {
+        self.membership.get(&lsk).copied().unwrap_or(false)
+    }
+
+    /// A row the plan did not ask for takes the same fail-closed reading as an absent one.
+    fn prior_stage2(&self, cohort_id: CohortId) -> PriorStage2State {
+        self.stage2.get(&cohort_id).copied().unwrap_or_default()
+    }
+}
+
+/// Executes one [`PersonReadPlan`] against the store, accumulating the decoded result.
+///
+/// Sync by design: it runs on the blocking pool inside [`StoreHandle::run_section`], so its direct
+/// [`CohortStore`] I/O is already off the runtime threads and the whole person costs one permit and
+/// one handoff. That permit is the maintenance one, which is what `run_section` draws — the seed
+/// paths took [`ReadLane::Maintenance`](crate::store::ReadLane) read by read before, and backfill
+/// still cannot contend with live event reads.
+///
+/// A section cannot be cancelled once started, and shutdown joins started sections, so its length
+/// matters. It is one point read plus one batched read per [`READ_CHUNK_KEYS`] of the person's
+/// distinct keys — fewer reads than the cohort-ordered path issues for the same person, but held
+/// under one permit instead of released between each. Nothing here caps that count: it grows with
+/// how many composable cohorts one person is in. Watch
+/// `store_offload_exec_duration_seconds{op="stage2_person_inputs"}` for what it turns out to be, and
+/// split the plan across sections if a tail appears.
+///
+/// Note the label move: `run_section` reports under `lane="section"` while still drawing the
+/// *maintenance* semaphore, so this work left `store_offload_inflight{lane="maintenance"}` when it
+/// moved here. A maintenance-saturation panel filtered on that label no longer sees seed
+/// recomputation, though it still competes for those permits. Filter on the `op` instead.
+struct PersonInputReader<'a> {
+    store: &'a CohortStore,
+    plan: &'a PersonReadPlan,
+    inputs: ResolvedPersonInputs,
+}
+
+#[allow(clippy::disallowed_methods)]
+impl<'a> PersonInputReader<'a> {
+    fn new(store: &'a CohortStore, plan: &'a PersonReadPlan) -> Self {
+        Self {
+            store,
+            plan,
+            inputs: ResolvedPersonInputs {
+                membership: HashMap::with_capacity(
+                    plan.behavioral.len() + plan.person_leaves.len(),
+                ),
+                stage2: HashMap::with_capacity(plan.stage2_cohorts.len()),
+            },
+        }
+    }
+
+    fn read(mut self) -> Result<ResolvedPersonInputs, StoreError> {
+        self.read_person_leaves()?;
+        self.read_behavioral_leaves()?;
+        self.read_stage2_rows()?;
+        Ok(self.inputs)
+    }
+
+    /// Resolve every person-property leaf from the one durable record: a person leaf's state key
+    /// *is* its condition hash, so its bit is `record.matched.contains(hash)`. An absent or corrupt
+    /// record reads every person leaf as a non-member; a corrupt one counts once here rather than
+    /// once per cohort that would have read it.
+    fn read_person_leaves(&mut self) -> Result<(), StoreError> {
+        if self.plan.person_leaves.is_empty() {
+            return Ok(());
+        }
+        let bytes = self
+            .store
+            .get_person_record(&self.plan.person_record_key())?;
+        ReadSource::PersonRecord.record(1, bytes.as_ref().map_or(0, Vec::len));
+
+        let matched = match bytes {
+            None => None,
+            Some(bytes) => match PersonRecord::decode(&bytes) {
+                Ok(record) => Some(record.matched),
+                Err(_) => {
+                    counter!(STAGE2_STATE_DECODE_ERROR).increment(1);
+                    None
+                }
+            },
+        };
+        for &lsk in &self.plan.person_leaves {
+            let member = matched
+                .as_ref()
+                .is_some_and(|matched| matched.contains(&lsk.0));
+            self.inputs.membership.insert(lsk, member);
+        }
+        Ok(())
+    }
+
+    /// Read the distinct behavioral leaves in bounded chunks, decoding each chunk and releasing its
+    /// raw values before the next is read.
+    fn read_behavioral_leaves(&mut self) -> Result<(), StoreError> {
+        for chunk in self.plan.behavioral.chunks(READ_CHUNK_KEYS) {
+            let keys: Vec<BehavioralKey> = chunk
+                .iter()
+                .map(|&(lsk, _)| self.plan.behavioral_key(lsk))
+                .collect();
+            let raw = self.store.multi_get_behavioral(&keys)?;
+            ReadSource::Behavioral.record(keys.len(), raw_bytes(&raw));
+            for (&(lsk, ref meta), bytes) in chunk.iter().zip(raw) {
+                let state = decode_stage1_state(bytes);
+                self.inputs
+                    .membership
+                    .insert(lsk, leaf_membership(state.as_ref(), meta));
+            }
+        }
+        Ok(())
+    }
+
+    /// Read the pairs' own prior membership rows and every composed referent's row as one key set,
+    /// so a referent that also recomputes here is read once, and read as stored.
+    fn read_stage2_rows(&mut self) -> Result<(), StoreError> {
+        for chunk in self.plan.stage2_cohorts.chunks(READ_CHUNK_KEYS) {
+            let keys: Vec<Stage2Key> = chunk
+                .iter()
+                .map(|&cohort_id| self.plan.stage2_key(cohort_id))
+                .collect();
+            let raw = self.store.multi_get_stage2(&keys)?;
+            ReadSource::Stage2.record(keys.len(), raw_bytes(&raw));
+            for (&cohort_id, bytes) in chunk.iter().zip(raw) {
+                self.inputs
+                    .stage2
+                    .insert(cohort_id, read_prior_stage2(bytes));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// The state source one batched read drew from. Closed, so the `source` label on the section
+/// counters stays a fixed set of three.
+#[derive(Debug, Clone, Copy)]
+enum ReadSource {
+    Behavioral,
+    PersonRecord,
+    Stage2,
+}
+
+impl ReadSource {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Behavioral => "behavioral",
+            Self::PersonRecord => "person_record",
+            Self::Stage2 => "stage2",
+        }
+    }
+
+    /// Record one batched read: the keys it asked for, and the raw bytes it brought back.
+    fn record(self, keys: usize, bytes: usize) {
+        counter!(SEED_RECOMPUTE_KEYS_FETCHED_TOTAL, "source" => self.label())
+            .increment(keys as u64);
+        histogram!(SEED_RECOMPUTE_CHUNK_BYTES, "source" => self.label()).record(bytes as f64);
+    }
+}
+
+fn raw_bytes(values: &[Option<Vec<u8>>]) -> usize {
+    values.iter().flatten().map(Vec::len).sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono_tz::UTC;
+    use serde_json::{json, Value};
+
+    use crate::filters::{TeamFiltersBuilder, TeamId};
+
+    const PARTITION: u16 = 0;
+    const TEAM: TeamId = TeamId(7);
+    const PERSON_HASH: &str = "person0000000001";
+
+    fn hash(text: &str) -> [u8; 16] {
+        text.as_bytes()
+            .try_into()
+            .expect("a 16-byte condition hash")
+    }
+
+    fn behavioral_leaf(condition_hash: &str) -> Value {
+        json!({
+            "type": "behavioral", "value": "performed_event", "key": "$pageview",
+            "time_value": 7, "time_interval": "day",
+            "conditionHash": condition_hash,
+            "bytecode": ["_H", 1, 32, "$pageview", 32, "event", 1, 1, 11],
+        })
+    }
+
+    fn person_leaf() -> Value {
+        json!({
+            "type": "person", "key": "email", "value": "u@p.com", "operator": "exact",
+            "conditionHash": PERSON_HASH,
+            "bytecode": ["_H", 1, 32, "u@p.com", 32, "email", 32, "properties", 32, "person", 1, 3, 11],
+        })
+    }
+
+    fn cohort_ref(target: i32) -> Value {
+        json!({ "type": "cohort", "value": target, "negation": false })
+    }
+
+    fn freeze(cohorts: Vec<(i32, Vec<Value>)>) -> TeamFilters {
+        let mut builder = TeamFiltersBuilder::default();
+        for (id, values) in cohorts {
+            let cohort = json!({ "properties": { "type": "AND", "values": values } });
+            builder.add_cohort(CohortId(id), TEAM, &cohort).unwrap();
+        }
+        builder.freeze_with(UTC, true)
+    }
+
+    fn plan_for(filters: &TeamFilters, cohorts: &[i32]) -> PersonReadPlan {
+        let cohorts: BTreeSet<CohortId> = cohorts.iter().map(|&id| CohortId(id)).collect();
+        PersonReadPlan::build(PARTITION, TEAM, Uuid::from_u128(1), &cohorts, filters)
+    }
+
+    fn behavioral_lsks(plan: &PersonReadPlan) -> Vec<LeafStateKey> {
+        plan.behavioral.iter().map(|&(lsk, _)| lsk).collect()
+    }
+
+    /// The whole point of planning first: whatever the fan-out, one person is one record read and
+    /// one key per distinct row. A regression here silently restores the per-cohort read.
+    #[test]
+    fn a_person_reads_one_record_and_one_key_per_distinct_row() {
+        let filters = freeze(vec![
+            (1, vec![behavioral_leaf("shared0000000001"), person_leaf()]),
+            (2, vec![behavioral_leaf("shared0000000001"), person_leaf()]),
+            (3, vec![behavioral_leaf("own0000000000003"), person_leaf()]),
+        ]);
+        let plan = plan_for(&filters, &[1, 2, 3]);
+
+        assert_eq!(plan.cohorts, [CohortId(1), CohortId(2), CohortId(3)]);
+        assert_eq!(
+            plan.person_leaves,
+            [LeafStateKey::for_person_property(&hash(PERSON_HASH))],
+            "three cohorts naming one person condition still read one record",
+        );
+        assert_eq!(
+            behavioral_lsks(&plan),
+            {
+                let mut want = vec![
+                    filters.by_condition_to_lsk[&hash("shared0000000001")][0],
+                    filters.by_condition_to_lsk[&hash("own0000000000003")][0],
+                ];
+                want.sort_unstable();
+                want
+            },
+            "the leaf two cohorts share is one key, not two",
+        );
+        assert_eq!(
+            plan.stage2_cohorts,
+            [CohortId(1), CohortId(2), CohortId(3)],
+            "each pair's own prior row, and nothing else",
+        );
+        assert!(plan.references.is_empty());
+    }
+
+    /// A referent recomputing in the same group is still one stored row, read alongside the pairs'
+    /// own priors rather than substituted with the bit this run is about to write.
+    #[test]
+    fn a_referent_recomputed_in_the_same_group_is_planned_as_one_stored_row() {
+        let filters = freeze(vec![
+            (1, vec![person_leaf(), cohort_ref(2)]),
+            (2, vec![behavioral_leaf("shared0000000001"), person_leaf()]),
+        ]);
+        let plan = plan_for(&filters, &[1, 2]);
+
+        assert_eq!(
+            plan.references,
+            BTreeMap::from([(CohortId(2), ReferenceSource::Stored)]),
+        );
+        assert_eq!(
+            plan.stage2_cohorts,
+            [CohortId(1), CohortId(2)],
+            "cohort 2's row serves both its own diff and cohort 1's reference",
+        );
+    }
+
+    /// Each reference kind reaches the state source that answers it, and only the composed kind
+    /// adds a row.
+    #[test]
+    fn each_reference_kind_routes_to_its_own_state_source() {
+        let single_leaf_hash = "singleleaf000003";
+        let filters = freeze(vec![
+            (
+                1,
+                vec![person_leaf(), cohort_ref(2), cohort_ref(3), cohort_ref(404)],
+            ),
+            (2, vec![behavioral_leaf("shared0000000001"), person_leaf()]),
+            (3, vec![behavioral_leaf(single_leaf_hash)]),
+        ]);
+        let referent_lsk = filters.by_condition_to_lsk[&hash(single_leaf_hash)][0];
+        let plan = plan_for(&filters, &[1]);
+
+        assert_eq!(
+            plan.references,
+            BTreeMap::from([
+                (CohortId(2), ReferenceSource::Stored),
+                (CohortId(3), ReferenceSource::Leaf(referent_lsk)),
+                (CohortId(404), ReferenceSource::NonMember),
+            ]),
+        );
+        assert_eq!(
+            plan.stage2_cohorts,
+            [CohortId(1), CohortId(2)],
+            "only the composed referent adds a row; the single-leaf one is read as a leaf",
+        );
+        assert!(
+            behavioral_lsks(&plan).contains(&referent_lsk),
+            "the single-leaf referent joins the behavioral batch, comparator and all",
+        );
+    }
+
+    /// A cohort the frozen catalog no longer carries is dropped before any read, so it costs no key
+    /// and composes no pair.
+    #[test]
+    fn a_cohort_the_catalog_dropped_is_not_planned() {
+        let filters = freeze(vec![(
+            1,
+            vec![behavioral_leaf("shared0000000001"), person_leaf()],
+        )]);
+        let plan = plan_for(&filters, &[1, 2]);
+
+        assert_eq!(plan.cohorts, [CohortId(1)]);
+        assert_eq!(plan.stage2_cohorts, [CohortId(1)]);
+    }
+}

--- a/rust/cohort-stream-processor/src/workers/stage2_person_inputs.rs
+++ b/rust/cohort-stream-processor/src/workers/stage2_person_inputs.rs
@@ -1,27 +1,15 @@
 //! Stage 2 recomputation for a seed run, sharing each person's store inputs across their cohorts.
 //!
-//! [`recompute_stage2_by_person`] answers exactly what
-//! [`recompute_stage2`](super::stage2_path::recompute_stage2) answers over the same store — the same
-//! pairs, the same flips, the same `cf_stage2` rows owed — but reaches it person by person. The
-//! cohort-ordered path re-reads a person's record, their behavioral leaves, and their prior
-//! membership once per affected cohort; a wide person seed touching a dozen composable cohorts pays
-//! that a dozen times over, and each read is its own blocking-pool handoff.
-//!
-//! Here a [`PersonReadPlan`] resolves each person's needs from the frozen catalog first, then one
-//! [`PersonInputReader`] fetches them in as few store sections as their width needs: one person
-//! record, each distinct behavioral key once, and one `cf_stage2` key set covering both the pairs'
-//! own prior rows and every composed referent.
+//! Same output as [`recompute_stage2`](super::stage2_path::recompute_stage2), reached by reading
+//! each person once rather than once per affected cohort.
 //!
 //! Two boundaries the sharing must not cross:
 //!
-//! - **Stored, not pending.** A composed referent resolves from the bit the store holds, even when
-//!   that referent recomputes in this same group. Substituting a freshly computed bit would emit a
-//!   cascade the referent has not acknowledged.
-//! - **One chunk at a time.** Behavioral values carry whole event histories, so the union is read in
-//!   bounded chunks and each chunk's raw buffers are decoded and dropped before the next is read.
-//!   The person's residue is their decoded membership bits, not their rows. A section reads at most
-//!   one chunk per source, so a wide person releases the maintenance permit between chunks instead
-//!   of holding it across all of them.
+//! - A composed referent resolves from the bit the store holds, even when that referent recomputes
+//!   in this same group. A freshly computed bit would emit a cascade nothing has acknowledged.
+//! - Behavioral values carry whole event histories, so a section reads at most one chunk per source
+//!   and drops its raw buffers before the next. A wide person releases the maintenance permit
+//!   between chunks instead of holding it across all of them.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
@@ -47,24 +35,20 @@ use crate::workers::stage2_path::{
     PriorStage2State, RecomputeDiff, RecomputedPair, Stage2Recompute,
 };
 
-/// Keys per batched read. A key count is not a byte bound — a behavioral value holds a window's
-/// history, and a person's leaves vary widely in size — so this caps the raw buffers held at once
-/// without promising a fixed footprint. [`SEED_RECOMPUTE_CHUNK_BYTES`] measures what it cost.
+/// Keys per batched read. This is not a byte bound, because behavioral values vary in size with
+/// their window; [`SEED_RECOMPUTE_CHUNK_BYTES`] measures what a chunk actually cost.
 const READ_CHUNK_KEYS: usize = 64;
 
-/// The `op` label these sections report their offload timings under.
 const SECTION_OP: &str = "stage2_person_inputs";
 
 /// Recompute one seed group's composable cohorts, sharing each person's reads across their cohorts.
 ///
-/// `team_id` is the group's team, which is also the key its `filters` sit under in the frozen
-/// catalog, so every cohort reached here composes from that team's keyspace.
+/// `team_id` is the key `filters` sit under in the frozen catalog, so every cohort here composes
+/// from that team's keyspace.
 ///
-/// Changes and writes come back in `(cohort, person)` order, matching the cohort-ordered path, so a
-/// caller cannot tell the two apart by the shape of what it produces.
+/// Changes and writes come back in `(cohort, person)` order, matching the cohort-ordered path.
 ///
-/// One store read failure holds the whole run: the error propagates before any output exists, so the
-/// caller has nothing partial to publish.
+/// A read failure returns before any output exists, so the held run publishes nothing partial.
 pub(crate) async fn recompute_stage2_by_person(
     partition_id: u16,
     handle: &StoreHandle,
@@ -84,8 +68,7 @@ pub(crate) async fn recompute_stage2_by_person(
         }
     }
 
-    // Collected before emitting, so the pairs come out in cohort order however they were grouped
-    // for reading.
+    // Buffered so the pairs come out in cohort order however they were grouped for reading.
     let mut pairs: BTreeMap<(CohortId, Uuid), RecomputeDiff> = BTreeMap::new();
     for (person_id, cohorts) in affected {
         let plan = PersonReadPlan::build(partition_id, team_id, person_id, &cohorts, filters);
@@ -113,9 +96,6 @@ pub(crate) async fn recompute_stage2_by_person(
                 .cohorts
                 .get(&cohort_id)
                 .expect("the plan keeps only cohorts this frozen catalog has a tree for");
-            // The cohort-ordered path stamps changes from the tree; this one from the group. The
-            // catalog keys one `TeamFilters` per team and stamps its trees with that same id, so
-            // they agree — and this is the only thing still saying so.
             debug_assert_eq!(
                 tree.team_id, team_id,
                 "a team's catalog holds only that team's cohorts",
@@ -150,41 +130,34 @@ pub(crate) async fn recompute_stage2_by_person(
 
 // ---- What one person's cohorts read ----
 
-/// How one referenced cohort resolves for a person.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ReferenceSource {
-    /// A single-leaf referent: its membership is that leaf's own bit, read through the same
-    /// comparator the referrer's own leaves use.
+    /// Membership is the leaf's own bit, read through that leaf's comparator.
     Leaf(LeafStateKey),
-    /// A referent that composes its own row: read the membership the store holds.
     Stored,
     /// Excluded, cyclic, or absent from the frozen catalog.
     NonMember,
 }
 
-/// Everything one person's affected cohorts read from the store, resolved from the frozen catalog
-/// before any I/O and owned, so the read runs in blocking sections.
+/// Everything one person's affected cohorts read from the store. Owned, so the read can run in
+/// blocking sections.
 #[derive(Debug)]
 struct PersonReadPlan {
     partition_id: u16,
     team_id: u64,
     person_id: Uuid,
-    /// The pairs to recompute, ascending. Every id here has a tree in the frozen catalog.
+    /// Ascending. Every id here has a tree in the frozen catalog.
     cohorts: Vec<CohortId>,
-    /// The distinct behavioral leaves the cohorts read, each with the metadata its comparator needs.
     behavioral: Vec<(LeafStateKey, LeafStateMeta)>,
-    /// The distinct person-property leaves, which all resolve from the one person record.
     person_leaves: Vec<LeafStateKey>,
-    /// The cohorts whose stored membership row is read: each recomputed pair's own prior row, plus
-    /// every composed referent. One row serves both when a referent also recomputes here.
+    /// Each recomputed pair's own prior row, plus every composed referent. One row serves both when
+    /// a referent also recomputes here.
     stage2_cohorts: Vec<CohortId>,
-    /// Every cohort the trees reference, and how each resolves.
     references: BTreeMap<CohortId, ReferenceSource>,
 }
 
 impl PersonReadPlan {
-    /// Walk one person's affected cohort trees once and collect what they read. Pure: it consults
-    /// the frozen catalog only, so the plan is settled before the run holds a store permit.
+    /// Reads the frozen catalog only, so the plan is settled before the run holds a store permit.
     fn build(
         partition_id: u16,
         team_id: TeamId,
@@ -210,7 +183,7 @@ impl PersonReadPlan {
                 continue;
             };
             plan.cohorts.push(cohort_id);
-            // The pair's own prior row, which the diff needs whether or not the cohort flips.
+            // The diff needs the prior row whether or not the cohort flips.
             plan.stage2_cohorts.push(cohort_id);
 
             lsks.clear();
@@ -230,25 +203,22 @@ impl PersonReadPlan {
         plan
     }
 
-    /// Route one leaf to the state source its variant reads from. A key the frozen catalog does not
-    /// carry is routed nowhere, so composition reads it as a non-member.
+    /// A key the frozen catalog does not carry is routed nowhere, so composition reads it as a
+    /// non-member.
     fn route_leaf(&mut self, lsk: LeafStateKey, filters: &TeamFilters) {
         let Some(meta) = filters.by_lsk.get(&lsk) else {
             return;
         };
         match meta.variant {
             StateVariant::PersonProperty => self.person_leaves.push(lsk),
-            // Exhaustive (no wildcard) so a future membership source resolving from another store
-            // fails to compile here instead of being silently misrouted into `cf_behavioral`.
+            // No wildcard, so a future membership source reading from another store fails to
+            // compile here instead of being misrouted into `cf_behavioral`.
             StateVariant::BehavioralSingle
             | StateVariant::BehavioralDailyBuckets
             | StateVariant::BehavioralCompressedHistory => self.behavioral.push((lsk, *meta)),
         }
     }
 
-    /// Classify one referenced cohort, and add whatever resolving it will need. Repeats are free:
-    /// a referent named by several of the person's cohorts, or twice in one tree, is classified and
-    /// read once.
     fn route_reference(&mut self, ref_id: CohortId, filters: &TeamFilters) {
         if self.references.contains_key(&ref_id) {
             return;
@@ -266,8 +236,6 @@ impl PersonReadPlan {
         self.references.insert(ref_id, source);
     }
 
-    /// Cohorts sharing a leaf route it once each, so the read sets arrive with duplicates. Order and
-    /// deduplicate them once here, which is what makes the read one key per distinct row.
     fn dedup_read_sets(&mut self) {
         self.behavioral.sort_unstable_by_key(|(lsk, _)| *lsk);
         self.behavioral.dedup_by_key(|(lsk, _)| *lsk);
@@ -277,7 +245,6 @@ impl PersonReadPlan {
         self.stage2_cohorts.dedup();
     }
 
-    /// No cohort of this person survived the frozen catalog, so there is nothing to read.
     fn is_empty(&self) -> bool {
         self.cohorts.is_empty()
     }
@@ -299,9 +266,8 @@ impl PersonReadPlan {
         }
     }
 
-    /// Resolve each referenced cohort to one bit, shared by every cohort of this person that names
-    /// it. Entries a given tree does not reference are inert: `evaluate_tree` reads only the ids its
-    /// own leaves carry.
+    /// One bit per referenced cohort, shared by every cohort of this person that names it. Entries
+    /// a given tree does not reference are inert, because `evaluate_tree` reads only its own ids.
     fn reference_membership(&self, inputs: &ResolvedPersonInputs) -> HashMap<CohortId, bool> {
         self.references
             .iter()
@@ -319,8 +285,8 @@ impl PersonReadPlan {
 
 // ---- Reading them ----
 
-/// One person's decoded inputs. Compact enough to outlive the sections that produced them: the raw
-/// values behind them were dropped chunk by chunk as they were decoded.
+/// One person's decoded inputs. Compact enough to outlive the sections that read them, because each
+/// chunk's raw values are dropped as they decode.
 #[derive(Debug, Default)]
 struct ResolvedPersonInputs {
     membership: HashMap<LeafStateKey, bool>,
@@ -339,25 +305,17 @@ impl ResolvedPersonInputs {
     }
 }
 
-/// Executes one [`PersonReadPlan`] against the store, accumulating the decoded result across as
-/// many sections as the plan's width needs.
+/// Executes one [`PersonReadPlan`] across as many [`StoreHandle::run_section`] calls as its width
+/// needs.
 ///
-/// Sync by design: it runs on the blocking pool inside [`StoreHandle::run_section`], so its direct
-/// [`CohortStore`] I/O is already off the runtime threads. Each section draws the maintenance
-/// permit, as the seed paths did read by read before through
-/// [`ReadLane::Maintenance`](crate::store::ReadLane), so backfill still cannot contend with live
-/// event reads.
+/// Each section draws the maintenance permit, so backfill cannot contend with live event reads.
 ///
-/// A section cannot be cancelled once started, and shutdown joins started sections, so its length
-/// matters. [`Self::read_section`] bounds it to the person record plus one [`READ_CHUNK_KEYS`] chunk
-/// of each batched source. A person within one chunk per source costs one permit and one handoff.
-/// A wider person resumes in further sections and releases the permit between them instead of
-/// holding it for every chunk.
+/// A started section cannot be cancelled and shutdown joins it, so [`Self::read_section`] bounds one
+/// section to the person record plus one [`READ_CHUNK_KEYS`] chunk of each batched source.
 struct PersonInputReader {
     plan: PersonReadPlan,
     inputs: ResolvedPersonInputs,
     started: bool,
-    /// How far into `plan.behavioral` and `plan.stage2_cohorts` the sections so far have read.
     behavioral_read: usize,
     stage2_read: usize,
 }
@@ -378,15 +336,12 @@ impl PersonInputReader {
         }
     }
 
-    /// Read one bounded section: the person record on the first call, then the next chunk of each
-    /// batched source.
     fn read_section(&mut self, store: &CohortStore) -> Result<(), StoreError> {
         if !self.started {
             self.started = true;
-            // Counted with the first section's keys, on the same blocking thread. A started blocking
-            // task runs to completion even if the caller future is dropped, so counting outside
-            // would let a cancelled offload record keys for a person it never recorded, skewing
-            // keys-per-person by exactly the reads that went missing.
+            // Counted on the blocking thread with the keys. A started section completes even when
+            // the caller future is dropped, so counting outside would record keys for a person the
+            // cancelled offload never counted.
             counter!(SEED_RECOMPUTE_PERSONS_TOTAL).increment(1);
             self.read_person_leaves(store)?;
         }
@@ -403,10 +358,9 @@ impl PersonInputReader {
         (self.plan, self.inputs)
     }
 
-    /// Resolve every person-property leaf from the one durable record: a person leaf's state key
-    /// *is* its condition hash, so its bit is `record.matched.contains(hash)`. An absent or corrupt
-    /// record reads every person leaf as a non-member; a corrupt one counts once here rather than
-    /// once per cohort that would have read it.
+    /// A person leaf's state key *is* its condition hash, so its bit is
+    /// `record.matched.contains(hash)`. An absent or corrupt record reads every person leaf as a
+    /// non-member, and a corrupt one counts once per person rather than once per cohort.
     fn read_person_leaves(&mut self, store: &CohortStore) -> Result<(), StoreError> {
         if self.plan.person_leaves.is_empty() {
             return Ok(());
@@ -433,8 +387,6 @@ impl PersonInputReader {
         Ok(())
     }
 
-    /// Read the next chunk of distinct behavioral leaves, decoding it and releasing its raw values
-    /// before the section ends.
     fn read_behavioral_chunk(&mut self, store: &CohortStore) -> Result<(), StoreError> {
         let rest = &self.plan.behavioral[self.behavioral_read..];
         let Some(chunk) = rest.chunks(READ_CHUNK_KEYS).next() else {
@@ -456,9 +408,8 @@ impl PersonInputReader {
         Ok(())
     }
 
-    /// Read the next chunk of the pairs' own prior membership rows and composed referents' rows.
-    /// They are one key set, so a referent that also recomputes here is read once, and read as
-    /// stored.
+    /// Prior rows and composed referents share one key set, so a referent that also recomputes here
+    /// is read once, and read as stored.
     fn read_stage2_chunk(&mut self, store: &CohortStore) -> Result<(), StoreError> {
         let rest = &self.plan.stage2_cohorts[self.stage2_read..];
         let Some(chunk) = rest.chunks(READ_CHUNK_KEYS).next() else {
@@ -480,8 +431,7 @@ impl PersonInputReader {
     }
 }
 
-/// The state source one batched read drew from. Closed, so the `source` label on the section
-/// counters stays a fixed set of three.
+/// The closed set of `source` label values on the section counters.
 #[derive(Debug, Clone, Copy)]
 enum ReadSource {
     Behavioral,
@@ -498,7 +448,6 @@ impl ReadSource {
         }
     }
 
-    /// Record one batched read: the keys it asked for, and the raw bytes it brought back.
     fn record(self, keys: usize, bytes: usize) {
         counter!(SEED_RECOMPUTE_KEYS_FETCHED_TOTAL, "source" => self.label())
             .increment(keys as u64);

--- a/rust/cohort-stream-processor/src/workers/stage2_person_inputs.rs
+++ b/rust/cohort-stream-processor/src/workers/stage2_person_inputs.rs
@@ -8,9 +8,9 @@
 //! that a dozen times over, and each read is its own blocking-pool handoff.
 //!
 //! Here a [`PersonReadPlan`] resolves each person's needs from the frozen catalog first, then one
-//! [`PersonInputReader`] fetches them in a single store section: one person record, each distinct
-//! behavioral key once, and one `cf_stage2` key set covering both the pairs' own prior rows and
-//! every composed referent.
+//! [`PersonInputReader`] fetches them in as few store sections as their width needs: one person
+//! record, each distinct behavioral key once, and one `cf_stage2` key set covering both the pairs'
+//! own prior rows and every composed referent.
 //!
 //! Two boundaries the sharing must not cross:
 //!
@@ -19,7 +19,9 @@
 //!   cascade the referent has not acknowledged.
 //! - **One chunk at a time.** Behavioral values carry whole event histories, so the union is read in
 //!   bounded chunks and each chunk's raw buffers are decoded and dropped before the next is read.
-//!   The person's residue is their decoded membership bits, not their rows.
+//!   The person's residue is their decoded membership bits, not their rows. A section reads at most
+//!   one chunk per source, so a wide person releases the maintenance permit between chunks instead
+//!   of holding it across all of them.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
@@ -91,18 +93,19 @@ pub(crate) async fn recompute_stage2_by_person(
             continue;
         }
 
-        let (plan, inputs) = handle
-            .run_section(SECTION_OP, move |store| {
-                // Counted here, not after the await, so it lands on the same thread as the key
-                // counters below it. A started blocking task runs to completion even if the caller
-                // future is dropped, so counting outside would let a cancelled offload record keys
-                // for a person it never recorded — skewing keys-per-person by exactly the reads
-                // that went missing.
-                counter!(SEED_RECOMPUTE_PERSONS_TOTAL).increment(1);
-                let inputs = PersonInputReader::new(store, &plan).read()?;
-                Ok((plan, inputs))
-            })
-            .await??;
+        let mut reader = PersonInputReader::new(plan);
+        loop {
+            reader = handle
+                .run_section(SECTION_OP, move |store| {
+                    reader.read_section(store)?;
+                    Ok(reader)
+                })
+                .await??;
+            if reader.is_done() {
+                break;
+            }
+        }
+        let (plan, inputs) = reader.finish();
 
         let references = plan.reference_membership(&inputs);
         for &cohort_id in &plan.cohorts {
@@ -160,7 +163,7 @@ enum ReferenceSource {
 }
 
 /// Everything one person's affected cohorts read from the store, resolved from the frozen catalog
-/// before any I/O and owned, so the whole read runs as one blocking section.
+/// before any I/O and owned, so the read runs in blocking sections.
 #[derive(Debug)]
 struct PersonReadPlan {
     partition_id: u16,
@@ -316,7 +319,7 @@ impl PersonReadPlan {
 
 // ---- Reading them ----
 
-/// One person's decoded inputs. Compact enough to outlive the section that produced them: the raw
+/// One person's decoded inputs. Compact enough to outlive the sections that produced them: the raw
 /// values behind them were dropped chunk by chunk as they were decoded.
 #[derive(Debug, Default)]
 struct ResolvedPersonInputs {
@@ -336,65 +339,79 @@ impl ResolvedPersonInputs {
     }
 }
 
-/// Executes one [`PersonReadPlan`] against the store, accumulating the decoded result.
+/// Executes one [`PersonReadPlan`] against the store, accumulating the decoded result across as
+/// many sections as the plan's width needs.
 ///
 /// Sync by design: it runs on the blocking pool inside [`StoreHandle::run_section`], so its direct
-/// [`CohortStore`] I/O is already off the runtime threads and the whole person costs one permit and
-/// one handoff. That permit is the maintenance one, which is what `run_section` draws — the seed
-/// paths took [`ReadLane::Maintenance`](crate::store::ReadLane) read by read before, and backfill
-/// still cannot contend with live event reads.
+/// [`CohortStore`] I/O is already off the runtime threads. Each section draws the maintenance
+/// permit, as the seed paths did read by read before through
+/// [`ReadLane::Maintenance`](crate::store::ReadLane), so backfill still cannot contend with live
+/// event reads.
 ///
 /// A section cannot be cancelled once started, and shutdown joins started sections, so its length
-/// matters. It is one point read plus one batched read per [`READ_CHUNK_KEYS`] of the person's
-/// distinct keys — fewer reads than the cohort-ordered path issues for the same person, but held
-/// under one permit instead of released between each. Nothing here caps that count: it grows with
-/// how many composable cohorts one person is in. Watch
-/// `store_offload_exec_duration_seconds{op="stage2_person_inputs"}` for what it turns out to be, and
-/// split the plan across sections if a tail appears.
-///
-/// Note the label move: `run_section` reports under `lane="section"` while still drawing the
-/// *maintenance* semaphore, so this work left `store_offload_inflight{lane="maintenance"}` when it
-/// moved here. A maintenance-saturation panel filtered on that label no longer sees seed
-/// recomputation, though it still competes for those permits. Filter on the `op` instead.
-struct PersonInputReader<'a> {
-    store: &'a CohortStore,
-    plan: &'a PersonReadPlan,
+/// matters. [`Self::read_section`] bounds it to the person record plus one [`READ_CHUNK_KEYS`] chunk
+/// of each batched source. A person within one chunk per source costs one permit and one handoff.
+/// A wider person resumes in further sections and releases the permit between them instead of
+/// holding it for every chunk.
+struct PersonInputReader {
+    plan: PersonReadPlan,
     inputs: ResolvedPersonInputs,
+    started: bool,
+    /// How far into `plan.behavioral` and `plan.stage2_cohorts` the sections so far have read.
+    behavioral_read: usize,
+    stage2_read: usize,
 }
 
 #[allow(clippy::disallowed_methods)]
-impl<'a> PersonInputReader<'a> {
-    fn new(store: &'a CohortStore, plan: &'a PersonReadPlan) -> Self {
+impl PersonInputReader {
+    fn new(plan: PersonReadPlan) -> Self {
+        let inputs = ResolvedPersonInputs {
+            membership: HashMap::with_capacity(plan.behavioral.len() + plan.person_leaves.len()),
+            stage2: HashMap::with_capacity(plan.stage2_cohorts.len()),
+        };
         Self {
-            store,
             plan,
-            inputs: ResolvedPersonInputs {
-                membership: HashMap::with_capacity(
-                    plan.behavioral.len() + plan.person_leaves.len(),
-                ),
-                stage2: HashMap::with_capacity(plan.stage2_cohorts.len()),
-            },
+            inputs,
+            started: false,
+            behavioral_read: 0,
+            stage2_read: 0,
         }
     }
 
-    fn read(mut self) -> Result<ResolvedPersonInputs, StoreError> {
-        self.read_person_leaves()?;
-        self.read_behavioral_leaves()?;
-        self.read_stage2_rows()?;
-        Ok(self.inputs)
+    /// Read one bounded section: the person record on the first call, then the next chunk of each
+    /// batched source.
+    fn read_section(&mut self, store: &CohortStore) -> Result<(), StoreError> {
+        if !self.started {
+            self.started = true;
+            // Counted with the first section's keys, on the same blocking thread. A started blocking
+            // task runs to completion even if the caller future is dropped, so counting outside
+            // would let a cancelled offload record keys for a person it never recorded, skewing
+            // keys-per-person by exactly the reads that went missing.
+            counter!(SEED_RECOMPUTE_PERSONS_TOTAL).increment(1);
+            self.read_person_leaves(store)?;
+        }
+        self.read_behavioral_chunk(store)?;
+        self.read_stage2_chunk(store)
+    }
+
+    fn is_done(&self) -> bool {
+        self.behavioral_read == self.plan.behavioral.len()
+            && self.stage2_read == self.plan.stage2_cohorts.len()
+    }
+
+    fn finish(self) -> (PersonReadPlan, ResolvedPersonInputs) {
+        (self.plan, self.inputs)
     }
 
     /// Resolve every person-property leaf from the one durable record: a person leaf's state key
     /// *is* its condition hash, so its bit is `record.matched.contains(hash)`. An absent or corrupt
     /// record reads every person leaf as a non-member; a corrupt one counts once here rather than
     /// once per cohort that would have read it.
-    fn read_person_leaves(&mut self) -> Result<(), StoreError> {
+    fn read_person_leaves(&mut self, store: &CohortStore) -> Result<(), StoreError> {
         if self.plan.person_leaves.is_empty() {
             return Ok(());
         }
-        let bytes = self
-            .store
-            .get_person_record(&self.plan.person_record_key())?;
+        let bytes = store.get_person_record(&self.plan.person_record_key())?;
         ReadSource::PersonRecord.record(1, bytes.as_ref().map_or(0, Vec::len));
 
         let matched = match bytes {
@@ -416,42 +433,49 @@ impl<'a> PersonInputReader<'a> {
         Ok(())
     }
 
-    /// Read the distinct behavioral leaves in bounded chunks, decoding each chunk and releasing its
-    /// raw values before the next is read.
-    fn read_behavioral_leaves(&mut self) -> Result<(), StoreError> {
-        for chunk in self.plan.behavioral.chunks(READ_CHUNK_KEYS) {
-            let keys: Vec<BehavioralKey> = chunk
-                .iter()
-                .map(|&(lsk, _)| self.plan.behavioral_key(lsk))
-                .collect();
-            let raw = self.store.multi_get_behavioral(&keys)?;
-            ReadSource::Behavioral.record(keys.len(), raw_bytes(&raw));
-            for (&(lsk, ref meta), bytes) in chunk.iter().zip(raw) {
-                let state = decode_stage1_state(bytes);
-                self.inputs
-                    .membership
-                    .insert(lsk, leaf_membership(state.as_ref(), meta));
-            }
+    /// Read the next chunk of distinct behavioral leaves, decoding it and releasing its raw values
+    /// before the section ends.
+    fn read_behavioral_chunk(&mut self, store: &CohortStore) -> Result<(), StoreError> {
+        let rest = &self.plan.behavioral[self.behavioral_read..];
+        let Some(chunk) = rest.chunks(READ_CHUNK_KEYS).next() else {
+            return Ok(());
+        };
+        let keys: Vec<BehavioralKey> = chunk
+            .iter()
+            .map(|&(lsk, _)| self.plan.behavioral_key(lsk))
+            .collect();
+        let raw = store.multi_get_behavioral(&keys)?;
+        ReadSource::Behavioral.record(keys.len(), raw_bytes(&raw));
+        for (&(lsk, ref meta), bytes) in chunk.iter().zip(raw) {
+            let state = decode_stage1_state(bytes);
+            self.inputs
+                .membership
+                .insert(lsk, leaf_membership(state.as_ref(), meta));
         }
+        self.behavioral_read += chunk.len();
         Ok(())
     }
 
-    /// Read the pairs' own prior membership rows and every composed referent's row as one key set,
-    /// so a referent that also recomputes here is read once, and read as stored.
-    fn read_stage2_rows(&mut self) -> Result<(), StoreError> {
-        for chunk in self.plan.stage2_cohorts.chunks(READ_CHUNK_KEYS) {
-            let keys: Vec<Stage2Key> = chunk
-                .iter()
-                .map(|&cohort_id| self.plan.stage2_key(cohort_id))
-                .collect();
-            let raw = self.store.multi_get_stage2(&keys)?;
-            ReadSource::Stage2.record(keys.len(), raw_bytes(&raw));
-            for (&cohort_id, bytes) in chunk.iter().zip(raw) {
-                self.inputs
-                    .stage2
-                    .insert(cohort_id, read_prior_stage2(bytes));
-            }
+    /// Read the next chunk of the pairs' own prior membership rows and composed referents' rows.
+    /// They are one key set, so a referent that also recomputes here is read once, and read as
+    /// stored.
+    fn read_stage2_chunk(&mut self, store: &CohortStore) -> Result<(), StoreError> {
+        let rest = &self.plan.stage2_cohorts[self.stage2_read..];
+        let Some(chunk) = rest.chunks(READ_CHUNK_KEYS).next() else {
+            return Ok(());
+        };
+        let keys: Vec<Stage2Key> = chunk
+            .iter()
+            .map(|&cohort_id| self.plan.stage2_key(cohort_id))
+            .collect();
+        let raw = store.multi_get_stage2(&keys)?;
+        ReadSource::Stage2.record(keys.len(), raw_bytes(&raw));
+        for (&cohort_id, bytes) in chunk.iter().zip(raw) {
+            self.inputs
+                .stage2
+                .insert(cohort_id, read_prior_stage2(bytes));
         }
+        self.stage2_read += chunk.len();
         Ok(())
     }
 }

--- a/rust/cohort-stream-processor/src/workers/stage2_person_inputs.rs
+++ b/rust/cohort-stream-processor/src/workers/stage2_person_inputs.rs
@@ -35,13 +35,20 @@ use crate::workers::stage2_path::{
     PriorStage2State, RecomputeDiff, RecomputedPair, Stage2Recompute,
 };
 
-/// Keys per batched read. This is not a byte bound, because behavioral values vary in size with
-/// their window; [`SEED_RECOMPUTE_CHUNK_BYTES`] measures what a chunk actually cost.
-const READ_CHUNK_KEYS: usize = 64;
+/// Keys per batched read, the same chunk the sweep prefetch uses. A chunk is decoded and dropped
+/// before the next is read, so this bounds the raw buffers one section holds and with them the
+/// drain time a started section can add. It is not a byte bound, because behavioral values vary
+/// in size with their window; [`SEED_RECOMPUTE_CHUNK_BYTES`] measures what a chunk actually cost.
+pub(super) const READ_CHUNK_KEYS: usize = 1024;
 
 const SECTION_OP: &str = "stage2_person_inputs";
 
 /// Recompute one seed group's composable cohorts, sharing each person's reads across their cohorts.
+///
+/// Seed-only by construction: the reads run through [`StoreHandle::run_section`], which draws the
+/// maintenance permit. The live, sweep, cascade and reconcile paths compose on
+/// [`ReadLane::Event`](crate::store::ReadLane) and cannot move here without putting hot-path reads
+/// behind the backfill lane.
 ///
 /// `team_id` is the key `filters` sit under in the frozen catalog, so every cohort here composes
 /// from that team's keyspace.
@@ -68,8 +75,14 @@ pub(crate) async fn recompute_stage2_by_person(
         }
     }
 
-    // Buffered so the pairs come out in cohort order however they were grouped for reading.
+    // A map rather than pushes. No consumer needs cohort order (changes are keyed by person and
+    // writes by row), but the differential tests compare this path with the cohort-ordered one
+    // verbatim, and the map also collapses a duplicate pair into one `record_pair`.
     let mut pairs: BTreeMap<(CohortId, Uuid), RecomputeDiff> = BTreeMap::new();
+    // Persons run one at a time on purpose. Every partition worker applies its own runs against
+    // this one maintenance lane, whose permits are already contended across partitions and shared
+    // with the sweep, merge and GC sections. Overlapping persons inside one run would add
+    // contenders to that lane without adding permits.
     for (person_id, cohorts) in affected {
         let plan = PersonReadPlan::build(partition_id, team_id, person_id, &cohorts, filters);
         if plan.is_empty() {
@@ -96,6 +109,9 @@ pub(crate) async fn recompute_stage2_by_person(
                 .cohorts
                 .get(&cohort_id)
                 .expect("the plan keeps only cohorts this frozen catalog has a tree for");
+            // The cohort-ordered path stamps changes from the tree; this one from the group. The
+            // catalog keys one `TeamFilters` per team and stamps its trees with that same id, so
+            // the two stamps agree.
             debug_assert_eq!(
                 tree.team_id, team_id,
                 "a team's catalog holds only that team's cohorts",
@@ -130,13 +146,27 @@ pub(crate) async fn recompute_stage2_by_person(
 
 // ---- What one person's cohorts read ----
 
+/// How a referenced cohort's membership resolves for one person. Both recompute orders classify
+/// through [`Self::classify`], so a referent cannot resolve from one store on the seed path and
+/// another on the live path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ReferenceSource {
+pub(super) enum ReferenceSource {
     /// Membership is the leaf's own bit, read through that leaf's comparator.
     Leaf(LeafStateKey),
+    /// Membership is the composed row the store holds.
     Stored,
     /// Excluded, cyclic, or absent from the frozen catalog.
     NonMember,
+}
+
+impl ReferenceSource {
+    pub(super) fn classify(filters: &TeamFilters, ref_id: CohortId) -> Self {
+        match filters.eligibility.get(&ref_id) {
+            Some(CohortEligibility::SingleLeaf(lsk)) => Self::Leaf(*lsk),
+            Some(eligibility) if eligibility.writes_cf_stage2() => Self::Stored,
+            _ => Self::NonMember,
+        }
+    }
 }
 
 /// Everything one person's affected cohorts read from the store. Owned, so the read can run in
@@ -223,11 +253,7 @@ impl PersonReadPlan {
         if self.references.contains_key(&ref_id) {
             return;
         }
-        let source = match filters.eligibility.get(&ref_id) {
-            Some(CohortEligibility::SingleLeaf(lsk)) => ReferenceSource::Leaf(*lsk),
-            Some(eligibility) if eligibility.writes_cf_stage2() => ReferenceSource::Stored,
-            _ => ReferenceSource::NonMember,
-        };
+        let source = ReferenceSource::classify(filters, ref_id);
         match source {
             ReferenceSource::Leaf(lsk) => self.route_leaf(lsk, filters),
             ReferenceSource::Stored => self.stage2_cohorts.push(ref_id),
@@ -303,6 +329,40 @@ impl ResolvedPersonInputs {
     fn prior_stage2(&self, cohort_id: CohortId) -> PriorStage2State {
         self.stage2.get(&cohort_id).copied().unwrap_or_default()
     }
+
+    /// A person leaf's state key *is* its condition hash, so its bit is
+    /// `record.matched.contains(hash)`. An absent or corrupt record reads every person leaf as a
+    /// non-member, and a corrupt one counts once per person rather than once per cohort.
+    fn absorb_person_record(&mut self, person_leaves: &[LeafStateKey], bytes: Option<Vec<u8>>) {
+        let matched = match bytes {
+            None => None,
+            Some(bytes) => match PersonRecord::decode(&bytes) {
+                Ok(record) => Some(record.matched),
+                Err(_) => {
+                    counter!(STAGE2_STATE_DECODE_ERROR).increment(1);
+                    None
+                }
+            },
+        };
+        for &lsk in person_leaves {
+            let member = matched
+                .as_ref()
+                .is_some_and(|matched| matched.contains(&lsk.0));
+            self.membership.insert(lsk, member);
+        }
+    }
+
+    fn absorb_behavioral(
+        &mut self,
+        chunk: &[(LeafStateKey, LeafStateMeta)],
+        raw: Vec<Option<Vec<u8>>>,
+    ) {
+        for (&(lsk, ref meta), bytes) in chunk.iter().zip(raw) {
+            let state = decode_stage1_state(bytes);
+            self.membership
+                .insert(lsk, leaf_membership(state.as_ref(), meta));
+        }
+    }
 }
 
 /// Executes one [`PersonReadPlan`] across as many [`StoreHandle::run_section`] calls as its width
@@ -337,20 +397,22 @@ impl PersonInputReader {
     }
 
     fn read_section(&mut self, store: &CohortStore) -> Result<(), StoreError> {
-        if !self.started {
+        if self.started {
+            self.read_behavioral_chunk(store)?;
+        } else {
             self.started = true;
             // Counted on the blocking thread with the keys. A started section completes even when
             // the caller future is dropped, so counting outside would record keys for a person the
             // cancelled offload never counted.
             counter!(SEED_RECOMPUTE_PERSONS_TOTAL).increment(1);
-            self.read_person_leaves(store)?;
+            self.read_record_with_first_behavioral_chunk(store)?;
         }
-        self.read_behavioral_chunk(store)?;
         self.read_stage2_chunk(store)
     }
 
     fn is_done(&self) -> bool {
-        self.behavioral_read == self.plan.behavioral.len()
+        self.started
+            && self.behavioral_read == self.plan.behavioral.len()
             && self.stage2_read == self.plan.stage2_cohorts.len()
     }
 
@@ -358,31 +420,34 @@ impl PersonInputReader {
         (self.plan, self.inputs)
     }
 
-    /// A person leaf's state key *is* its condition hash, so its bit is
-    /// `record.matched.contains(hash)`. An absent or corrupt record reads every person leaf as a
-    /// non-member, and a corrupt one counts once per person rather than once per cohort.
-    fn read_person_leaves(&mut self, store: &CohortStore) -> Result<(), StoreError> {
-        if self.plan.person_leaves.is_empty() {
-            return Ok(());
+    /// The person record rides along the first behavioral chunk in one mixed-CF `multi_get`, the
+    /// read the event fold already issues, so a person costs one RocksDB lookup fewer.
+    fn read_record_with_first_behavioral_chunk(
+        &mut self,
+        store: &CohortStore,
+    ) -> Result<(), StoreError> {
+        let chunk = self
+            .plan
+            .behavioral
+            .chunks(READ_CHUNK_KEYS)
+            .next()
+            .unwrap_or(&[]);
+        let keys: Vec<BehavioralKey> = chunk
+            .iter()
+            .map(|&(lsk, _)| self.plan.behavioral_key(lsk))
+            .collect();
+        let record_key =
+            (!self.plan.person_leaves.is_empty()).then(|| self.plan.person_record_key());
+        let snapshot = store.read_event_snapshot(&keys, record_key.as_ref())?;
+        if let Some(record) = snapshot.record {
+            ReadSource::PersonRecord.record(1, record.as_ref().map_or(0, Vec::len));
+            self.inputs
+                .absorb_person_record(&self.plan.person_leaves, record);
         }
-        let bytes = store.get_person_record(&self.plan.person_record_key())?;
-        ReadSource::PersonRecord.record(1, bytes.as_ref().map_or(0, Vec::len));
-
-        let matched = match bytes {
-            None => None,
-            Some(bytes) => match PersonRecord::decode(&bytes) {
-                Ok(record) => Some(record.matched),
-                Err(_) => {
-                    counter!(STAGE2_STATE_DECODE_ERROR).increment(1);
-                    None
-                }
-            },
-        };
-        for &lsk in &self.plan.person_leaves {
-            let member = matched
-                .as_ref()
-                .is_some_and(|matched| matched.contains(&lsk.0));
-            self.inputs.membership.insert(lsk, member);
+        if !keys.is_empty() {
+            ReadSource::Behavioral.record(keys.len(), raw_bytes(&snapshot.behavioral));
+            self.inputs.absorb_behavioral(chunk, snapshot.behavioral);
+            self.behavioral_read += chunk.len();
         }
         Ok(())
     }
@@ -398,12 +463,7 @@ impl PersonInputReader {
             .collect();
         let raw = store.multi_get_behavioral(&keys)?;
         ReadSource::Behavioral.record(keys.len(), raw_bytes(&raw));
-        for (&(lsk, ref meta), bytes) in chunk.iter().zip(raw) {
-            let state = decode_stage1_state(bytes);
-            self.inputs
-                .membership
-                .insert(lsk, leaf_membership(state.as_ref(), meta));
-        }
+        self.inputs.absorb_behavioral(chunk, raw);
         self.behavioral_read += chunk.len();
         Ok(())
     }
@@ -516,8 +576,7 @@ mod tests {
         plan.behavioral.iter().map(|&(lsk, _)| lsk).collect()
     }
 
-    /// The whole point of planning first: whatever the fan-out, one person is one record read and
-    /// one key per distinct row. A regression here silently restores the per-cohort read.
+    /// Whatever the fan-out, one person is one record read and one key per distinct row.
     #[test]
     fn a_person_reads_one_record_and_one_key_per_distinct_row() {
         let filters = freeze(vec![

--- a/rust/cohort-stream-processor/tests/stage1_worker.rs
+++ b/rust/cohort-stream-processor/tests/stage1_worker.rs
@@ -2981,17 +2981,14 @@ async fn both_lanes_drain_before_the_worker_exits() {
     );
 }
 
-/// The composed half of the same guarantee. A seed run that flips a two-leaf cohort commits stage 1,
-/// fails its produce, and holds; nothing downstream was told and no `cf_stage2` row says otherwise,
-/// so the redelivery re-derives the flip and only then commits the offset.
-///
-/// The seed apply shares one read across a person's cohorts, so this pins that the sharing did not
-/// move the stage-2 write before the produce that justifies it.
+/// The composed half of the same guarantee: a run that flips two cohorts commits stage 1, fails its
+/// produce, and holds. Nothing downstream was told and no `cf_stage2` row says otherwise, so the
+/// redelivery re-derives both flips and only then commits the offset.
 #[tokio::test]
 async fn a_failed_composed_seed_produce_replays_from_the_row_it_never_wrote() {
     let (_dir, store) = temp_store();
-    // Two composable cohorts on the same leaf, so the run recomputes one person for both from one
-    // shared read — the shape this test's guarantee is about.
+    // Two composable cohorts on the same leaf, so one person recomputes for both from one shared
+    // read.
     let composed = || {
         build_team_filters(vec![
             (CohortId(1), cohort(vec![behavioral_leaf(7), person_leaf()])),
@@ -3044,8 +3041,8 @@ async fn a_failed_composed_seed_produce_replays_from_the_row_it_never_wrote() {
         "the failed produce holds the seed offset",
     );
 
-    // The redelivered tile merges to `Unchanged` and mints no transition. Only the absent stage-2
-    // row can still say the flip was never emitted.
+    // The redelivered tile merges to `Unchanged` and mints no transition, so only the absent
+    // stage-2 row can say the flips were never emitted.
     let replay_sink = CaptureSink::new();
     let replay_deps = MergeWorkerDeps::capture();
     let (live_tx, live_rx) = mpsc::channel(16);

--- a/rust/cohort-stream-processor/tests/stage1_worker.rs
+++ b/rust/cohort-stream-processor/tests/stage1_worker.rs
@@ -2981,6 +2981,125 @@ async fn both_lanes_drain_before_the_worker_exits() {
     );
 }
 
+/// The composed half of the same guarantee. A seed run that flips a two-leaf cohort commits stage 1,
+/// fails its produce, and holds; nothing downstream was told and no `cf_stage2` row says otherwise,
+/// so the redelivery re-derives the flip and only then commits the offset.
+///
+/// The seed apply shares one read across a person's cohorts, so this pins that the sharing did not
+/// move the stage-2 write before the produce that justifies it.
+#[tokio::test]
+async fn a_failed_composed_seed_produce_replays_from_the_row_it_never_wrote() {
+    let (_dir, store) = temp_store();
+    // Two composable cohorts on the same leaf, so the run recomputes one person for both from one
+    // shared read — the shape this test's guarantee is about.
+    let composed = || {
+        build_team_filters(vec![
+            (CohortId(1), cohort(vec![behavioral_leaf(7), person_leaf()])),
+            (CohortId(2), cohort(vec![behavioral_leaf(7), person_leaf()])),
+        ])
+    };
+    let bob = person(2);
+    // The person leaf already holds, so the seed tile's behavioral leaf is what completes the AND.
+    write_person_record(&store, bob, &[PERSON_HASH], AppliedOffsets::default(), &[]);
+
+    let sink = CaptureSink::failing_first(1);
+    let deps = MergeWorkerDeps::capture();
+    let (live_tx, live_rx) = mpsc::channel(16);
+    let (seed_tx, seed_rx) = mpsc::channel(16);
+    let worker = Stage1Worker::spawn(
+        PARTITION_ID,
+        WorkerInbox::unmetered(live_rx, seed_rx),
+        test_handle(&store),
+        catalog_of(composed()),
+        Arc::new(sink.clone()),
+        Arc::new(OffsetTracker::new()),
+        deps.clone(),
+        false,
+    );
+    deps.seed_tracker.mark_dispatched(PARTITION_ID as i32, 8);
+    seed_tx
+        .send(consumed_seed(bob, utc_today(), 1, 7))
+        .await
+        .unwrap();
+    drop(seed_tx);
+    drop(live_tx);
+    worker.join().await.unwrap();
+
+    assert!(
+        sink.changes().is_empty(),
+        "the produce failed, so downstream was told nothing",
+    );
+    for cohort_id in [1, 2] {
+        assert_eq!(
+            membership_register_at(&store, cohort_id, bob),
+            None,
+            "the composed bits commit only after their produce acks",
+        );
+    }
+    assert_eq!(
+        deps.seed_tracker
+            .committable_offsets()
+            .get(&(PARTITION_ID as i32)),
+        None,
+        "the failed produce holds the seed offset",
+    );
+
+    // The redelivered tile merges to `Unchanged` and mints no transition. Only the absent stage-2
+    // row can still say the flip was never emitted.
+    let replay_sink = CaptureSink::new();
+    let replay_deps = MergeWorkerDeps::capture();
+    let (live_tx, live_rx) = mpsc::channel(16);
+    let (seed_tx, seed_rx) = mpsc::channel(16);
+    let worker = Stage1Worker::spawn(
+        PARTITION_ID,
+        WorkerInbox::unmetered(live_rx, seed_rx),
+        test_handle(&store),
+        catalog_of(composed()),
+        Arc::new(replay_sink.clone()),
+        Arc::new(OffsetTracker::new()),
+        replay_deps.clone(),
+        false,
+    );
+    replay_deps
+        .seed_tracker
+        .mark_dispatched(PARTITION_ID as i32, 8);
+    seed_tx
+        .send(consumed_seed(bob, utc_today(), 1, 7))
+        .await
+        .unwrap();
+    drop(seed_tx);
+    drop(live_tx);
+    worker.join().await.unwrap();
+
+    let changes = replay_sink.changes();
+    assert_eq!(
+        changes
+            .iter()
+            .map(|change| (change.cohort_id, change.person_id.clone(), change.status))
+            .collect::<Vec<_>>(),
+        vec![
+            (1, bob.to_string(), MembershipStatus::Entered),
+            (2, bob.to_string(), MembershipStatus::Entered),
+        ],
+        "the redelivery re-derived both lost changes from one shared read",
+    );
+    for cohort_id in [1, 2] {
+        assert_eq!(
+            membership_register_at(&store, cohort_id, bob).map(|state| state.in_cohort),
+            Some(true),
+            "and the rows it emitted are now durable",
+        );
+    }
+    assert_eq!(
+        replay_deps
+            .seed_tracker
+            .committable_offsets()
+            .get(&(PARTITION_ID as i32)),
+        Some(&8),
+        "the seed offset commits once the re-emission acks",
+    );
+}
+
 /// A failed seed emission holds only the seed tracker; the events tracker is unaffected, and the
 /// next tenure's redelivery re-emits the lost change.
 #[tokio::test]


### PR DESCRIPTION
## Problem

A cohort backfill applies seeds slower than it needs to. Stage 2 recomputation reads the same person state once for every cohort that person is in.

A person in fourteen composable cohorts pays fourteen person record reads, fourteen behavioral batches, and fourteen membership reads, each on its own blocking pool handoff.

## Changes

* Seed applies now read a person once and reuse that state across every cohort the person is in. One store section replaces roughly three handoffs per cohort. The new module is `stage2_person_inputs.rs`.
* Live, sweep, cascade and reconcile keep the old order, which suits them because they touch one or two cohorts per event.
* Composed references still resolve from stored membership, so a referent recomputed in the same group cannot leak an unacknowledged bit into a cascade.
* Three metrics report persons read, keys fetched by state source, and raw bytes per batch.
* Nothing a person sees changes. Emitted membership, persisted state and offset progress are identical.
* `store_offload_inflight` relabels: `lane="section"` counted merge drain/apply and GC; those move to `lane="maintenance"`, which now means "holds a maintenance permit". `lane="section"` is left as `stats_snapshot` only. Retarget any panel or alert filtering on `lane="section"`.

A local benchmark over one store with 500 persons runs 1.29x faster at one cohort per person, 1.70x at four, and 1.77x at fourteen. It runs one recompute at a time against a warm store, so it does not measure the permit contention this change is mostly for.

## How did you test this code?

* Differential tests run both orders over one store and compare emitted changes, pending writes and pairs composed.
* New coverage catches four regressions no existing test caught. A single leaf referent resolved from a stored row rather than its own comparator. A person record collapsed into one bit instead of answered per condition. A read that stops at the 64 key chunk boundary. A composed produce failure that never replays.
* Breaking the implementation both ways confirms the two new tests fail, so neither is tautological.
* Not done: no production run, no canary, and no memory measurement under load.

## Docs update

None.