### PR TITLE
fix(azure-blob): Validate connection string

### DIFF
--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -1229,16 +1229,23 @@ class TestAzureBlobIntegration:
             self.organization, "test@posthog.com", "test", level=OrganizationMembership.Level.ADMIN
         )
 
-    def test_create_azure_blob_integration(self, client: HttpClient):
+    @pytest.mark.parametrize(
+        "connection_string",
+        [
+            "DefaultEndpointsProtocol=https;AccountName=my-storage-account;AccountKey=my-key;EndpointSuffix=core.windows.net",
+            "DefaultEndpointsProtocol=https;AccountName=my-storage-account;AccountKey=my-key;EndpointSuffix=core.usgovcloudapi.net",
+            "AccountName=my-storage-account;AccountKey=my-key",
+        ],
+    )
+    @override_settings(FORCE_URL_VALIDATION=True)
+    def test_create_azure_blob_integration(self, connection_string, client: HttpClient):
         client.force_login(self.user)
 
         response = client.post(
             f"/api/environments/{self.team.pk}/integrations",
             {
                 "kind": "azure-blob",
-                "config": {
-                    "connection_string": "DefaultEndpointsProtocol=https;AccountName=my-storage-account;AccountKey=my-key;EndpointSuffix=core.windows.net"
-                },
+                "config": {"connection_string": connection_string},
             },
             content_type="application/json",
         )
@@ -1252,6 +1259,9 @@ class TestAzureBlobIntegration:
         [
             "UseDevelopmentStorage=true;AccountName=devstoreaccount1",
             "AccountName=my-storage-account;AccountKey=my-key;BlobEndpoint=http://169.254.169.254/",
+            # Attacker-controlled DefaultEndpointsProtocol is interpolated raw into the derived
+            # endpoint by the SDK, so the derived URL must be validated, not assumed https.
+            "DefaultEndpointsProtocol=http://169.254.169.254/latest/meta-data?x=;AccountName=a;AccountKey=YQ==;EndpointSuffix=core.windows.net",
         ],
     )
     @override_settings(FORCE_URL_VALIDATION=True)

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -1235,6 +1235,7 @@ class TestAzureBlobIntegration:
             "DefaultEndpointsProtocol=https;AccountName=my-storage-account;AccountKey=my-key;EndpointSuffix=core.windows.net",
             "DefaultEndpointsProtocol=https;AccountName=my-storage-account;AccountKey=my-key;EndpointSuffix=core.usgovcloudapi.net",
             "AccountName=my-storage-account;AccountKey=my-key",
+            "AccountName=my-storage-account;AccountKey=YQ==; BlobEndpoint=https://example.com;EndpointSuffix=169.254.169.254",
         ],
     )
     @override_settings(FORCE_URL_VALIDATION=True)
@@ -1264,10 +1265,6 @@ class TestAzureBlobIntegration:
             "DefaultEndpointsProtocol=http://169.254.169.254/latest/meta-data?x=;AccountName=a;AccountKey=YQ==;EndpointSuffix=core.windows.net",
             "DefaultEndpointsProtocol=http;AccountName=a;AccountKey=YQ==",
             "AccountName=a;AccountKey=YQ==;BlobEndpoint=http://example.com",
-            # The SDK parses keys without stripping whitespace, so a padded key is ignored by
-            # the SDK while a stripping validator would see a safe endpoint and skip the
-            # attacker-controlled derived one.
-            "AccountName=a;AccountKey=YQ==; BlobEndpoint=https://example.com;EndpointSuffix=169.254.169.254",
         ],
     )
     @override_settings(FORCE_URL_VALIDATION=True)

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -1262,6 +1262,12 @@ class TestAzureBlobIntegration:
             # Attacker-controlled DefaultEndpointsProtocol is interpolated raw into the derived
             # endpoint by the SDK, so the derived URL must be validated, not assumed https.
             "DefaultEndpointsProtocol=http://169.254.169.254/latest/meta-data?x=;AccountName=a;AccountKey=YQ==;EndpointSuffix=core.windows.net",
+            "DefaultEndpointsProtocol=http;AccountName=a;AccountKey=YQ==",
+            "AccountName=a;AccountKey=YQ==;BlobEndpoint=http://example.com",
+            # The SDK parses keys without stripping whitespace, so a padded key is ignored by
+            # the SDK while a stripping validator would see a safe endpoint and skip the
+            # attacker-controlled derived one.
+            "AccountName=a;AccountKey=YQ==; BlobEndpoint=https://example.com;EndpointSuffix=169.254.169.254",
         ],
     )
     @override_settings(FORCE_URL_VALIDATION=True)

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -1220,6 +1220,57 @@ class TestSnowflakeIntegration:
         assert expected_error_message in response.json()["detail"]
 
 
+class TestAzureBlobIntegration:
+    @pytest.fixture(autouse=True)
+    def setup_integration(self, db):
+        self.organization = Organization.objects.create(name="Test Org")
+        self.team = Team.objects.create(organization=self.organization, name="Test Team")
+        self.user = User.objects.create_and_join(
+            self.organization, "test@posthog.com", "test", level=OrganizationMembership.Level.ADMIN
+        )
+
+    def test_create_azure_blob_integration(self, client: HttpClient):
+        client.force_login(self.user)
+
+        response = client.post(
+            f"/api/environments/{self.team.pk}/integrations",
+            {
+                "kind": "azure-blob",
+                "config": {
+                    "connection_string": "DefaultEndpointsProtocol=https;AccountName=my-storage-account;AccountKey=my-key;EndpointSuffix=core.windows.net"
+                },
+            },
+            content_type="application/json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        integration = Integration.objects.get(id=response.json()["id"])
+        assert integration.integration_id == "my-storage-account"
+
+    @pytest.mark.parametrize(
+        "connection_string",
+        [
+            "UseDevelopmentStorage=true;AccountName=devstoreaccount1",
+            "AccountName=my-storage-account;AccountKey=my-key;BlobEndpoint=http://169.254.169.254/",
+        ],
+    )
+    @override_settings(FORCE_URL_VALIDATION=True)
+    def test_create_azure_blob_integration_rejects_internal_endpoints(self, connection_string, client: HttpClient):
+        client.force_login(self.user)
+
+        response = client.post(
+            f"/api/environments/{self.team.pk}/integrations",
+            {
+                "kind": "azure-blob",
+                "config": {"connection_string": connection_string},
+            },
+            content_type="application/json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert not Integration.objects.filter(team=self.team, kind="azure-blob").exists()
+
+
 class TestIntegrationAPIKeyAccess:
     @pytest.fixture(autouse=True)
     def setup_integration(self, db):

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -1239,7 +1239,12 @@ class TestAzureBlobIntegration:
         ],
     )
     @override_settings(FORCE_URL_VALIDATION=True)
-    def test_create_azure_blob_integration(self, connection_string, client: HttpClient):
+    @patch("posthog.models.integration.azure_blob.is_url_allowed")
+    def test_create_azure_blob_integration(
+        self, mock_is_url_allowed: MagicMock, connection_string: str, client: HttpClient
+    ) -> None:
+        # Required mock otherwise we need a valid hostname for tests
+        mock_is_url_allowed.return_value = (True, None)
         client.force_login(self.user)
 
         response = client.post(

--- a/posthog/models/integration/azure_blob.py
+++ b/posthog/models/integration/azure_blob.py
@@ -90,14 +90,7 @@ def validate_azure_blob_connection_string(connection_string: str) -> None:
     Extract its parts, evaluate all required settings are included, and check
     that values are supported.
     """
-    # For azure blob, we only care about BlobEndpoint.
-    # But the docs also mention all these other ones, so we check all of
-    # them if present.
-    endpoint_keys = {"blobendpoint", "fileendpoint", "tableendpoint", "queueendpoint"}
-
-    endpoint_suffix: str | None = None
-    account_name: str | None = None
-
+    settings: dict[str, str] = {}
     for part in connection_string.split(";"):
         part = part.strip()
         if not part:
@@ -106,32 +99,41 @@ def validate_azure_blob_connection_string(connection_string: str) -> None:
 
         try:
             key, value = part.split("=", maxsplit=1)
-            key, value = key.lower(), value.lower()
         except Exception:
             raise ValueError("Malformed connection string")
 
-        if key == "usedevelopmentstorage" and value == "true":
-            raise ValueError("Emulator account not supported")
+        settings[key.lower()] = value
 
-        if key in endpoint_keys:
-            allowed, error = is_url_allowed(value)
-            if not allowed:
-                raise ValueError(f"Invalid endpoint found in connection string: {error}")
+    if settings.get("usedevelopmentstorage", "").lower() == "true":
+        raise ValueError("Emulator account not supported")
 
-        if key == "endpointsuffix":
-            endpoint_suffix = value
+    protocol = settings.get("defaultendpointsprotocol", "https").lower()
+    if protocol not in ("http", "https"):
+        raise ValueError("'DefaultEndpointsProtocol' must be 'http' or 'https'")
 
-        if key == "accountname":
-            account_name = value
-
+    account_name = settings.get("accountname")
     if not account_name:
         raise ValueError(
             "Could not extract AccountName from connection string. "
             "Ensure it contains 'AccountName=<your-account-name>;'"
         )
 
-    if endpoint_suffix:
-        derived = f"https://{account_name}.blob.{endpoint_suffix}"
-        allowed, error = is_url_allowed(derived)
+    explicit_endpoints: list[str] = []
+    derived_endpoints: list[str] = []
+
+    # For azure blob, we only care about BlobEndpoint.
+    # But the docs also mention all these other ones, so we check all of
+    # them if present.
+    for key in ("blobendpoint", "blobsecondaryendpoint", "fileendpoint", "tableendpoint", "queueendpoint"):
+        if key in settings:
+            explicit_endpoints.append(settings[key])
+
+    if "blobendpoint" not in settings:
+        suffix = settings.get("endpointsuffix") or "core.windows.net"
+        derived_endpoints.append(f"{protocol}://{account_name}.blob.{suffix}")
+        derived_endpoints.append(f"https://{account_name}-secondary.blob.{suffix}")
+
+    for endpoint in explicit_endpoints + derived_endpoints:
+        allowed, error = is_url_allowed(endpoint)
         if not allowed:
-            raise ValueError(f"Invalid 'EndpointSuffix' found in connection string: {error}")
+            raise ValueError(f"Invalid endpoint found in connection string: {error}")

--- a/posthog/models/integration/azure_blob.py
+++ b/posthog/models/integration/azure_blob.py
@@ -144,6 +144,7 @@ def validate_azure_blob_connection_string(connection_string: str) -> None:
     for endpoint in explicit_endpoints + derived_endpoints:
         if validation_applies and not endpoint.lower().startswith("https://"):
             raise ValueError("Endpoints in the connection string must use https")
-        allowed, error = is_url_allowed(endpoint)
-        if not allowed:
-            raise EndpointNotAllowedError(f"Invalid endpoint found in connection string: {error}")
+        if validation_applies:
+            allowed, error = is_url_allowed(endpoint)
+            if not allowed:
+                raise EndpointNotAllowedError(f"Invalid endpoint found in connection string: {error}")

--- a/posthog/models/integration/azure_blob.py
+++ b/posthog/models/integration/azure_blob.py
@@ -99,8 +99,13 @@ def validate_azure_blob_connection_string(connection_string: str) -> None:
     account_name: str | None = None
 
     for part in connection_string.split(";"):
+        part = part.strip()
+        if not part:
+            # The SDK accepts a trailing semicolon.
+            continue
+
         try:
-            key, value = part.strip().split("=", maxsplit=1)
+            key, value = part.split("=", maxsplit=1)
             key, value = key.lower(), value.lower()
         except Exception:
             raise ValueError("Malformed connection string")

--- a/posthog/models/integration/azure_blob.py
+++ b/posthog/models/integration/azure_blob.py
@@ -49,6 +49,7 @@ class AzureBlobIntegration:
 
         config: dict[str, str] = {}
 
+        connection_string = strip_leading_whitespace(connection_string)
         try:
             validate_azure_blob_connection_string(connection_string)
         except ValueError as e:
@@ -144,7 +145,19 @@ def validate_azure_blob_connection_string(connection_string: str) -> None:
     for endpoint in explicit_endpoints + derived_endpoints:
         if validation_applies and not endpoint.lower().startswith("https://"):
             raise ValueError("Endpoints in the connection string must use https")
+
         if validation_applies:
             allowed, error = is_url_allowed(endpoint)
             if not allowed:
                 raise EndpointNotAllowedError(f"Invalid endpoint found in connection string: {error}")
+
+
+def strip_leading_whitespace(conn_str: str) -> str:
+    """Remove any leading whitespace from key=value pairs.
+
+    This is rejected by Azure SDK when parsing. In contrast, I like to help our users
+    get things right. I do not strip trailing whitespace as I cannot confirm whether
+    values can have trailing whitespace, in contrast to keys, which most definitely
+    don't.
+    """
+    return ";".join(value.lstrip() for value in conn_str.split(";"))

--- a/posthog/models/integration/azure_blob.py
+++ b/posthog/models/integration/azure_blob.py
@@ -1,6 +1,7 @@
 """Azure Blob Storage integration."""
 
 from posthog.models.user import User
+from posthog.security.url_validation import is_url_allowed
 
 from . import model
 
@@ -47,6 +48,12 @@ class AzureBlobIntegration:
             )
 
         config: dict[str, str] = {}
+
+        try:
+            validate_azure_blob_connection_string(connection_string)
+        except ValueError as e:
+            raise AzureBlobIntegrationError(str(e))
+
         sensitive_config = {
             "connection_string": connection_string,
         }
@@ -75,3 +82,51 @@ class AzureBlobIntegration:
             if part.startswith("AccountName="):
                 return part.split("=", 1)[1]
         return None
+
+
+def validate_azure_blob_connection_string(connection_string: str) -> None:
+    """Validate an Azure Blob connection string.
+
+    Extract its parts, evaluate all required settings are included, and check
+    that values are supported.
+    """
+    # For azure blob, we only care about BlobEndpoint.
+    # But the docs also mention all these other ones, so we check all of
+    # them if present.
+    endpoint_keys = {"blobendpoint", "fileendpoint", "tableendpoint", "queueendpoint"}
+
+    endpoint_suffix: str | None = None
+    account_name: str | None = None
+
+    for part in connection_string.split(";"):
+        try:
+            key, value = part.strip().split("=", maxsplit=1)
+            key, value = key.lower(), value.lower()
+        except Exception:
+            raise ValueError("Malformed connection string")
+
+        if key == "usedevelopmentstorage" and value == "true":
+            raise ValueError("Emulator account not supported")
+
+        if key in endpoint_keys:
+            allowed, error = is_url_allowed(value)
+            if not allowed:
+                raise ValueError(f"Invalid endpoint found in connection string: {error}")
+
+        if key == "endpointsuffix":
+            endpoint_suffix = value
+
+        if key == "accountname":
+            account_name = value
+
+    if not account_name:
+        raise ValueError(
+            "Could not extract AccountName from connection string. "
+            "Ensure it contains 'AccountName=<your-account-name>;'"
+        )
+
+    if endpoint_suffix:
+        derived = f"https://{account_name}.blob.{endpoint_suffix}"
+        allowed, error = is_url_allowed(derived)
+        if not allowed:
+            raise ValueError(f"Invalid 'EndpointSuffix' found in connection string: {error}")

--- a/posthog/models/integration/azure_blob.py
+++ b/posthog/models/integration/azure_blob.py
@@ -84,6 +84,10 @@ class AzureBlobIntegration:
         return None
 
 
+class EndpointNotAllowedError(ValueError):
+    """Distinct error raised when an endpoint is not allowed."""
+
+
 def validate_azure_blob_connection_string(connection_string: str) -> None:
     """Validate an Azure Blob connection string.
 
@@ -142,4 +146,4 @@ def validate_azure_blob_connection_string(connection_string: str) -> None:
             raise ValueError("Endpoints in the connection string must use https")
         allowed, error = is_url_allowed(endpoint)
         if not allowed:
-            raise ValueError(f"Invalid endpoint found in connection string: {error}")
+            raise EndpointNotAllowedError(f"Invalid endpoint found in connection string: {error}")

--- a/posthog/models/integration/azure_blob.py
+++ b/posthog/models/integration/azure_blob.py
@@ -149,7 +149,7 @@ def validate_azure_blob_connection_string(connection_string: str) -> None:
         if validation_applies:
             allowed, error = is_url_allowed(endpoint)
             if not allowed:
-                raise EndpointNotAllowedError(f"Invalid endpoint found in connection string: {error}")
+                raise EndpointNotAllowedError("Invalid endpoint found in connection string")
 
 
 def strip_leading_whitespace(conn_str: str) -> str:

--- a/posthog/models/integration/azure_blob.py
+++ b/posthog/models/integration/azure_blob.py
@@ -1,7 +1,7 @@
 """Azure Blob Storage integration."""
 
 from posthog.models.user import User
-from posthog.security.url_validation import _dev_bypass_enabled, is_url_allowed
+from posthog.security.url_validation import _dev_bypass_enabled, _test_bypass_enabled, is_url_allowed
 
 from . import model
 
@@ -109,7 +109,7 @@ def validate_azure_blob_connection_string(connection_string: str) -> None:
     # HTTPS is required so TLS certificate verification at connect time closes the DNS
     # rebinding window between validation and the SDK's own resolution. Local emulators
     # (Azurite) use HTTP, so the requirement lifts with the dev bypass.
-    validation_applies = not _dev_bypass_enabled()
+    validation_applies = not (_dev_bypass_enabled() or _test_bypass_enabled())
     protocol = settings.get("DEFAULTENDPOINTSPROTOCOL", "https").lower()
     if protocol not in ("http", "https"):
         raise ValueError("'DefaultEndpointsProtocol' must be 'http' or 'https'")

--- a/posthog/models/integration/azure_blob.py
+++ b/posthog/models/integration/azure_blob.py
@@ -129,14 +129,13 @@ def validate_azure_blob_connection_string(connection_string: str) -> None:
     # For azure blob, we only care about BlobEndpoint.
     # But the docs also mention all these other ones, so we check all of
     # them if present.
-    for key in ("BLOBENDPOINT", "BLOBSECONDARYENDPOINT", "FILEENDPOINT", "TABLEENDPOINT", "QUEUEENDPOINT"):
+    for key in ("BLOBENDPOINT", "FILEENDPOINT", "TABLEENDPOINT", "QUEUEENDPOINT"):
         if key in settings:
             explicit_endpoints.append(settings[key])
 
     if "BLOBENDPOINT" not in settings:
         suffix = settings.get("ENDPOINTSUFFIX") or "core.windows.net"
         derived_endpoints.append(f"{protocol}://{account_name}.blob.{suffix}")
-        derived_endpoints.append(f"https://{account_name}-secondary.blob.{suffix}")
 
     for endpoint in explicit_endpoints + derived_endpoints:
         if validation_applies and not endpoint.lower().startswith("https://"):

--- a/posthog/models/integration/azure_blob.py
+++ b/posthog/models/integration/azure_blob.py
@@ -1,7 +1,7 @@
 """Azure Blob Storage integration."""
 
 from posthog.models.user import User
-from posthog.security.url_validation import is_url_allowed
+from posthog.security.url_validation import _dev_bypass_enabled, is_url_allowed
 
 from . import model
 
@@ -90,28 +90,33 @@ def validate_azure_blob_connection_string(connection_string: str) -> None:
     Extract its parts, evaluate all required settings are included, and check
     that values are supported.
     """
+    # Parse exactly as the SDK's parse_connection_str does: no stripping, keys uppercased,
+    # later duplicates win. Stricter than the SDK on whitespace-padded keys, which the SDK
+    # would silently ignore — a validation/SDK key mismatch is an SSRF bypass.
     settings: dict[str, str] = {}
-    for part in connection_string.split(";"):
-        part = part.strip()
-        if not part:
-            # The SDK accepts a trailing semicolon.
-            continue
-
+    for part in connection_string.rstrip(";").split(";"):
         try:
             key, value = part.split("=", maxsplit=1)
-        except Exception:
+        except ValueError:
             raise ValueError("Malformed connection string")
+        if key != key.strip():
+            raise ValueError("Malformed connection string")
+        settings[key.upper()] = value
 
-        settings[key.lower()] = value
-
-    if settings.get("usedevelopmentstorage", "").lower() == "true":
+    if settings.get("USEDEVELOPMENTSTORAGE", "").lower() == "true":
         raise ValueError("Emulator account not supported")
 
-    protocol = settings.get("defaultendpointsprotocol", "https").lower()
+    # HTTPS is required so TLS certificate verification at connect time closes the DNS
+    # rebinding window between validation and the SDK's own resolution. Local emulators
+    # (Azurite) use HTTP, so the requirement lifts with the dev bypass.
+    validation_applies = not _dev_bypass_enabled()
+    protocol = settings.get("DEFAULTENDPOINTSPROTOCOL", "https").lower()
     if protocol not in ("http", "https"):
         raise ValueError("'DefaultEndpointsProtocol' must be 'http' or 'https'")
+    if validation_applies and protocol != "https":
+        raise ValueError("'DefaultEndpointsProtocol' must be 'https'")
 
-    account_name = settings.get("accountname")
+    account_name = settings.get("ACCOUNTNAME")
     if not account_name:
         raise ValueError(
             "Could not extract AccountName from connection string. "
@@ -124,16 +129,18 @@ def validate_azure_blob_connection_string(connection_string: str) -> None:
     # For azure blob, we only care about BlobEndpoint.
     # But the docs also mention all these other ones, so we check all of
     # them if present.
-    for key in ("blobendpoint", "blobsecondaryendpoint", "fileendpoint", "tableendpoint", "queueendpoint"):
+    for key in ("BLOBENDPOINT", "BLOBSECONDARYENDPOINT", "FILEENDPOINT", "TABLEENDPOINT", "QUEUEENDPOINT"):
         if key in settings:
             explicit_endpoints.append(settings[key])
 
-    if "blobendpoint" not in settings:
-        suffix = settings.get("endpointsuffix") or "core.windows.net"
+    if "BLOBENDPOINT" not in settings:
+        suffix = settings.get("ENDPOINTSUFFIX") or "core.windows.net"
         derived_endpoints.append(f"{protocol}://{account_name}.blob.{suffix}")
         derived_endpoints.append(f"https://{account_name}-secondary.blob.{suffix}")
 
     for endpoint in explicit_endpoints + derived_endpoints:
+        if validation_applies and not endpoint.lower().startswith("https://"):
+            raise ValueError("Endpoints in the connection string must use https")
         allowed, error = is_url_allowed(endpoint)
         if not allowed:
             raise ValueError(f"Invalid endpoint found in connection string: {error}")

--- a/posthog/models/test/integration/test_azure_blob.py
+++ b/posthog/models/test/integration/test_azure_blob.py
@@ -1,0 +1,18 @@
+import pytest
+
+from posthog.models.integration.azure_blob import strip_leading_whitespace
+
+
+@pytest.mark.parametrize(
+    "conn_str,expected",
+    [
+        # No changes without leading whitespace
+        ("AccountName=name;AccountKey=key;SomeKey=value", "AccountName=name;AccountKey=key;SomeKey=value"),
+        # Stripped leading whitespace one time
+        ("AccountName=name; AccountKey=key;SomeKey=value", "AccountName=name;AccountKey=key;SomeKey=value"),
+        # Stripped leading whitespace two times
+        ("AccountName=name; AccountKey=key; SomeKey=value", "AccountName=name;AccountKey=key;SomeKey=value"),
+    ],
+)
+def test_strip_leading_whitespace(conn_str: str, expected: str) -> None:
+    assert strip_leading_whitespace(conn_str) == expected

--- a/products/batch_exports/backend/api/destination_tests/azure_blob.py
+++ b/products/batch_exports/backend/api/destination_tests/azure_blob.py
@@ -1,5 +1,7 @@
 import collections.abc
 
+from posthog.models.integration.azure_blob import validate_azure_blob_connection_string
+
 from products.batch_exports.backend.api.destination_tests.base import (
     DestinationTest,
     DestinationTestStep,
@@ -39,6 +41,14 @@ class AzureBlobContainerTestStep(DestinationTestStep):
 
         assert self.connection_string is not None
         assert self.container_name is not None
+
+        try:
+            validate_azure_blob_connection_string(self.connection_string)
+        except ValueError as e:
+            return DestinationTestStepResult(
+                status=Status.FAILED,
+                message=f"Invalid connection string: {str(e)}",
+            )
 
         try:
             async with BlobServiceClient.from_connection_string(self.connection_string) as blob_service_client:

--- a/products/batch_exports/backend/api/destination_tests/azure_blob.py
+++ b/products/batch_exports/backend/api/destination_tests/azure_blob.py
@@ -1,6 +1,6 @@
 import collections.abc
 
-from posthog.models.integration.azure_blob import validate_azure_blob_connection_string
+from posthog.models.integration.azure_blob import strip_leading_whitespace, validate_azure_blob_connection_string
 
 from products.batch_exports.backend.api.destination_tests.base import (
     DestinationTest,
@@ -42,8 +42,9 @@ class AzureBlobContainerTestStep(DestinationTestStep):
         assert self.connection_string is not None
         assert self.container_name is not None
 
+        connection_string = strip_leading_whitespace(self.connection_string)
         try:
-            validate_azure_blob_connection_string(self.connection_string)
+            validate_azure_blob_connection_string(connection_string)
         except ValueError as e:
             return DestinationTestStepResult(
                 status=Status.FAILED,
@@ -52,7 +53,7 @@ class AzureBlobContainerTestStep(DestinationTestStep):
 
         try:
             async with BlobServiceClient.from_connection_string(
-                self.connection_string, permit_redirects=False
+                connection_string, permit_redirects=False
             ) as blob_service_client:
                 container_client = blob_service_client.get_container_client(self.container_name)
                 await container_client.get_container_properties()

--- a/products/batch_exports/backend/api/destination_tests/azure_blob.py
+++ b/products/batch_exports/backend/api/destination_tests/azure_blob.py
@@ -51,7 +51,9 @@ class AzureBlobContainerTestStep(DestinationTestStep):
             )
 
         try:
-            async with BlobServiceClient.from_connection_string(self.connection_string) as blob_service_client:
+            async with BlobServiceClient.from_connection_string(
+                self.connection_string, permit_redirects=False
+            ) as blob_service_client:
                 container_client = blob_service_client.get_container_client(self.container_name)
                 await container_client.get_container_properties()
 

--- a/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
@@ -1,4 +1,5 @@
 import json
+import asyncio
 import datetime as dt
 import dataclasses
 
@@ -195,7 +196,7 @@ class AzureBlobConsumer(Consumer):
 
         try:
             connection_string = _strip_leading_whitespace(connection_string)
-            validate_azure_blob_connection_string(connection_string)
+            await asyncio.to_thread(validate_azure_blob_connection_string, connection_string)
             blob_service_client = BlobServiceClient.from_connection_string(
                 conn_str=connection_string,
                 max_single_put_size=64 * 1024 * 1024,  # 64 MiB

--- a/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
@@ -115,17 +115,6 @@ def _is_authorization_failure_response_error(err: HttpResponseError) -> bool:
     return getattr(err, "error_code", None) == StorageErrorCode.AUTHORIZATION_FAILURE
 
 
-def _strip_leading_whitespace(conn_str: str) -> str:
-    """Remove any leading whitespace from key=value pairs.
-
-    This is rejected by Azure SDK when parsing. In contrast, I like to help our users
-    get things right. I do not strip trailing whitespace as I cannot confirm whether
-    values can have trailing whitespace, in contrast to keys, which most definitely
-    don't.
-    """
-    return ";".join(value.lstrip() for value in conn_str.split(";"))
-
-
 @dataclasses.dataclass(kw_only=True)
 class AzureBlobInsertInputs(BatchExportInsertInputs):
     container_name: str
@@ -195,7 +184,6 @@ class AzureBlobConsumer(Consumer):
         # See: https://learn.microsoft.com/en-us/python/api/azure-storage-blob/azure.storage.blob.blobserviceclient
 
         try:
-            connection_string = _strip_leading_whitespace(connection_string)
             await asyncio.to_thread(validate_azure_blob_connection_string, connection_string)
             blob_service_client = BlobServiceClient.from_connection_string(
                 conn_str=connection_string,

--- a/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
@@ -205,6 +205,7 @@ class AzureBlobConsumer(Consumer):
                 read_timeout=600,
                 # Azure SDK defaults but we set them explicitly for visibility.
                 retry_policy=ExponentialRetry(initial_backoff=15, increment_base=3, retry_total=3),
+                permit_redirects=False,
             )
         except EndpointNotAllowedError:
             raise

--- a/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
@@ -13,7 +13,7 @@ from temporalio import activity, exceptions, workflow
 from temporalio.common import RetryPolicy
 
 from posthog.models.integration import AzureBlobIntegration, Integration
-from posthog.models.integration.azure_blob import validate_azure_blob_connection_string
+from posthog.models.integration.azure_blob import EndpointNotAllowedError, validate_azure_blob_connection_string
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_write_only_logger
@@ -206,6 +206,8 @@ class AzureBlobConsumer(Consumer):
                 # Azure SDK defaults but we set them explicitly for visibility.
                 retry_policy=ExponentialRetry(initial_backoff=15, increment_base=3, retry_total=3),
             )
+        except EndpointNotAllowedError:
+            raise
         except ValueError:
             raise MalformedConnectionStringError()
 

--- a/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
@@ -12,6 +12,7 @@ from temporalio import activity, exceptions, workflow
 from temporalio.common import RetryPolicy
 
 from posthog.models.integration import AzureBlobIntegration, Integration
+from posthog.models.integration.azure_blob import validate_azure_blob_connection_string
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_write_only_logger
@@ -101,7 +102,7 @@ class MalformedConnectionStringError(Exception):
 
     def __init__(self):
         super().__init__(
-            "The provided connection string was rejected by Azure. Ensure the connection string is made up of key=value pairs separated only by a semicolon (;) with no additional characters in between. Example: AccountName=name;AccountKey=key;SomeKey=somevalue"
+            "The provided connection string is malformed or invalid. Ensure the connection string is made up of key=value pairs separated only by a semicolon (;) with no additional characters in between. Additionally, ensure any endpoints point to valid URLs you control. Example: AccountName=name;AccountKey=key;SomeKey=somevalue"
         )
 
 
@@ -193,8 +194,10 @@ class AzureBlobConsumer(Consumer):
         # See: https://learn.microsoft.com/en-us/python/api/azure-storage-blob/azure.storage.blob.blobserviceclient
 
         try:
+            connection_string = _strip_leading_whitespace(connection_string)
+            validate_azure_blob_connection_string(connection_string)
             blob_service_client = BlobServiceClient.from_connection_string(
-                conn_str=_strip_leading_whitespace(connection_string),
+                conn_str=connection_string,
                 max_single_put_size=64 * 1024 * 1024,  # 64 MiB
                 max_block_size=4 * 1024 * 1024,  # 4 MiB
                 # Increase the read timeout to 10 minutes to account for large uploads.

--- a/products/batch_exports/backend/tests/api/destination_tests/test_azure_blob_destination_tests.py
+++ b/products/batch_exports/backend/tests/api/destination_tests/test_azure_blob_destination_tests.py
@@ -67,6 +67,18 @@ async def test_azure_blob_check_container_invalid_connection_string():
     assert "Invalid connection string format" in result.message
 
 
+async def test_azure_blob_check_container_emulator_connection_string():
+    test_step = AzureBlobContainerTestStep(
+        connection_string="UseDevelopmentStorage=true;AccountName=devstoreaccount1",
+        container_name="test-container",
+    )
+    result = await test_step.run()
+
+    assert result.status == Status.FAILED
+    assert result.message is not None
+    assert "Invalid connection string" in result.message
+
+
 @pytest.mark.parametrize("step", [AzureBlobContainerTestStep()])
 async def test_test_steps_fail_if_not_configured(step):
     result = await step.run()

--- a/products/batch_exports/backend/tests/api/destination_tests/test_azure_blob_destination_tests.py
+++ b/products/batch_exports/backend/tests/api/destination_tests/test_azure_blob_destination_tests.py
@@ -64,7 +64,7 @@ async def test_azure_blob_check_container_invalid_connection_string():
 
     assert result.status == Status.FAILED
     assert result.message is not None
-    assert "Invalid connection string format" in result.message
+    assert "Invalid connection string: Malformed connection string" in result.message
 
 
 async def test_azure_blob_check_container_emulator_connection_string():

--- a/products/batch_exports/backend/tests/api/destination_tests/test_azure_blob_destination_tests.py
+++ b/products/batch_exports/backend/tests/api/destination_tests/test_azure_blob_destination_tests.py
@@ -79,6 +79,16 @@ async def test_azure_blob_check_container_emulator_connection_string():
     assert "Invalid connection string" in result.message
 
 
+async def test_azure_blob_check_container_trailing_semicolon_connection_string(container_name, azurite_container):
+    test_step = AzureBlobContainerTestStep(
+        connection_string=AZURITE_CONNECTION_STRING + ";",
+        container_name=container_name,
+    )
+    result = await test_step.run()
+
+    assert result.status == Status.PASSED
+
+
 @pytest.mark.parametrize("step", [AzureBlobContainerTestStep()])
 async def test_test_steps_fail_if_not_configured(step):
     result = await step.run()

--- a/products/batch_exports/backend/tests/temporal/destinations/azure_blob/test_utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/azure_blob/test_utils.py
@@ -3,26 +3,10 @@ import pytest
 from products.batch_exports.backend.temporal.destinations.azure_blob_batch_export import (
     COMPRESSION_EXTENSIONS,
     FILE_FORMAT_EXTENSIONS,
-    _strip_leading_whitespace,
 )
 from products.batch_exports.backend.temporal.destinations.utils import get_key_prefix, get_manifest_key, get_object_key
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.django_db]
-
-
-@pytest.mark.parametrize(
-    "conn_str,expected",
-    [
-        # No changes without leading whitespace
-        ("AccountName=name;AccountKey=key;SomeKey=value", "AccountName=name;AccountKey=key;SomeKey=value"),
-        # Stripped leading whitespace one time
-        ("AccountName=name; AccountKey=key;SomeKey=value", "AccountName=name;AccountKey=key;SomeKey=value"),
-        # Stripped leading whitespace two times
-        ("AccountName=name; AccountKey=key; SomeKey=value", "AccountName=name;AccountKey=key;SomeKey=value"),
-    ],
-)
-def test_strip_leading_whitespace(conn_str: str, expected: str) -> None:
-    assert _strip_leading_whitespace(conn_str) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem

We do not validate user-provided connection strings for azure blob batch exports.

<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Adds a validation function to the integration, call it on integration create, destination tests, and at workflow runtime.

This protects against endpoints referencing internal IPs, and other malformations.

<!-- For each change a person can notice, say what they will now see or do differently, not only the code path that does it. Mark the rest as mechanical so a reviewer knows nothing user-visible is hiding in it. -->

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

I had mr robot review & add some tests. They look ok.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->
<!-- Don't recite pass counts for suites CI runs; the checks report those with more authority. Link the evidence instead (run, permalink, error tracking issue), and say what you did not check. Long transcripts go in a <details> block. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

No
- [ ] Publish to changelog?

## Docs update

No
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

See above.

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - No duplicate: when this PR fixes something believed to be live on master, no open PR already fixes it. A broken master attracts parallel agents, so search before opening — `gh pr list --state open --search "<keywords>" --limit 20`, which lists drafts too, and most agent PRs start as drafts. Say here which PR you found and why this one is still needed, or that the search found nothing.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Voice: the subject of every sentence is the change, never its author. No "I", "me" or "my" anywhere in the body. "I (actually Claude)" is worse than either half: it hands the assignee an account of work they did not do. Authorship is one stated fact in the Agent context section below.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Flow and topology changes: include separate before-and-after Mermaid `flowchart` blocks with PostHog colors. This includes CI wiring, pipelines, state machines, and request paths. Use `/writing-pr-descriptions` for the palette and role mapping.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Simplify before opening: if your agent has a behavior-preserving cleanup pass (Claude Code: `/simplify`), run it on a non-trivial diff before final tests and preflight, since it edits the tree. Skip it for small mechanical changes.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->
