### PR TITLE
fix(metrics): make the alpha gate enrollment toggle reachable

### DIFF
--- a/frontend/src/layout/scenes/components/FeaturePreviewSceneGate.test.tsx
+++ b/frontend/src/layout/scenes/components/FeaturePreviewSceneGate.test.tsx
@@ -418,6 +418,33 @@ describe('FeaturePreviewSceneGate', () => {
         })
     })
 
+    describe('alpha stage (self-serve enrollment)', () => {
+        const ALPHA_FEATURE = {
+            flagKey: BASE_CONFIG.flag,
+            enabled: false,
+            stage: 'alpha',
+            payload: { survey_id: 'survey-1' },
+        }
+
+        test('shows the enrollment toggle even when the feature carries a waitlist survey', () => {
+            setupMocks({ earlyAccessFeatures: [ALPHA_FEATURE], waitlistSurveysEnabled: true })
+
+            render(<FeaturePreviewSceneGate config={BASE_CONFIG}>{CHILDREN}</FeaturePreviewSceneGate>)
+
+            expect(screen.getByRole('switch')).toBeInTheDocument()
+            expect(screen.queryByPlaceholderText('email@yourcompany.com')).not.toBeInTheDocument()
+        })
+
+        test('toggling on enrolls with the alpha stage, which unlocks the flag', async () => {
+            setupMocks({ earlyAccessFeatures: [ALPHA_FEATURE] })
+
+            render(<FeaturePreviewSceneGate config={BASE_CONFIG}>{CHILDREN}</FeaturePreviewSceneGate>)
+            await userEvent.click(screen.getByRole('switch'))
+
+            expect(mockUpdateEarlyAccessFeatureEnrollment).toHaveBeenCalledWith(BASE_CONFIG.flag, true, 'alpha')
+        })
+    })
+
     describe('request access', () => {
         const CONFIG_WITH_SUPPORT: FeaturePreviewGateConfig = {
             ...BASE_CONFIG,

--- a/frontend/src/layout/scenes/components/FeaturePreviewSceneGate.tsx
+++ b/frontend/src/layout/scenes/components/FeaturePreviewSceneGate.tsx
@@ -56,6 +56,8 @@ function FeaturePreviewGateContent({ config }: { config: FeaturePreviewGateConfi
 
     // Concept ("Coming Soon") features never enable their flag, so the enrollment toggle is a
     // dead end there. When the feature carries a waitlist survey, collect an email instead.
+    // Alpha and beta enrollments do enable their flag, so those stages keep the self-serve
+    // toggle even when a legacy waitlist survey id is still attached to the payload.
     if (feature?.stage === 'concept' && feature.payload?.survey_id) {
         return (
             <SceneContent>

--- a/frontend/src/lib/components/FeaturePreviews/FeaturePreviews.test.tsx
+++ b/frontend/src/lib/components/FeaturePreviews/FeaturePreviews.test.tsx
@@ -125,6 +125,18 @@ describe('FeaturePreviews', () => {
         }
     )
 
+    test.each([
+        ['beta', true],
+        ['alpha', true],
+        ['concept', false],
+    ])('a %s-stage preview is listed: %s', (stage, expectedVisible) => {
+        setupMocks({ features: [{ ...BETA_FEATURE, stage }] })
+
+        render(<FeaturePreviews />)
+
+        expect(!!screen.queryByRole('switch')).toBe(expectedVisible)
+    })
+
     test('hides the banner when the instance has only concept previews, which this list does not render', () => {
         setupMocks({ cloud: false, features: [CONCEPT_FEATURE] })
 

--- a/frontend/src/lib/components/FeaturePreviews/FeaturePreviews.test.tsx
+++ b/frontend/src/lib/components/FeaturePreviews/FeaturePreviews.test.tsx
@@ -129,7 +129,7 @@ describe('FeaturePreviews', () => {
         ['beta', true],
         ['alpha', true],
         ['concept', false],
-    ])('a %s-stage preview is listed: %s', (stage, expectedVisible) => {
+    ] as const)('a %s-stage preview is listed: %s', (stage, expectedVisible) => {
         setupMocks({ features: [{ ...BETA_FEATURE, stage }] })
 
         render(<FeaturePreviews />)

--- a/frontend/src/lib/components/FeaturePreviews/FeaturePreviews.tsx
+++ b/frontend/src/lib/components/FeaturePreviews/FeaturePreviews.tsx
@@ -54,7 +54,9 @@ export function FeaturePreviews(): JSX.Element {
     // fires too early — defer the scroll + highlight until the cards exist.
     useAnchor(rawEarlyAccessFeaturesLoading ? '' : window.location.hash)
 
-    const betaFeatures = filteredEarlyAccessFeatures.filter((f) => f.stage === 'beta')
+    // Active stages the enrollment toggle can unlock: alpha and beta both set feature
+    // enrollment on their flag. Concept ("Coming Soon") cards live in FeaturePreviewsComingSoon.
+    const betaFeatures = filteredEarlyAccessFeatures.filter((f) => f.stage === 'beta' || f.stage === 'alpha')
     const shouldShowEmptyState =
         filteredEarlyAccessFeatures.length === 0 && !rawEarlyAccessFeaturesLoading && !searchTerm
     const failedToLoadFeaturePreviews = shouldShowEmptyState && hasPosthogJsFailedToLoadFeaturePreviews()

--- a/frontend/src/lib/components/FeaturePreviews/featurePreviewsLogic.test.ts
+++ b/frontend/src/lib/components/FeaturePreviews/featurePreviewsLogic.test.ts
@@ -93,14 +93,16 @@ describe('featurePreviewsLogic - loadEarlyAccessFeatures', () => {
 
         await logic.asyncActions.loadEarlyAccessFeatures()
 
-        expect(mockGetEarlyAccessFeatures).toHaveBeenCalledWith(expect.any(Function), true, ['concept', 'alpha', 'beta'])
+        expect(mockGetEarlyAccessFeatures).toHaveBeenCalledWith(expect.any(Function), true, [
+            'concept',
+            'alpha',
+            'beta',
+        ])
     })
 
     test('an alpha-stage feature is stored so the gate can offer its enrollment toggle', async () => {
         const alphaFeature = { id: '1', name: 'Metrics', stage: 'alpha', flagKey: 'metrics' }
-        mockGetEarlyAccessFeatures.mockImplementation((callback: (features: any[]) => void) =>
-            callback([alphaFeature])
-        )
+        mockGetEarlyAccessFeatures.mockImplementation((callback: (features: any[]) => void) => callback([alphaFeature]))
 
         await logic.asyncActions.loadEarlyAccessFeatures()
 

--- a/frontend/src/lib/components/FeaturePreviews/featurePreviewsLogic.test.ts
+++ b/frontend/src/lib/components/FeaturePreviews/featurePreviewsLogic.test.ts
@@ -74,6 +74,40 @@ describe('featurePreviewsLogic - submitEarlyAccessFeatureFeedback failure', () =
     })
 })
 
+describe('featurePreviewsLogic - loadEarlyAccessFeatures', () => {
+    let logic: ReturnType<typeof featurePreviewsLogic.build>
+    const mockGetEarlyAccessFeatures = jest.fn()
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        ;(posthog as any).getEarlyAccessFeatures = mockGetEarlyAccessFeatures
+
+        initKeaTests()
+        logic = featurePreviewsLogic()
+        logic.mount()
+        userLogic.actions.loadUserSuccess(MOCK_DEFAULT_USER)
+    })
+
+    test('requests concept, alpha, and beta stages so alpha features render', async () => {
+        mockGetEarlyAccessFeatures.mockImplementation((callback: (features: any[]) => void) => callback([]))
+
+        await logic.asyncActions.loadEarlyAccessFeatures()
+
+        expect(mockGetEarlyAccessFeatures).toHaveBeenCalledWith(expect.any(Function), true, ['concept', 'alpha', 'beta'])
+    })
+
+    test('an alpha-stage feature is stored so the gate can offer its enrollment toggle', async () => {
+        const alphaFeature = { id: '1', name: 'Metrics', stage: 'alpha', flagKey: 'metrics' }
+        mockGetEarlyAccessFeatures.mockImplementation((callback: (features: any[]) => void) =>
+            callback([alphaFeature])
+        )
+
+        await logic.asyncActions.loadEarlyAccessFeatures()
+
+        await expectLogic(logic).toMatchValues({ rawEarlyAccessFeatures: [alphaFeature] })
+    })
+})
+
 describe('featurePreviewsLogic - updateEarlyAccessFeatureEnrollment', () => {
     let logic: ReturnType<typeof featurePreviewsLogic.build>
     const mockUpdateEnrollment = jest.fn()

--- a/frontend/src/lib/components/FeaturePreviews/featurePreviewsLogic.test.ts
+++ b/frontend/src/lib/components/FeaturePreviews/featurePreviewsLogic.test.ts
@@ -19,302 +19,309 @@ jest.mock('lib/lemon-ui/LemonToast')
 const mockedPosthog = posthog as jest.Mocked<typeof posthog>
 mockedPosthog.get_session_replay_url = jest.fn(() => 'http://localhost/replay/123')
 
-describe('featurePreviewsLogic - submitEarlyAccessFeatureFeedback', () => {
-    let logic: ReturnType<typeof featurePreviewsLogic.build>
+describe('featurePreviewsLogic', () => {
+    describe('submitEarlyAccessFeatureFeedback', () => {
+        let logic: ReturnType<typeof featurePreviewsLogic.build>
 
-    beforeEach(() => {
-        jest.clearAllMocks()
+        beforeEach(() => {
+            jest.clearAllMocks()
 
-        ;(posthog as any).conversations = {
-            isAvailable: () => true,
-            sendMessage: jest.fn().mockResolvedValue({ ticket_id: '123', ticket_status: 'open', created_at: '' }),
-        }
-        initKeaTests()
-        logic = featurePreviewsLogic()
-        logic.mount()
-        userLogic.actions.loadUserSuccess(MOCK_DEFAULT_USER)
-    })
-
-    test('submitting feedback', async () => {
-        logic.actions.beginEarlyAccessFeatureFeedback('test')
-        const promise = logic.asyncActions.submitEarlyAccessFeatureFeedback('test')
-        await expectLogic(logic)
-            .toMatchValues({ activeFeedbackFlagKeyLoading: true })
-            .toDispatchActions(['submitEarlyAccessFeatureFeedback'])
-            .toNotHaveDispatchedActions(['submitEarlyAccessFeatureFeedbackSuccess'])
-        await promise
-        await expectLogic(logic)
-            .toMatchValues({ activeFeedbackFlagKeyLoading: false })
-            .toDispatchActions(['submitEarlyAccessFeatureFeedbackSuccess'])
-    })
-})
-
-describe('featurePreviewsLogic - submitEarlyAccessFeatureFeedback failure', () => {
-    let logic: ReturnType<typeof featurePreviewsLogic.build>
-
-    beforeEach(() => {
-        jest.clearAllMocks()
-        ;(posthog as any).conversations = {
-            isAvailable: () => true,
-            sendMessage: jest.fn().mockRejectedValue(new Error('network down')),
-        }
-        initKeaTests()
-        logic = featurePreviewsLogic()
-        logic.mount()
-        userLogic.actions.loadUserSuccess(MOCK_DEFAULT_USER)
-    })
-
-    test('keeps the feedback panel open so the text survives for a retry', async () => {
-        logic.actions.beginEarlyAccessFeatureFeedback('test')
-        await logic.asyncActions.submitEarlyAccessFeatureFeedback('important feedback')
-
-        // The submit failed, so activeFeedbackFlagKey stays set — the panel (and the component's
-        // local draft) survive. On success it would be cleared to null, closing the panel.
-        await expectLogic(logic).toMatchValues({ activeFeedbackFlagKey: 'test', activeFeedbackFlagKeyLoading: false })
-    })
-})
-
-describe('featurePreviewsLogic - loadEarlyAccessFeatures', () => {
-    let logic: ReturnType<typeof featurePreviewsLogic.build>
-    const mockGetEarlyAccessFeatures = jest.fn()
-
-    beforeEach(() => {
-        jest.clearAllMocks()
-        ;(posthog as any).getEarlyAccessFeatures = mockGetEarlyAccessFeatures
-
-        initKeaTests()
-        logic = featurePreviewsLogic()
-        logic.mount()
-        userLogic.actions.loadUserSuccess(MOCK_DEFAULT_USER)
-    })
-
-    test('requests concept, alpha, and beta stages so alpha features render', async () => {
-        mockGetEarlyAccessFeatures.mockImplementation((callback: (features: any[]) => void) => callback([]))
-
-        await logic.asyncActions.loadEarlyAccessFeatures()
-
-        expect(mockGetEarlyAccessFeatures).toHaveBeenCalledWith(expect.any(Function), true, [
-            'concept',
-            'alpha',
-            'beta',
-        ])
-    })
-
-    test('an alpha-stage feature is stored so the gate can offer its enrollment toggle', async () => {
-        const alphaFeature = { id: '1', name: 'Metrics', stage: 'alpha', flagKey: 'metrics' }
-        mockGetEarlyAccessFeatures.mockImplementation((callback: (features: any[]) => void) => callback([alphaFeature]))
-
-        await logic.asyncActions.loadEarlyAccessFeatures()
-
-        await expectLogic(logic).toMatchValues({ rawEarlyAccessFeatures: [alphaFeature] })
-    })
-})
-
-describe('featurePreviewsLogic - updateEarlyAccessFeatureEnrollment', () => {
-    let logic: ReturnType<typeof featurePreviewsLogic.build>
-    const mockUpdateEnrollment = jest.fn()
-
-    beforeEach(() => {
-        jest.clearAllMocks()
-
-        // Set up the mock implementation for posthog
-        ;(posthog as any).updateEarlyAccessFeatureEnrollment = mockUpdateEnrollment
-
-        initKeaTests()
-        logic = featurePreviewsLogic()
-        logic.mount()
-        userLogic.actions.loadUserSuccess(MOCK_DEFAULT_USER)
-    })
-
-    test('updating early access feature enrollment without stage', () => {
-        logic.actions.updateEarlyAccessFeatureEnrollment('test-flag', true)
-
-        expect(mockUpdateEnrollment).toHaveBeenCalledWith('test-flag', true, undefined)
-    })
-
-    test('updating early access feature enrollment with stage', () => {
-        logic.actions.updateEarlyAccessFeatureEnrollment('test-flag', true, 'beta')
-
-        expect(mockUpdateEnrollment).toHaveBeenCalledWith('test-flag', true, 'beta')
-    })
-
-    test('updating early access feature enrollment with different stages', () => {
-        // Test concept stage
-        logic.actions.updateEarlyAccessFeatureEnrollment('concept-flag', false, 'concept')
-        expect(mockUpdateEnrollment).toHaveBeenCalledWith('concept-flag', false, 'concept')
-
-        // Test alpha stage
-        logic.actions.updateEarlyAccessFeatureEnrollment('alpha-flag', true, 'alpha')
-        expect(mockUpdateEnrollment).toHaveBeenCalledWith('alpha-flag', true, 'alpha')
-    })
-})
-
-describe('featurePreviewsLogic - conceptEnrollments reducer', () => {
-    let logic: ReturnType<typeof featurePreviewsLogic.build>
-
-    beforeEach(() => {
-        jest.clearAllMocks()
-        ;(posthog as any).updateEarlyAccessFeatureEnrollment = jest.fn()
-
-        initKeaTests()
-        logic = featurePreviewsLogic()
-        logic.mount()
-        userLogic.actions.loadUserSuccess(MOCK_DEFAULT_USER)
-    })
-
-    test.each([
-        ['concept', true, { 'concept-flag': true }],
-        ['beta', true, {}],
-        ['concept', false, { 'concept-flag': false }],
-    ])('stage=%s enabled=%s → conceptEnrollments=%j', async (stage, enabled, expected) => {
-        logic.actions.updateEarlyAccessFeatureEnrollment('concept-flag', enabled, stage)
-        await expectLogic(logic).toMatchValues({ conceptEnrollments: expected })
-    })
-
-    test('tracks multiple concept enrollments', async () => {
-        logic.actions.updateEarlyAccessFeatureEnrollment('concept-a', true, 'concept')
-        logic.actions.updateEarlyAccessFeatureEnrollment('concept-b', true, 'concept')
-
-        await expectLogic(logic).toMatchValues({
-            conceptEnrollments: { 'concept-a': true, 'concept-b': true },
+            ;(posthog as any).conversations = {
+                isAvailable: () => true,
+                sendMessage: jest.fn().mockResolvedValue({ ticket_id: '123', ticket_status: 'open', created_at: '' }),
+            }
+            initKeaTests()
+            logic = featurePreviewsLogic()
+            logic.mount()
+            userLogic.actions.loadUserSuccess(MOCK_DEFAULT_USER)
         })
-    })
-})
 
-describe('featurePreviewsLogic - submitConceptSurvey', () => {
-    let logic: ReturnType<typeof featurePreviewsLogic.build>
-    const mockCapture = jest.fn()
-    const mockUpdateEnrollment = jest.fn()
-    let originalImpersonatedSession: boolean | undefined
-
-    afterEach(() => {
-        window.IMPERSONATED_SESSION = originalImpersonatedSession
-    })
-
-    beforeEach(() => {
-        jest.clearAllMocks()
-        originalImpersonatedSession = window.IMPERSONATED_SESSION
-        ;(posthog as any).capture = mockCapture
-        ;(posthog as any).updateEarlyAccessFeatureEnrollment = mockUpdateEnrollment
-
-        initKeaTests()
-        logic = featurePreviewsLogic()
-        logic.mount()
-        userLogic.actions.loadUserSuccess(MOCK_DEFAULT_USER)
-    })
-
-    test('captures the survey response, records enrollment, and marks the flag submitted', async () => {
-        logic.actions.loadEarlyAccessFeaturesSuccess([
-            {
-                flagKey: 'concept-flag',
-                stage: 'concept',
-                payload: { survey_id: 'survey-123', survey_question_id: 'question-456' },
-            } as any,
-        ])
-
-        logic.actions.submitConceptSurvey('concept-flag', 'test@example.com')
-
-        expect(mockCapture).toHaveBeenCalledWith('survey sent', {
-            $survey_id: 'survey-123',
-            $survey_response: 'test@example.com',
-            '$survey_response_question-456': 'test@example.com',
-        })
-        expect(mockUpdateEnrollment).toHaveBeenCalledWith('concept-flag', true, 'concept')
-        await expectLogic(logic)
-            .toDispatchActions(['conceptSurveySubmitted'])
-            .toMatchValues({ conceptSurveySubmissions: { 'concept-flag': true } })
-    })
-
-    test('captures without a per-question key when the payload has no question id', () => {
-        logic.actions.loadEarlyAccessFeaturesSuccess([
-            { flagKey: 'concept-flag', stage: 'concept', payload: { survey_id: 'survey-123' } } as any,
-        ])
-
-        logic.actions.submitConceptSurvey('concept-flag', 'test@example.com')
-
-        expect(mockCapture).toHaveBeenCalledWith('survey sent', {
-            $survey_id: 'survey-123',
-            $survey_response: 'test@example.com',
+        test('submitting feedback', async () => {
+            logic.actions.beginEarlyAccessFeatureFeedback('test')
+            const promise = logic.asyncActions.submitEarlyAccessFeatureFeedback('test')
+            await expectLogic(logic)
+                .toMatchValues({ activeFeedbackFlagKeyLoading: true })
+                .toDispatchActions(['submitEarlyAccessFeatureFeedback'])
+                .toNotHaveDispatchedActions(['submitEarlyAccessFeatureFeedbackSuccess'])
+            await promise
+            await expectLogic(logic)
+                .toMatchValues({ activeFeedbackFlagKeyLoading: false })
+                .toDispatchActions(['submitEarlyAccessFeatureFeedbackSuccess'])
         })
     })
 
-    test('shows an error and does not mark submitted when the feature has no linked survey', async () => {
-        logic.actions.loadEarlyAccessFeaturesSuccess([
-            { flagKey: 'concept-flag', stage: 'concept', payload: {} } as any,
-        ])
+    describe('submitEarlyAccessFeatureFeedback failure', () => {
+        let logic: ReturnType<typeof featurePreviewsLogic.build>
 
-        logic.actions.submitConceptSurvey('concept-flag', 'test@example.com')
+        beforeEach(() => {
+            jest.clearAllMocks()
+            ;(posthog as any).conversations = {
+                isAvailable: () => true,
+                sendMessage: jest.fn().mockRejectedValue(new Error('network down')),
+            }
+            initKeaTests()
+            logic = featurePreviewsLogic()
+            logic.mount()
+            userLogic.actions.loadUserSuccess(MOCK_DEFAULT_USER)
+        })
 
-        expect(mockCapture).not.toHaveBeenCalled()
-        expect(mockUpdateEnrollment).not.toHaveBeenCalled()
-        expect(lemonToast.error).toHaveBeenCalledWith(
-            "This feature isn't accepting sign-ups yet. Please try again later."
-        )
-        await expectLogic(logic).toMatchValues({ conceptSurveySubmissions: {} })
+        test('keeps the feedback panel open so the text survives for a retry', async () => {
+            logic.actions.beginEarlyAccessFeatureFeedback('test')
+            await logic.asyncActions.submitEarlyAccessFeatureFeedback('important feedback')
+
+            // The submit failed, so activeFeedbackFlagKey stays set — the panel (and the component's
+            // local draft) survive. On success it would be cleared to null, closing the panel.
+            await expectLogic(logic).toMatchValues({
+                activeFeedbackFlagKey: 'test',
+                activeFeedbackFlagKeyLoading: false,
+            })
+        })
     })
 
-    test('does not capture anything during an impersonated session', async () => {
-        window.IMPERSONATED_SESSION = true
-        logic.actions.loadEarlyAccessFeaturesSuccess([
-            {
-                flagKey: 'concept-flag',
-                stage: 'concept',
-                payload: { survey_id: 'survey-123' },
-            } as any,
-        ])
+    describe('loadEarlyAccessFeatures', () => {
+        let logic: ReturnType<typeof featurePreviewsLogic.build>
+        const mockGetEarlyAccessFeatures = jest.fn()
 
-        logic.actions.submitConceptSurvey('concept-flag', 'test@example.com')
+        beforeEach(() => {
+            jest.clearAllMocks()
+            ;(posthog as any).getEarlyAccessFeatures = mockGetEarlyAccessFeatures
 
-        expect(mockCapture).not.toHaveBeenCalled()
-        expect(mockUpdateEnrollment).not.toHaveBeenCalled()
-        expect(lemonToast.error).toHaveBeenCalledWith('Cannot sign up for a waitlist while impersonating a user')
-        await expectLogic(logic).toMatchValues({ conceptSurveySubmissions: {} })
-    })
-})
+            initKeaTests()
+            logic = featurePreviewsLogic()
+            logic.mount()
+            userLogic.actions.loadUserSuccess(MOCK_DEFAULT_USER)
+        })
 
-describe('featurePreviewsLogic - updateEarlyAccessFeatureEnrollment (impersonated session)', () => {
-    let logic: ReturnType<typeof featurePreviewsLogic.build>
-    const mockUpdateEnrollment = jest.fn()
-    let originalImpersonatedSession: boolean | undefined
+        test('requests concept, alpha, and beta stages so alpha features render', async () => {
+            mockGetEarlyAccessFeatures.mockImplementation((callback: (features: any[]) => void) => callback([]))
 
-    beforeEach(() => {
-        jest.clearAllMocks()
+            await logic.asyncActions.loadEarlyAccessFeatures()
 
-        // Mock window.IMPERSONATED_SESSION
-        originalImpersonatedSession = window.IMPERSONATED_SESSION
-        window.IMPERSONATED_SESSION = true
+            expect(mockGetEarlyAccessFeatures).toHaveBeenCalledWith(expect.any(Function), true, [
+                'concept',
+                'alpha',
+                'beta',
+            ])
+        })
 
-        // Set up the mock implementation for posthog
-        ;(posthog as any).updateEarlyAccessFeatureEnrollment = mockUpdateEnrollment
+        test('an alpha-stage feature is stored so the gate can offer its enrollment toggle', async () => {
+            const alphaFeature = { id: '1', name: 'Metrics', stage: 'alpha', flagKey: 'metrics' }
+            mockGetEarlyAccessFeatures.mockImplementation((callback: (features: any[]) => void) =>
+                callback([alphaFeature])
+            )
 
-        initKeaTests()
-        logic = featurePreviewsLogic()
-        logic.mount()
-        userLogic.actions.loadUserSuccess(MOCK_DEFAULT_USER)
+            await logic.asyncActions.loadEarlyAccessFeatures()
+
+            await expectLogic(logic).toMatchValues({ rawEarlyAccessFeatures: [alphaFeature] })
+        })
     })
 
-    afterEach(() => {
-        window.IMPERSONATED_SESSION = originalImpersonatedSession
-        jest.restoreAllMocks()
+    describe('updateEarlyAccessFeatureEnrollment', () => {
+        let logic: ReturnType<typeof featurePreviewsLogic.build>
+        const mockUpdateEnrollment = jest.fn()
+
+        beforeEach(() => {
+            jest.clearAllMocks()
+
+            // Set up the mock implementation for posthog
+            ;(posthog as any).updateEarlyAccessFeatureEnrollment = mockUpdateEnrollment
+
+            initKeaTests()
+            logic = featurePreviewsLogic()
+            logic.mount()
+            userLogic.actions.loadUserSuccess(MOCK_DEFAULT_USER)
+        })
+
+        test('updating early access feature enrollment without stage', () => {
+            logic.actions.updateEarlyAccessFeatureEnrollment('test-flag', true)
+
+            expect(mockUpdateEnrollment).toHaveBeenCalledWith('test-flag', true, undefined)
+        })
+
+        test('updating early access feature enrollment with stage', () => {
+            logic.actions.updateEarlyAccessFeatureEnrollment('test-flag', true, 'beta')
+
+            expect(mockUpdateEnrollment).toHaveBeenCalledWith('test-flag', true, 'beta')
+        })
+
+        test('updating early access feature enrollment with different stages', () => {
+            // Test concept stage
+            logic.actions.updateEarlyAccessFeatureEnrollment('concept-flag', false, 'concept')
+            expect(mockUpdateEnrollment).toHaveBeenCalledWith('concept-flag', false, 'concept')
+
+            // Test alpha stage
+            logic.actions.updateEarlyAccessFeatureEnrollment('alpha-flag', true, 'alpha')
+            expect(mockUpdateEnrollment).toHaveBeenCalledWith('alpha-flag', true, 'alpha')
+        })
     })
 
-    test('shows error toast when trying to update enrollment while impersonating', () => {
-        logic.actions.updateEarlyAccessFeatureEnrollment('test-flag', true)
+    describe('conceptEnrollments reducer', () => {
+        let logic: ReturnType<typeof featurePreviewsLogic.build>
 
-        expect(mockUpdateEnrollment).not.toHaveBeenCalled()
-        expect(lemonToast.error).toHaveBeenCalledWith(
-            'Cannot update early access feature enrollment while impersonating a user'
-        )
+        beforeEach(() => {
+            jest.clearAllMocks()
+            ;(posthog as any).updateEarlyAccessFeatureEnrollment = jest.fn()
+
+            initKeaTests()
+            logic = featurePreviewsLogic()
+            logic.mount()
+            userLogic.actions.loadUserSuccess(MOCK_DEFAULT_USER)
+        })
+
+        test.each([
+            ['concept', true, { 'concept-flag': true }],
+            ['beta', true, {}],
+            ['concept', false, { 'concept-flag': false }],
+        ])('stage=%s enabled=%s → conceptEnrollments=%j', async (stage, enabled, expected) => {
+            logic.actions.updateEarlyAccessFeatureEnrollment('concept-flag', enabled, stage)
+            await expectLogic(logic).toMatchValues({ conceptEnrollments: expected })
+        })
+
+        test('tracks multiple concept enrollments', async () => {
+            logic.actions.updateEarlyAccessFeatureEnrollment('concept-a', true, 'concept')
+            logic.actions.updateEarlyAccessFeatureEnrollment('concept-b', true, 'concept')
+
+            await expectLogic(logic).toMatchValues({
+                conceptEnrollments: { 'concept-a': true, 'concept-b': true },
+            })
+        })
     })
 
-    test('shows error toast for all update attempts during impersonation', () => {
-        logic.actions.updateEarlyAccessFeatureEnrollment('test-flag', false)
-        logic.actions.updateEarlyAccessFeatureEnrollment('beta-flag', true, 'beta')
+    describe('submitConceptSurvey', () => {
+        let logic: ReturnType<typeof featurePreviewsLogic.build>
+        const mockCapture = jest.fn()
+        const mockUpdateEnrollment = jest.fn()
+        let originalImpersonatedSession: boolean | undefined
 
-        expect(mockUpdateEnrollment).not.toHaveBeenCalled()
-        expect(lemonToast.error).toHaveBeenCalledTimes(2)
-        expect(lemonToast.error).toHaveBeenCalledWith(
-            'Cannot update early access feature enrollment while impersonating a user'
-        )
+        afterEach(() => {
+            window.IMPERSONATED_SESSION = originalImpersonatedSession
+        })
+
+        beforeEach(() => {
+            jest.clearAllMocks()
+            originalImpersonatedSession = window.IMPERSONATED_SESSION
+            ;(posthog as any).capture = mockCapture
+            ;(posthog as any).updateEarlyAccessFeatureEnrollment = mockUpdateEnrollment
+
+            initKeaTests()
+            logic = featurePreviewsLogic()
+            logic.mount()
+            userLogic.actions.loadUserSuccess(MOCK_DEFAULT_USER)
+        })
+
+        test('captures the survey response, records enrollment, and marks the flag submitted', async () => {
+            logic.actions.loadEarlyAccessFeaturesSuccess([
+                {
+                    flagKey: 'concept-flag',
+                    stage: 'concept',
+                    payload: { survey_id: 'survey-123', survey_question_id: 'question-456' },
+                } as any,
+            ])
+
+            logic.actions.submitConceptSurvey('concept-flag', 'test@example.com')
+
+            expect(mockCapture).toHaveBeenCalledWith('survey sent', {
+                $survey_id: 'survey-123',
+                $survey_response: 'test@example.com',
+                '$survey_response_question-456': 'test@example.com',
+            })
+            expect(mockUpdateEnrollment).toHaveBeenCalledWith('concept-flag', true, 'concept')
+            await expectLogic(logic)
+                .toDispatchActions(['conceptSurveySubmitted'])
+                .toMatchValues({ conceptSurveySubmissions: { 'concept-flag': true } })
+        })
+
+        test('captures without a per-question key when the payload has no question id', () => {
+            logic.actions.loadEarlyAccessFeaturesSuccess([
+                { flagKey: 'concept-flag', stage: 'concept', payload: { survey_id: 'survey-123' } } as any,
+            ])
+
+            logic.actions.submitConceptSurvey('concept-flag', 'test@example.com')
+
+            expect(mockCapture).toHaveBeenCalledWith('survey sent', {
+                $survey_id: 'survey-123',
+                $survey_response: 'test@example.com',
+            })
+        })
+
+        test('shows an error and does not mark submitted when the feature has no linked survey', async () => {
+            logic.actions.loadEarlyAccessFeaturesSuccess([
+                { flagKey: 'concept-flag', stage: 'concept', payload: {} } as any,
+            ])
+
+            logic.actions.submitConceptSurvey('concept-flag', 'test@example.com')
+
+            expect(mockCapture).not.toHaveBeenCalled()
+            expect(mockUpdateEnrollment).not.toHaveBeenCalled()
+            expect(lemonToast.error).toHaveBeenCalledWith(
+                "This feature isn't accepting sign-ups yet. Please try again later."
+            )
+            await expectLogic(logic).toMatchValues({ conceptSurveySubmissions: {} })
+        })
+
+        test('does not capture anything during an impersonated session', async () => {
+            window.IMPERSONATED_SESSION = true
+            logic.actions.loadEarlyAccessFeaturesSuccess([
+                {
+                    flagKey: 'concept-flag',
+                    stage: 'concept',
+                    payload: { survey_id: 'survey-123' },
+                } as any,
+            ])
+
+            logic.actions.submitConceptSurvey('concept-flag', 'test@example.com')
+
+            expect(mockCapture).not.toHaveBeenCalled()
+            expect(mockUpdateEnrollment).not.toHaveBeenCalled()
+            expect(lemonToast.error).toHaveBeenCalledWith('Cannot sign up for a waitlist while impersonating a user')
+            await expectLogic(logic).toMatchValues({ conceptSurveySubmissions: {} })
+        })
+    })
+
+    describe('updateEarlyAccessFeatureEnrollment (impersonated session)', () => {
+        let logic: ReturnType<typeof featurePreviewsLogic.build>
+        const mockUpdateEnrollment = jest.fn()
+        let originalImpersonatedSession: boolean | undefined
+
+        beforeEach(() => {
+            jest.clearAllMocks()
+
+            // Mock window.IMPERSONATED_SESSION
+            originalImpersonatedSession = window.IMPERSONATED_SESSION
+            window.IMPERSONATED_SESSION = true
+
+            // Set up the mock implementation for posthog
+            ;(posthog as any).updateEarlyAccessFeatureEnrollment = mockUpdateEnrollment
+
+            initKeaTests()
+            logic = featurePreviewsLogic()
+            logic.mount()
+            userLogic.actions.loadUserSuccess(MOCK_DEFAULT_USER)
+        })
+
+        afterEach(() => {
+            window.IMPERSONATED_SESSION = originalImpersonatedSession
+            jest.restoreAllMocks()
+        })
+
+        test('shows error toast when trying to update enrollment while impersonating', () => {
+            logic.actions.updateEarlyAccessFeatureEnrollment('test-flag', true)
+
+            expect(mockUpdateEnrollment).not.toHaveBeenCalled()
+            expect(lemonToast.error).toHaveBeenCalledWith(
+                'Cannot update early access feature enrollment while impersonating a user'
+            )
+        })
+
+        test('shows error toast for all update attempts during impersonation', () => {
+            logic.actions.updateEarlyAccessFeatureEnrollment('test-flag', false)
+            logic.actions.updateEarlyAccessFeatureEnrollment('beta-flag', true, 'beta')
+
+            expect(mockUpdateEnrollment).not.toHaveBeenCalled()
+            expect(lemonToast.error).toHaveBeenCalledTimes(2)
+            expect(lemonToast.error).toHaveBeenCalledWith(
+                'Cannot update early access feature enrollment while impersonating a user'
+            )
+        })
     })
 })

--- a/frontend/src/lib/components/FeaturePreviews/featurePreviewsLogic.tsx
+++ b/frontend/src/lib/components/FeaturePreviews/featurePreviewsLogic.tsx
@@ -168,7 +168,11 @@ export const featurePreviewsLogic = kea<featurePreviewsLogicType>([
             {
                 loadEarlyAccessFeatures: async () => {
                     return await new Promise((resolve) =>
-                        posthog.getEarlyAccessFeatures((features) => resolve(features), true, ['concept', 'beta'])
+                        posthog.getEarlyAccessFeatures((features) => resolve(features), true, [
+                            'concept',
+                            'alpha',
+                            'beta',
+                        ])
                     )
                 },
             },


### PR DESCRIPTION
## Problem

A user who opens Metrics and turns on the feature preview expects the viewer to unlock immediately — that is the self-serve open-alpha flow from #95280. On master it cannot work: the gate never learns that the Metrics early access feature exists, because `loadEarlyAccessFeatures` only asks posthog-js for the `concept` and `beta` stages. An alpha-stage feature is never returned, so the gate falls back to a lone "Open feature previews" button and the previews list also omits the feature entirely. The enrollment toggle that would flip the flag is unreachable.

## Changes

- `loadEarlyAccessFeatures` requests `['concept', 'alpha', 'beta']`, so alpha features load in the gate and in the feature previews list.
- Comment in `FeaturePreviewSceneGate` records that alpha/beta keep the self-serve toggle even when a legacy waitlist `survey_id` is still attached to the payload (only `concept` renders the email form).

## How did you test this code?

- New logic tests: the loader requests the alpha stage, and an alpha-stage feature is stored so the gate can offer its toggle (catches a regression of the stage list).
- New gate tests: an alpha feature carrying a legacy `survey_id` still renders the enrollment toggle, and toggling on enrolls with the `alpha` stage (catches the waitlist form swallowing active stages).
- `jest --testPathPattern='(FeaturePreviewSceneGate|FeaturePreviews)'` — all suites pass.
- Live validation on the PostHog App project (config, not code): moved the Metrics early access feature concept → alpha (the flag edit #95280 flagged as a prerequisite — the audit trail showed it never happened), and removed a catch-all release group from the `metrics` flag that matched every user at 100% (verified via flag test evaluation: a random identity returned true before, false after). Enrollment now decides access.
- Not checked: visual pass over the gated scene in a browser.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — docs already describe the feature preview toggle.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent: Claude Code (PostHog Desktop cloud task). Direction: validate that the metrics self-serve alpha actually works end to end.
- No duplicate: #94218 is open and overlapping in area, but it takes a different route (request-access button + SQL link, no stage load change) and was opened while the feature was concept-stage. This PR is the minimal change for the decided direction: alpha-stage self-serve enrollment. If #94218 lands first, the stage-list fix here is still required.
- The live config edits (stage change, catch-all group removal) were made through the API during validation and are project data, not part of this diff.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*