### PR TITLE
fix(oauth-proxy): key the intercepted callback by a proxy nonce

### DIFF
--- a/services/oauth-proxy/README.md
+++ b/services/oauth-proxy/README.md
@@ -56,15 +56,15 @@ Clients registered directly against a region keep their own `redirect_uri` and f
 
 ## KV keys
 
-| Key                 | TTL    | Value                                                                 |
-| ------------------- | ------ | --------------------------------------------------------------------- |
-| `client:<proxy_id>` | none   | US and EU `client_id`s, secrets, and registered `redirect_uris`       |
-| `region:<sha256>`   | 1 hour | `us` or `eu`, stored under `client_id`                                |
-| `callback:<sha256>` | 1 hour | The client's original `redirect_uri`, stored under `client_id`        |
-| `flow:<sha256>`     | 1 hour | The client's original `redirect_uri` and `state`, under a proxy nonce |
+| Key                         | TTL    | Value                                                                 |
+| --------------------------- | ------ | --------------------------------------------------------------------- |
+| `client:<proxy_id>`         | none   | US and EU `client_id`s, secrets, and registered `redirect_uris`       |
+| `region:<sha256>`           | 1 hour | `us` or `eu`, stored under `client_id`                                |
+| `callback:<sha256>`         | 1 hour | The client's original `redirect_uri`, stored under `client_id`        |
+| `pending_callback:<sha256>` | 1 hour | The client's original `redirect_uri` and `state`, under a proxy nonce |
 
 Key material is SHA-256 hashed because `state` and the nonce are opaque and can exceed Cloudflare's 512 byte key limit.
-`flow:` records are deleted once `/oauth/callback` reads them, so a nonce is single-use.
+`pending_callback:` records are deleted once `/oauth/callback` reads them, so a nonce is single-use.
 KV is eventually consistent across Cloudflare's edge locations, so this single-use guarantee is best effort; the authorization code itself is still single-use at the regional server.
 
 ## Development

--- a/services/oauth-proxy/README.md
+++ b/services/oauth-proxy/README.md
@@ -34,9 +34,11 @@ Trailing slashes are optional; paths are normalized before matching.
 2. **Authorize.**
    `/oauth/authorize` serves a static region picker.
    The picker re-requests the same URL with `_region=us|eu` appended.
-   The worker stores that choice in KV under both the `state` and the `client_id`, swaps in the regional `client_id`, replaces `redirect_uri` with the proxy callback, and redirects to the region.
+   The worker stores the region choice in KV under the `client_id`, swaps in the regional `client_id`, replaces `redirect_uri` with the proxy callback, and redirects to the region.
+   For clients with a stored `redirect_uris` list, it also generates a nonce, stores the client's original `redirect_uri` and `state` under it, and sends the regional server that nonce as `state` instead of the client's own.
 3. **Callback.**
-   The regional server sends the user to `/oauth/callback`, which looks up the client's original `redirect_uri` by `state` and forwards every query param on to it.
+   The regional server sends the user to `/oauth/callback` with the nonce from step 2 as `state`.
+   The worker looks up and deletes the matching record, then forwards every query param to the client's original `redirect_uri`, restoring the client's own `state`.
    The client never sees a regional URL, so its token request comes back through the proxy.
 4. **Token.**
    `/oauth/token` looks up the region by `client_id`.
@@ -54,13 +56,16 @@ Clients registered directly against a region keep their own `redirect_uri` and f
 
 ## KV keys
 
-| Key                 | TTL    | Value                                                           |
-| ------------------- | ------ | --------------------------------------------------------------- |
-| `client:<proxy_id>` | none   | US and EU `client_id`s, secrets, and registered `redirect_uris` |
-| `region:<sha256>`   | 1 hour | `us` or `eu`, stored under both `state` and `client_id`         |
-| `callback:<sha256>` | 1 hour | The client's original `redirect_uri`                            |
+| Key                 | TTL    | Value                                                                 |
+| ------------------- | ------ | --------------------------------------------------------------------- |
+| `client:<proxy_id>` | none   | US and EU `client_id`s, secrets, and registered `redirect_uris`       |
+| `region:<sha256>`   | 1 hour | `us` or `eu`, stored under `client_id`                                |
+| `callback:<sha256>` | 1 hour | The client's original `redirect_uri`, stored under `client_id`        |
+| `flow:<sha256>`     | 1 hour | The client's original `redirect_uri` and `state`, under a proxy nonce |
 
-Key material is SHA-256 hashed because `state` is opaque and can exceed Cloudflare's 512 byte key limit.
+Key material is SHA-256 hashed because `state` and the nonce are opaque and can exceed Cloudflare's 512 byte key limit.
+`flow:` records are deleted once `/oauth/callback` reads them, so a nonce is single-use.
+KV is eventually consistent across Cloudflare's edge locations, so this single-use guarantee is best effort; the authorization code itself is still single-use at the regional server.
 
 ## Development
 

--- a/services/oauth-proxy/src/handlers/authorize.ts
+++ b/services/oauth-proxy/src/handlers/authorize.ts
@@ -1,5 +1,11 @@
 import { type Region, baseUrlForRegion } from '@/lib/constants'
-import { type ClientMapping, getClientMapping, putCallbackRedirectUri, putRegionSelection } from '@/lib/kv'
+import {
+    type ClientMapping,
+    getClientMapping,
+    putCallbackRedirectUri,
+    putFlowRecord,
+    putRegionSelection,
+} from '@/lib/kv'
 import { type ValidationError, errorResponse } from '@/lib/validation'
 
 import REGION_PICKER_HTML from '../static/region-picker.html'
@@ -72,24 +78,22 @@ async function redirectToRegionalAuthorize(url: URL, region: Region, kv: KVNames
         return errorResponse(redirectUriError)
     }
 
-    // Store region selection keyed by both state and client_id.
-    // The token exchange only has client_id (state is not sent to the token endpoint),
-    // but we also store by state for the callback interception.
+    // Region selection is keyed by client_id; the token exchange only has client_id
+    // (state is not sent to the token endpoint).
     const kvWrites: Promise<void>[] = []
-    if (state) {
-        kvWrites.push(putRegionSelection(kv, state, region))
-    }
     if (clientId) {
         kvWrites.push(putRegionSelection(kv, clientId, region))
     }
 
-    // Store original redirect_uri and intercept callback only for clients with stored
-    // redirect_uris (the proxy callback URL is only in their registered redirect_uris).
-    // Legacy clients without redirect_uris fall through to regional server validation.
+    // Intercept the callback only for clients with stored redirect_uris (the proxy
+    // callback URL is only in their registered redirect_uris). Legacy clients without
+    // redirect_uris fall through to regional server validation.
+    let nonce: string | null = null
     if (mapping?.redirect_uris && originalRedirectUri) {
-        if (state) {
-            kvWrites.push(putCallbackRedirectUri(kv, state, originalRedirectUri))
-        }
+        // Keyed by a proxy-generated nonce so nobody who merely knows the client's state
+        // can write or overwrite the record.
+        nonce = crypto.randomUUID()
+        kvWrites.push(putFlowRecord(kv, nonce, { redirect_uri: originalRedirectUri, state: state ?? null }))
         if (clientId) {
             kvWrites.push(putCallbackRedirectUri(kv, clientId, originalRedirectUri))
         }
@@ -111,6 +115,9 @@ async function redirectToRegionalAuthorize(url: URL, region: Region, kv: KVNames
         if (key === '_region') {
             continue
         }
+        if (key === 'state' && nonce) {
+            continue
+        }
         if (key === 'client_id' && regionalClientId) {
             regionalUrl.searchParams.set(key, regionalClientId)
         } else if (key === 'redirect_uri' && mapping?.redirect_uris) {
@@ -118,6 +125,9 @@ async function redirectToRegionalAuthorize(url: URL, region: Region, kv: KVNames
         } else {
             regionalUrl.searchParams.set(key, value)
         }
+    }
+    if (nonce) {
+        regionalUrl.searchParams.set('state', nonce)
     }
 
     return Response.redirect(regionalUrl.toString(), 302)

--- a/services/oauth-proxy/src/handlers/authorize.ts
+++ b/services/oauth-proxy/src/handlers/authorize.ts
@@ -78,20 +78,15 @@ async function redirectToRegionalAuthorize(url: URL, region: Region, kv: KVNames
         return errorResponse(redirectUriError)
     }
 
-    // Region selection is keyed by client_id; the token exchange only has client_id
-    // (state is not sent to the token endpoint).
     const kvWrites: Promise<void>[] = []
     if (clientId) {
         kvWrites.push(putRegionSelection(kv, clientId, region))
     }
 
-    // Intercept the callback only for clients with stored redirect_uris (the proxy
-    // callback URL is only in their registered redirect_uris). Legacy clients without
-    // redirect_uris fall through to regional server validation.
+    // Only proxy-registered clients have the proxy callback in their registered redirect_uris.
     let nonce: string | null = null
     if (mapping?.redirect_uris && originalRedirectUri) {
-        // Keyed by a proxy-generated nonce so nobody who merely knows the client's state
-        // can write or overwrite the record.
+        // A proxy nonce keys the record so knowing the client's state cannot overwrite it.
         nonce = crypto.randomUUID()
         kvWrites.push(putFlowRecord(kv, nonce, { redirect_uri: originalRedirectUri, state: state ?? null }))
         if (clientId) {

--- a/services/oauth-proxy/src/handlers/authorize.ts
+++ b/services/oauth-proxy/src/handlers/authorize.ts
@@ -3,7 +3,7 @@ import {
     type ClientMapping,
     getClientMapping,
     putCallbackRedirectUri,
-    putFlowRecord,
+    putPendingCallback,
     putRegionSelection,
 } from '@/lib/kv'
 import { type ValidationError, errorResponse } from '@/lib/validation'
@@ -88,7 +88,7 @@ async function redirectToRegionalAuthorize(url: URL, region: Region, kv: KVNames
     if (mapping?.redirect_uris && originalRedirectUri) {
         // A proxy nonce keys the record so knowing the client's state cannot overwrite it.
         nonce = crypto.randomUUID()
-        kvWrites.push(putFlowRecord(kv, nonce, { redirect_uri: originalRedirectUri, state: state ?? null }))
+        kvWrites.push(putPendingCallback(kv, nonce, { redirect_uri: originalRedirectUri, state: state ?? null }))
         if (clientId) {
             kvWrites.push(putCallbackRedirectUri(kv, clientId, originalRedirectUri))
         }

--- a/services/oauth-proxy/src/handlers/callback.ts
+++ b/services/oauth-proxy/src/handlers/callback.ts
@@ -1,4 +1,4 @@
-import { getCallbackRedirectUri } from '@/lib/kv'
+import { deleteFlowRecord, getFlowRecord } from '@/lib/kv'
 
 /**
  * OAuth Callback Interception — proxy receives the regional server's callback
@@ -15,15 +15,27 @@ export async function handleCallback(request: Request, kv: KVNamespace): Promise
         return new Response('Missing state parameter', { status: 400 })
     }
 
-    const originalRedirectUri = await getCallbackRedirectUri(kv, state)
-    if (!originalRedirectUri) {
+    const record = await getFlowRecord(kv, state)
+    if (!record) {
         return new Response('State expired or invalid', { status: 400 })
     }
 
-    // Forward all query params (code, state, error, error_description) to the client
-    const clientUrl = new URL(originalRedirectUri)
+    // A transient KV failure here should not turn an already-verified callback into a 500.
+    try {
+        await deleteFlowRecord(kv, state)
+    } catch {
+        console.warn(JSON.stringify({ handler: 'callback', error: 'flow_record_delete_failed' }))
+    }
+
+    const clientUrl = new URL(record.redirect_uri)
     for (const [key, value] of url.searchParams.entries()) {
+        if (key === 'state') {
+            continue
+        }
         clientUrl.searchParams.set(key, value)
+    }
+    if (record.state !== null) {
+        clientUrl.searchParams.set('state', record.state)
     }
 
     return Response.redirect(clientUrl.toString(), 302)

--- a/services/oauth-proxy/src/handlers/callback.ts
+++ b/services/oauth-proxy/src/handlers/callback.ts
@@ -1,4 +1,4 @@
-import { deleteFlowRecord, getFlowRecord } from '@/lib/kv'
+import { deletePendingCallback, getPendingCallback } from '@/lib/kv'
 
 /**
  * OAuth Callback Interception — proxy receives the regional server's callback
@@ -15,16 +15,16 @@ export async function handleCallback(request: Request, kv: KVNamespace): Promise
         return new Response('Missing state parameter', { status: 400 })
     }
 
-    const record = await getFlowRecord(kv, state)
+    const record = await getPendingCallback(kv, state)
     if (!record) {
         return new Response('State expired or invalid', { status: 400 })
     }
 
     // A transient KV failure here should not turn an already-verified callback into a 500.
     try {
-        await deleteFlowRecord(kv, state)
+        await deletePendingCallback(kv, state)
     } catch {
-        console.warn(JSON.stringify({ handler: 'callback', error: 'flow_record_delete_failed' }))
+        console.warn(JSON.stringify({ handler: 'callback', error: 'pending_callback_delete_failed' }))
     }
 
     const clientUrl = new URL(record.redirect_uri)

--- a/services/oauth-proxy/src/lib/kv.ts
+++ b/services/oauth-proxy/src/lib/kv.ts
@@ -12,11 +12,11 @@ export interface ClientMapping {
 const CLIENT_PREFIX = 'client:'
 const REGION_PREFIX = 'region:'
 const CALLBACK_PREFIX = 'callback:'
-const FLOW_PREFIX = 'flow:'
+const PENDING_CALLBACK_PREFIX = 'pending_callback:'
 
 const REGION_SELECTION_TTL = 3600
 const CALLBACK_TTL = 3600
-const FLOW_TTL = 3600
+const PENDING_CALLBACK_TTL = 3600
 
 // Cloudflare KV caps key names at 512 bytes. Callers may pass opaque values
 // (notably the OAuth `state` parameter) that exceed that limit, so we derive
@@ -59,22 +59,24 @@ export async function getCallbackRedirectUri(kv: KVNamespace, key: string): Prom
     return kv.get(`${CALLBACK_PREFIX}${await hashKey(key)}`)
 }
 
-export interface FlowRecord {
+export interface PendingCallback {
     redirect_uri: string
     state: string | null
 }
 
-export async function putFlowRecord(kv: KVNamespace, nonce: string, record: FlowRecord): Promise<void> {
-    await kv.put(`${FLOW_PREFIX}${await hashKey(nonce)}`, JSON.stringify(record), { expirationTtl: FLOW_TTL })
+export async function putPendingCallback(kv: KVNamespace, nonce: string, record: PendingCallback): Promise<void> {
+    await kv.put(`${PENDING_CALLBACK_PREFIX}${await hashKey(nonce)}`, JSON.stringify(record), {
+        expirationTtl: PENDING_CALLBACK_TTL,
+    })
 }
 
-export async function getFlowRecord(kv: KVNamespace, nonce: string): Promise<FlowRecord | null> {
-    const data = await kv.get(`${FLOW_PREFIX}${await hashKey(nonce)}`, 'json')
-    return data as FlowRecord | null
+export async function getPendingCallback(kv: KVNamespace, nonce: string): Promise<PendingCallback | null> {
+    const data = await kv.get(`${PENDING_CALLBACK_PREFIX}${await hashKey(nonce)}`, 'json')
+    return data as PendingCallback | null
 }
 
-export async function deleteFlowRecord(kv: KVNamespace, nonce: string): Promise<void> {
-    await kv.delete(`${FLOW_PREFIX}${await hashKey(nonce)}`)
+export async function deletePendingCallback(kv: KVNamespace, nonce: string): Promise<void> {
+    await kv.delete(`${PENDING_CALLBACK_PREFIX}${await hashKey(nonce)}`)
 }
 
 /**

--- a/services/oauth-proxy/src/lib/kv.ts
+++ b/services/oauth-proxy/src/lib/kv.ts
@@ -12,9 +12,11 @@ export interface ClientMapping {
 const CLIENT_PREFIX = 'client:'
 const REGION_PREFIX = 'region:'
 const CALLBACK_PREFIX = 'callback:'
+const FLOW_PREFIX = 'flow:'
 
 const REGION_SELECTION_TTL = 3600
 const CALLBACK_TTL = 3600
+const FLOW_TTL = 3600
 
 // Cloudflare KV caps key names at 512 bytes. Callers may pass opaque values
 // (notably the OAuth `state` parameter) that exceed that limit, so we derive
@@ -55,6 +57,24 @@ export async function putCallbackRedirectUri(kv: KVNamespace, key: string, redir
 
 export async function getCallbackRedirectUri(kv: KVNamespace, key: string): Promise<string | null> {
     return kv.get(`${CALLBACK_PREFIX}${await hashKey(key)}`)
+}
+
+export interface FlowRecord {
+    redirect_uri: string
+    state: string | null
+}
+
+export async function putFlowRecord(kv: KVNamespace, nonce: string, record: FlowRecord): Promise<void> {
+    await kv.put(`${FLOW_PREFIX}${await hashKey(nonce)}`, JSON.stringify(record), { expirationTtl: FLOW_TTL })
+}
+
+export async function getFlowRecord(kv: KVNamespace, nonce: string): Promise<FlowRecord | null> {
+    const data = await kv.get(`${FLOW_PREFIX}${await hashKey(nonce)}`, 'json')
+    return data as FlowRecord | null
+}
+
+export async function deleteFlowRecord(kv: KVNamespace, nonce: string): Promise<void> {
+    await kv.delete(`${FLOW_PREFIX}${await hashKey(nonce)}`)
 }
 
 /**

--- a/services/oauth-proxy/tests/authorize.test.ts
+++ b/services/oauth-proxy/tests/authorize.test.ts
@@ -108,7 +108,7 @@ describe('handleAuthorize', () => {
         expect(data.error_description).toBe('redirect_uri is not registered for this client')
     })
 
-    it('stores region selection and callback redirect_uri keyed by state and client_id', async () => {
+    it('stores region selection and callback redirect_uri keyed by client_id, and a flow record keyed by nonce', async () => {
         const mapping = {
             us_client_id: 'us_id',
             eu_client_id: 'eu_id',
@@ -125,31 +125,43 @@ describe('handleAuthorize', () => {
         const request = new Request(
             'https://oauth.posthog.com/oauth/authorize/?client_id=us_id&redirect_uri=http://localhost:3000/callback&response_type=code&state=abc123&_region=eu'
         )
-        await handleAuthorize(request, mockKV)
+        const response = await handleAuthorize(request, mockKV)
+
+        // The outbound state is a proxy nonce, not the client's own state.
+        const location = new URL(response.headers.get('location')!)
+        const nonce = location.searchParams.get('state')!
+        expect(nonce).not.toBe('abc123')
 
         const putCalls = vi.mocked(mockKV.put).mock.calls
 
-        const stateHash = await hashKey('abc123')
         const clientHash = await hashKey('us_id')
+        const nonceHash = await hashKey(nonce)
 
-        // Region selection stored by both state and client_id
-        const regionByState = putCalls.find(([key]) => (key as string) === `region:${stateHash}`)
+        // Region selection stored by client_id only
         const regionByClient = putCalls.find(([key]) => (key as string) === `region:${clientHash}`)
-        expect(regionByState).toBeTruthy()
-        expect(regionByState![1]).toBe('eu')
         expect(regionByClient).toBeTruthy()
         expect(regionByClient![1]).toBe('eu')
 
-        // Callback redirect_uri stored by both state and client_id
-        const callbackByState = putCalls.find(([key]) => (key as string) === `callback:${stateHash}`)
+        // Callback redirect_uri stored by client_id (used by the token exchange)
         const callbackByClient = putCalls.find(([key]) => (key as string) === `callback:${clientHash}`)
-        expect(callbackByState).toBeTruthy()
-        expect(callbackByState![1]).toBe('http://localhost:3000/callback')
         expect(callbackByClient).toBeTruthy()
         expect(callbackByClient![1]).toBe('http://localhost:3000/callback')
+
+        // Flow record stored by the nonce, holding the client's original redirect_uri and state
+        const flowByNonce = putCalls.find(([key]) => (key as string) === `flow:${nonceHash}`)
+        expect(flowByNonce).toBeTruthy()
+        expect(JSON.parse(flowByNonce![1] as string)).toEqual({
+            redirect_uri: 'http://localhost:3000/callback',
+            state: 'abc123',
+        })
+
+        // Nothing is keyed by the client's own state anymore
+        const stateHash = await hashKey('abc123')
+        expect(putCalls.find(([key]) => (key as string) === `region:${stateHash}`)).toBeUndefined()
+        expect(putCalls.find(([key]) => (key as string) === `callback:${stateHash}`)).toBeUndefined()
     })
 
-    it('writes bounded-length KV keys even for very large state values', async () => {
+    it('writes bounded-length KV keys even for very large state values, and holds the state in the flow record', async () => {
         const mapping = {
             us_client_id: 'us_id',
             eu_client_id: 'eu_id',
@@ -171,11 +183,23 @@ describe('handleAuthorize', () => {
         const response = await handleAuthorize(request, mockKV)
 
         expect(response.status).toBe(302)
+
+        // The outbound state is the short proxy nonce, not the large client state.
+        const location = new URL(response.headers.get('location')!)
+        const nonce = location.searchParams.get('state')!
+        expect(nonce).not.toBe(longState)
+        expect(nonce.length).toBeLessThan(100)
+
         const putCalls = vi.mocked(mockKV.put).mock.calls
         expect(putCalls.length).toBeGreaterThan(0)
         for (const [key] of putCalls) {
             expect((key as string).length).toBeLessThanOrEqual(512)
         }
+
+        const nonceHash = await hashKey(nonce)
+        const flowRecord = putCalls.find(([key]) => (key as string) === `flow:${nonceHash}`)
+        expect(flowRecord).toBeTruthy()
+        expect((JSON.parse(flowRecord![1] as string) as { state: string }).state).toBe(longState)
     })
 
     it('passes redirect_uri through without interception for legacy clients (no stored redirect_uris)', async () => {

--- a/services/oauth-proxy/tests/authorize.test.ts
+++ b/services/oauth-proxy/tests/authorize.test.ts
@@ -108,7 +108,7 @@ describe('handleAuthorize', () => {
         expect(data.error_description).toBe('redirect_uri is not registered for this client')
     })
 
-    it('stores region selection and callback redirect_uri keyed by client_id, and a flow record keyed by nonce', async () => {
+    it('stores region selection and callback redirect_uri keyed by client_id, and a pending callback keyed by nonce', async () => {
         const mapping = {
             us_client_id: 'us_id',
             eu_client_id: 'eu_id',
@@ -144,9 +144,9 @@ describe('handleAuthorize', () => {
         expect(callbackByClient).toBeTruthy()
         expect(callbackByClient![1]).toBe('http://localhost:3000/callback')
 
-        const flowByNonce = putCalls.find(([key]) => (key as string) === `flow:${nonceHash}`)
-        expect(flowByNonce).toBeTruthy()
-        expect(JSON.parse(flowByNonce![1] as string)).toEqual({
+        const pendingByNonce = putCalls.find(([key]) => (key as string) === `pending_callback:${nonceHash}`)
+        expect(pendingByNonce).toBeTruthy()
+        expect(JSON.parse(pendingByNonce![1] as string)).toEqual({
             redirect_uri: 'http://localhost:3000/callback',
             state: 'abc123',
         })
@@ -191,9 +191,9 @@ describe('handleAuthorize', () => {
         }
 
         const nonceHash = await hashKey(nonce)
-        const flowRecord = putCalls.find(([key]) => (key as string) === `flow:${nonceHash}`)
-        expect(flowRecord).toBeTruthy()
-        expect((JSON.parse(flowRecord![1] as string) as { state: string }).state).toBe(longState)
+        const pendingCallback = putCalls.find(([key]) => (key as string) === `pending_callback:${nonceHash}`)
+        expect(pendingCallback).toBeTruthy()
+        expect((JSON.parse(pendingCallback![1] as string) as { state: string }).state).toBe(longState)
     })
 
     it('passes redirect_uri through without interception for legacy clients (no stored redirect_uris)', async () => {

--- a/services/oauth-proxy/tests/authorize.test.ts
+++ b/services/oauth-proxy/tests/authorize.test.ts
@@ -127,7 +127,6 @@ describe('handleAuthorize', () => {
         )
         const response = await handleAuthorize(request, mockKV)
 
-        // The outbound state is a proxy nonce, not the client's own state.
         const location = new URL(response.headers.get('location')!)
         const nonce = location.searchParams.get('state')!
         expect(nonce).not.toBe('abc123')
@@ -137,17 +136,14 @@ describe('handleAuthorize', () => {
         const clientHash = await hashKey('us_id')
         const nonceHash = await hashKey(nonce)
 
-        // Region selection stored by client_id only
         const regionByClient = putCalls.find(([key]) => (key as string) === `region:${clientHash}`)
         expect(regionByClient).toBeTruthy()
         expect(regionByClient![1]).toBe('eu')
 
-        // Callback redirect_uri stored by client_id (used by the token exchange)
         const callbackByClient = putCalls.find(([key]) => (key as string) === `callback:${clientHash}`)
         expect(callbackByClient).toBeTruthy()
         expect(callbackByClient![1]).toBe('http://localhost:3000/callback')
 
-        // Flow record stored by the nonce, holding the client's original redirect_uri and state
         const flowByNonce = putCalls.find(([key]) => (key as string) === `flow:${nonceHash}`)
         expect(flowByNonce).toBeTruthy()
         expect(JSON.parse(flowByNonce![1] as string)).toEqual({
@@ -155,7 +151,6 @@ describe('handleAuthorize', () => {
             state: 'abc123',
         })
 
-        // Nothing is keyed by the client's own state anymore
         const stateHash = await hashKey('abc123')
         expect(putCalls.find(([key]) => (key as string) === `region:${stateHash}`)).toBeUndefined()
         expect(putCalls.find(([key]) => (key as string) === `callback:${stateHash}`)).toBeUndefined()
@@ -184,7 +179,6 @@ describe('handleAuthorize', () => {
 
         expect(response.status).toBe(302)
 
-        // The outbound state is the short proxy nonce, not the large client state.
         const location = new URL(response.headers.get('location')!)
         const nonce = location.searchParams.get('state')!
         expect(nonce).not.toBe(longState)

--- a/services/oauth-proxy/tests/callback.test.ts
+++ b/services/oauth-proxy/tests/callback.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { handleCallback } from '@/handlers/callback'
 import { hashKey } from '@/lib/kv'
 
-import { createMockKV, mockKVGet } from './helpers'
+import { createInMemoryKV, createMockKV, mockKVGet } from './helpers'
 
 const mockKV = createMockKV()
 
@@ -12,16 +12,18 @@ beforeEach(() => {
 })
 
 describe('handleCallback', () => {
-    it('redirects to original redirect_uri with code and state', async () => {
-        const stateHash = await hashKey('test_state_123')
+    it("redirects to original redirect_uri with code and the client's original state", async () => {
+        const nonceHash = await hashKey('proxy_nonce_123')
         mockKVGet(mockKV, (key: string) => {
-            if (key === `callback:${stateHash}`) {
-                return Promise.resolve('http://localhost:3000/callback')
+            if (key === `flow:${nonceHash}`) {
+                return Promise.resolve({ redirect_uri: 'http://localhost:3000/callback', state: 'test_state_123' })
             }
             return Promise.resolve(null)
         })
 
-        const request = new Request('https://oauth.posthog.com/oauth/callback/?code=auth_code_abc&state=test_state_123')
+        const request = new Request(
+            'https://oauth.posthog.com/oauth/callback/?code=auth_code_abc&state=proxy_nonce_123'
+        )
         const response = await handleCallback(request, mockKV)
 
         expect(response.status).toBe(302)
@@ -29,6 +31,65 @@ describe('handleCallback', () => {
         expect(location.origin + location.pathname).toBe('http://localhost:3000/callback')
         expect(location.searchParams.get('code')).toBe('auth_code_abc')
         expect(location.searchParams.get('state')).toBe('test_state_123')
+    })
+
+    it('deletes the flow record after reading it, so the nonce is single-use', async () => {
+        const kv = createInMemoryKV()
+        const nonceHash = await hashKey('single_use_nonce')
+        await kv.put(
+            `flow:${nonceHash}`,
+            JSON.stringify({ redirect_uri: 'http://localhost:3000/callback', state: 'orig_state' })
+        )
+
+        const request = new Request(
+            'https://oauth.posthog.com/oauth/callback/?code=auth_code_abc&state=single_use_nonce'
+        )
+        const first = await handleCallback(request, kv)
+        expect(first.status).toBe(302)
+
+        const second = await handleCallback(request, kv)
+        expect(second.status).toBe(400)
+        expect(await second.text()).toBe('State expired or invalid')
+    })
+
+    it('still redirects to the client when deleting the flow record fails', async () => {
+        const nonceHash = await hashKey('delete_fails_nonce')
+        mockKVGet(mockKV, (key: string) => {
+            if (key === `flow:${nonceHash}`) {
+                return Promise.resolve({ redirect_uri: 'http://localhost:3000/callback', state: 'orig_state' })
+            }
+            return Promise.resolve(null)
+        })
+        vi.mocked(mockKV.delete).mockRejectedValue(new Error('KV transient failure'))
+
+        const request = new Request(
+            'https://oauth.posthog.com/oauth/callback/?code=auth_code_abc&state=delete_fails_nonce'
+        )
+        const response = await handleCallback(request, mockKV)
+
+        expect(response.status).toBe(302)
+        const location = new URL(response.headers.get('location')!)
+        expect(location.origin + location.pathname).toBe('http://localhost:3000/callback')
+        expect(location.searchParams.get('code')).toBe('auth_code_abc')
+        expect(location.searchParams.get('state')).toBe('orig_state')
+    })
+
+    it('carries no state param when the flow record has no client state', async () => {
+        const nonceHash = await hashKey('nonce_no_state')
+        mockKVGet(mockKV, (key: string) => {
+            if (key === `flow:${nonceHash}`) {
+                return Promise.resolve({ redirect_uri: 'http://localhost:3000/callback', state: null })
+            }
+            return Promise.resolve(null)
+        })
+
+        const request = new Request('https://oauth.posthog.com/oauth/callback/?code=auth_code_abc&state=nonce_no_state')
+        const response = await handleCallback(request, mockKV)
+
+        expect(response.status).toBe(302)
+        const location = new URL(response.headers.get('location')!)
+        expect(location.searchParams.get('code')).toBe('auth_code_abc')
+        expect(location.searchParams.has('state')).toBe(false)
     })
 
     it('returns 400 when state parameter is missing', async () => {
@@ -39,7 +100,7 @@ describe('handleCallback', () => {
         expect(await response.text()).toBe('Missing state parameter')
     })
 
-    it('returns 400 when state is expired or unknown', async () => {
+    it('returns 400 when the nonce is expired or unknown', async () => {
         mockKVGet(mockKV, () => Promise.resolve(null))
 
         const request = new Request('https://oauth.posthog.com/oauth/callback/?code=auth_code_abc&state=expired_state')
@@ -49,17 +110,17 @@ describe('handleCallback', () => {
         expect(await response.text()).toBe('State expired or invalid')
     })
 
-    it('forwards error params to client redirect_uri', async () => {
-        const stateHash = await hashKey('err_state')
+    it("forwards error params to the client's redirect_uri and restores its original state", async () => {
+        const nonceHash = await hashKey('err_nonce')
         mockKVGet(mockKV, (key: string) => {
-            if (key === `callback:${stateHash}`) {
-                return Promise.resolve('http://localhost:3000/callback')
+            if (key === `flow:${nonceHash}`) {
+                return Promise.resolve({ redirect_uri: 'http://localhost:3000/callback', state: 'client_err_state' })
             }
             return Promise.resolve(null)
         })
 
         const request = new Request(
-            'https://oauth.posthog.com/oauth/callback/?error=access_denied&error_description=User+denied+access&state=err_state'
+            'https://oauth.posthog.com/oauth/callback/?error=access_denied&error_description=User+denied+access&state=err_nonce'
         )
         const response = await handleCallback(request, mockKV)
 
@@ -67,6 +128,6 @@ describe('handleCallback', () => {
         const location = new URL(response.headers.get('location')!)
         expect(location.searchParams.get('error')).toBe('access_denied')
         expect(location.searchParams.get('error_description')).toBe('User denied access')
-        expect(location.searchParams.get('state')).toBe('err_state')
+        expect(location.searchParams.get('state')).toBe('client_err_state')
     })
 })

--- a/services/oauth-proxy/tests/callback.test.ts
+++ b/services/oauth-proxy/tests/callback.test.ts
@@ -15,7 +15,7 @@ describe('handleCallback', () => {
     it("redirects to original redirect_uri with code and the client's original state", async () => {
         const nonceHash = await hashKey('proxy_nonce_123')
         mockKVGet(mockKV, (key: string) => {
-            if (key === `flow:${nonceHash}`) {
+            if (key === `pending_callback:${nonceHash}`) {
                 return Promise.resolve({ redirect_uri: 'http://localhost:3000/callback', state: 'test_state_123' })
             }
             return Promise.resolve(null)
@@ -37,7 +37,7 @@ describe('handleCallback', () => {
         const kv = createInMemoryKV()
         const nonceHash = await hashKey('single_use_nonce')
         await kv.put(
-            `flow:${nonceHash}`,
+            `pending_callback:${nonceHash}`,
             JSON.stringify({ redirect_uri: 'http://localhost:3000/callback', state: 'orig_state' })
         )
 
@@ -55,7 +55,7 @@ describe('handleCallback', () => {
     it('still redirects to the client when deleting the flow record fails', async () => {
         const nonceHash = await hashKey('delete_fails_nonce')
         mockKVGet(mockKV, (key: string) => {
-            if (key === `flow:${nonceHash}`) {
+            if (key === `pending_callback:${nonceHash}`) {
                 return Promise.resolve({ redirect_uri: 'http://localhost:3000/callback', state: 'orig_state' })
             }
             return Promise.resolve(null)
@@ -77,7 +77,7 @@ describe('handleCallback', () => {
     it('carries no state param when the flow record has no client state', async () => {
         const nonceHash = await hashKey('nonce_no_state')
         mockKVGet(mockKV, (key: string) => {
-            if (key === `flow:${nonceHash}`) {
+            if (key === `pending_callback:${nonceHash}`) {
                 return Promise.resolve({ redirect_uri: 'http://localhost:3000/callback', state: null })
             }
             return Promise.resolve(null)
@@ -113,7 +113,7 @@ describe('handleCallback', () => {
     it("forwards error params to the client's redirect_uri and restores its original state", async () => {
         const nonceHash = await hashKey('err_nonce')
         mockKVGet(mockKV, (key: string) => {
-            if (key === `flow:${nonceHash}`) {
+            if (key === `pending_callback:${nonceHash}`) {
                 return Promise.resolve({ redirect_uri: 'http://localhost:3000/callback', state: 'client_err_state' })
             }
             return Promise.resolve(null)

--- a/services/oauth-proxy/tests/helpers.ts
+++ b/services/oauth-proxy/tests/helpers.ts
@@ -10,6 +10,29 @@ export function createMockKV(): KVNamespace {
     } as unknown as KVNamespace
 }
 
+export function createInMemoryKV(): KVNamespace {
+    const store = new Map<string, string>()
+    return {
+        get: vi.fn((key: string, options?: unknown) => {
+            const value = store.get(key)
+            if (value === undefined) {
+                return Promise.resolve(null)
+            }
+            return Promise.resolve(options === 'json' ? JSON.parse(value) : value)
+        }),
+        put: vi.fn((key: string, value: string) => {
+            store.set(key, value)
+            return Promise.resolve(undefined)
+        }),
+        delete: vi.fn((key: string) => {
+            store.delete(key)
+            return Promise.resolve(undefined)
+        }),
+        list: vi.fn(),
+        getWithMetadata: vi.fn(),
+    } as unknown as KVNamespace
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyFn = (...args: any[]) => any
 

--- a/services/oauth-proxy/tests/security.test.ts
+++ b/services/oauth-proxy/tests/security.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+
+import { handleAuthorize } from '@/handlers/authorize'
+import { handleCallback } from '@/handlers/callback'
+import { putClientMapping } from '@/lib/kv'
+
+import { createInMemoryKV } from './helpers'
+
+describe('cross-client state collision', () => {
+    it("does not let a second client's flow steal the first client's authorization code", async () => {
+        const kv = createInMemoryKV()
+
+        await putClientMapping(kv, 'clientA', {
+            us_client_id: 'clientA_us',
+            eu_client_id: 'clientA_eu',
+            redirect_uris: ['https://a.example/cb'],
+            created_at: Date.now(),
+        })
+        await putClientMapping(kv, 'clientB', {
+            us_client_id: 'clientB_us',
+            eu_client_id: 'clientB_eu',
+            redirect_uris: ['https://b.example/cb'],
+            created_at: Date.now(),
+        })
+
+        // Flow A: the victim authorizes with client A, using state "shared".
+        const requestA = new Request(
+            'https://oauth.posthog.com/oauth/authorize/?client_id=clientA&redirect_uri=https://a.example/cb&response_type=code&state=shared&_region=us'
+        )
+        const responseA = await handleAuthorize(requestA, kv)
+        const locationA = new URL(responseA.headers.get('location')!)
+        const stateSentForA = locationA.searchParams.get('state')!
+
+        // Flow B: an attacker registers client B and authorizes with the same state value.
+        const requestB = new Request(
+            'https://oauth.posthog.com/oauth/authorize/?client_id=clientB&redirect_uri=https://b.example/cb&response_type=code&state=shared&_region=us'
+        )
+        await handleAuthorize(requestB, kv)
+
+        // The regional server calls back with the state value the proxy sent for flow A.
+        const callbackRequest = new Request(
+            `https://oauth.posthog.com/oauth/callback/?code=victim_auth_code&state=${stateSentForA}`
+        )
+        const callbackResponse = await handleCallback(callbackRequest, kv)
+
+        expect(callbackResponse.status).toBe(302)
+        const location = new URL(callbackResponse.headers.get('location')!)
+        expect(location.origin + location.pathname).toBe('https://a.example/cb')
+        expect(location.searchParams.get('code')).toBe('victim_auth_code')
+        expect(location.searchParams.get('state')).toBe('shared')
+    })
+})

--- a/services/oauth-proxy/tests/security.test.ts
+++ b/services/oauth-proxy/tests/security.test.ts
@@ -23,7 +23,6 @@ describe('cross-client state collision', () => {
             created_at: Date.now(),
         })
 
-        // Flow A: the victim authorizes with client A, using state "shared".
         const requestA = new Request(
             'https://oauth.posthog.com/oauth/authorize/?client_id=clientA&redirect_uri=https://a.example/cb&response_type=code&state=shared&_region=us'
         )
@@ -31,13 +30,11 @@ describe('cross-client state collision', () => {
         const locationA = new URL(responseA.headers.get('location')!)
         const stateSentForA = locationA.searchParams.get('state')!
 
-        // Flow B: an attacker registers client B and authorizes with the same state value.
         const requestB = new Request(
             'https://oauth.posthog.com/oauth/authorize/?client_id=clientB&redirect_uri=https://b.example/cb&response_type=code&state=shared&_region=us'
         )
         await handleAuthorize(requestB, kv)
 
-        // The regional server calls back with the state value the proxy sent for flow A.
         const callbackRequest = new Request(
             `https://oauth.posthog.com/oauth/callback/?code=victim_auth_code&state=${stateSentForA}`
         )


### PR DESCRIPTION
## Problem

An attacker can receive the authorization code of a user who authorizes an OAuth client through oauth.posthog.com.

- The proxy stored the client's redirect_uri in KV under sha256(state). Any unauthenticated request to /oauth/authorize wrote that key.
- An attacker registers a throwaway client through the proxy and preloads the entry for a state value they choose. They then send a victim an authorize link for a different client that carries that state.
- PKCE makes a stolen code useless in flows the attacker did not start. The attack needs the victim to click Authorize on the attacker's link.

## Changes

- The callback record is keyed by a proxy-generated nonce, and the regional server receives that nonce as state. A person who knows the client's state cannot write the record.
- The callback restores the client's own state. Clients see no difference.
- The record is single-use. KV is eventually consistent, so this is best effort. The authorization code stays single-use at the regional server.
- When the KV delete fails, the callback logs a warning and still redirects.
- Mechanical: the region entry keyed by state had no reader and is removed. The README describes the new key.

> [!NOTE]
> Deploy: a flow that is mid-consent when the worker deploys gets "State expired or invalid" and the client retries. The old state-keyed record is the one an attacker can pre-seed, so the callback does not honor it during its remaining TTL.
>
> The region and callback entries keyed by client_id are unchanged. They stay writable without authentication and can misroute a token exchange for a shared client_id. That is a separate follow-up. Binding the record to a browser cookie at authorize time, as Cloudflare's OAuth guide does, is a further hardening option.

## How did you test this code?

- New test: two clients authorize with the same state value, and the first client's callback still lands at its own redirect_uri. It fails on master.
- New test: the callback still redirects when the KV delete rejects. It fails on master.
- The existing authorize and callback tests use the new key shape. New cases cover clients that send no state and the single-use nonce.
- Not run: a live flow against oauth.posthog.com.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The service README changes in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5.1) with Sonnet sub-agents for the implementation and an adversarial review. Session: https://claude.ai/code/session_0152qKYrkLi5iDCHDb6WRLrr
- Skills invoked: writing-pr-descriptions, unambiguous-agent-text.
- The review pass added the non-fatal delete and the KV consistency caveat. No open PR covers this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0152qKYrkLi5iDCHDb6WRLrr
