### PR TITLE
fix(personhog): make mapping re-emission a no-op on the personhog backend

### DIFF
--- a/nodejs/src/common/personhog/personhog-person-repository.ts
+++ b/nodejs/src/common/personhog/personhog-person-repository.ts
@@ -168,7 +168,10 @@ export class PersonHogPersonRepository implements PersonRepository {
     }
 
     fetchPersonDistinctIdMappings(_teamId: TeamId, _distinctIds: string[]): Promise<PersonDistinctIdMapping[]> {
-        return Promise.reject(new Error('fetchPersonDistinctIdMappings is not implemented for personhog'))
+        // The personhog identity service produces the ClickHouse mapping messages
+        // itself, so mapping re-emission has nothing to heal on this backend.
+        // Returning no rows disables it without failing the merge.
+        return Promise.resolve([])
     }
 
     // All write operations delegate directly to Postgres


### PR DESCRIPTION
## Problem

A merge that arrives already satisfied re-emits its committed distinct id mappings (#96917). On a deployment where the personhog rollout backs the person repository, that read throws, so an already-satisfied merge fails the event instead of proceeding.

- The personhog identity service produces the ClickHouse mapping messages itself, so there is nothing for the re-emission to read or heal on that backend.
- Dev currently keeps the emission flag off to avoid this collision.

## Changes

- `fetchPersonDistinctIdMappings` on the personhog repository returns no rows instead of rejecting: re-emission quietly disables itself on that backend and the merge proceeds.
- Nothing user-visible changes; deployments without the personhog rollout are unaffected.

## How did you test this code?

- Existing personhog repository suite passes; the method has no personhog-specific behavior left to assert beyond its type.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Cherry-picked from the closed #96988 (its identity RPC is no longer needed once this backend opts out of re-emission).
- Skills invoked: /writing-pr-descriptions.
- No session-sensitive material.
