### PR TITLE
fix(warehouse-sources): tell users to reconnect when a source's account is gone

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
@@ -116,6 +116,11 @@ LOGGER = get_logger(__name__)
 MAX_RESUMABLE_SOURCE_RETRIES = 3 if settings.DEBUG else 15
 MAX_INCREMENTAL_SOURCE_RETRIES = 3 if settings.DEBUG else 9
 
+MISSING_INTEGRATION_MESSAGE = (
+    "The connected account for this source is no longer available — it may have been disconnected. "
+    "Please reconnect the source's account."
+)
+
 Any_Source_Errors: dict[str, str | None] = {
     "Could not establish session to SSH gateway": None,
     # Raised by `_check_direct_host` when a direct (untunneled) database connection's host doesn't
@@ -145,7 +150,13 @@ Any_Source_Errors: dict[str, str | None] = {
         "rows to update. Choose a unique primary key in the table's sync settings, or switch it to full "
         "table replication, then re-enable the sync."
     ),
-    "Integration matching query does not exist": "The connected account for this source is no longer available — it may have been disconnected. Please reconnect the source's account.",
+    "Integration matching query does not exist": MISSING_INTEGRATION_MESSAGE,
+    # `OAuthMixin.get_oauth_integration` catches `Integration.DoesNotExist` and re-raises these
+    # two, so the ORM wording above never reaches here for the sources that go through it. Left
+    # unclassified they were retried to exhaustion and then shown raw, echoing an internal
+    # integration id back at the customer.
+    "Integration not found:": MISSING_INTEGRATION_MESSAGE,
+    "Missing integration ID": MISSING_INTEGRATION_MESSAGE,
     # A fatal TLS alert from the remote host (raised in the shared HTTP transport for every
     # REST-based source). The server refused the handshake, which is deterministic for a given
     # host/TLS config — retrying replays the identical failure, so it's not transient. Usually a

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/test_mixins.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/test_mixins.py
@@ -13,7 +13,10 @@ from parameterized import parameterized
 from posthog.models.integration import Integration
 from posthog.temporal.common.errors import NonReportableError
 
-from products.warehouse_sources.backend.temporal.data_imports.external_data_job import Any_Source_Errors
+from products.warehouse_sources.backend.temporal.data_imports.external_data_job import (
+    MISSING_INTEGRATION_MESSAGE,
+    Any_Source_Errors,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import error_message_matches
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.mixins import (
     HostNotAllowedError,
@@ -495,6 +498,37 @@ class TestOAuthMixinIntegrationFetchResilience(SimpleTestCase):
                 OAuthMixin().get_oauth_integration(integration_id=1, team_id=2)
 
         assert get.call_count == 2
+
+    @parameterized.expand(
+        [
+            ("deleted_integration", Integration.DoesNotExist(), 4212),
+            ("unset_integration_id", None, 0),
+        ]
+    )
+    def test_lookup_failure_is_classified_for_every_oauth_source(
+        self, _name: str, side_effect: Exception | None, integration_id: int
+    ):
+        # Every OAuth source shares this lookup, so its two failure messages have to be in the
+        # all-source map: unclassified they get retried to exhaustion and then shown to the
+        # customer raw, with the integration id in them.
+        get = mock.Mock(side_effect=side_effect)
+
+        with (
+            patch(f"{_MIXINS_MODULE}.Integration.objects.get", get),
+            patch(f"{_MIXINS_MODULE}.close_old_connections"),
+            patch(f"{_MIXINS_MODULE}.time.sleep"),
+        ):
+            with pytest.raises(ValueError) as raised:
+                OAuthMixin().get_oauth_integration(integration_id=integration_id, team_id=2)
+
+        assert error_message_matches(str(raised.value), Any_Source_Errors.keys())
+        friendly = next(
+            message
+            for pattern, message in Any_Source_Errors.items()
+            if error_message_matches(str(raised.value), [pattern])
+        )
+        assert friendly == MISSING_INTEGRATION_MESSAGE
+        assert str(integration_id) not in MISSING_INTEGRATION_MESSAGE
 
 
 class TestDirectHostIsCheckedAtConnect(SimpleTestCase):


### PR DESCRIPTION
## Problem

- A customer who disconnects (or re-connects) the account behind an OAuth warehouse source sees their next sync fail with `Integration not found: 41927` — an internal id, and no indication that reconnecting is the fix.
- Before that message even appears, the sync burns its full Temporal retry budget, because the failure is never classified as non-retryable. The table stays enabled and fails again on schedule.
- Every OAuth source resolves its account through the same shared lookup (`OAuthMixin.get_oauth_integration`), so this affects the whole set — the ad platforms, the CRMs, the search consoles — not one connector.
- The shared error map already carries a message for exactly this failure, keyed on Django's `Integration matching query does not exist`. The shared lookup catches that exception and re-raises its own wording, so the key never matched.

## Changes

- A sync that can no longer reach its connected account now fails with "The connected account for this source is no longer available — it may have been disconnected. Please reconnect the source's account." No integration id, and a next step the customer can take.
- That sync now stops on the first failure and disables the table, instead of retrying an account that no longer exists.
- The wording is the one already written for this failure, reused rather than re-authored, so the same problem reads the same way across sources.
- Mechanical: the message becomes a named constant, and the two new keys sit beside the existing one in the all-source map.
- Sources that map these strings themselves (GitHub, Intercom, Stripe) keep their own wording — per-source entries still win over the shared map.

## How did you test this code?

- Extended `TestOAuthMixinIntegrationFetchResilience` in `test_mixins.py` with a parameterized case that raises through the real shared lookup — once for a deleted integration, once for an unset id — and asserts the resulting message is matched by the all-source map, resolves to the shared reconnect text, and does not contain the integration id.
- The regression it catches that no existing test did: the raise site and the classification map drifting apart. The existing test asserts the wording of the raise, and a comment there already claims sources classify it as non-retryable — nothing checked that they do.
- Ran `pytest products/warehouse_sources/backend/temporal/data_imports/sources/common/test_mixins.py -k OAuthMixinIntegrationFetch` locally; 8 passed.
- No manual testing against a live source was done.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no documented behavior changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Written by Claude Code (Opus 5) while reviewing Replay Vision session summaries of the data warehouse new-source onboarding flow. Several sessions showed people repeatedly disconnecting and reconnecting a source's integration, which is what pointed at this path.
- Skills invoked: `/writing-pr-descriptions`, `/writing-tests`, `/writing-code-comments`.
- No duplicate: searched open PRs for "Integration not found", "reconnect", "Any_Source_Errors" and "oauth integration", and read the plausible matches (#95519, #91331, #97415). #95519 touches the same file but adds an auth-error marker for Meta Ads in a different function; #91331 is a HubSpot-specific 401 mapping; #97415 fixes a Pardot callback URL. None classify the shared lookup's messages.
- Public artifact: nothing here comes from the session's input. The observations are customer session summaries and were used only to decide where to look; the code, comments, and this description name no customer, org, host, or id, and the test uses an invented integration id.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
