### PR TITLE
feat(metrics): pull Google Cloud Monitoring metrics with the metrics agent

### DIFF
--- a/products/metrics/agent/README.md
+++ b/products/metrics/agent/README.md
@@ -1,10 +1,10 @@
 # PostHog metrics agent
 
-A small deployable image that scrapes the Prometheus `/metrics` endpoints you already expose and forwards them to PostHog as OTLP metrics.
+A small deployable image that scrapes the Prometheus `/metrics` endpoints you already expose, or pulls metrics from Google Cloud Monitoring, and forwards them to PostHog as OTLP metrics.
 Use it when you want PostHog Metrics without touching application code: no PostHog SDK, no exporter changes.
 
 Under the hood it is the OpenTelemetry Collector (contrib distribution, pinned) with a PostHog-rendered config:
-prometheus receiver → memory_limiter + batch → otlphttp exporter pointed at PostHog ingestion.
+prometheus and/or googlecloudmonitoring receiver → memory_limiter + batch → otlphttp exporter pointed at PostHog ingestion.
 Exemplars survive the trip: counters and histograms scraped with OpenMetrics exemplars (`trace_id`/`span_id`) become clickable trace links in the PostHog Metrics UI.
 
 ## Quickstart (Docker)
@@ -21,22 +21,89 @@ EU cloud: set `POSTHOG_HOST=https://eu.i.posthog.com`.
 
 ## Environment variables
 
-| Variable              | Required | Default                    | Meaning                                                                 |
-| --------------------- | -------- | -------------------------- | ----------------------------------------------------------------------- |
-| `POSTHOG_API_KEY`     | yes      | —                          | Project API key, sent as `Authorization: Bearer`                        |
-| `POSTHOG_HOST`        | no       | `https://us.i.posthog.com` | PostHog ingestion origin                                                |
-| `SCRAPE_TARGETS`      | yes\*    | —                          | Comma-separated `host:port` list to scrape                              |
-| `SCRAPE_INTERVAL`     | no       | `15s`                      | Scrape interval                                                         |
-| `SCRAPE_METRICS_PATH` | no       | `/metrics`                 | Metrics path on the targets                                             |
-| `SCRAPE_JOB_NAME`     | no       | `posthog-metrics-agent`    | Prometheus job name; becomes `service_name` on every metric in PostHog  |
-| `POSTHOG_DEBUG`       | no       | unset                      | `1`/`true`: also log exported batches to the container's stdout         |
-| `POSTHOG_INGEST_PATH` | no       | `/i/v1/metrics`            | Advanced: override the ingest route (used by tests)                     |
-| `SHARD_COUNT`         | no       | `1`                        | Size of an agent fleet; above 1 each instance scrapes only its share    |
-| `SHARD_INDEX`         | no       | from hostname ordinal      | This instance's index in `0..SHARD_COUNT-1` (see Scaling out)           |
-| `PERSIST_QUEUE`       | no       | unset                      | `1`/`true`: buffer undelivered batches to disk so restarts lose nothing |
-| `QUEUE_DIR`           | no       | `/var/lib/posthog-agent`   | Where the persistent queue is stored                                    |
+| Variable                         | Required | Default                    | Meaning                                                                          |
+| -------------------------------- | -------- | -------------------------- | -------------------------------------------------------------------------------- |
+| `POSTHOG_API_KEY`                | yes      | —                          | Project API key, sent as `Authorization: Bearer`                                 |
+| `POSTHOG_HOST`                   | no       | `https://us.i.posthog.com` | PostHog ingestion origin                                                         |
+| `SCRAPE_TARGETS`                 | yes\*    | —                          | Comma-separated `host:port` list to scrape                                       |
+| `SCRAPE_INTERVAL`                | no       | `15s`                      | Scrape interval                                                                  |
+| `SCRAPE_METRICS_PATH`            | no       | `/metrics`                 | Metrics path on the targets                                                      |
+| `SCRAPE_JOB_NAME`                | no       | `posthog-metrics-agent`    | Prometheus job name; becomes `service_name` on every metric in PostHog           |
+| `GCP_PROJECT_ID`                 | no       | unset                      | GCP project to pull Cloud Monitoring metrics from; setting it enables the source |
+| `GCP_METRICS`                    | yes\*\*  | —                          | Comma-separated metric types to pull                                             |
+| `GCP_METRIC_FILTERS`             | yes\*\*  | —                          | **Semicolon**-separated metric descriptor filters                                |
+| `GCP_COLLECTION_INTERVAL`        | no       | `60s`                      | Pull interval. The collector rejects values under `60s`                          |
+| `GCP_SERVICE_NAME`               | no       | `google-cloud-monitoring`  | `service_name` set on every pulled metric in PostHog                             |
+| `GOOGLE_APPLICATION_CREDENTIALS` | no       | unset                      | Path to a service account JSON key. Omit on GKE Workload Identity / GCE          |
+| `POSTHOG_DEBUG`                  | no       | unset                      | `1`/`true`: also log exported batches to the container's stdout                  |
+| `POSTHOG_INGEST_PATH`            | no       | `/i/v1/metrics`            | Advanced: override the ingest route (used by tests)                              |
+| `SHARD_COUNT`                    | no       | `1`                        | Size of an agent fleet; above 1 each instance scrapes only its share             |
+| `SHARD_INDEX`                    | no       | from hostname ordinal      | This instance's index in `0..SHARD_COUNT-1` (see Scaling out)                    |
+| `PERSIST_QUEUE`                  | no       | unset                      | `1`/`true`: buffer undeliverable batches to disk so restarts lose nothing        |
+| `QUEUE_DIR`                      | no       | `/var/lib/posthog-agent`   | Where the persistent queue is stored                                             |
 
-\* not required when you mount your own scrape configs, see below.
+\* not required when you mount your own scrape configs (see Escape hatches) or set `GCP_PROJECT_ID`.
+\*\* with `GCP_PROJECT_ID`: at least one of `GCP_METRICS`, `GCP_METRIC_FILTERS`, or a mounted `gcp_metrics_list.yaml`. Filters are separated by `;`, **not** `,`, because filter expressions can contain commas (e.g. `one_of("a", "b")`).
+
+## Pull metrics from Google Cloud Monitoring
+
+Google Cloud Monitoring cannot push OTLP by itself, so the agent polls it: when `GCP_PROJECT_ID` is set, the agent calls the Cloud Monitoring `timeSeries.list` API for the metric types you list and forwards the points to PostHog, in the same pipeline as any Prometheus scrape.
+
+Use each path for what it is for:
+
+- **Prometheus scrape** — anything that exposes a `/metrics` endpoint (your apps, exporters).
+- **Direct OTLP** — application code you control (PostHog SDK `posthog.metrics`, or an OpenTelemetry exporter pointed at PostHog).
+- **Cloud Monitoring pull** — metrics only Google has: Cloud SQL, GKE, Cloud Run, load balancers, Pub/Sub, and the other managed services.
+
+```sh
+# The service account needs roles/monitoring.viewer (monitoring.timeSeries.list).
+# The key file must be readable by the agent's uid 10001 (chmod 644 sa.json).
+docker run -d --name posthog-gcp-agent \
+  -e POSTHOG_API_KEY=<your project API key> \
+  -e GCP_PROJECT_ID=<gcp-project-id> \
+  -e GCP_METRICS=compute.googleapis.com/instance/cpu/utilization,cloudsql.googleapis.com/database/cpu/utilization \
+  -v "$PWD/sa.json:/etc/gcp/sa.json:ro" \
+  -e GOOGLE_APPLICATION_CREDENTIALS=/etc/gcp/sa.json \
+  posthog/metrics-agent:latest
+```
+
+For a prefix of metric types instead of an explicit list, use a filter:
+
+```sh
+-e GCP_METRIC_FILTERS='metric.type = starts_with("compute.googleapis.com/instance/cpu/")'
+```
+
+Both sources in one agent is fine — add `SCRAPE_TARGETS` as usual and the two receivers share the pipeline.
+
+On GKE, skip the key file and use Workload Identity instead. Create a GCP service account with `roles/monitoring.viewer`, let the agent's Kubernetes service account use it, and annotate:
+
+```sh
+gcloud iam service-accounts add-iam-policy-binding agent@<gcp-project-id>.iam.gserviceaccount.com \
+  --role roles/iam.workloadIdentityUser \
+  --member "serviceAccount:<gcp-project-id>.svc.id.goog[<namespace>/<k8s-service-account>]"
+```
+
+```yaml
+# helm values
+scrape:
+    annotationDiscovery: false
+gcp:
+    projectId: <gcp-project-id>
+    metrics:
+        - compute.googleapis.com/instance/cpu/utilization
+serviceAccount:
+    annotations:
+        iam.gke.io/gcp-service-account: agent@<gcp-project-id>.iam.gserviceaccount.com
+```
+
+(Outside Workload Identity, put the JSON key in a Secret and set `gcp.credentialsSecret.name`; the chart mounts it and sets `GOOGLE_APPLICATION_CREDENTIALS` for you.)
+
+Notes:
+
+- `GCP_COLLECTION_INTERVAL` defaults to `60s`, the collector's minimum (Cloud Sampling period for most metrics; lower values are rejected). Each `metrics_list` entry costs one `timeSeries.list` API call per interval — prefer a `metric_descriptor_filter` prefix over a long name list, and raise the interval for large lists (Cloud Monitoring API quota applies).
+- Not compatible with sharding (`SHARD_COUNT` > 1 / Helm `shards` > 1): every shard would pull the same series. Run a separate single-instance agent (or Helm release) for Cloud Monitoring.
+- The pulled metrics get `service_name = google-cloud-monitoring` (override with `GCP_SERVICE_NAME`) so they group cleanly in the Metrics UI.
+- The upstream receiver is alpha: metric naming and resource attributes can change across collector versions, and on restart there is no checkpoint, so a gap of up to one pull interval is possible.
 
 ## Scaling out (sharding)
 
@@ -59,7 +126,8 @@ Checked in this order:
 
 1. **Full config override**: mount a complete collector config at `/etc/posthog/config.yaml`. It is used verbatim (`${env:POSTHOG_API_KEY}`-style references still resolve). This is how the Helm chart drives the image.
 2. **Custom scrape configs**: mount a YAML list of Prometheus `scrape_configs` at `/etc/posthog/scrape_configs.yaml` to replace the env-generated job while keeping the PostHog exporter wiring. Tip: add `scrape_protocols: [OpenMetricsText1.0.0, OpenMetricsText0.0.1, PrometheusText0.0.4]` to each job so exemplars keep flowing.
-3. Otherwise the scrape job is rendered from `SCRAPE_TARGETS`.
+3. **Custom Cloud Monitoring metric list**: mount a raw `metrics_list` YAML list at `/etc/posthog/gcp_metrics_list.yaml` to control exactly which metric types and filters the `googlecloudmonitoring` receiver pulls (requires `GCP_PROJECT_ID`).
+4. Otherwise the scrape job is rendered from `SCRAPE_TARGETS` and the Cloud Monitoring source from `GCP_PROJECT_ID` + `GCP_METRICS` / `GCP_METRIC_FILTERS`.
 
 ## Exemplars (metric ↔ trace linking)
 
@@ -70,7 +138,7 @@ Checked in this order:
 ## Notes and limits
 
 - One `service_name` per scrape job: Prometheus `job_name` maps to `service_name` in PostHog and target labels cannot override it. Run one agent (or one mounted scrape job) per logical service if you need distinct service names.
-- Don't run bare replicas of one agent — they all scrape the same targets and double-count. To scale, use a sharded fleet (see Scaling out) so each instance takes a disjoint slice.
+- Don't run bare replicas of one agent — they all scrape the same targets (and pull the same Cloud Monitoring series) and double-count. To scale scraping, use a sharded fleet (see Scaling out) so each instance takes a disjoint slice. Cloud Monitoring is not shardable: run one puller.
 - Metrics are rate limited server side per project; keep label cardinality sane (avoid user IDs, request IDs and the like as label values).
 - Health endpoint for probes: `:13133`.
 - The agent exposes its own metrics (scrape success, queue depth, points sent/dropped) at `:8888/metrics` — point your monitoring at it, or scrape it with the agent itself.
@@ -85,7 +153,8 @@ tests/render/run.sh
 # Helm chart render + behavior tests (needs helm):
 tests/helm/run.sh
 
-# Integration smoke test (builds the image; asserts exemplars survive scrape -> OTLP):
+# Integration smoke test (builds the image; asserts exemplars survive scrape -> OTLP,
+# and validates the rendered configs — including the GCP source — with the real collector):
 tests/integration/run.sh
 
 # Durability: scrape through a simulated outage, hard-kill, assert nothing lost:
@@ -119,3 +188,5 @@ FROM posthog.metrics
 WHERE service_name = 'agent-e2e'
 GROUP BY 1, 2
 ```
+
+The Google Cloud Monitoring source is covered by the render goldens and the offline collector `validate` step in the integration suite; a live pull needs real GCP credentials and cannot run in CI. To verify it end to end, run the agent with a service account (see above) and check for rows with `service_name = 'google-cloud-monitoring'` in the same query.

--- a/products/metrics/agent/README.md
+++ b/products/metrics/agent/README.md
@@ -86,14 +86,14 @@ gcloud iam service-accounts add-iam-policy-binding agent@<gcp-project-id>.iam.gs
 ```yaml
 # helm values
 scrape:
-    annotationDiscovery: false
+  annotationDiscovery: false
 gcp:
-    projectId: <gcp-project-id>
-    metrics:
-        - compute.googleapis.com/instance/cpu/utilization
+  projectId: <gcp-project-id>
+  metrics:
+    - compute.googleapis.com/instance/cpu/utilization
 serviceAccount:
-    annotations:
-        iam.gke.io/gcp-service-account: agent@<gcp-project-id>.iam.gserviceaccount.com
+  annotations:
+    iam.gke.io/gcp-service-account: agent@<gcp-project-id>.iam.gserviceaccount.com
 ```
 
 (Outside Workload Identity, put the JSON key in a Secret and set `gcp.credentialsSecret.name`; the chart mounts it and sets `GOOGLE_APPLICATION_CREDENTIALS` for you.)

--- a/products/metrics/agent/README.md
+++ b/products/metrics/agent/README.md
@@ -57,12 +57,14 @@ Use each path for what it is for:
 
 ```sh
 # The service account needs roles/monitoring.viewer (monitoring.timeSeries.list).
-# The key file must be readable by the agent's uid 10001 (chmod 644 sa.json).
+# Keep a dedicated copy of the key readable only by the agent's uid 10001
+# (install -m 0600 -o 10001 sa.json /run/posthog-gcp/sa.json). Do not chmod 644
+# the original key: that makes the private key readable by every local user.
 docker run -d --name posthog-gcp-agent \
   -e POSTHOG_API_KEY=<your project API key> \
   -e GCP_PROJECT_ID=<gcp-project-id> \
   -e GCP_METRICS=compute.googleapis.com/instance/cpu/utilization,cloudsql.googleapis.com/database/cpu/utilization \
-  -v "$PWD/sa.json:/etc/gcp/sa.json:ro" \
+  -v /run/posthog-gcp/sa.json:/etc/gcp/sa.json:ro \
   -e GOOGLE_APPLICATION_CREDENTIALS=/etc/gcp/sa.json \
   posthog/metrics-agent:latest
 ```

--- a/products/metrics/agent/chart/posthog-metrics-agent/Chart.yaml
+++ b/products/metrics/agent/chart/posthog-metrics-agent/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: posthog-metrics-agent
-description: Scrapes Prometheus /metrics endpoints in your cluster and forwards them to PostHog
+description: Scrapes Prometheus /metrics endpoints in your cluster, or pulls Google Cloud Monitoring metrics, and forwards them to PostHog
 type: application
-version: 0.2.0
+version: 0.3.0
 # The image tag installs pin to by default. CD publishes the image under this
 # tag, so bump it together with `version` to release a new agent.
-appVersion: 0.2.0
+appVersion: 0.3.0
 home: https://posthog.com/docs/metrics
 sources:
     - https://github.com/PostHog/posthog/tree/master/products/metrics/agent

--- a/products/metrics/agent/chart/posthog-metrics-agent/templates/_helpers.tpl
+++ b/products/metrics/agent/chart/posthog-metrics-agent/templates/_helpers.tpl
@@ -60,10 +60,19 @@ final __address__, after the annotation port rewrite.
 {{- end }}
 
 {{- define "posthog-metrics-agent.collectorConfig" -}}
-{{- if and (not .Values.scrape.annotationDiscovery) (not .Values.scrape.staticTargets) (not .Values.scrape.extraScrapeConfigs) }}
-{{- fail "at least one of scrape.annotationDiscovery, scrape.staticTargets or scrape.extraScrapeConfigs must be set" }}
+{{- $scrape := or .Values.scrape.annotationDiscovery .Values.scrape.staticTargets .Values.scrape.extraScrapeConfigs }}
+{{- $gcp := .Values.gcp.projectId }}
+{{- if and (not $scrape) (not $gcp) }}
+{{- fail "at least one of scrape.annotationDiscovery, scrape.staticTargets, scrape.extraScrapeConfigs or gcp.projectId must be set" }}
+{{- end }}
+{{- if and $gcp (gt (int .Values.shards) 1) }}
+{{- fail "gcp.projectId cannot be combined with shards > 1: every shard would pull the same Cloud Monitoring series. Run a separate release for Google Cloud Monitoring" }}
+{{- end }}
+{{- if and $gcp (not .Values.gcp.metrics) (not .Values.gcp.metricFilters) }}
+{{- fail "gcp.metrics or gcp.metricFilters is required when gcp.projectId is set" }}
 {{- end }}
 receivers:
+{{- if $scrape }}
     prometheus:
         config:
             scrape_configs:
@@ -112,6 +121,19 @@ receivers:
 {{- with .Values.scrape.extraScrapeConfigs }}
 {{ tpl . $ | indent 16 }}
 {{- end }}
+{{- end }}
+{{- if $gcp }}
+    googlecloudmonitoring:
+        project_id: {{ .Values.gcp.projectId }}
+        collection_interval: {{ .Values.gcp.collectionInterval }}
+        metrics_list:
+{{- range .Values.gcp.metrics }}
+            - metric_name: '{{ . | replace "'" "''" }}'
+{{- end }}
+{{- range .Values.gcp.metricFilters }}
+            - metric_descriptor_filter: '{{ . | replace "'" "''" }}'
+{{- end }}
+{{- end }}
 
 processors:
     # Shed load instead of buffering unbounded memory when PostHog is unreachable.
@@ -120,6 +142,15 @@ processors:
         limit_mib: 512
         spike_limit_mib: 128
     batch:
+{{- if $gcp }}
+    # Cloud Monitoring resources carry no service.name; give them one so they
+    # group in the Metrics UI. `insert` never overrides a scraped job_name.
+    resource/gcp:
+        attributes:
+            - key: service.name
+              value: '{{ .Values.gcp.serviceName | default "google-cloud-monitoring" | replace "'" "''" }}'
+              action: insert
+{{- end }}
 
 exporters:
     otlphttp:
@@ -161,7 +192,7 @@ service:
     extensions: [health_check{{ if .Values.persistence.enabled }}, file_storage{{ end }}]
     pipelines:
         metrics:
-            receivers: [prometheus]
-            processors: [memory_limiter, batch]
+            receivers: [{{ if $scrape }}prometheus{{ end }}{{ if and $scrape $gcp }}, {{ end }}{{ if $gcp }}googlecloudmonitoring{{ end }}]
+            processors: [memory_limiter, {{ if $gcp }}resource/gcp, {{ end }}batch]
             exporters: [otlphttp]
 {{- end }}

--- a/products/metrics/agent/chart/posthog-metrics-agent/templates/deployment.yaml
+++ b/products/metrics/agent/chart/posthog-metrics-agent/templates/deployment.yaml
@@ -67,6 +67,10 @@ spec:
                       - name: PERSIST_QUEUE
                         value: '1'
                       {{- end }}
+                      {{- if .Values.gcp.credentialsSecret.name }}
+                      - name: GOOGLE_APPLICATION_CREDENTIALS
+                        value: /var/run/secrets/gcp/{{ .Values.gcp.credentialsSecret.key }}
+                      {{- end }}
                       {{- range $k, $v := .Values.podEnv }}
                       - name: {{ $k }}
                         value: {{ $v | quote }}
@@ -79,6 +83,11 @@ spec:
                       {{- if .Values.persistence.enabled }}
                       - name: queue
                         mountPath: /var/lib/posthog-agent
+                      {{- end }}
+                      {{- if .Values.gcp.credentialsSecret.name }}
+                      - name: gcp-credentials
+                        mountPath: /var/run/secrets/gcp
+                        readOnly: true
                       {{- end }}
                   ports:
                       - name: health
@@ -103,6 +112,11 @@ spec:
                 - name: queue
                   persistentVolumeClaim:
                       claimName: {{ include "posthog-metrics-agent.fullname" . }}-queue
+                {{- end }}
+                {{- if .Values.gcp.credentialsSecret.name }}
+                - name: gcp-credentials
+                  secret:
+                      secretName: {{ .Values.gcp.credentialsSecret.name }}
                 {{- end }}
             {{- with .Values.nodeSelector }}
             nodeSelector:

--- a/products/metrics/agent/chart/posthog-metrics-agent/templates/serviceaccount.yaml
+++ b/products/metrics/agent/chart/posthog-metrics-agent/templates/serviceaccount.yaml
@@ -5,4 +5,8 @@ metadata:
     name: {{ include "posthog-metrics-agent.serviceAccountName" . }}
     labels:
         {{- include "posthog-metrics-agent.labels" . | nindent 8 }}
+    {{- with .Values.serviceAccount.annotations }}
+    annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
 {{- end }}

--- a/products/metrics/agent/chart/posthog-metrics-agent/values.yaml
+++ b/products/metrics/agent/chart/posthog-metrics-agent/values.yaml
@@ -39,6 +39,27 @@ scrape:
 # the full env surface.
 podEnv: {}
 
+# Pull metrics from Google Cloud Monitoring in addition to (or instead of)
+# Prometheus scraping. Set projectId to enable. Not compatible with shards > 1:
+# every shard would pull the same series. Run a separate release for Google
+# Cloud Monitoring instead. A GCP-only install sets
+# scrape.annotationDiscovery: false and may set rbac.create: false.
+gcp:
+    projectId: ''
+    # Metric types to pull, e.g. ['compute.googleapis.com/instance/cpu/utilization'].
+    metrics: []
+    # Metric descriptor filters, e.g. ['metric.type = starts_with("compute.googleapis.com/")'].
+    metricFilters: []
+    # Minimum 60s (rejected by the collector below that: Cloud Monitoring quota).
+    collectionInterval: 60s
+    # service_name set on every pulled metric in PostHog.
+    serviceName: google-cloud-monitoring
+    # Service account JSON key in an existing Secret. Leave name empty on GKE
+    # with Workload Identity (annotate the service account below instead).
+    credentialsSecret:
+        name: ''
+        key: credentials.json
+
 # Disk-backed delivery queue: samples scraped while PostHog is unreachable
 # survive pod restarts and deliver on recovery. Without it the queue is
 # in-memory and a restart during an outage drops whatever was buffered.
@@ -60,6 +81,9 @@ rbac:
 serviceAccount:
     create: true
     name: ''
+    # e.g. GKE Workload Identity for Google Cloud Monitoring:
+    # iam.gke.io/gcp-service-account: agent@my-project.iam.gserviceaccount.com
+    annotations: {}
 
 nodeSelector: {}
 tolerations: []

--- a/products/metrics/agent/entrypoint.sh
+++ b/products/metrics/agent/entrypoint.sh
@@ -2,15 +2,19 @@
 # Renders the OpenTelemetry Collector config for the PostHog metrics agent,
 # then execs the collector. See README.md for the env var surface.
 #
-# Config resolution order:
-#   1. $CONFIG_DIR/config.yaml          - full config override, used verbatim
-#   2. $CONFIG_DIR/scrape_configs.yaml  - custom scrape_configs spliced into the template
-#   3. SCRAPE_TARGETS env var           - static scrape job rendered from env
+# Config resolution order. Sources are additive: prometheus scraping and
+# Google Cloud Monitoring can both feed the same pipeline.
+#   1. $CONFIG_DIR/config.yaml            - full config override, used verbatim
+#   2. $CONFIG_DIR/scrape_configs.yaml    - custom scrape_configs spliced into the template
+#   3. SCRAPE_TARGETS env var             - static scrape job rendered from env
+#   4. $CONFIG_DIR/gcp_metrics_list.yaml  - custom metrics_list for the GCM receiver
+#   5. GCP_PROJECT_ID + GCP_METRICS / GCP_METRIC_FILTERS - GCM receiver rendered from env
 #
 # Scalar values (API key, host, interval, ...) are left as ${env:VAR} references
 # for the collector's native config substitution, so secrets never pass through
-# this script. Only the scrape_configs block structure is rendered here, because
-# env substitution cannot expand a comma-separated string into a YAML list.
+# this script. Only the scrape_configs and metrics_list block structures are
+# rendered here, because env substitution cannot expand a comma-separated
+# string into a YAML list.
 #
 # RENDER_ONLY=1 prints the resolved config and exits (used by tests/render).
 set -eu
@@ -73,28 +77,31 @@ if [ -z "${POSTHOG_API_KEY:-}" ]; then
     exit 1
 fi
 
-SNIPPET=$(mktemp)
-trap 'rm -f "$SNIPPET"' EXIT
+PROM_SNIPPET=$(mktemp)
+GCP_SNIPPET=$(mktemp)
+trap 'rm -f "$PROM_SNIPPET" "$GCP_SNIPPET"' EXIT
 
+# Double single quotes so a value stays valid inside YAML single quotes.
+yaml_squote() {
+    printf '%s' "$1" | sed "s/'/''/g"
+}
+
+# --- prometheus source ---
 if [ -f "$CONFIG_DIR/scrape_configs.yaml" ]; then
     # Re-indent the mounted scrape_configs list under the prometheus receiver.
-    awk '{ if ($0 == "") print ""; else print "                " $0 }' \
-        "$CONFIG_DIR/scrape_configs.yaml" >"$SNIPPET"
-else
-    if [ -z "${SCRAPE_TARGETS:-}" ]; then
-        echo "error: SCRAPE_TARGETS is required (comma-separated host:port list)," \
-            "unless you mount $CONFIG_DIR/scrape_configs.yaml or $CONFIG_DIR/config.yaml" >&2
-        exit 1
-    fi
-
+    {
+        printf '%s\n' '    prometheus:' '        config:' '            scrape_configs:'
+        awk '{ if ($0 == "") print ""; else print "                " $0 }' \
+            "$CONFIG_DIR/scrape_configs.yaml"
+    } >"$PROM_SNIPPET"
+elif [ -n "${SCRAPE_TARGETS:-}" ]; then
     TARGETS=""
     OLDIFS=$IFS
     IFS=,
     for target in $SCRAPE_TARGETS; do
         target=$(printf '%s' "$target" | sed 's/^ *//;s/ *$//')
         [ -n "$target" ] || continue
-        # Double single quotes so the target stays valid inside YAML quotes.
-        target=$(printf '%s' "$target" | sed "s/'/''/g")
+        target=$(yaml_squote "$target")
         if [ -n "$TARGETS" ]; then
             TARGETS="$TARGETS, '$target'"
         else
@@ -108,7 +115,10 @@ else
         exit 1
     fi
 
-    cat >"$SNIPPET" <<EOF
+    cat >"$PROM_SNIPPET" <<EOF
+    prometheus:
+        config:
+            scrape_configs:
                 - job_name: '\${env:SCRAPE_JOB_NAME:-posthog-metrics-agent}'
                   scrape_interval: '\${env:SCRAPE_INTERVAL:-15s}'
                   metrics_path: '\${env:SCRAPE_METRICS_PATH:-/metrics}'
@@ -119,7 +129,7 @@ else
 EOF
 
     if [ "$SHARD_COUNT" -gt 1 ]; then
-        cat >>"$SNIPPET" <<EOF
+        cat >>"$PROM_SNIPPET" <<EOF
                   # Shard $SHARD_INDEX of $SHARD_COUNT: keep only targets that hash to this shard.
                   relabel_configs:
                       - source_labels: [__address__]
@@ -133,6 +143,82 @@ EOF
     fi
 fi
 
+PROM_ENABLED=0
+[ -s "$PROM_SNIPPET" ] && PROM_ENABLED=1
+
+# --- google cloud monitoring source ---
+GCP_ENABLED=0
+if [ -n "${GCP_PROJECT_ID:-}" ]; then
+    GCP_ENABLED=1
+fi
+if [ "$GCP_ENABLED" -eq 0 ] && {
+    [ -n "${GCP_METRICS:-}" ] || [ -n "${GCP_METRIC_FILTERS:-}" ] || [ -f "$CONFIG_DIR/gcp_metrics_list.yaml" ]
+}; then
+    echo "error: GCP_PROJECT_ID is required when GCP_METRICS or GCP_METRIC_FILTERS is set" \
+        "or $CONFIG_DIR/gcp_metrics_list.yaml is mounted" >&2
+    exit 1
+fi
+if [ "$GCP_ENABLED" -eq 1 ]; then
+    if [ "$SHARD_COUNT" -gt 1 ]; then
+        echo "error: GCP_PROJECT_ID cannot be combined with SHARD_COUNT > 1" \
+            "(every shard would pull the same Cloud Monitoring series);" \
+            "run a separate single-instance agent for Google Cloud Monitoring" >&2
+        exit 1
+    fi
+    if [ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ] && [ ! -r "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
+        echo "error: GOOGLE_APPLICATION_CREDENTIALS points to '$GOOGLE_APPLICATION_CREDENTIALS'" \
+            "which is missing or not readable by uid 10001" >&2
+        exit 1
+    fi
+
+    cat >"$GCP_SNIPPET" <<EOF
+    googlecloudmonitoring:
+        project_id: '\${env:GCP_PROJECT_ID}'
+        collection_interval: '\${env:GCP_COLLECTION_INTERVAL:-60s}'
+        metrics_list:
+EOF
+    if [ -f "$CONFIG_DIR/gcp_metrics_list.yaml" ]; then
+        # Re-indent the mounted metrics_list under the receiver.
+        awk '{ if ($0 == "") print ""; else print "            " $0 }' \
+            "$CONFIG_DIR/gcp_metrics_list.yaml" >>"$GCP_SNIPPET"
+    else
+        if [ -n "${GCP_METRICS:-}" ]; then
+            OLDIFS=$IFS
+            IFS=,
+            for metric in $GCP_METRICS; do
+                metric=$(printf '%s' "$metric" | sed 's/^ *//;s/ *$//')
+                [ -n "$metric" ] || continue
+                printf "            - metric_name: '%s'\n" "$(yaml_squote "$metric")" >>"$GCP_SNIPPET"
+            done
+            IFS=$OLDIFS
+        fi
+        if [ -n "${GCP_METRIC_FILTERS:-}" ]; then
+            # Filters can contain commas (one_of("a", "b")), so they split on
+            # semicolons, which never appear in the filter grammar.
+            OLDIFS=$IFS
+            IFS=';'
+            for filter in $GCP_METRIC_FILTERS; do
+                filter=$(printf '%s' "$filter" | sed 's/^ *//;s/ *$//')
+                [ -n "$filter" ] || continue
+                printf "            - metric_descriptor_filter: '%s'\n" "$(yaml_squote "$filter")" >>"$GCP_SNIPPET"
+            done
+            IFS=$OLDIFS
+        fi
+        if ! grep -q 'metric_' "$GCP_SNIPPET"; then
+            echo "error: GCP_METRICS or GCP_METRIC_FILTERS is required with GCP_PROJECT_ID" \
+                "(or mount $CONFIG_DIR/gcp_metrics_list.yaml)" >&2
+            exit 1
+        fi
+    fi
+fi
+
+if [ "$PROM_ENABLED" -eq 0 ] && [ "$GCP_ENABLED" -eq 0 ]; then
+    echo "error: SCRAPE_TARGETS is required (comma-separated host:port list)," \
+        "unless you mount $CONFIG_DIR/scrape_configs.yaml or $CONFIG_DIR/config.yaml," \
+        "or set GCP_PROJECT_ID to pull from Google Cloud Monitoring" >&2
+    exit 1
+fi
+
 DEBUG_ENABLED=0
 case "${POSTHOG_DEBUG:-}" in
     1 | true | TRUE | yes) DEBUG_ENABLED=1 ;;
@@ -143,10 +229,30 @@ case "${PERSIST_QUEUE:-}" in
     1 | true | TRUE | yes) PERSIST_ENABLED=1 ;;
 esac
 
-awk -v snippet="$SNIPPET" -v debug="$DEBUG_ENABLED" -v persist="$PERSIST_ENABLED" '
-    $0 == "#__SCRAPE_CONFIGS__" {
-        while ((getline line < snippet) > 0) print line
-        close(snippet)
+awk -v prom="$PROM_SNIPPET" -v gcp="$GCP_SNIPPET" -v prom_on="$PROM_ENABLED" -v gcp_on="$GCP_ENABLED" \
+    -v debug="$DEBUG_ENABLED" -v persist="$PERSIST_ENABLED" '
+    function splice(file) {
+        while ((getline line < file) > 0) print line
+        close(file)
+    }
+    $0 == "#__PROMETHEUS_RECEIVER__" {
+        if (prom_on == "1") splice(prom)
+        next
+    }
+    $0 == "#__GCP_RECEIVER__" {
+        if (gcp_on == "1") splice(gcp)
+        next
+    }
+    $0 == "#__GCP_RESOURCE_PROCESSOR__" {
+        if (gcp_on == "1") {
+            print "    # Cloud Monitoring resources carry no service.name; give them one so they"
+            print "    # group in the Metrics UI. `insert` never overrides a scraped job_name."
+            print "    resource/gcp:"
+            print "        attributes:"
+            print "            - key: service.name"
+            print "              value: \x27${env:GCP_SERVICE_NAME:-google-cloud-monitoring}\x27"
+            print "              action: insert"
+        }
         next
     }
     $0 == "#__DEBUG_EXPORTER__" {
@@ -171,6 +277,24 @@ awk -v snippet="$SNIPPET" -v debug="$DEBUG_ENABLED" -v persist="$PERSIST_ENABLED
             print "        directory: \x27${env:QUEUE_DIR:-/var/lib/posthog-agent}\x27"
             print "        create_directory: true"
         }
+        next
+    }
+    index($0, "__PIPELINE_RECEIVERS__") {
+        if (prom_on == "1" && gcp_on == "1") {
+            receivers = "prometheus, googlecloudmonitoring"
+        } else if (gcp_on == "1") {
+            receivers = "googlecloudmonitoring"
+        } else {
+            receivers = "prometheus"
+        }
+        sub(/__PIPELINE_RECEIVERS__/, receivers)
+        print
+        next
+    }
+    index($0, "__PIPELINE_PROCESSORS__") {
+        processors = (gcp_on == "1") ? "memory_limiter, resource/gcp, batch" : "memory_limiter, batch"
+        sub(/__PIPELINE_PROCESSORS__/, processors)
+        print
         next
     }
     index($0, "__SERVICE_EXTENSIONS__") {

--- a/products/metrics/agent/entrypoint.sh
+++ b/products/metrics/agent/entrypoint.sh
@@ -204,11 +204,11 @@ EOF
             done
             IFS=$OLDIFS
         fi
-        if ! grep -q 'metric_' "$GCP_SNIPPET"; then
-            echo "error: GCP_METRICS or GCP_METRIC_FILTERS is required with GCP_PROJECT_ID" \
-                "(or mount $CONFIG_DIR/gcp_metrics_list.yaml)" >&2
-            exit 1
-        fi
+    fi
+    if ! grep -q 'metric_' "$GCP_SNIPPET"; then
+        echo "error: GCP_METRICS or GCP_METRIC_FILTERS is required with GCP_PROJECT_ID" \
+            "(or mount $CONFIG_DIR/gcp_metrics_list.yaml with at least one entry)" >&2
+        exit 1
     fi
 fi
 

--- a/products/metrics/agent/tests/helm/golden/default.yaml
+++ b/products/metrics/agent/tests/helm/golden/default.yaml
@@ -5,10 +5,10 @@ kind: ServiceAccount
 metadata:
     name: test-release-posthog-metrics-agent
     labels:
-        helm.sh/chart: posthog-metrics-agent-0.2.0
+        helm.sh/chart: posthog-metrics-agent-0.3.0
         app.kubernetes.io/name: posthog-metrics-agent
         app.kubernetes.io/instance: test-release
-        app.kubernetes.io/version: "0.2.0"
+        app.kubernetes.io/version: "0.3.0"
         app.kubernetes.io/managed-by: Helm
 ---
 # Source: posthog-metrics-agent/templates/secret.yaml
@@ -17,10 +17,10 @@ kind: Secret
 metadata:
     name: test-release-posthog-metrics-agent
     labels:
-        helm.sh/chart: posthog-metrics-agent-0.2.0
+        helm.sh/chart: posthog-metrics-agent-0.3.0
         app.kubernetes.io/name: posthog-metrics-agent
         app.kubernetes.io/instance: test-release
-        app.kubernetes.io/version: "0.2.0"
+        app.kubernetes.io/version: "0.3.0"
         app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
@@ -32,10 +32,10 @@ kind: ConfigMap
 metadata:
     name: test-release-posthog-metrics-agent
     labels:
-        helm.sh/chart: posthog-metrics-agent-0.2.0
+        helm.sh/chart: posthog-metrics-agent-0.3.0
         app.kubernetes.io/name: posthog-metrics-agent
         app.kubernetes.io/instance: test-release
-        app.kubernetes.io/version: "0.2.0"
+        app.kubernetes.io/version: "0.3.0"
         app.kubernetes.io/managed-by: Helm
 data:
     config.yaml: |
@@ -112,10 +112,10 @@ kind: ClusterRole
 metadata:
     name: test-release-posthog-metrics-agent
     labels:
-        helm.sh/chart: posthog-metrics-agent-0.2.0
+        helm.sh/chart: posthog-metrics-agent-0.3.0
         app.kubernetes.io/name: posthog-metrics-agent
         app.kubernetes.io/instance: test-release
-        app.kubernetes.io/version: "0.2.0"
+        app.kubernetes.io/version: "0.3.0"
         app.kubernetes.io/managed-by: Helm
 rules:
     # Prometheus kubernetes_sd needs to watch scrape targets across the cluster.
@@ -132,10 +132,10 @@ kind: ClusterRoleBinding
 metadata:
     name: test-release-posthog-metrics-agent
     labels:
-        helm.sh/chart: posthog-metrics-agent-0.2.0
+        helm.sh/chart: posthog-metrics-agent-0.3.0
         app.kubernetes.io/name: posthog-metrics-agent
         app.kubernetes.io/instance: test-release
-        app.kubernetes.io/version: "0.2.0"
+        app.kubernetes.io/version: "0.3.0"
         app.kubernetes.io/managed-by: Helm
 roleRef:
     apiGroup: rbac.authorization.k8s.io
@@ -152,10 +152,10 @@ kind: Deployment
 metadata:
     name: test-release-posthog-metrics-agent
     labels:
-        helm.sh/chart: posthog-metrics-agent-0.2.0
+        helm.sh/chart: posthog-metrics-agent-0.3.0
         app.kubernetes.io/name: posthog-metrics-agent
         app.kubernetes.io/instance: test-release
-        app.kubernetes.io/version: "0.2.0"
+        app.kubernetes.io/version: "0.3.0"
         app.kubernetes.io/managed-by: Helm
 spec:
     # A single replica by design: multiple replicas would scrape every target
@@ -173,7 +173,7 @@ spec:
             annotations:
                 checksum/config: fb8d668241257723315f18c0fe4dd43a8d388a91d53d004a2b77075b8b5d1957
                 # Covers the chart-managed Secret so an API key rotation rolls the pod.
-                checksum/secret: 2a1d8b23d96e03bb0c0b75692dfb4292d1a13c646b65f645da7f81a0daa32d58
+                checksum/secret: 7bd53dcd6d8870f80c69d246740a8b7c87ec21b6673c1de813e76271e941b928
         spec:
             serviceAccountName: test-release-posthog-metrics-agent
             securityContext:
@@ -182,7 +182,7 @@ spec:
                     type: RuntimeDefault
             containers:
                 - name: agent
-                  image: 'posthog/metrics-agent:0.2.0'
+                  image: 'posthog/metrics-agent:0.3.0'
                   imagePullPolicy: IfNotPresent
                   securityContext:
                       allowPrivilegeEscalation: false

--- a/products/metrics/agent/tests/helm/run.sh
+++ b/products/metrics/agent/tests/helm/run.sh
@@ -168,6 +168,53 @@ out=$(render --set posthog.apiKey=phc_test --set persistence.enabled=true --set 
 assert_contains persist-sharded-claim-template 'volumeClaimTemplates:' "$out"
 assert_not_contains persist-sharded-no-standalone-pvc 'kind: PersistentVolumeClaim' "$out"
 
+# --- google cloud monitoring: gcp.projectId enables the pull source ---
+out=$(render --set posthog.apiKey=phc_test -f values/gcp-only.yaml)
+assert_contains gcp-receiver 'googlecloudmonitoring:' "$out"
+assert_contains gcp-project 'project_id: my-project' "$out"
+assert_contains gcp-interval 'collection_interval: 60s' "$out"
+assert_contains gcp-metric-name "metric_name: 'compute.googleapis.com/instance/cpu/utilization'" "$out"
+assert_contains gcp-metric-filter "metric_descriptor_filter: 'metric.type = starts_with(\"run.googleapis.com/\")'" "$out"
+assert_contains gcp-resource-processor 'resource/gcp:' "$out"
+assert_contains gcp-service-name 'google-cloud-monitoring' "$out"
+assert_contains gcp-only-receivers 'receivers: [googlecloudmonitoring]' "$out"
+assert_contains gcp-only-processors 'processors: [memory_limiter, resource/gcp, batch]' "$out"
+# Not scrape_configs: the telemetry reader also mentions prometheus.
+assert_not_contains gcp-only-no-prometheus 'scrape_configs' "$out"
+assert_not_contains gcp-no-creds-default 'GOOGLE_APPLICATION_CREDENTIALS' "$out"
+
+# --- gcm alongside the default annotation discovery ---
+out=$(render --set posthog.apiKey=phc_test --set gcp.projectId=my-project --set 'gcp.metrics[0]=compute.googleapis.com/instance/cpu/utilization')
+assert_contains gcp-plus-discovery-receivers 'receivers: [prometheus, googlecloudmonitoring]' "$out"
+assert_contains gcp-plus-discovery-scrape 'kubernetes_sd_configs' "$out"
+
+# --- service account JSON key mounted from an existing secret ---
+out=$(render --set posthog.apiKey=phc_test -f values/gcp-only.yaml --set gcp.credentialsSecret.name=gcp-sa)
+assert_contains gcp-creds-env 'name: GOOGLE_APPLICATION_CREDENTIALS' "$out"
+assert_contains gcp-creds-path 'value: /var/run/secrets/gcp/credentials.json' "$out"
+assert_contains gcp-creds-secret 'secretName: gcp-sa' "$out"
+assert_contains gcp-creds-mount 'mountPath: /var/run/secrets/gcp' "$out"
+
+# --- workload identity: annotation on the chart-managed service account ---
+out=$(render --set posthog.apiKey=phc_test -f values/gcp-only.yaml --set 'serviceAccount.annotations.iam\.gke\.io/gcp-service-account=agent@my-project.iam.gserviceaccount.com')
+assert_contains gcp-workload-identity 'iam.gke.io/gcp-service-account: agent@my-project.iam.gserviceaccount.com' "$out"
+
+# --- every shard would pull the same series, so gcm + sharding is rejected ---
+out=$(render --set posthog.apiKey=phc_test -f values/gcp-only.yaml --set shards=3)
+assert_contains gcp-shards-rejected 'cannot be combined with shards' "$out"
+
+# --- gcm needs at least one metric or filter ---
+out=$(render --set posthog.apiKey=phc_test --set gcp.projectId=my-project)
+assert_contains gcp-requires-metrics 'gcp.metrics or gcp.metricFilters is required' "$out"
+
+# --- with no scrape source and no gcm there is nothing to run ---
+out=$(render --set posthog.apiKey=phc_test --set scrape.annotationDiscovery=false)
+assert_contains no-source-rejected 'gcp.projectId must be set' "$out"
+
+# --- the default render has no gcm wiring ---
+out=$(render --set posthog.apiKey=phc_test)
+assert_not_contains default-no-gcp 'googlecloudmonitoring' "$out"
+
 # --- golden drift guard for the fully default render ---
 # Blank lines are stripped before comparing: helm 3 and 4 disagree on
 # blank-line placement between documents, and that isn't drift we care about.

--- a/products/metrics/agent/tests/helm/values/gcp-only.yaml
+++ b/products/metrics/agent/tests/helm/values/gcp-only.yaml
@@ -1,0 +1,8 @@
+scrape:
+    annotationDiscovery: false
+gcp:
+    projectId: my-project
+    metrics:
+        - compute.googleapis.com/instance/cpu/utilization
+    metricFilters:
+        - 'metric.type = starts_with("run.googleapis.com/")'

--- a/products/metrics/agent/tests/integration/run.sh
+++ b/products/metrics/agent/tests/integration/run.sh
@@ -28,4 +28,35 @@ docker run --rm --entrypoint /bin/sh \
     -c 'RENDER_ONLY=1 /entrypoint.sh > /tmp/validate.yaml && /usr/local/bin/otelcol-contrib validate --config /tmp/validate.yaml' \
     && echo "PASS collector config validates"
 
+# Google Cloud Monitoring: `validate` is a dry run that checks the receiver's
+# config (factory present, interval, metrics_list) without credentials, which
+# are only needed at Start(). This also proves the receiver ships in the image.
+docker run --rm --entrypoint /bin/sh \
+    -e POSTHOG_API_KEY=phc_test -e GCP_PROJECT_ID=test-project \
+    -e GCP_METRICS=compute.googleapis.com/instance/cpu/utilization \
+    posthog-metrics-agent:test \
+    -c 'RENDER_ONLY=1 /entrypoint.sh > /tmp/validate.yaml && /usr/local/bin/otelcol-contrib validate --config /tmp/validate.yaml' \
+    && echo "PASS collector validates gcp-only config"
+
+docker run --rm --entrypoint /bin/sh \
+    -e POSTHOG_API_KEY=phc_test -e SCRAPE_TARGETS=app:9090 -e GCP_PROJECT_ID=test-project \
+    -e GCP_METRICS=compute.googleapis.com/instance/cpu/utilization \
+    posthog-metrics-agent:test \
+    -c 'RENDER_ONLY=1 /entrypoint.sh > /tmp/validate.yaml && /usr/local/bin/otelcol-contrib validate --config /tmp/validate.yaml' \
+    && echo "PASS collector validates gcp-plus-scrape config"
+
+# The receiver rejects intervals under 60s (Cloud Monitoring quota floor);
+# pin the README claim to real collector behaviour.
+if docker run --rm --entrypoint /bin/sh \
+    -e POSTHOG_API_KEY=phc_test -e GCP_PROJECT_ID=test-project \
+    -e GCP_METRICS=compute.googleapis.com/instance/cpu/utilization \
+    -e GCP_COLLECTION_INTERVAL=30s \
+    posthog-metrics-agent:test \
+    -c 'RENDER_ONLY=1 /entrypoint.sh > /tmp/validate.yaml && /usr/local/bin/otelcol-contrib validate --config /tmp/validate.yaml' \
+    >/dev/null 2>&1; then
+    echo "FAIL gcp-interval-floor: collector accepted a 30s pull interval"
+    exit 1
+fi
+echo "PASS gcp-interval-floor"
+
 ./assert.sh

--- a/products/metrics/agent/tests/render/golden/gcp-filter.yaml
+++ b/products/metrics/agent/tests/render/golden/gcp-filter.yaml
@@ -1,6 +1,10 @@
 receivers:
-#__PROMETHEUS_RECEIVER__
-#__GCP_RECEIVER__
+    googlecloudmonitoring:
+        project_id: '${env:GCP_PROJECT_ID}'
+        collection_interval: '${env:GCP_COLLECTION_INTERVAL:-60s}'
+        metrics_list:
+            - metric_descriptor_filter: 'metric.type = starts_with("compute.googleapis.com/")'
+            - metric_descriptor_filter: 'resource.type = "gce_instance"'
 
 processors:
     # Shed load instead of buffering unbounded memory when PostHog is unreachable.
@@ -9,10 +13,15 @@ processors:
         limit_mib: 512
         spike_limit_mib: 128
     batch:
-#__GCP_RESOURCE_PROCESSOR__
+    # Cloud Monitoring resources carry no service.name; give them one so they
+    # group in the Metrics UI. `insert` never overrides a scraped job_name.
+    resource/gcp:
+        attributes:
+            - key: service.name
+              value: '${env:GCP_SERVICE_NAME:-google-cloud-monitoring}'
+              action: insert
 
 exporters:
-#__DEBUG_EXPORTER__
     otlphttp:
         # The otlphttp exporter appends /v1/metrics to `endpoint`, but PostHog's
         # public ingest route is /i/v1/metrics, so pin the per-signal path.
@@ -20,12 +29,10 @@ exporters:
         compression: gzip
         headers:
             authorization: 'Bearer ${env:POSTHOG_API_KEY}'
-#__SENDING_QUEUE__
         retry_on_failure:
             enabled: true
 
 extensions:
-#__FILE_STORAGE__
     health_check:
         endpoint: 0.0.0.0:13133
 
@@ -40,9 +47,9 @@ service:
                           prometheus:
                               host: 0.0.0.0
                               port: 8888
-    extensions: [__SERVICE_EXTENSIONS__]
+    extensions: [health_check]
     pipelines:
         metrics:
-            receivers: [__PIPELINE_RECEIVERS__]
-            processors: [__PIPELINE_PROCESSORS__]
-            exporters: [__PIPELINE_EXPORTERS__]
+            receivers: [googlecloudmonitoring]
+            processors: [memory_limiter, resource/gcp, batch]
+            exporters: [otlphttp]

--- a/products/metrics/agent/tests/render/golden/gcp-mounted-metrics-list.yaml
+++ b/products/metrics/agent/tests/render/golden/gcp-mounted-metrics-list.yaml
@@ -1,6 +1,10 @@
 receivers:
-#__PROMETHEUS_RECEIVER__
-#__GCP_RECEIVER__
+    googlecloudmonitoring:
+        project_id: '${env:GCP_PROJECT_ID}'
+        collection_interval: '${env:GCP_COLLECTION_INTERVAL:-60s}'
+        metrics_list:
+            - metric_name: 'compute.googleapis.com/instance/cpu/utilization'
+            - metric_descriptor_filter: 'metric.type = starts_with("run.googleapis.com/")'
 
 processors:
     # Shed load instead of buffering unbounded memory when PostHog is unreachable.
@@ -9,10 +13,15 @@ processors:
         limit_mib: 512
         spike_limit_mib: 128
     batch:
-#__GCP_RESOURCE_PROCESSOR__
+    # Cloud Monitoring resources carry no service.name; give them one so they
+    # group in the Metrics UI. `insert` never overrides a scraped job_name.
+    resource/gcp:
+        attributes:
+            - key: service.name
+              value: '${env:GCP_SERVICE_NAME:-google-cloud-monitoring}'
+              action: insert
 
 exporters:
-#__DEBUG_EXPORTER__
     otlphttp:
         # The otlphttp exporter appends /v1/metrics to `endpoint`, but PostHog's
         # public ingest route is /i/v1/metrics, so pin the per-signal path.
@@ -20,12 +29,10 @@ exporters:
         compression: gzip
         headers:
             authorization: 'Bearer ${env:POSTHOG_API_KEY}'
-#__SENDING_QUEUE__
         retry_on_failure:
             enabled: true
 
 extensions:
-#__FILE_STORAGE__
     health_check:
         endpoint: 0.0.0.0:13133
 
@@ -40,9 +47,9 @@ service:
                           prometheus:
                               host: 0.0.0.0
                               port: 8888
-    extensions: [__SERVICE_EXTENSIONS__]
+    extensions: [health_check]
     pipelines:
         metrics:
-            receivers: [__PIPELINE_RECEIVERS__]
-            processors: [__PIPELINE_PROCESSORS__]
-            exporters: [__PIPELINE_EXPORTERS__]
+            receivers: [googlecloudmonitoring]
+            processors: [memory_limiter, resource/gcp, batch]
+            exporters: [otlphttp]

--- a/products/metrics/agent/tests/render/golden/gcp-only.yaml
+++ b/products/metrics/agent/tests/render/golden/gcp-only.yaml
@@ -1,6 +1,10 @@
 receivers:
-#__PROMETHEUS_RECEIVER__
-#__GCP_RECEIVER__
+    googlecloudmonitoring:
+        project_id: '${env:GCP_PROJECT_ID}'
+        collection_interval: '${env:GCP_COLLECTION_INTERVAL:-60s}'
+        metrics_list:
+            - metric_name: 'compute.googleapis.com/instance/cpu/utilization'
+            - metric_name: 'compute.googleapis.com/instance/cpu/usage_time'
 
 processors:
     # Shed load instead of buffering unbounded memory when PostHog is unreachable.
@@ -9,10 +13,15 @@ processors:
         limit_mib: 512
         spike_limit_mib: 128
     batch:
-#__GCP_RESOURCE_PROCESSOR__
+    # Cloud Monitoring resources carry no service.name; give them one so they
+    # group in the Metrics UI. `insert` never overrides a scraped job_name.
+    resource/gcp:
+        attributes:
+            - key: service.name
+              value: '${env:GCP_SERVICE_NAME:-google-cloud-monitoring}'
+              action: insert
 
 exporters:
-#__DEBUG_EXPORTER__
     otlphttp:
         # The otlphttp exporter appends /v1/metrics to `endpoint`, but PostHog's
         # public ingest route is /i/v1/metrics, so pin the per-signal path.
@@ -20,12 +29,10 @@ exporters:
         compression: gzip
         headers:
             authorization: 'Bearer ${env:POSTHOG_API_KEY}'
-#__SENDING_QUEUE__
         retry_on_failure:
             enabled: true
 
 extensions:
-#__FILE_STORAGE__
     health_check:
         endpoint: 0.0.0.0:13133
 
@@ -40,9 +47,9 @@ service:
                           prometheus:
                               host: 0.0.0.0
                               port: 8888
-    extensions: [__SERVICE_EXTENSIONS__]
+    extensions: [health_check]
     pipelines:
         metrics:
-            receivers: [__PIPELINE_RECEIVERS__]
-            processors: [__PIPELINE_PROCESSORS__]
-            exporters: [__PIPELINE_EXPORTERS__]
+            receivers: [googlecloudmonitoring]
+            processors: [memory_limiter, resource/gcp, batch]
+            exporters: [otlphttp]

--- a/products/metrics/agent/tests/render/golden/gcp-plus-scrape.yaml
+++ b/products/metrics/agent/tests/render/golden/gcp-plus-scrape.yaml
@@ -1,0 +1,65 @@
+receivers:
+    prometheus:
+        config:
+            scrape_configs:
+                - job_name: '${env:SCRAPE_JOB_NAME:-posthog-metrics-agent}'
+                  scrape_interval: '${env:SCRAPE_INTERVAL:-15s}'
+                  metrics_path: '${env:SCRAPE_METRICS_PATH:-/metrics}'
+                  # OpenMetrics first so exemplars (trace links) survive the scrape.
+                  scrape_protocols: [OpenMetricsText1.0.0, OpenMetricsText0.0.1, PrometheusText0.0.4]
+                  static_configs:
+                      - targets: ['app:9090']
+    googlecloudmonitoring:
+        project_id: '${env:GCP_PROJECT_ID}'
+        collection_interval: '${env:GCP_COLLECTION_INTERVAL:-60s}'
+        metrics_list:
+            - metric_name: 'compute.googleapis.com/instance/cpu/utilization'
+            - metric_name: 'compute.googleapis.com/instance/cpu/usage_time'
+
+processors:
+    # Shed load instead of buffering unbounded memory when PostHog is unreachable.
+    memory_limiter:
+        check_interval: 1s
+        limit_mib: 512
+        spike_limit_mib: 128
+    batch:
+    # Cloud Monitoring resources carry no service.name; give them one so they
+    # group in the Metrics UI. `insert` never overrides a scraped job_name.
+    resource/gcp:
+        attributes:
+            - key: service.name
+              value: '${env:GCP_SERVICE_NAME:-google-cloud-monitoring}'
+              action: insert
+
+exporters:
+    otlphttp:
+        # The otlphttp exporter appends /v1/metrics to `endpoint`, but PostHog's
+        # public ingest route is /i/v1/metrics, so pin the per-signal path.
+        metrics_endpoint: '${env:POSTHOG_HOST:-https://us.i.posthog.com}${env:POSTHOG_INGEST_PATH:-/i/v1/metrics}'
+        compression: gzip
+        headers:
+            authorization: 'Bearer ${env:POSTHOG_API_KEY}'
+        retry_on_failure:
+            enabled: true
+
+extensions:
+    health_check:
+        endpoint: 0.0.0.0:13133
+
+service:
+    # Expose the collector's own metrics (scrape health, queue depth, drops)
+    # on :8888 so the agent is self-observable, the way vmagent exposes its.
+    telemetry:
+        metrics:
+            readers:
+                - pull:
+                      exporter:
+                          prometheus:
+                              host: 0.0.0.0
+                              port: 8888
+    extensions: [health_check]
+    pipelines:
+        metrics:
+            receivers: [prometheus, googlecloudmonitoring]
+            processors: [memory_limiter, resource/gcp, batch]
+            exporters: [otlphttp]

--- a/products/metrics/agent/tests/render/golden/gcp-service-name.yaml
+++ b/products/metrics/agent/tests/render/golden/gcp-service-name.yaml
@@ -1,6 +1,9 @@
 receivers:
-#__PROMETHEUS_RECEIVER__
-#__GCP_RECEIVER__
+    googlecloudmonitoring:
+        project_id: '${env:GCP_PROJECT_ID}'
+        collection_interval: '${env:GCP_COLLECTION_INTERVAL:-60s}'
+        metrics_list:
+            - metric_name: 'compute.googleapis.com/instance/cpu/utilization'
 
 processors:
     # Shed load instead of buffering unbounded memory when PostHog is unreachable.
@@ -9,10 +12,15 @@ processors:
         limit_mib: 512
         spike_limit_mib: 128
     batch:
-#__GCP_RESOURCE_PROCESSOR__
+    # Cloud Monitoring resources carry no service.name; give them one so they
+    # group in the Metrics UI. `insert` never overrides a scraped job_name.
+    resource/gcp:
+        attributes:
+            - key: service.name
+              value: '${env:GCP_SERVICE_NAME:-google-cloud-monitoring}'
+              action: insert
 
 exporters:
-#__DEBUG_EXPORTER__
     otlphttp:
         # The otlphttp exporter appends /v1/metrics to `endpoint`, but PostHog's
         # public ingest route is /i/v1/metrics, so pin the per-signal path.
@@ -20,12 +28,10 @@ exporters:
         compression: gzip
         headers:
             authorization: 'Bearer ${env:POSTHOG_API_KEY}'
-#__SENDING_QUEUE__
         retry_on_failure:
             enabled: true
 
 extensions:
-#__FILE_STORAGE__
     health_check:
         endpoint: 0.0.0.0:13133
 
@@ -40,9 +46,9 @@ service:
                           prometheus:
                               host: 0.0.0.0
                               port: 8888
-    extensions: [__SERVICE_EXTENSIONS__]
+    extensions: [health_check]
     pipelines:
         metrics:
-            receivers: [__PIPELINE_RECEIVERS__]
-            processors: [__PIPELINE_PROCESSORS__]
-            exporters: [__PIPELINE_EXPORTERS__]
+            receivers: [googlecloudmonitoring]
+            processors: [memory_limiter, resource/gcp, batch]
+            exporters: [otlphttp]

--- a/products/metrics/agent/tests/render/run.sh
+++ b/products/metrics/agent/tests/render/run.sh
@@ -133,6 +133,55 @@ new_case_dir
 cp golden/full-override.yaml "$CASE_DIR/config.yaml"
 run_render full-override
 
+# Google Cloud Monitoring: GCP_PROJECT_ID enables a googlecloudmonitoring
+# receiver alongside (or instead of) the prometheus scrape.
+new_case_dir
+run_render gcp-only POSTHOG_API_KEY=phc_test GCP_PROJECT_ID=my-project \
+    GCP_METRICS='compute.googleapis.com/instance/cpu/utilization, compute.googleapis.com/instance/cpu/usage_time'
+
+new_case_dir
+run_render gcp-plus-scrape POSTHOG_API_KEY=phc_test SCRAPE_TARGETS=app:9090 GCP_PROJECT_ID=my-project \
+    GCP_METRICS='compute.googleapis.com/instance/cpu/utilization, compute.googleapis.com/instance/cpu/usage_time'
+
+# Filters can contain commas, so GCP_METRIC_FILTERS splits on semicolons.
+new_case_dir
+run_render gcp-filter POSTHOG_API_KEY=phc_test GCP_PROJECT_ID=my-project \
+    GCP_METRIC_FILTERS='metric.type = starts_with("compute.googleapis.com/") ; resource.type = "gce_instance"'
+
+# A mounted gcp_metrics_list.yaml is spliced as the receiver's metrics_list.
+new_case_dir
+cat >"$CASE_DIR/gcp_metrics_list.yaml" <<'EOF'
+- metric_name: 'compute.googleapis.com/instance/cpu/utilization'
+- metric_descriptor_filter: 'metric.type = starts_with("run.googleapis.com/")'
+EOF
+run_render gcp-mounted-metrics-list POSTHOG_API_KEY=phc_test GCP_PROJECT_ID=my-project
+
+new_case_dir
+run_render gcp-service-name POSTHOG_API_KEY=phc_test GCP_PROJECT_ID=my-project \
+    GCP_METRICS='compute.googleapis.com/instance/cpu/utilization' GCP_SERVICE_NAME=gcp-prod
+
+new_case_dir
+expect_failure gcp-missing-metrics GCP_METRICS POSTHOG_API_KEY=phc_test GCP_PROJECT_ID=my-project
+
+new_case_dir
+expect_failure gcp-empty-metrics GCP_METRICS POSTHOG_API_KEY=phc_test GCP_PROJECT_ID=my-project GCP_METRICS=' , '
+
+new_case_dir
+expect_failure gcp-metrics-without-project GCP_PROJECT_ID POSTHOG_API_KEY=phc_test SCRAPE_TARGETS=app:9090 \
+    GCP_METRICS=compute.googleapis.com/instance/cpu/utilization
+
+# Every shard would pull the same Cloud Monitoring series, so GCP sources
+# are rejected on a sharded agent; run a separate single-instance agent.
+new_case_dir
+expect_failure gcp-sharded-rejected SHARD_COUNT POSTHOG_API_KEY=phc_test SCRAPE_TARGETS=app:9090 \
+    GCP_PROJECT_ID=my-project GCP_METRICS=x SHARD_COUNT=2 SHARD_INDEX=0
+
+# A credentials file the collector user cannot read fails at startup with a
+# Google auth error; the entrypoint turns it into a one-line error instead.
+new_case_dir
+expect_failure gcp-credentials-file-missing GOOGLE_APPLICATION_CREDENTIALS POSTHOG_API_KEY=phc_test \
+    GCP_PROJECT_ID=my-project GCP_METRICS=x GOOGLE_APPLICATION_CREDENTIALS="$CASE_DIR/missing.json"
+
 new_case_dir
 expect_failure missing-api-key POSTHOG_API_KEY SCRAPE_TARGETS=app:9090
 

--- a/products/metrics/agent/tests/render/run.sh
+++ b/products/metrics/agent/tests/render/run.sh
@@ -160,6 +160,12 @@ new_case_dir
 run_render gcp-service-name POSTHOG_API_KEY=phc_test GCP_PROJECT_ID=my-project \
     GCP_METRICS='compute.googleapis.com/instance/cpu/utilization' GCP_SERVICE_NAME=gcp-prod
 
+# A mounted but empty gcp_metrics_list.yaml yields no metrics_list entries and
+# must be rejected like a missing GCP_METRICS, not rendered into a bad config.
+new_case_dir
+: >"$CASE_DIR/gcp_metrics_list.yaml"
+expect_failure gcp-mounted-metrics-list-empty GCP_METRICS POSTHOG_API_KEY=phc_test GCP_PROJECT_ID=my-project
+
 new_case_dir
 expect_failure gcp-missing-metrics GCP_METRICS POSTHOG_API_KEY=phc_test GCP_PROJECT_ID=my-project
 


### PR DESCRIPTION
## Problem

Users who run on GCP and want Google Cloud Monitoring metrics in PostHog Metrics have no supported path: Cloud Monitoring cannot push OTLP, and the metrics agent only scraped Prometheus endpoints. With this change, a user on GCP can run one container — or one Helm release on GKE with Workload Identity — and see managed-service metrics (Cloud SQL, GKE, Cloud Run, load balancers) in PostHog Metrics.

Refs #80881 (which asks for a data-warehouse source; #82619 implements that separate product. This PR is the Metrics-product path, not a duplicate.)

## Changes

- The agent renders a `googlecloudmonitoring` receiver (already present in the pinned contrib image — no image change) when `GCP_PROJECT_ID` is set. `GCP_METRICS` (comma-separated metric types) or `GCP_METRIC_FILTERS` (**semicolon**-separated descriptor filters — commas are valid filter syntax) list what to pull; `/etc/posthog/gcp_metrics_list.yaml` is the mount escape hatch for full control.
- Additive, not a mode switch: scrape and pull share one pipeline (`receivers: [prometheus, googlecloudmonitoring]`). Prometheus-only setups render **byte-identical** configs — all nine existing render goldens are untouched.
- Pulled metrics get `service.name` inserted (`GCP_SERVICE_NAME`, default `google-cloud-monitoring`) via a `resource/gcp` processor rendered only when the source is on, because Cloud Monitoring resources carry no `service.name` and the Metrics UI groups by it.
- Fail-fast guards: metrics/filters/mounted list without `GCP_PROJECT_ID`; unreadable `GOOGLE_APPLICATION_CREDENTIALS` (uid 10001 mount-perm footgun); `SHARD_COUNT > 1` / Helm `shards > 1` with GCP (every shard would pull identical series — run a separate instance).
- Helm: `gcp.*` values (`projectId`, `metrics`, `metricFilters`, `collectionInterval`, `serviceName`, `credentialsSecret`) plus `serviceAccount.annotations` for Workload Identity. Chart 0.2.0 → 0.3.0. Chart description updated.
- README: new "Pull metrics from Google Cloud Monitoring" section (Docker + GKE Workload Identity examples, IAM role, 60s interval floor and quota note, alpha caveat, sharding note).

## How did you test this code?

Automated only (agent-run; no manual testing claimed):

- `tests/render/run.sh` — 5 new golden renders (gcp-only, gcp-plus-scrape, gcp-filter, gcp-mounted-metrics-list, gcp-service-name) and 5 failure cases (missing metrics, metrics without project, sharding, unreadable credentials). Catches: silent dropping of GCP config, duplicate pulls on sharded fleets, filter corruption from comma splitting. All 9 pre-existing goldens pass unchanged — that is the no-regression guarantee for current users.
- `tests/helm/run.sh` — 18 new assertions (receiver block, receivers/processors lists, credentials secret mount, Workload Identity annotation, shards rejection, no-source rejection). `golden-default` passed unchanged before the deliberate 0.3.0 version bump (whose label change then regenerated it with `--update-golden`).
- `tests/integration/run.sh` — offline `otelcol-contrib validate` of rendered gcp-only and gcp-plus-scrape configs against the real collector (proves the receiver factory ships in the pinned image), plus a negative case pinning that the collector rejects `GCP_COLLECTION_INTERVAL=30s`.

Not checked: a live pull against real GCP (needs credentials; cannot run in CI). The README's Development section documents the end-to-end check (`service_name = 'google-cloud-monitoring'` in `posthog.metrics`).

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- No duplicate: the search found #82619 (`feat(warehouse-sources): gcp cloud monitoring source`), which lands metrics in warehouse tables for SQL — a different product. No open PR touches the metrics agent's GCP path.
- Patch coverage: all changed shell/template lines are exercised by the render/helm/integration suites named above.
- Public artifact: the work drew on an internal customer conversation for motivation only; everything committed (env names, examples, fixtures) is invented and public-safe.
- Approach was test-driven: red tests (5 goldens + failure cases) were written and observed failing before the entrypoint/template/Helm changes made them green.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
