### PR TITLE
fix(analytics-platform): emit insight alert scheduler metrics

### DIFF
--- a/posthog/temporal/alerts/activities.py
+++ b/posthog/temporal/alerts/activities.py
@@ -35,6 +35,7 @@ from posthog.tasks.alerts.utils import (
     skip_because_of_weekend,
 )
 from posthog.temporal.alerts.investigation import claim_investigation_slot, decide_investigation
+from posthog.temporal.alerts.metrics import record_due_alert_metrics
 from posthog.temporal.alerts.types import (
     AlertInfo,
     EvaluateAlertActivityInputs,
@@ -92,7 +93,13 @@ async def retrieve_due_alerts() -> list[AlertInfo]:
             .filter(insight__deleted=False)
             .annotate(_interval_order=calculation_interval_order)
             .order_by("_interval_order", F("next_check_at").asc(nulls_first=True))
-            .only("id", "team_id", "calculation_interval", "insight_id")
+            .only("id", "team_id", "calculation_interval", "insight_id", "next_check_at")
+        )
+
+        due_alerts = list(alerts)
+        record_due_alert_metrics(
+            due_count=len(due_alerts),
+            oldest_due_at=due_alerts[0].next_check_at if due_alerts else None,
         )
 
         return [
@@ -103,7 +110,7 @@ async def retrieve_due_alerts() -> list[AlertInfo]:
                 calculation_interval=a.calculation_interval,
                 insight_id=a.insight_id,
             )
-            for a in alerts
+            for a in due_alerts
         ]
 
     async with Heartbeater():

--- a/posthog/temporal/alerts/metrics.py
+++ b/posthog/temporal/alerts/metrics.py
@@ -1,0 +1,26 @@
+from datetime import UTC, datetime
+
+from prometheus_client import Gauge
+
+
+INSIGHT_ALERTS_DUE_COUNT = Gauge(
+    "posthog_insight_alerts_due_count",
+    "Number of insight alerts due for evaluation",
+)
+INSIGHT_ALERTS_OLDEST_DUE_AGE_SECONDS = Gauge(
+    "posthog_insight_alerts_oldest_due_age_seconds",
+    "Age of the oldest insight alert due for evaluation",
+)
+INSIGHT_ALERTS_SCHEDULER_LAST_POLL_TIMESTAMP_SECONDS = Gauge(
+    "posthog_insight_alerts_scheduler_last_poll_timestamp_seconds",
+    "Unix timestamp of the last successful insight alert scheduler poll",
+)
+
+
+def record_due_alert_metrics(*, due_count: int, oldest_due_at: datetime | None) -> None:
+    now = datetime.now(UTC)
+    INSIGHT_ALERTS_DUE_COUNT.set(due_count)
+    INSIGHT_ALERTS_OLDEST_DUE_AGE_SECONDS.set(
+        max(0, (now - oldest_due_at).total_seconds()) if oldest_due_at else 0
+    )
+    INSIGHT_ALERTS_SCHEDULER_LAST_POLL_TIMESTAMP_SECONDS.set(now.timestamp())

--- a/posthog/temporal/tests/test_alerts_activities.py
+++ b/posthog/temporal/tests/test_alerts_activities.py
@@ -41,6 +41,7 @@ from posthog.temporal.alerts.activities import (
     notify_alert,
     prepare_alert,
     record_failed_evaluation,
+    retrieve_due_alerts,
 )
 from posthog.temporal.alerts.retry_policy import alert_timeouts
 from posthog.temporal.alerts.types import (
@@ -189,6 +190,21 @@ async def _create_alert_check(
         )
 
     return await _create()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+class TestRetrieveDueAlerts:
+    async def test_records_due_alert_metrics(self, ateam) -> None:
+        oldest_due_at = datetime(2026, 9, 9, 11, tzinfo=UTC)
+        await _create_alert(ateam, next_check_at=oldest_due_at)
+        await _create_alert(ateam, next_check_at=datetime(2026, 9, 9, 12, tzinfo=UTC))
+
+        with patch("posthog.temporal.alerts.activities.record_due_alert_metrics") as record_metrics:
+            alerts = await ActivityEnvironment().run(retrieve_due_alerts)
+
+        assert len(alerts) == 2
+        record_metrics.assert_called_once_with(due_count=2, oldest_due_at=oldest_due_at)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

- **Why:** On-call alerts need a current signal when insight alert checks become overdue.
- The alert rules reference scheduler metrics that the worker does not emit.

## Changes

- The scheduler now reports the due-alert count, oldest due age, and last successful poll time.
- The metrics update only after the due-alert query completes successfully.
- The new test checks that due alerts report both count and oldest due time.

```mermaid
flowchart LR
  Worker{{Scheduler worker}} --> Query[Due-alert query]
  Query --> Alerts[Alert checks]
  classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
  classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
  class Worker phBlue;
  class Query,Alerts phYellow;
```

```mermaid
flowchart LR
  Worker{{Scheduler worker}} --> Query[Due-alert query]
  Query --> Metrics[Scheduler metrics]
  Query --> Alerts[Alert checks]
  Metrics --> Monitoring[Alert rules]
  classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
  classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
  class Worker phBlue;
  class Query,Alerts,Metrics,Monitoring phYellow;
```

## How did you test this code?

- The Temporal activity test checks a due-alert query with multiple due alerts.
- The test checks that the oldest due time and total count reach the metric recorder.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No user-facing documentation changes.

## 🤖 Agent context

- **Autonomy:** Human-driven (agent-assisted)
- Codex added the metric producer after a QA review found that the alert rules lacked source metrics.
- Skills used: `instrumenting-first-party-metrics`, `writing-pr-descriptions`.
- The open-issue search found no matching issue.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*