### PR TITLE
fix(aio): populate playground from trace data

### DIFF
--- a/products/ai_observability/frontend/AIObservabilityTraceScene.tsx
+++ b/products/ai_observability/frontend/AIObservabilityTraceScene.tsx
@@ -1568,13 +1568,12 @@ const EventContent = React.memo(
         // Check if we're viewing a trace with actual content vs. a pseudo-trace (grouping of generations w/o input/output state)
         const isTopLevelTraceWithoutContent = !event || (!isLLMEvent(event) && !event.inputState && !event.outputState)
 
-        // Only pre-load for generation events ($ai_input/$ai_output_choices).
         // TODO: Figure out why spans can't load properties async
         const eventData = isGenerationEvent
             ? {
                   uuid: event.id,
                   input: event.properties.$ai_input,
-                  output: selectAiValue(event.properties.$ai_output_choices, event.properties.$ai_output),
+                  output: event.properties.$ai_output_choices,
                   tools: event.properties.$ai_tools,
                   traceId: trace.id,
                   timestamp: event.createdAt,
@@ -1594,7 +1593,8 @@ const EventContent = React.memo(
 
             const model = event.properties.$ai_model
             const provider = event.properties.$ai_provider
-            openInPlayground({ model, provider, input: loadedInput, output: loadedOutput, tools: loadedTools })
+            const output = selectAiValue(loadedOutput, event.properties.$ai_output)
+            openInPlayground({ model, provider, input: loadedInput, output, tools: loadedTools })
         }
 
         return (

--- a/products/ai_observability/frontend/AIObservabilityTraceScene.tsx
+++ b/products/ai_observability/frontend/AIObservabilityTraceScene.tsx
@@ -50,6 +50,7 @@ import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
 import { IconWithCount } from 'lib/lemon-ui/icons/icons'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
+import { isObject } from 'lib/utils/guards'
 import { identifierToHuman, pluralize } from 'lib/utils/strings'
 import { InsightEmptyState, InsightErrorState } from 'scenes/insights/EmptyStates'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
@@ -1574,10 +1575,18 @@ const EventContent = React.memo(
             ? {
                   uuid: event.id,
                   input: event.properties.$ai_input,
-                  output: event.properties.$ai_output_choices,
+                  output: selectAiValue(event.properties.$ai_output_choices, event.properties.$ai_output),
+                  tools: event.properties.$ai_tools,
+                  traceId: trace.id,
+                  timestamp: event.createdAt,
               }
             : undefined
-        const { input: loadedInput, output: loadedOutput } = useAIData(eventData)
+        const {
+            input: loadedInput,
+            output: loadedOutput,
+            tools: loadedTools,
+            isLoading: aiDataLoading,
+        } = useAIData(eventData)
 
         const handleOpenInPlayground = (): void => {
             if (!event || !isLLMEvent(event)) {
@@ -1586,8 +1595,7 @@ const EventContent = React.memo(
 
             const model = event.properties.$ai_model
             const provider = event.properties.$ai_provider
-            const tools = event.properties.$ai_tools
-
+            const tools = Array.isArray(loadedTools) && loadedTools.every(isObject) ? loadedTools : undefined
             openInPlayground({ model, provider, input: loadedInput, output: loadedOutput, tools })
         }
 
@@ -1697,6 +1705,7 @@ const EventContent = React.memo(
                                             size="xsmall"
                                             icon={<IconPlay />}
                                             onClick={handleOpenInPlayground}
+                                            loading={aiDataLoading}
                                             tooltip="Open in Playground"
                                             data-attr="llma-playground-open-from-trace"
                                         >

--- a/products/ai_observability/frontend/AIObservabilityTraceScene.tsx
+++ b/products/ai_observability/frontend/AIObservabilityTraceScene.tsx
@@ -50,7 +50,6 @@ import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
 import { IconWithCount } from 'lib/lemon-ui/icons/icons'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
-import { isObject } from 'lib/utils/guards'
 import { identifierToHuman, pluralize } from 'lib/utils/strings'
 import { InsightEmptyState, InsightErrorState } from 'scenes/insights/EmptyStates'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
@@ -1595,8 +1594,7 @@ const EventContent = React.memo(
 
             const model = event.properties.$ai_model
             const provider = event.properties.$ai_provider
-            const tools = Array.isArray(loadedTools) && loadedTools.every(isObject) ? loadedTools : undefined
-            openInPlayground({ model, provider, input: loadedInput, output: loadedOutput, tools })
+            openInPlayground({ model, provider, input: loadedInput, output: loadedOutput, tools: loadedTools })
         }
 
         return (

--- a/products/ai_observability/frontend/playground/llmPlaygroundLogic.test.ts
+++ b/products/ai_observability/frontend/playground/llmPlaygroundLogic.test.ts
@@ -870,6 +870,10 @@ describe('llmPlaygroundLogic', () => {
                     { type: 'function', function: { name: 'search', description: 'Search tool' } },
                     { type: 'function', function: { name: 'calculator', description: 'Math tool' } },
                 ],
+                [
+                    { type: 'function', function: { name: 'search', description: 'Search tool' } },
+                    { type: 'function', function: { name: 'calculator', description: 'Math tool' } },
+                ],
             ],
             [
                 'a dictionary',
@@ -877,14 +881,28 @@ describe('llmPlaygroundLogic', () => {
                     search: { type: 'function', function: { name: 'search', description: 'Search tool' } },
                     calculator: { type: 'function', function: { name: 'calculator', description: 'Math tool' } },
                 },
+                [
+                    { type: 'function', function: { name: 'search', description: 'Search tool' } },
+                    { type: 'function', function: { name: 'calculator', description: 'Math tool' } },
+                ],
             ],
-        ])('should handle tools parameter as %s', (_, tools) => {
+            [
+                'a single tool object',
+                { type: 'function', function: { name: 'search', description: 'Search tool' } },
+                [{ type: 'function', function: { name: 'search', description: 'Search tool' } }],
+            ],
+            [
+                'a provider container',
+                { functionDeclarations: [{ name: 'search', description: 'Search tool' }] },
+                [{ functionDeclarations: [{ name: 'search', description: 'Search tool' }] }],
+            ],
+        ])('should handle tools parameter as %s', (_, tools, expectedTools) => {
             llmPlaygroundPromptsLogic.actions.setupPlaygroundFromEvent({
                 input: 'Test',
                 tools,
             })
 
-            expect(llmPlaygroundPromptsLogic.values.tools).toEqual(Array.isArray(tools) ? tools : Object.values(tools))
+            expect(llmPlaygroundPromptsLogic.values.tools).toEqual(expectedTools)
         })
 
         it('should default messages with unknown roles to user', () => {

--- a/products/ai_observability/frontend/playground/llmPlaygroundLogic.test.ts
+++ b/products/ai_observability/frontend/playground/llmPlaygroundLogic.test.ts
@@ -863,18 +863,28 @@ describe('llmPlaygroundLogic', () => {
             expect(llmPlaygroundPromptsLogic.values.messages[0].content).toContain('123')
         })
 
-        it('should handle tools parameter', () => {
-            const tools = [
-                { type: 'function', function: { name: 'search', description: 'Search tool' } },
-                { type: 'function', function: { name: 'calculator', description: 'Math tool' } },
-            ]
-
+        it.each([
+            [
+                'an array',
+                [
+                    { type: 'function', function: { name: 'search', description: 'Search tool' } },
+                    { type: 'function', function: { name: 'calculator', description: 'Math tool' } },
+                ],
+            ],
+            [
+                'a dictionary',
+                {
+                    search: { type: 'function', function: { name: 'search', description: 'Search tool' } },
+                    calculator: { type: 'function', function: { name: 'calculator', description: 'Math tool' } },
+                },
+            ],
+        ])('should handle tools parameter as %s', (_, tools) => {
             llmPlaygroundPromptsLogic.actions.setupPlaygroundFromEvent({
                 input: 'Test',
                 tools,
             })
 
-            expect(llmPlaygroundPromptsLogic.values.tools).toEqual(tools)
+            expect(llmPlaygroundPromptsLogic.values.tools).toEqual(Array.isArray(tools) ? tools : Object.values(tools))
         })
 
         it('should default messages with unknown roles to user', () => {

--- a/products/ai_observability/frontend/playground/llmPlaygroundPromptsLogic.ts
+++ b/products/ai_observability/frontend/playground/llmPlaygroundPromptsLogic.ts
@@ -73,8 +73,14 @@ export interface PlaygroundSetupPayload {
 }
 
 function normalizePlaygroundTools(tools: unknown): Record<string, unknown>[] | undefined {
-    const values = Array.isArray(tools) ? tools : isObject(tools) ? Object.values(tools) : undefined
-    return values?.every(isObject) ? values : undefined
+    if (Array.isArray(tools)) {
+        return tools.every(isObject) ? tools : undefined
+    }
+    if (!isObject(tools)) {
+        return undefined
+    }
+    const values = Object.values(tools)
+    return values.every(isObject) ? values : [tools]
 }
 
 export const DEFAULT_SYSTEM_PROMPT = 'You are a helpful AI assistant.'

--- a/products/ai_observability/frontend/playground/llmPlaygroundPromptsLogic.ts
+++ b/products/ai_observability/frontend/playground/llmPlaygroundPromptsLogic.ts
@@ -69,7 +69,12 @@ export interface PlaygroundSetupPayload {
     sourceEvaluationId?: string
     input?: unknown
     output?: unknown
-    tools?: Record<string, unknown>[]
+    tools?: unknown
+}
+
+function normalizePlaygroundTools(tools: unknown): Record<string, unknown>[] | undefined {
+    const values = Array.isArray(tools) ? tools : isObject(tools) ? Object.values(tools) : undefined
+    return values?.every(isObject) ? values : undefined
 }
 
 export const DEFAULT_SYSTEM_PROMPT = 'You are a helpful AI assistant.'
@@ -1180,7 +1185,8 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
                 source_type: sourceType ?? 'unknown',
             })
             actions.setSourceSetupLoading(true)
-            const { input, tools, systemPrompt } = payload
+            const { input, systemPrompt } = payload
+            const tools = normalizePlaygroundTools(payload.tools)
             const currentPrompt = values.promptConfigs[0] ?? createPromptConfig({ id: INITIAL_PROMPT.id })
             const promptId = currentPrompt.id
 


### PR DESCRIPTION
## Problem

People opening an AI generation from a trace can reach Playground with empty input messages when the generation data uses heavy properties.

The trace scene only forwarded inline previews and omitted the coordinates needed to load the full generation data.

## Changes

- Playground now opens with the full trace input, output, and tools after heavy properties finish loading.
- Playground preserves array, keyed dictionary, single-object, and provider-container tool catalogs.
- The standard output fallback no longer skips the heavy-property lookup.
- No screenshot: the existing button only uses its standard transient loading state, with no layout change.

## How did you test this code?

- `aiObservabilityAIDataLogic.test.ts` covers heavy-property loading and fallback behavior.
- `llmPlaygroundLogic.test.ts` covers message parsing and the supported tool catalog shapes.
- Browser QA in a `hogli devbox` confirmed the heavy-property lookup and populated Playground messages with invented fixtures.
- The isolated worktree could not complete the full typecheck because Quill packages were not built. CI runs the complete check.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update is needed because the fix restores the existing Playground workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- RAS Code used `hogli devbox`, browser QA, and a seven-lens self-review swarm.
- Skills: `/hogli`, `/setting-up-devbox`, `/run-posthog`, `/qa-frontend`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, `/rs-ship`, `/rs-pr-shepherd`, `/rs-review-swarm`, `/rs-update-pr`, and `/rs-tone`.
- Duplicate search: no open PR matched this fix.
- Coverage: focused logic tests cover loaded data and tool normalization, while browser QA covers the scene wiring.
- Public artifact: all browser fixtures are invented, and no private trace content or identifiers appear.