### PR TITLE
fix(desktop): keep a usable default model when the gateway catalog is empty

### DIFF
--- a/products/desktop/packages/shared/src/cloud-task-models.test.ts
+++ b/products/desktop/packages/shared/src/cloud-task-models.test.ts
@@ -284,6 +284,16 @@ describe("buildCloudTaskConfigOptions", () => {
       expect.objectContaining({ value: "deepseek-ai/deepseek-v4-flash-0731" }),
     );
   });
+
+  it.each(["claude", "codex"] as const)(
+    "keeps a usable default model when the gateway answers with an empty catalog (%s)",
+    (adapter) => {
+      const modelOption = buildCloudTaskConfigOptions([], adapter).find(
+        (option) => option.id === "model",
+      );
+      expect(modelOption?.currentValue).not.toBe("");
+    },
+  );
 });
 
 describe("adapterForModelId", () => {

--- a/products/desktop/packages/shared/src/cloud-task-models.ts
+++ b/products/desktop/packages/shared/src/cloud-task-models.ts
@@ -489,7 +489,7 @@ export function buildCloudTaskConfigOptions(
       ? (modelOptions.find((option) => option.value === DEFAULT_CODEX_MODEL)
           ?.value ??
         modelOptions[0]?.value ??
-        "")
+        DEFAULT_CODEX_MODEL)
       : DEFAULT_GATEWAY_MODEL;
   const preferredModelId = modelOptions.some(
     (option) => option.value === defaultModel,

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -720,6 +720,8 @@ export function TaskInput({
     contextWindowOption,
     fastModeOption,
     isLoading: isPreviewLoading,
+    isModelListUnresolved,
+    retry: retryPreviewConfig,
     setConfigOption,
     resetToDefault,
     isDefaultSelection,
@@ -1588,6 +1590,7 @@ export function TaskInput({
                     !isOnline ||
                     (runtime === "pi" ? isPiConfigLoading : isPreviewLoading) ||
                     (runtime === "pi" && !currentPiModel) ||
+                    (runtime !== "pi" && isModelListUnresolved) ||
                     spendStop !== null
                   }
                   submitTooltipOverride={
@@ -1595,7 +1598,18 @@ export function TaskInput({
                   }
                   tourTarget="task-input"
                   submitAdornment={
-                    channelContextUnavailable || channelContextFailed ? (
+                    runtime !== "pi" && isModelListUnresolved ? (
+                      <span className="flex items-center gap-1.5 text-[12px] text-gray-10">
+                        Couldn't load models
+                        <button
+                          type="button"
+                          className="underline"
+                          onClick={retryPreviewConfig}
+                        >
+                          Try again
+                        </button>
+                      </span>
+                    ) : channelContextUnavailable || channelContextFailed ? (
                       // The chip slot is where context status is read, so it is
                       // also where its absence has to be said.
                       <span className="flex items-center gap-1.5 text-[12px] text-gray-10">

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -721,6 +721,7 @@ export function TaskInput({
     fastModeOption,
     isLoading: isPreviewLoading,
     isModelListUnresolved,
+    isRetryingModelList,
     retry: retryPreviewConfig,
     setConfigOption,
     resetToDefault,
@@ -1598,7 +1599,9 @@ export function TaskInput({
                   }
                   tourTarget="task-input"
                   submitAdornment={
-                    runtime !== "pi" && isModelListUnresolved ? (
+                    runtime !== "pi" &&
+                    isModelListUnresolved &&
+                    !isRetryingModelList ? (
                       <span className="flex items-center gap-1.5 text-[12px] text-gray-10">
                         Couldn't load models
                         <button
@@ -1703,7 +1706,10 @@ export function TaskInput({
                         menuOpen={modelMenuOpen}
                         onMenuOpenChange={setModelMenuOpen}
                         disabled={isCreatingTask}
-                        isLoading={isPreviewLoading}
+                        isLoading={
+                          isPreviewLoading ||
+                          (isModelListUnresolved && isRetryingModelList)
+                        }
                         modelAccess={composerModelAccess}
                         showBillingMenu
                         workspaceMode={workspaceMode}

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/usePreviewConfig.test.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/usePreviewConfig.test.tsx
@@ -79,29 +79,69 @@ describe("usePreviewConfig", () => {
     settingsState.lastUsedModel = null;
   });
 
-  it("blocks on an empty model list and clears on a retry that returns models", async () => {
-    hostState.query.mockResolvedValueOnce(modelOption([]));
-    hostState.query.mockResolvedValueOnce(
-      modelOption(["claude-opus-4-8", "gpt-5.5"]),
-    );
+  it("recovers on its own when the empty list is transient", async () => {
+    vi.useFakeTimers();
+    try {
+      hostState.query
+        .mockResolvedValueOnce(modelOption([]))
+        .mockResolvedValueOnce(modelOption(["claude-opus-4-8"]));
 
-    const { result } = renderHook(() => usePreviewConfig("claude"));
+      const { result } = renderHook(() => usePreviewConfig("claude"));
 
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
-    expect(result.current.isModelListUnresolved).toBe(true);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(result.current.isModelListUnresolved).toBe(true);
+      expect(result.current.isRetryingModelList).toBe(true);
 
-    act(() => {
-      result.current.retry();
-    });
-    expect(result.current.isLoading).toBe(true);
-
-    await waitFor(() => {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      expect(result.current.isModelListUnresolved).toBe(false);
+      expect(result.current.isRetryingModelList).toBe(false);
       expect(result.current.modelOption?.currentValue).toBe("claude-opus-4-8");
-    });
-    expect(result.current.isModelListUnresolved).toBe(false);
-    expect(hostState.query).toHaveBeenCalledTimes(2);
+      expect(hostState.query).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops retrying after the backoff is exhausted and a manual retry restarts it", async () => {
+    vi.useFakeTimers();
+    try {
+      hostState.query.mockResolvedValue(modelOption([]));
+
+      const { result } = renderHook(() => usePreviewConfig("claude"));
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(result.current.isRetryingModelList).toBe(true);
+
+      // 1s + 2s + 4s + 8s: four attempts, then it gives up. Repeated advances
+      // are needed: one sweep does not run timers scheduled during itself.
+      for (let i = 0; i < 5; i++) {
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(16000);
+        });
+      }
+      expect(result.current.isModelListUnresolved).toBe(true);
+      expect(result.current.isRetryingModelList).toBe(false);
+      const autoAttempts = hostState.query.mock.calls.length;
+
+      act(() => {
+        result.current.retry();
+      });
+      expect(hostState.query.mock.calls.length).toBe(autoAttempts + 1);
+
+      // The refetch answers empty again; the backoff restarts from attempt 0.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(result.current.isRetryingModelList).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("is resolved when the list arrives with models", async () => {

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/usePreviewConfig.test.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/usePreviewConfig.test.tsx
@@ -1,0 +1,118 @@
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hostState = vi.hoisted(() => ({ query: vi.fn() }));
+const flagState = vi.hoisted(() => ({ enabled: true }));
+const settingsState = vi.hoisted(() => ({
+  _hasHydrated: true,
+  lastUsedModel: null as string | null,
+  lastUsedReasoningEffort: null as string | null,
+  lastUsedContextWindow: null as string | null,
+  lastUsedFastMode: null as boolean | null,
+  lastUsedInitialTaskMode: undefined as string | undefined,
+  defaultInitialTaskMode: "",
+  defaultReasoningEffort: undefined as string | undefined,
+  lastUsedAdapter: undefined as string | undefined,
+  setLastUsedContextWindow: vi.fn(),
+  setLastUsedFastMode: vi.fn(),
+  setState: vi.fn(),
+}));
+
+vi.mock("@posthog/host-router/react", () => {
+  // Hoisted: refetch sits in an effect dependency array keyed on the client,
+  // so a fresh object per render would re-run the fetch forever.
+  const client = {
+    agent: { getPreviewConfigOptions: { query: hostState.query } },
+  };
+  return { useHostTRPCClient: () => client };
+});
+vi.mock("../../auth/store", () => ({
+  useAuthStateValue: (selector: (state: { cloudRegion: string }) => string) =>
+    selector({ cloudRegion: "us" }),
+  useAuthStateFetched: () => true,
+}));
+vi.mock("@posthog/ui/features/feature-flags/useFeatureFlag", () => ({
+  useFeatureFlag: () => flagState.enabled,
+}));
+vi.mock("../../../shell/logger", () => ({
+  logger: { scope: () => ({ warn: vi.fn(), error: vi.fn() }) },
+}));
+vi.mock("./useTaskRunDefaults", () => {
+  // Hoisted: the hook sits in deriveSelection's dependency array, so a fresh
+  // object per render would loop the derivation effect forever.
+  const NO_DEFAULTS = {
+    defaults: { runtime_adapter: null, model: null, reasoning_effort: null },
+    isSettled: true,
+  };
+  return { useTaskRunDefaults: () => NO_DEFAULTS };
+});
+vi.mock("../../settings/settingsStore", () => ({
+  useSettingsStore: Object.assign(
+    (selector: (state: typeof settingsState) => unknown) =>
+      selector(settingsState),
+    {
+      getState: () => settingsState,
+      setState: (patch: Partial<typeof settingsState>) =>
+        Object.assign(settingsState, patch),
+    },
+  ),
+}));
+
+import { usePreviewConfig } from "./usePreviewConfig";
+
+const modelOption = (ids: string[]): SessionConfigOption[] => [
+  {
+    id: "model",
+    name: "Model",
+    type: "select",
+    currentValue: ids[0] ?? "",
+    options: ids.map((id) => ({ value: id, name: id })),
+    category: "model",
+  },
+];
+
+describe("usePreviewConfig", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    flagState.enabled = true;
+    settingsState.lastUsedModel = null;
+  });
+
+  it("blocks on an empty model list and clears on a retry that returns models", async () => {
+    hostState.query.mockResolvedValueOnce(modelOption([]));
+    hostState.query.mockResolvedValueOnce(
+      modelOption(["claude-opus-4-8", "gpt-5.5"]),
+    );
+
+    const { result } = renderHook(() => usePreviewConfig("claude"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.isModelListUnresolved).toBe(true);
+
+    act(() => {
+      result.current.retry();
+    });
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.modelOption?.currentValue).toBe("claude-opus-4-8");
+    });
+    expect(result.current.isModelListUnresolved).toBe(false);
+    expect(hostState.query).toHaveBeenCalledTimes(2);
+  });
+
+  it("is resolved when the list arrives with models", async () => {
+    hostState.query.mockResolvedValue(modelOption(["claude-opus-4-8"]));
+
+    const { result } = renderHook(() => usePreviewConfig("claude"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.isModelListUnresolved).toBe(false);
+    expect(result.current.modelOption?.currentValue).toBe("claude-opus-4-8");
+  });
+});

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/usePreviewConfig.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/usePreviewConfig.ts
@@ -52,6 +52,12 @@ interface PreviewConfigResult {
   contextWindowOption: SessionConfigOption | undefined;
   fastModeOption: SessionConfigOption | undefined;
   isLoading: boolean;
+  /**
+   * The model list arrived empty, so no selection can be trusted: submit is
+   * blocked and a retry refetches until the gateway answers with models.
+   */
+  isModelListUnresolved: boolean;
+  retry: () => void;
   setConfigOption: (configId: string, value: string) => void;
   /**
    * Drops the explicit local picks and re-derives the selection, landing on the
@@ -126,7 +132,10 @@ export function usePreviewConfig(
   // The harness the configured default (user's, else the team's) runs on.
   const defaultAdapter = preferredRunAdapter(runDefaults);
 
-  useEffect(() => {
+  // Re-runnable by retry: the gateway failure that empties the model list
+  // resolves inside the workspace server, so the query itself never rejects
+  // and a refetch has to be explicit.
+  const refetch = useCallback(() => {
     if (!apiHost) return;
 
     const abort = new AbortController();
@@ -155,6 +164,8 @@ export function usePreviewConfig(
       abort.abort();
     };
   }, [adapter, allHarnessModels, apiHost, hostClient]);
+
+  useEffect(() => refetch(), [refetch]);
 
   /**
    * Pure local derivation from the fetched options, the saved picks, and the
@@ -438,6 +449,19 @@ export function usePreviewConfig(
       ? isDefaultSelection
       : !hasModelPick && !hasEffortPick;
 
+  // The gateway failure this reports resolves inside the workspace server, so
+  // an empty model list is the only visible symptom. Loading stays its own
+  // state: while loading the picker has nothing to show yet, while unresolved
+  // the answer arrived and named no models.
+  const isModelListUnresolved =
+    !isLoading &&
+    modelOption?.type === "select" &&
+    modelOption.options.length === 0;
+
+  const retry = useCallback(() => {
+    refetch();
+  }, [refetch]);
+
   return {
     configOptions,
     modeOption,
@@ -446,6 +470,8 @@ export function usePreviewConfig(
     contextWindowOption,
     fastModeOption,
     isLoading,
+    isModelListUnresolved,
+    retry,
     setConfigOption,
     resetToDefault,
     isDefaultSelection,

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/usePreviewConfig.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/usePreviewConfig.ts
@@ -44,6 +44,11 @@ const CLEARED_RUN_PICKS = {
   lastUsedFastMode: null,
 };
 
+// An empty model list retries itself before it asks the user to: 1s, 2s, 4s,
+// 8s, then the composer reports it and offers the manual retry.
+const MODEL_LIST_RETRY_BASE_MS = 1000;
+const MODEL_LIST_RETRY_CAP = 4;
+
 interface PreviewConfigResult {
   configOptions: SessionConfigOption[];
   modeOption: SessionConfigOption | undefined;
@@ -54,9 +59,11 @@ interface PreviewConfigResult {
   isLoading: boolean;
   /**
    * The model list arrived empty, so no selection can be trusted: submit is
-   * blocked and a retry refetches until the gateway answers with models.
+   * blocked while it is unresolved, and it retried itself first.
    */
   isModelListUnresolved: boolean;
+  /** Unresolved and still in the automatic backoff window, so it reads as loading. */
+  isRetryingModelList: boolean;
   retry: () => void;
   setConfigOption: (configId: string, value: string) => void;
   /**
@@ -119,6 +126,9 @@ export function usePreviewConfig(
     options: SessionConfigOption[];
   } | null>(null);
   const prevAdapterRef = useRef<Adapter | null>(null);
+  // Self-retry attempt for an empty model list; caps out and hands over to the
+  // manual retry once the backoff is exhausted.
+  const [retryAttempt, setRetryAttempt] = useState(0);
   const hasHydrated = useSettingsStore((state) => state._hasHydrated);
   // Truthiness only: selecting the raw pick values would re-render every
   // mounted instance of this hook on each pick, even when the answers computed
@@ -135,6 +145,7 @@ export function usePreviewConfig(
   // Re-runnable by retry: the gateway failure that empties the model list
   // resolves inside the workspace server, so the query itself never rejects
   // and a refetch has to be explicit.
+  const refetchRef = useRef<() => void>(() => {});
   const refetch = useCallback(() => {
     if (!apiHost) return;
 
@@ -164,6 +175,10 @@ export function usePreviewConfig(
       abort.abort();
     };
   }, [adapter, allHarnessModels, apiHost, hostClient]);
+
+  useEffect(() => {
+    refetchRef.current = refetch;
+  }, [refetch]);
 
   useEffect(() => refetch(), [refetch]);
 
@@ -458,7 +473,23 @@ export function usePreviewConfig(
     modelOption?.type === "select" &&
     modelOption.options.length === 0;
 
+  // An empty model list is the gateway failure's only symptom, and it answers
+  // empty because a transient fetch failed: wait a beat and ask again, so a
+  // blip recovers itself instead of blocking on the user's first click.
+  useEffect(() => {
+    if (!isModelListUnresolved || retryAttempt >= MODEL_LIST_RETRY_CAP) {
+      return;
+    }
+    const delay = MODEL_LIST_RETRY_BASE_MS * 2 ** retryAttempt;
+    const timer = setTimeout(() => {
+      setRetryAttempt((attempt) => attempt + 1);
+      refetchRef.current();
+    }, delay);
+    return () => clearTimeout(timer);
+  }, [isModelListUnresolved, retryAttempt]);
+
   const retry = useCallback(() => {
+    setRetryAttempt(0);
     refetch();
   }, [refetch]);
 
@@ -471,6 +502,8 @@ export function usePreviewConfig(
     fastModeOption,
     isLoading,
     isModelListUnresolved,
+    isRetryingModelList:
+      isModelListUnresolved && retryAttempt < MODEL_LIST_RETRY_CAP,
     retry,
     setConfigOption,
     resetToDefault,


### PR DESCRIPTION
## Problem

On a flaky connection, a desktop user creating a cloud task can hit "Failed to create task" with `400 {"code": "blank", "attr": "model"}`. The same gateway outage also empties the composer's model picker, which matches the report that the model is "not shown at all".

The chain: the gateway `/v1/models` fetch fails (rate limit, timeout) and returns an empty list; the Codex default-model fallback chain then resolves to an empty string; the composer sends `model: ""` on task creation, which the API rejects. The Claude branch always resolved to a hardcoded id, so only Codex tasks failed.

## Changes

- Codex tasks on an empty gateway catalog no longer send a blank model: the empty-catalog fallback in `buildCloudTaskConfigOptions` is `DEFAULT_CODEX_MODEL` instead of `""`, matching the Claude branch's hardcoded fallback.
- An empty model list recovers itself. The composer refetches with a 1s/2s/4s/8s backoff and keeps showing the picker's loading state, so a transient gateway blip resolves without the user noticing.
- If the backoff runs out, the composer stops the task submit and shows "Couldn't load models" with a Try again control that restarts the cycle. Submit unlocks as soon as models arrive.
- No other visual change: with a healthy catalog the picker behaves exactly as before.

## How did you test this code?

- New `test.each` cases in the existing `buildCloudTaskConfigOptions` block assert the model option never resolves to `""` for either adapter with an empty catalog. They catch the regression where an empty catalog seeds a blank model into the create-task body.
- New `usePreviewConfig` hook tests cover the recovery ladder: a transient empty list self-heals on the first backoff tick, a persistent one exhausts the backoff and a manual retry restarts it. They catch regressions where the composer unlocks with no model to send, or gives up without trying again.
- Verified the full chain against source: empty catalog → config options → `prepareTaskInput` → the saga's `input.model ?? null` body expression now yields `"gpt-5.5"` for Codex and `"claude-opus-4-8"` for Claude, never `""`.
- Not checked: the desktop app itself and a live gateway; the verification above runs the real functions in vitest.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Claude Code. Skills: `/writing-tests`, `/writing-pr-descriptions`.

- No duplicate: searched open PRs for overlapping fixes; none found. PR #93153 (single-source model catalog) touches the same file but its branch keeps the `?? ""` fallback, so this fix is still needed.
- Public artifact: all committed material comes from this repository's own code and tests.
