### PR TITLE
fix(provisioning): attribute the account_creation_disabled refusal to its partner

### DIFF
--- a/ee/api/agentic_provisioning/test/test_account_requests.py
+++ b/ee/api/agentic_provisioning/test/test_account_requests.py
@@ -176,6 +176,20 @@ class TestAccountRequests(ProvisioningTestBase):
         assert kwargs["team_id"] == team.id
         assert kwargs["partner"] == self.partner
 
+    @patch("ee.api.agentic_provisioning.views.account_requests.capture_provisioning_event")
+    def test_account_creation_disabled_refusal_is_attributed_to_partner(self, mock_capture_event):
+        self.partner.update_provisioning(can_create_accounts=False)
+
+        res = self._post_account_request(self._account_request_payload())
+
+        assert res.status_code == 403
+        assert res.json()["error"]["code"] == "forbidden"
+        assert not User.objects.filter(email="newuser@example.com").exists()
+        refusals = [call for call in mock_capture_event.call_args_list if call.args[:2] == ("account_request", "error")]
+        assert len(refusals) == 1
+        assert refusals[0].kwargs["error_code"] == "account_creation_disabled"
+        assert refusals[0].kwargs["partner"] == self.partner
+
 
 class TestPKCEPartnerExistingUserConsent(ProvisioningTestBase):
     def setUp(self):

--- a/ee/api/agentic_provisioning/views/account_requests.py
+++ b/ee/api/agentic_provisioning/views/account_requests.py
@@ -74,7 +74,9 @@ class AccountRequestsView(ProvisioningAPIView):
         configuration = data["configuration"]
 
         if not partner.provisioning.can_create_accounts:
-            capture_provisioning_event("account_request", "error", error_code="account_creation_disabled")
+            capture_provisioning_event(
+                "account_request", "error", partner=partner, error_code="account_creation_disabled"
+            )
             raise ProvisioningError("forbidden", "Account creation is not enabled for this partner", status=403)
 
         self.charge_rate_limit(request, partner)


### PR DESCRIPTION
## Problem

- An engineer looking at a refused account request in the analytics cannot see which partner app sent it.
- The `agentic_provisioning account_request` event with `error_code=account_creation_disabled` carries no `partner_id` or `client_name`. Every other outcome of that event names the partner.
- Today you work it out from which apps have account creation off, which fails once two do.

## Changes

- The refusal event now carries `partner_id` and `client_name`, as the GitHub grants view already does for the same refusal.
- The 403 response does not change.
- The `missing_email` and `expired` errors on the same event still carry no partner, because their serializer receives none. Not changed here.

## How did you test this code?

- A new test sends an account request for a partner with account creation off. It checks the 403 and that the captured event names the partner.
- The test fails on the base branch with `KeyError: 'partner'`.
- Manual testing: none.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Claude Fable 5.1) made the change under the assignee's direction. One Sonnet sub-agent wrote the fix and the test, a second one reviewed the diff and re-ran the failing-first check. Session: https://claude.ai/code/session_01XwEyqaSzSXf5svE9FVEycm
- Skills invoked: /pr-ready, writing-pr-descriptions, unambiguous-agent-text.
- Duplicate search: `gh pr list --state open --search "account_creation_disabled"` returned only this PR.
- The diff and this description contain no customer material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

