### PR TITLE
fix(alerts): increase due alert schedule cap

### DIFF
--- a/posthog/temporal/alerts/activities.py
+++ b/posthog/temporal/alerts/activities.py
@@ -68,7 +68,7 @@ from products.notifications.backend.facade.api import (
 logger = structlog.get_logger(__name__)
 
 _NOTIFICATION_DELIVERY_EXECUTOR = ThreadPoolExecutor(max_workers=10, thread_name_prefix="insight-alert-delivery")
-MAX_DUE_ALERTS_PER_SCHEDULE_RUN = 50
+MAX_DUE_ALERTS_PER_SCHEDULE_RUN = 300
 
 
 @temporalio.activity.defn

--- a/posthog/temporal/alerts/activities.py
+++ b/posthog/temporal/alerts/activities.py
@@ -46,6 +46,7 @@ from posthog.temporal.alerts.types import (
     PrepareAlertResult,
     RecordFailedEvaluationActivityInputs,
     RecordFailedEvaluationResult,
+    ScheduleDueAlertChecksWorkflowInputs,
     SkipReason,
 )
 from posthog.temporal.common.heartbeat import Heartbeater
@@ -68,11 +69,13 @@ from products.notifications.backend.facade.api import (
 logger = structlog.get_logger(__name__)
 
 _NOTIFICATION_DELIVERY_EXECUTOR = ThreadPoolExecutor(max_workers=10, thread_name_prefix="insight-alert-delivery")
-MAX_DUE_ALERTS_PER_SCHEDULE_RUN = 300
 
 
 @temporalio.activity.defn
-async def retrieve_due_alerts() -> list[AlertInfo]:
+async def retrieve_due_alerts(inputs: ScheduleDueAlertChecksWorkflowInputs | None = None) -> list[AlertInfo]:
+    if inputs is None:
+        inputs = ScheduleDueAlertChecksWorkflowInputs()
+
     @database_sync_to_async(thread_sensitive=False)
     def get_alerts() -> list[AlertInfo]:
         now = datetime.now(UTC)
@@ -111,7 +114,7 @@ async def retrieve_due_alerts() -> list[AlertInfo]:
                 "team_id",
                 "id",
             )
-            .only("id", "team_id", "calculation_interval", "insight_id")[:MAX_DUE_ALERTS_PER_SCHEDULE_RUN]
+            .only("id", "team_id", "calculation_interval", "insight_id")[: inputs.max_alerts_per_run]
         )
 
         return [

--- a/posthog/temporal/alerts/schedule.py
+++ b/posthog/temporal/alerts/schedule.py
@@ -27,7 +27,7 @@ async def create_schedule_due_alert_checks_schedule(client: Client) -> None:
             execution_timeout=dt.timedelta(minutes=10),
         ),
         spec=ScheduleSpec(cron_expressions=["*/1 * * * *"]),
-        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.ALLOW_ALL),
+        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
     )
 
     if await a_schedule_exists(client, SCHEDULE_ID):

--- a/posthog/temporal/alerts/schedule.py
+++ b/posthog/temporal/alerts/schedule.py
@@ -11,6 +11,7 @@ from temporalio.client import (
     ScheduleSpec,
 )
 
+from posthog.temporal.alerts.types import ScheduleDueAlertChecksWorkflowInputs
 from posthog.temporal.common.schedule import a_create_schedule, a_schedule_exists, a_update_schedule
 
 SCHEDULE_ID = "schedule-due-alert-checks-schedule"
@@ -22,6 +23,7 @@ async def create_schedule_due_alert_checks_schedule(client: Client) -> None:
     schedule = Schedule(
         action=ScheduleActionStartWorkflow(
             "schedule-due-alert-checks",
+            ScheduleDueAlertChecksWorkflowInputs(),
             id=SCHEDULE_ID,
             task_queue=settings.ANALYTICS_PLATFORM_TASK_QUEUE,
             execution_timeout=dt.timedelta(minutes=10),

--- a/posthog/temporal/alerts/schedule.py
+++ b/posthog/temporal/alerts/schedule.py
@@ -27,7 +27,7 @@ async def create_schedule_due_alert_checks_schedule(client: Client) -> None:
             execution_timeout=dt.timedelta(minutes=10),
         ),
         spec=ScheduleSpec(cron_expressions=["*/1 * * * *"]),
-        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
+        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.ALLOW_ALL),
     )
 
     if await a_schedule_exists(client, SCHEDULE_ID):

--- a/posthog/temporal/alerts/types.py
+++ b/posthog/temporal/alerts/types.py
@@ -3,7 +3,10 @@ from enum import StrEnum
 
 from posthog.schema import AlertState
 
+from posthog.dataclasses import frozen
 from posthog.slo.types import SloConfig
+
+DEFAULT_MAX_DUE_ALERTS_PER_SCHEDULE_RUN = 300
 
 
 class PrepareAction(StrEnum):
@@ -29,6 +32,11 @@ class AlertInfo:
     distinct_id: str
     calculation_interval: str | None
     insight_id: int
+
+
+@frozen
+class ScheduleDueAlertChecksWorkflowInputs:
+    max_alerts_per_run: int = DEFAULT_MAX_DUE_ALERTS_PER_SCHEDULE_RUN
 
 
 @dataclasses.dataclass(frozen=True)

--- a/posthog/temporal/alerts/workflows.py
+++ b/posthog/temporal/alerts/workflows.py
@@ -32,6 +32,7 @@ from posthog.temporal.alerts.types import (
     PrepareAction,
     PrepareAlertActivityInputs,
     RecordFailedEvaluationActivityInputs,
+    ScheduleDueAlertChecksWorkflowInputs,
 )
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.errors import MAX_ERROR_MESSAGE_CHARS, truncate_for_temporal_payload, unwrap_temporal_cause
@@ -45,13 +46,21 @@ with temporalio.workflow.unsafe.imports_passed_through():
 @temporalio.workflow.defn(name="schedule-due-alert-checks")
 class ScheduleDueAlertChecksWorkflow(PostHogWorkflow):
     @staticmethod
-    def parse_inputs(inputs: list[str]) -> None:
-        return None
+    def parse_inputs(inputs: list[str]) -> ScheduleDueAlertChecksWorkflowInputs:
+        if not inputs:
+            return ScheduleDueAlertChecksWorkflowInputs()
+
+        loaded = json.loads(inputs[0])
+        return ScheduleDueAlertChecksWorkflowInputs(**loaded)
 
     @temporalio.workflow.run
-    async def run(self) -> None:
+    async def run(self, inputs: ScheduleDueAlertChecksWorkflowInputs | None = None) -> None:
+        if inputs is None:
+            inputs = ScheduleDueAlertChecksWorkflowInputs()
+
         alerts = await temporalio.workflow.execute_activity(
             retrieve_due_alerts,
+            inputs,
             start_to_close_timeout=dt.timedelta(minutes=2),
             retry_policy=temporalio.common.RetryPolicy(
                 initial_interval=dt.timedelta(seconds=5),

--- a/posthog/temporal/tests/test_alerts_activities.py
+++ b/posthog/temporal/tests/test_alerts_activities.py
@@ -36,6 +36,7 @@ from posthog.tasks.alerts.utils import (
     send_notifications_for_errors,
 )
 from posthog.temporal.alerts.activities import (
+    MAX_DUE_ALERTS_PER_SCHEDULE_RUN,
     cleanup_alert_checks,
     evaluate_alert,
     notify_alert,
@@ -133,10 +134,10 @@ async def _create_alert(
 
 @pytest.mark.asyncio
 @pytest.mark.django_db
-async def test_retrieve_due_alerts_limits_each_schedule_run_to_three_hundred_without_starving_other_teams(
+async def test_retrieve_due_alerts_limits_each_schedule_run_without_starving_other_teams(
     ateam: Team,
 ) -> None:
-    for _ in range(300):
+    for _ in range(MAX_DUE_ALERTS_PER_SCHEDULE_RUN):
         await _create_alert(ateam, calculation_interval=AlertCalculationInterval.REAL_TIME.value)
 
     other_team = await sync_to_async(Team.objects.create)(
@@ -148,7 +149,7 @@ async def test_retrieve_due_alerts_limits_each_schedule_run_to_three_hundred_wit
 
     alerts = await ActivityEnvironment().run(retrieve_due_alerts)
 
-    assert len(alerts) == 300
+    assert len(alerts) == MAX_DUE_ALERTS_PER_SCHEDULE_RUN
     assert str(other_alert.id) in {alert.alert_id for alert in alerts}
 
 

--- a/posthog/temporal/tests/test_alerts_activities.py
+++ b/posthog/temporal/tests/test_alerts_activities.py
@@ -133,10 +133,10 @@ async def _create_alert(
 
 @pytest.mark.asyncio
 @pytest.mark.django_db
-async def test_retrieve_due_alerts_limits_each_schedule_run_to_fifty_without_starving_other_teams(
+async def test_retrieve_due_alerts_limits_each_schedule_run_to_three_hundred_without_starving_other_teams(
     ateam: Team,
 ) -> None:
-    for _ in range(50):
+    for _ in range(300):
         await _create_alert(ateam, calculation_interval=AlertCalculationInterval.REAL_TIME.value)
 
     other_team = await sync_to_async(Team.objects.create)(
@@ -148,7 +148,7 @@ async def test_retrieve_due_alerts_limits_each_schedule_run_to_fifty_without_sta
 
     alerts = await ActivityEnvironment().run(retrieve_due_alerts)
 
-    assert len(alerts) == 50
+    assert len(alerts) == 300
     assert str(other_alert.id) in {alert.alert_id for alert in alerts}
 
 

--- a/posthog/temporal/tests/test_alerts_activities.py
+++ b/posthog/temporal/tests/test_alerts_activities.py
@@ -36,7 +36,6 @@ from posthog.tasks.alerts.utils import (
     send_notifications_for_errors,
 )
 from posthog.temporal.alerts.activities import (
-    MAX_DUE_ALERTS_PER_SCHEDULE_RUN,
     cleanup_alert_checks,
     evaluate_alert,
     notify_alert,
@@ -51,6 +50,7 @@ from posthog.temporal.alerts.types import (
     PrepareAction,
     PrepareAlertActivityInputs,
     RecordFailedEvaluationActivityInputs,
+    ScheduleDueAlertChecksWorkflowInputs,
     SkipReason,
 )
 
@@ -137,7 +137,8 @@ async def _create_alert(
 async def test_retrieve_due_alerts_limits_each_schedule_run_without_starving_other_teams(
     ateam: Team,
 ) -> None:
-    for _ in range(MAX_DUE_ALERTS_PER_SCHEDULE_RUN):
+    max_alerts_per_run = 2
+    for _ in range(max_alerts_per_run):
         await _create_alert(ateam, calculation_interval=AlertCalculationInterval.REAL_TIME.value)
 
     other_team = await sync_to_async(Team.objects.create)(
@@ -147,9 +148,12 @@ async def test_retrieve_due_alerts_limits_each_schedule_run_without_starving_oth
     )
     other_alert = await _create_alert(other_team)
 
-    alerts = await ActivityEnvironment().run(retrieve_due_alerts)
+    alerts = await ActivityEnvironment().run(
+        retrieve_due_alerts,
+        ScheduleDueAlertChecksWorkflowInputs(max_alerts_per_run=max_alerts_per_run),
+    )
 
-    assert len(alerts) == MAX_DUE_ALERTS_PER_SCHEDULE_RUN
+    assert len(alerts) == max_alerts_per_run
     assert str(other_alert.id) in {alert.alert_id for alert in alerts}
 
 

--- a/posthog/temporal/tests/test_alerts_workflows.py
+++ b/posthog/temporal/tests/test_alerts_workflows.py
@@ -33,7 +33,12 @@ from posthog.tasks.alerts.utils import AlertEvaluationResult
 from posthog.temporal.alerts.activities import evaluate_alert, notify_alert, prepare_alert, record_failed_evaluation
 from posthog.temporal.alerts.retry_policy import ALERT_EVALUATE_RETRY_POLICY
 from posthog.temporal.alerts.schedule import create_schedule_due_alert_checks_schedule
-from posthog.temporal.alerts.types import AlertInfo, CheckAlertWorkflowInputs, SkipReason
+from posthog.temporal.alerts.types import (
+    AlertInfo,
+    CheckAlertWorkflowInputs,
+    ScheduleDueAlertChecksWorkflowInputs,
+    SkipReason,
+)
 from posthog.temporal.alerts.workflows import CheckAlertWorkflow, ScheduleDueAlertChecksWorkflow
 from posthog.temporal.common.slo_interceptor import SloInterceptor
 from posthog.temporal.tests.test_alerts_activities import _email_delivery
@@ -47,6 +52,42 @@ CHECK_ALERT_ACTIVITIES: list[Callable[..., Any]] = [
     notify_alert,
     record_failed_evaluation,
 ]
+
+
+@pytest.mark.asyncio
+async def test_schedule_due_alert_checks_passes_configured_limit_to_retrieval() -> None:
+    execute_activity = AsyncMock(return_value=[])
+    inputs = ScheduleDueAlertChecksWorkflowInputs(max_alerts_per_run=17)
+
+    with patch(
+        "posthog.temporal.alerts.workflows.temporalio.workflow.execute_activity",
+        new=execute_activity,
+    ):
+        await ScheduleDueAlertChecksWorkflow().run(inputs)
+
+    assert execute_activity.await_args is not None
+    assert execute_activity.await_args.args[1] == inputs
+
+
+@pytest.mark.asyncio
+async def test_schedule_due_alert_checks_defaults_to_three_hundred_alerts() -> None:
+    create_schedule = AsyncMock()
+
+    with (
+        patch(
+            "posthog.temporal.alerts.schedule.a_schedule_exists",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "posthog.temporal.alerts.schedule.a_create_schedule",
+            new=create_schedule,
+        ),
+    ):
+        await create_schedule_due_alert_checks_schedule(MagicMock())
+
+    assert create_schedule.await_args is not None
+    schedule = create_schedule.await_args.args[2]
+    assert schedule.action.args == [ScheduleDueAlertChecksWorkflowInputs(max_alerts_per_run=300)]
 
 
 @pytest.mark.asyncio

--- a/products/billing_alerts/backend/temporal/workflows.py
+++ b/products/billing_alerts/backend/temporal/workflows.py
@@ -22,7 +22,7 @@ from products.billing_alerts.backend.temporal.types import (
     EvaluateBillingAlertBatchActivityInputs,
 )
 
-BILLING_ALERT_BATCH_SIZE = 50
+BILLING_ALERT_BATCH_SIZE = 300
 BILLING_ALERT_BATCH_EXECUTION_TIMEOUT = dt.timedelta(minutes=70)
 
 

--- a/products/billing_alerts/backend/temporal/workflows.py
+++ b/products/billing_alerts/backend/temporal/workflows.py
@@ -22,7 +22,7 @@ from products.billing_alerts.backend.temporal.types import (
     EvaluateBillingAlertBatchActivityInputs,
 )
 
-BILLING_ALERT_BATCH_SIZE = 300
+BILLING_ALERT_BATCH_SIZE = 50
 BILLING_ALERT_BATCH_EXECUTION_TIMEOUT = dt.timedelta(minutes=70)
 
 


### PR DESCRIPTION
## Problem

Operators cannot adjust the number of due alert checks per scheduler run without a code release.

A fixed cap also makes backlog recovery harder to tune safely.

## Changes

- Operators can edit `max_alerts_per_run` in the Temporal Schedule action input.
- The input defaults to `300` for scheduled and legacy no-input executions.
- The scheduler passes the input to alert retrieval while preserving cross-team ordering.
- No user-visible UI changes.

```diff
- fixed code constant: 300
+ Temporal input: {"max_alerts_per_run": 300}
```

This PR stacks on [#97378](https://github.com/PostHog/posthog/pull/97378).

## How did you test this code?

- The commit hook passed Python lint, formatting, and type checks.
- CI validates the focused workflow and database-backed retrieval tests.
- Not run locally: the test suite, to keep the incident release moving.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This changes an internal Temporal Schedule input.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used repository inspection, GitHub CLI, an isolated worktree, and signed commit tooling. The brainstorming, code review, dataclass, testing, verification, and PR-description skills shaped the update.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0C0PRQA2HJ/p1788959306507939?thread_ts=1788959306.507939&cid=C0C0PRQA2HJ)*
