### PR TITLE
feat(desktop): enforce staged task isolation

### DIFF
--- a/products/desktop/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/claude-agent.ts
@@ -2838,7 +2838,11 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       mcpServers,
       permissionMode,
       posthogExecPermissionRegex,
-      canUseTool: this.createCanUseTool(sessionId, meta?.allowedDomains),
+      canUseTool: this.createCanUseTool(
+        sessionId,
+        meta?.allowedDomains,
+        meta?.disabledTools,
+      ),
       logger: this.logger,
       systemPrompt,
       userProvidedOptions: meta?.claudeCode?.options,
@@ -2854,6 +2858,8 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
         ...(params.additionalDirectories ?? meta?.additionalRoots ?? []),
       ],
       disableBuiltInTools: meta?.disableBuiltInTools,
+      disabledTools: meta?.disabledTools,
+      strictMcpConfig: meta?.strictMcpConfig,
       outputFormat,
       settingsManager,
       onModeChange: this.createOnModeChange(),
@@ -3132,6 +3138,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
   private createCanUseTool(
     sessionId: string,
     allowedDomains?: string[],
+    disabledTools?: string[],
   ): CanUseTool {
     return async (toolName, toolInput, { suggestions, toolUseID, signal }) =>
       canUseTool({
@@ -3149,6 +3156,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
           this.updateConfigOption(configId, value),
         applySessionMode: (modeId: string) => this.applySessionMode(modeId),
         allowedDomains,
+        disabledTools,
         emittedToolCalls: this.emittedToolCalls,
         supportsTerminalOutput:
           (

--- a/products/desktop/packages/agent/src/adapters/claude/permissions/permission-handlers.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/permissions/permission-handlers.test.ts
@@ -75,6 +75,18 @@ function createContext(
 }
 
 describe("canUseTool MCP approval enforcement", () => {
+  it("denies platform-disabled tools before bypass mode can allow them", async () => {
+    const context = createContext("WebFetch", {
+      disabledTools: ["WebFetch"],
+      session: { permissionMode: "bypassPermissions" },
+    });
+
+    const result = await canUseTool(context);
+
+    expect(result.behavior).toBe("deny");
+    expect(context.client.requestPermission).not.toHaveBeenCalled();
+  });
+
   beforeEach(() => {
     clearMcpToolMetadataCache();
   });

--- a/products/desktop/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
@@ -77,6 +77,7 @@ interface ToolHandlerContext {
   updateConfigOption: (configId: string, value: string) => Promise<void>;
   applySessionMode: (modeId: string) => Promise<void>;
   allowedDomains?: string[];
+  disabledTools?: readonly string[];
   /** Shared with the streamed tool_use path; first emitter wins. */
   emittedToolCalls?: Set<string>;
   supportsTerminalOutput?: boolean;
@@ -804,7 +805,14 @@ function isDomainAllowed(hostname: string, allowedDomains: string[]): boolean {
 export async function canUseTool(
   context: ToolHandlerContext,
 ): Promise<ToolPermissionResult> {
-  const { toolName, toolInput, session, allowedDomains } = context;
+  const { toolName, toolInput, session, allowedDomains, disabledTools } =
+    context;
+
+  if (disabledTools?.includes(toolName)) {
+    const message = `This tool is disabled for the current task.`;
+    await emitToolDenial(context, message);
+    return { behavior: "deny", message, interrupt: false };
+  }
 
   recordPlanFile(context);
 

--- a/products/desktop/packages/agent/src/adapters/claude/session/options.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/options.test.ts
@@ -50,6 +50,30 @@ function makeParams() {
 }
 
 describe("buildSessionOptions", () => {
+  it("keeps platform-disabled tools disallowed when user options try to restore them", () => {
+    const options = buildSessionOptions({
+      ...makeParams(),
+      disabledTools: ["WebFetch", "WebSearch"],
+      userProvidedOptions: { disallowedTools: ["Bash"] },
+    });
+
+    expect(options.disallowedTools).toEqual(["Bash", "WebFetch", "WebSearch"]);
+  });
+
+  it("uses only server-provided MCP configuration for a strict protected session", () => {
+    const options = buildSessionOptions({
+      ...makeParams(),
+      strictMcpConfig: true,
+      userProvidedOptions: {
+        settingSources: ["user", "project"],
+        mcpServers: { ambient: { type: "stdio", command: "ambient" } },
+      },
+    });
+
+    expect(options.settingSources).toEqual([]);
+    expect(options.mcpServers).not.toHaveProperty("ambient");
+  });
+
   it("replaces unprocessable Read images before model delivery", async () => {
     const options = buildSessionOptions(makeParams());
     const hooks = (options.hooks?.PostToolUse ?? []).flatMap(

--- a/products/desktop/packages/agent/src/adapters/claude/session/options.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/options.ts
@@ -100,6 +100,8 @@ export interface BuildOptionsParams {
   forkSession?: boolean;
   additionalDirectories?: string[];
   disableBuiltInTools?: boolean;
+  disabledTools?: string[];
+  strictMcpConfig?: boolean;
   outputFormat?: OutputFormat;
   settingsManager: SettingsManager;
   onModeChange?: OnModeChange;
@@ -637,11 +639,13 @@ export function buildSessionOptions(params: BuildOptionsParams): Options {
     ...params.userProvidedOptions,
     betas: ["context-1m-2025-08-07"],
     systemPrompt: params.systemPrompt ?? buildSystemPrompt(),
-    settingSources: params.userProvidedOptions?.settingSources ?? [
-      "user",
-      "project",
-      "local",
-    ],
+    settingSources: params.strictMcpConfig
+      ? []
+      : (params.userProvidedOptions?.settingSources ?? [
+          "user",
+          "project",
+          "local",
+        ]),
     stderr: (err) => params.logger.error(err),
     cwd: params.cwd,
     includePartialMessages: true,
@@ -649,6 +653,12 @@ export function buildSessionOptions(params: BuildOptionsParams): Options {
     permissionMode: toSdkPermissionMode(params.permissionMode),
     canUseTool: params.canUseTool,
     tools,
+    disallowedTools: Array.from(
+      new Set([
+        ...(params.userProvidedOptions?.disallowedTools ?? []),
+        ...(params.disabledTools ?? []),
+      ]),
+    ),
     agents,
     extraArgs: {
       ...params.userProvidedOptions?.extraArgs,
@@ -660,9 +670,13 @@ export function buildSessionOptions(params: BuildOptionsParams): Options {
       params.userProvidedOptions?.includeHookEvents ??
       traceparentHookSettings !== undefined,
     mcpServers: buildMcpServers(
-      params.userProvidedOptions?.mcpServers,
+      params.strictMcpConfig
+        ? undefined
+        : params.userProvidedOptions?.mcpServers,
       params.mcpServers,
-      loadUserClaudeJsonMcpServers(params.cwd, params.logger),
+      params.strictMcpConfig
+        ? {}
+        : loadUserClaudeJsonMcpServers(params.cwd, params.logger),
     ),
     // Feedback events stamp the task id as $ai_session_id, so generations
     // carry the same id for LLMA to group a task's runs and ratings together.

--- a/products/desktop/packages/agent/src/adapters/claude/types.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/types.ts
@@ -244,6 +244,8 @@ export type NewSessionMeta = {
   persistence?: { taskId?: string; runId?: string; logUrl?: string };
   additionalRoots?: string[];
   allowedDomains?: string[];
+  disabledTools?: string[];
+  strictMcpConfig?: boolean;
   /** Model ID to use for this session (e.g. "claude-sonnet-4-6") */
   model?: string;
   /** Context window choice for 1M-capable models; unset means the 1M default. */

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -2133,6 +2133,8 @@ export class AgentServer {
       systemPrompt: sessionSystemPrompt,
       ...(this.config.model && { model: this.config.model }),
       allowedDomains: this.config.allowedDomains,
+      disabledTools: this.config.disabledTools,
+      strictMcpConfig: this.config.strictMcpConfig,
       jsonSchema: preTask?.json_schema ?? null,
       permissionMode: initialPermissionMode,
       ...(channelMode && { channelMode: true }),

--- a/products/desktop/packages/agent/src/server/bin.ts
+++ b/products/desktop/packages/agent/src/server/bin.ts
@@ -177,6 +177,11 @@ program
     "--allowedDomains <domains>",
     "Comma-separated list of domains allowed for web tools (WebFetch, WebSearch)",
   )
+  .option("--disabledTools <json>", "Server-enforced disabled Claude tools")
+  .option(
+    "--strictMcpConfig <boolean>",
+    "Ignore ambient Claude MCP configuration",
+  )
   .action(async (options) => {
     const envResult = envSchema.safeParse(process.env);
 
@@ -240,6 +245,15 @@ program
           .map((d: string) => d.trim())
           .filter(Boolean)
       : undefined;
+    const disabledTools = parseJsonOption(
+      options.disabledTools,
+      z.array(z.string().min(1)),
+      "--disabledTools",
+    );
+    const strictMcpConfig = parseBooleanOption(
+      options.strictMcpConfig,
+      "--strictMcpConfig",
+    );
 
     if (
       env.POSTHOG_CODE_RUNTIME_ADAPTER &&
@@ -290,6 +304,8 @@ program
       baseBranch: options.baseBranch,
       claudeCode,
       allowedDomains,
+      disabledTools,
+      strictMcpConfig,
       piRpcHostPath: fileURLToPath(
         new URL("../pi/rpc-host.js", import.meta.url),
       ),

--- a/products/desktop/packages/agent/src/server/types.ts
+++ b/products/desktop/packages/agent/src/server/types.ts
@@ -56,6 +56,8 @@ export interface AgentServerConfig {
   baseBranch?: string;
   claudeCode?: ClaudeCodeConfig;
   allowedDomains?: string[];
+  disabledTools?: string[];
+  strictMcpConfig?: boolean;
   piRpcHostPath?: string;
   runtimeAdapter?: Adapter;
   model?: string;

--- a/products/desktop/packages/agent/src/utils/gateway-routing-cases.json
+++ b/products/desktop/packages/agent/src/utils/gateway-routing-cases.json
@@ -110,6 +110,12 @@
       "expected": "posthog_ai"
     },
     {
+      "origin_product": "pulse_subscription",
+      "ai_stage": null,
+      "internal": true,
+      "expected": "pulse_subscription"
+    },
+    {
       "origin_product": "image_builder",
       "ai_stage": null,
       "internal": true,

--- a/products/desktop/packages/agent/src/utils/gateway.ts
+++ b/products/desktop/packages/agent/src/utils/gateway.ts
@@ -6,6 +6,7 @@ export type GatewayProduct =
   | "signals"
   | "slack_app"
   | "posthog_ai"
+  | "pulse_subscription"
   | "conversations"
   | "onboarding"
   | "review_hog";
@@ -24,6 +25,7 @@ export function resolveGatewayProduct({
     loop: "posthog_code",
     onboarding: "onboarding",
     posthog_ai: "posthog_ai",
+    pulse_subscription: "pulse_subscription",
     review_hog: "review_hog",
     scout_suggestions: "signals",
     signal_report: "signals",


### PR DESCRIPTION
## Problem

Protected Pulse tasks need the Desktop agent to honor server-controlled tool restrictions without depending on ambient user MCP settings.

## Changes

- Adds server inputs for disabled Claude tools and strict MCP configuration.
- Enforces the denylist in permission handling and passes both controls into Claude session options.
- Strict sessions ignore ambient settings and MCP servers while normal sessions remain unchanged.
- Routes `pulse_subscription` task usage to the matching gateway billing product.
- This PR has no visual changes.

Before:

```mermaid
flowchart LR
    A[Backend starts agent] --> B[Claude session reads ambient settings]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phYellow;
    class B phBlue;
```

After:

```mermaid
flowchart LR
    A[Backend sends constraints] --> B[Agent enforces policy]
    B --> C[Claude session starts]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phYellow;
    class B phRed;
    class C phBlue;
```

## How did you test this code?

- The focused permission-handler and session-option suites passed locally.
- All 114 focused gateway-routing cases passed locally.
- The Desktop formatter and complete typecheck passed through the commit hook.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This layer extends an internal agent protocol and adds no user-facing setup.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used /debugging-ci-failures, /stacking-prs, /writing-code-comments, and /writing-pr-descriptions.

Desktop coupling CI required this release boundary. The duplicate search found only unrelated PR #93058.

All tests use repository fixtures. No customer material or private session data is included.
