### PR TITLE
fix(mcp-apps): block widget tool calls that were never approved

### DIFF
--- a/products/desktop/packages/core/src/mcp-apps/mcp-apps.test.ts
+++ b/products/desktop/packages/core/src/mcp-apps/mcp-apps.test.ts
@@ -564,11 +564,26 @@ describe("McpAppsService.proxyToolCall", () => {
   });
 
   it.each([
-    ["a model-only tool", "posthog", "secret-tool"],
-    ["a tool with no UI association", "posthog", "exec-helper"],
-    ["the exec tool without a UI association", "posthog", "exec"],
-    ["the exec tool name on a non-built-in server", "acme", "exec"],
-  ])("denies %s", async (_label, serverName, toolName) => {
+    ["a model-only tool", "posthog", "secret-tool", "(model)"],
+    [
+      "a tool with no UI association",
+      "posthog",
+      "exec-helper",
+      "(no UI association)",
+    ],
+    [
+      "the exec tool without a UI association",
+      "posthog",
+      "exec",
+      "(no UI association)",
+    ],
+    [
+      "the exec tool name on a non-built-in server",
+      "acme",
+      "exec",
+      "(no UI association)",
+    ],
+  ])("denies %s", async (_label, serverName, toolName, reason) => {
     service.setServerConfigs([config("posthog"), config("acme")]);
     const client = makeProxyClient([
       {
@@ -586,7 +601,7 @@ describe("McpAppsService.proxyToolCall", () => {
     connectProxyClient(service, client);
 
     await expect(service.proxyToolCall(serverName, toolName)).rejects.toThrow(
-      "is not accessible to apps",
+      `is not accessible to apps ${reason}`,
     );
     expect(client.callTool).not.toHaveBeenCalled();
   });

--- a/products/desktop/packages/core/src/mcp-apps/mcp-apps.test.ts
+++ b/products/desktop/packages/core/src/mcp-apps/mcp-apps.test.ts
@@ -496,3 +496,98 @@ describe("McpAppsService lazy discovery", () => {
     expect(posthogClient.readResource).toHaveBeenCalledTimes(2);
   });
 });
+
+function makeProxyClient(
+  tools: Array<{ name: string; _meta?: { ui: Record<string, unknown> } }>,
+) {
+  return {
+    ...makeClient(),
+    listTools: vi.fn(async () => ({ tools })),
+    callTool: vi.fn(async ({ name }: { name: string }) => ({
+      content: [{ type: "text", text: `ran ${name}` }],
+    })),
+  };
+}
+
+function connectProxyClient(
+  service: McpAppsService,
+  client: ReturnType<typeof makeProxyClient>,
+) {
+  vi.spyOn(internals(service), "createConnection").mockImplementation(
+    async (c) => ({ name: c.name, client, transport: {} }),
+  );
+  return client;
+}
+
+describe("McpAppsService.proxyToolCall", () => {
+  let service: McpAppsService;
+
+  beforeEach(() => {
+    service = makeService();
+  });
+
+  it("calls a tool whose visibility includes app", async () => {
+    service.setServerConfigs([config("posthog")]);
+    const client = makeProxyClient([
+      {
+        name: "loops-review",
+        _meta: {
+          ui: { resourceUri: REVIEW_URI, visibility: ["model", "app"] },
+        },
+      },
+    ]);
+    connectProxyClient(service, client);
+
+    await expect(
+      service.proxyToolCall("posthog", "loops-review", { id: "123" }),
+    ).resolves.toEqual({
+      content: [{ type: "text", text: "ran loops-review" }],
+    });
+    expect(client.callTool).toHaveBeenCalledWith({
+      name: "loops-review",
+      arguments: { id: "123" },
+    });
+  });
+
+  it("calls a tool with a UI association and no explicit visibility", async () => {
+    service.setServerConfigs([config("posthog")]);
+    const client = makeProxyClient([
+      { name: "loops-review", _meta: { ui: { resourceUri: REVIEW_URI } } },
+    ]);
+    connectProxyClient(service, client);
+
+    await expect(
+      service.proxyToolCall("posthog", "loops-review"),
+    ).resolves.toEqual({
+      content: [{ type: "text", text: "ran loops-review" }],
+    });
+  });
+
+  it.each([
+    ["a model-only tool", "posthog", "secret-tool"],
+    ["a tool with no UI association", "posthog", "exec-helper"],
+    ["the exec tool without a UI association", "posthog", "exec"],
+    ["the exec tool name on a non-built-in server", "acme", "exec"],
+  ])("denies %s", async (_label, serverName, toolName) => {
+    service.setServerConfigs([config("posthog"), config("acme")]);
+    const client = makeProxyClient([
+      {
+        name: "secret-tool",
+        _meta: {
+          ui: {
+            resourceUri: "ui://posthog/secret.html",
+            visibility: ["model"],
+          },
+        },
+      },
+      { name: "exec-helper" },
+      { name: "exec" },
+    ]);
+    connectProxyClient(service, client);
+
+    await expect(service.proxyToolCall(serverName, toolName)).rejects.toThrow(
+      "is not accessible to apps",
+    );
+    expect(client.callTool).not.toHaveBeenCalled();
+  });
+});

--- a/products/desktop/packages/core/src/mcp-apps/mcp-apps.ts
+++ b/products/desktop/packages/core/src/mcp-apps/mcp-apps.ts
@@ -602,12 +602,16 @@ export class McpAppsService extends TypedEventEmitter<McpAppsServiceEvents> {
     toolName: string,
     args?: Record<string, unknown>,
   ): Promise<unknown> {
-    // Validate visibility: reject if tool is model-only
     const toolKey = `mcp__${serverName}__${toolName}`;
-    const association = this.toolAssociations.get(toolKey);
-    if (association?.visibility && !association.visibility.includes("app")) {
+    const association = await this.resolveAssociation(toolKey);
+    const isAppCallable =
+      association !== undefined &&
+      (!association.visibility || association.visibility.includes("app"));
+    if (!isAppCallable) {
+      const visibility =
+        association?.visibility?.join(", ") ?? "no UI association";
       throw new Error(
-        `Tool "${toolName}" is not accessible to apps (visibility: ${association.visibility.join(", ")})`,
+        `Tool "${toolName}" is not accessible to apps (${visibility})`,
       );
     }
 


### PR DESCRIPTION
## Problem

The desktop app runs small widgets made by MCP servers. A widget can ask the app to run tools on the server, using your login.

The app was supposed to check that each tool is allowed to run from a widget.If a tool had no rule about widgets at all, the app ran it anyway. 

## Changes

- The app now blocks a tool unless its server clearly says "widgets may run this".
- If the server says nothing, the tool is blocked.
- The error message says why a tool was blocked.

## How did you test this code?

- New tests in `mcp-apps.test.ts` cover the blocked cases (no rule, model-only tools, the `exec` tool) and the allowed cases. No existing test covered the missing-rule case.
- Ran the `@posthog/core` Vitest suite, `pnpm typecheck`, and Biome locally.
- Not run: driving the desktop app against a live widget. Note for reviewers: PostHog's own `exec` tool has no such rule yet, so widget calls to it are now blocked until the server adds one.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with pi (coding agent); directed and reviewed by the assignee across the session.
- Skills invoked: /posthog-desktop (workspace scoping), /writing-pr-descriptions.
- Decisions: an earlier draft kept an allowlist exception for the built-in PostHog `exec` tool; removed so enforcement matches the reported recommendation exactly, with the server-side metadata fix called out above.
