### PR TITLE
perf(hogql): match LIKE patterns in linear time

### DIFF
--- a/posthog/hogql/test/test_utils.py
+++ b/posthog/hogql/test/test_utils.py
@@ -1,3 +1,5 @@
+import time
+
 from posthog.test.base import BaseTest
 from unittest import TestCase
 
@@ -343,6 +345,17 @@ class TestLikeMatches(BaseTest):
             f"Python like_matches({pattern!r}, {text!r}) returned {python_result}, "
             f"but ClickHouse returned {clickhouse_result}",
         )
+
+    def test_like_matches_is_linear_for_many_wildcards(self) -> None:
+        # A pattern of N `%` followed by a non-matching char used to translate to N `.*` groups and
+        # backtrack super-linearly against a short text: ~hours of CPU for N=1000 (ReDoS, CWE-1333).
+        # The linear matcher must stay well under a second, so a regex reintroduction hangs this test.
+        pattern = "%" * 1000 + "x"
+        start = time.perf_counter()
+        result = like_matches(pattern, "null")
+        elapsed = time.perf_counter() - start
+        self.assertFalse(result)
+        self.assertLess(elapsed, 2.0, f"like_matches took {elapsed:.2f}s — wildcard matching is not linear")
 
 
 class TestUtils(BaseTest):

--- a/posthog/hogql/utils.py
+++ b/posthog/hogql/utils.py
@@ -1,9 +1,11 @@
-import re
 from dataclasses import fields
 from typing import Any, Union, get_args, get_origin
 
 from posthog.hogql import ast
 from posthog.hogql.ast import AST, AST_CLASSES, Constant, Expr, HogQLXAttribute, HogQLXTag
+
+_LIKE_ANY = object()  # '%' token: matches any run of characters, including empty
+_LIKE_ONE = object()  # '_' token: matches exactly one character
 
 
 def like_matches(pattern: str, text: str) -> bool:
@@ -16,26 +18,52 @@ def like_matches(pattern: str, text: str) -> bool:
     - _ matches exactly one character
     - \\ escapes the next character (\\%, \\_, \\\\)
     - Other characters match literally (case-sensitive)
+
+    Uses a greedy linear-scan matcher (O(len(pattern) * len(text))) rather than a
+    translated regex: a regex with one `.*` per `%` backtracks super-linearly, so a
+    pattern of many `%` against a short text pins a CPU for minutes (ReDoS, CWE-1333).
     """
-    # Convert SQL LIKE pattern to regex
-    regex_parts: list[str] = []
+    tokens: list[object] = []
     i = 0
-    while i < len(pattern):
+    n = len(pattern)
+    while i < n:
         char = pattern[i]
         if char == "%":
-            regex_parts.append(".*")
+            tokens.append(_LIKE_ANY)
         elif char == "_":
-            regex_parts.append(".")
-        elif char == "\\" and i + 1 < len(pattern):
-            # Escape sequence - next char is literal
+            tokens.append(_LIKE_ONE)
+        elif char == "\\" and i + 1 < n:
             i += 1
-            regex_parts.append(re.escape(pattern[i]))
+            tokens.append(pattern[i])
         else:
-            regex_parts.append(re.escape(char))
+            tokens.append(char)
         i += 1
 
-    regex_pattern = f"^{''.join(regex_parts)}$"
-    return bool(re.match(regex_pattern, text, re.DOTALL))
+    # Greedy two-pointer wildcard match: advance through text and tokens together, and
+    # on a mismatch fall back to the most recent `%`, letting it consume one more char.
+    t = 0
+    p = 0
+    star_p = -1
+    star_t = 0
+    tlen = len(text)
+    plen = len(tokens)
+    while t < tlen:
+        if p < plen and (tokens[p] is _LIKE_ONE or tokens[p] == text[t]):
+            t += 1
+            p += 1
+        elif p < plen and tokens[p] is _LIKE_ANY:
+            star_p = p
+            star_t = t
+            p += 1
+        elif star_p != -1:
+            p = star_p + 1
+            star_t += 1
+            t = star_t
+        else:
+            return False
+    while p < plen and tokens[p] is _LIKE_ANY:
+        p += 1
+    return p == plen
 
 
 def ilike_matches(pattern: str, text: str) -> bool:


### PR DESCRIPTION
## Problem

A HogQL query that filters a materialized string property with `LIKE` or `ILIKE` and a pattern carrying many `%` wildcards is slow to plan, before any SQL reaches ClickHouse.

- The materialized-column optimizer probes whether the pattern could match a stored NULL sentinel (`""` or `"null"`).
- It translated the pattern to a regex with one `.*` per `%`, then ran `re.match`.
- That regex backtracks super-linearly against a short text, so planning cost grows steeply with the wildcard count while the pattern itself stays small.

## Changes

- A wildcard-heavy `LIKE`/`ILIKE` filter now plans in linear time instead of stalling. Nothing else about the query changes.
- The regex translation in `like_matches` is replaced with a greedy two-pointer matcher, O(len(pattern) × len(text)). It tokenizes the pattern once (`%`, `_`, `\` escape, literal) and scans text and tokens together.
- `ilike_matches` is unchanged: it still lower-cases both sides and calls `like_matches`.
- No user-visible output changes. Match results are identical; only worst-case planning cost drops.

## How did you test this code?

- Verified the new matcher against every case in the existing ClickHouse-parity suite (`test_like_matches_against_clickhouse`, `test_ilike_matches_against_clickhouse`): escapes, UTF-8 code points, newlines, consecutive wildcards, and case sensitivity all match the previous implementation.
- Added `test_like_matches_is_linear_for_many_wildcards`: a wildcard-heavy pattern must resolve in well under a second. It catches any future change that reintroduces super-linear matching, which the parity cases alone would not.
- `uv run mypy --cache-fine-grained posthog/hogql/utils.py`: clean. `ruff check` / `ruff format`: clean.
- Not run here: the two ClickHouse-backed parity tests need the ClickHouse stack, which this sandbox lacks. Their assertions were reproduced offline against the previous implementation. CI runs them.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by PostHog Desktop (Claude, Opus 4.8), directed by the assignee.
- Skills invoked: `/writing-tests` (to gate the added regression test) and `/writing-pr-descriptions` (for this body).
- Design decision: the probe only ever matches against `""` and `"null"`, so the regex was never needed. A linear matcher removes the amplification at the source; a caller-side length cap was considered and left out because it would change which patterns the optimizer fires on.
- No customer data, tickets, or session material appear in the diff, tests, or this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
