### PR TITLE
chore(devex): install the coderabbit cli on flox activate

### DIFF
--- a/.agents/skills/reviewing-with-coderabbit/SKILL.md
+++ b/.agents/skills/reviewing-with-coderabbit/SKILL.md
@@ -31,13 +31,18 @@ The correct outcome is a PR that opens without a local pass.
 
 ## Setup
 
+Flox activation installs the pinned CLI and puts `coderabbit` and `cr` on PATH.
+Sign in once per machine:
+
 ```sh
-brew install coderabbit          # or: curl -fsSL https://cli.coderabbit.ai/install.sh | sh
 cr auth login                    # opens a browser; use the @posthog.com account
 cr auth status                   # confirms the session and the organization
 ```
 
 `cr doctor` reports what is wrong and exits non-zero when a check fails.
+
+Outside flox, install it by hand with `brew install coderabbit`.
+An activation that failed to install the CLI prints a warning and keeps the previous version, and retries on the next activation.
 
 ## The flow
 

--- a/.flox/env/on-activate.sh
+++ b/.flox/env/on-activate.sh
@@ -370,6 +370,70 @@ if [[ "$_PHROCS_SKIP" -eq 0 ]]; then
   _BG_PHROCS_START=$(date +%s)
 fi
 
+# CodeRabbit CLI: machine-global, version-addressed store. The CLI ships as a
+# binary release rather than a flox catalog package, and the
+# reviewing-with-coderabbit skill needs it before `gh pr create`. One download
+# per machine per pinned version serves every checkout and survives .flox/cache
+# wipes; each activation only ensures the version and symlinks it into the venv
+# bin (Step 2b), so worktrees on different branches resolve their own pin.
+# A failed install must not break activation: the CLI is only needed at PR-open
+# time, and the skill opens the PR without a local review when it is absent.
+# The vendor install script stays unused on purpose. It appends a PATH export to
+# the user's shell profile whenever its target directory is off PATH, and this
+# store is off PATH by design.
+_CODERABBIT_VERSION="0.7.6"
+_CODERABBIT_STORE="$HOME/.config/posthog/tools/coderabbit/$_CODERABBIT_VERSION"
+_CODERABBIT_BIN="$_CODERABBIT_STORE/coderabbit"
+_CODERABBIT_STAMP="$_CODERABBIT_STORE/.complete"
+
+_install_coderabbit() {
+  # Explicit `|| return`/`|| exit`: callers suppress errexit, so a failed
+  # install would otherwise fall through and stamp the broken state.
+  local os arch url
+  command -v unzip >/dev/null 2>&1 || return 1
+  case "$(uname -s)" in
+    Darwin) os="darwin" ;;
+    Linux) os="linux" ;;
+    *) return 1 ;;
+  esac
+  case "$(uname -m)" in
+    x86_64 | amd64) arch="x64" ;;
+    arm64 | aarch64) arch="arm64" ;;
+    *) return 1 ;;
+  esac
+  # The release path carries no leading "v", unlike the vendor script's example.
+  url="https://cli.coderabbit.ai/releases/$_CODERABBIT_VERSION/coderabbit-$os-$arch.zip"
+  mkdir -p "$_CODERABBIT_STORE" || return 1
+  (
+    # The store is shared across checkouts, so serialize concurrent
+    # activations (fresh worktrees) installing the same version.
+    flock 9 || exit 1
+    if [[ ! -x "$_CODERABBIT_BIN" || ! -f "$_CODERABBIT_STAMP" ]]; then
+      local tmp
+      tmp=$(mktemp -d) || exit 1
+      trap 'rm -rf "$tmp"' EXIT
+      curl -fsSL "$url" -o "$tmp/coderabbit.zip" || exit 1
+      unzip -qo "$tmp/coderabbit.zip" -d "$tmp" || exit 1
+      [[ -f "$tmp/coderabbit" ]] || exit 1
+      chmod +x "$tmp/coderabbit" || exit 1
+      # Move the binary into place before the stamp, so an interrupted install
+      # leaves no stamped store.
+      mv -f "$tmp/coderabbit" "$_CODERABBIT_BIN" || exit 1
+      touch "$_CODERABBIT_STAMP" || exit 1
+    fi
+  ) 9>"$_CODERABBIT_STORE/.install.lock"
+}
+
+_CODERABBIT_SKIP=0
+[[ -x "$_CODERABBIT_BIN" && -f "$_CODERABBIT_STAMP" ]] && _CODERABBIT_SKIP=1
+if [[ "$_CODERABBIT_SKIP" -eq 0 ]]; then
+  _BG_CODERABBIT_LOG=$(mktemp)
+  _ACTIVATION_TMPFILES+=("$_BG_CODERABBIT_LOG")
+  ( _install_coderabbit ) >"$_BG_CODERABBIT_LOG" 2>&1 &
+  _BG_CODERABBIT_PID=$!
+  _BG_CODERABBIT_START=$(date +%s)
+fi
+
 # ── Step 1: Python packages (must run before hogli — it needs Click) ─
 if [[ "$_UV_SKIP" -eq 1 ]]; then
   done_step "Python packages (cached)"
@@ -420,6 +484,18 @@ if [[ "$_PNPM_SKIP" -eq 1 ]]; then
   done_step "Node packages (cached)"
 else
   wait_bg_step "Node packages" "$_BG_PNPM_PID" "$_BG_PNPM_START" "$_BG_PNPM_LOG"
+fi
+
+# ── Step 2b: CodeRabbit CLI (reap; launched above with the other jobs) ──
+if [[ "$_CODERABBIT_SKIP" -eq 1 ]]; then
+  done_step "CodeRabbit CLI (cached)"
+else
+  wait_bg_step "CodeRabbit CLI" "$_BG_CODERABBIT_PID" "$_BG_CODERABBIT_START" "$_BG_CODERABBIT_LOG" \
+    || warn_step "CodeRabbit CLI install failed  ${C_DIM}(reviews skip until it installs)${C_RESET}"
+fi
+if [[ -x "$_CODERABBIT_BIN" && -d "$UV_PROJECT_ENVIRONMENT/bin" ]]; then
+  ln -sf "$_CODERABBIT_BIN" "$UV_PROJECT_ENVIRONMENT/bin/coderabbit"
+  ln -sf "$_CODERABBIT_BIN" "$UV_PROJECT_ENVIRONMENT/bin/cr"
 fi
 
 # ── Step 3: /etc/hosts ──────────────────────────────────────────────


### PR DESCRIPTION
## Problem

An engineer with this stack's lower layer merged still gets no CodeRabbit review before `gh pr create`, because nobody has the CLI installed.

- #97510 makes `/reviewing-with-coderabbit` always-invoke, and the skill stops when the CLI is absent. On a machine without it, every review silently takes that stop path.
- A reader of a PR cannot tell a review that was skipped from one that was never possible.
- The CLI ships as a binary release, so it is not in the flox catalog and no existing step installs it.

## Changes

- `cr` and `coderabbit` are on PATH after a flox activation, so the pre-PR review runs instead of skipping.
- The pinned version lands in a machine-shared, version-addressed store at `~/.config/posthog/tools/coderabbit/<version>`. Every checkout symlinks the same binary into the venv bin, so a new worktree skips the download and a `.flox/cache` wipe keeps it.
- A `flock` serializes concurrent activations, so two fresh worktrees cannot corrupt one store.
- A failed install prints a warning, writes no stamp, and retries on the next activation. Activation still succeeds, because the CLI is only needed at PR-open time.
- The download is about 65 MB, once per machine per pinned version. It runs in the background with the other install jobs and is reaped at Step 2b.
- The vendor install script stays unused. It appends a `PATH` export to the user's shell profile whenever its target directory is off `PATH`, and a version-addressed store is off `PATH` by design. This block downloads and unzips the release directly instead.
- The skill's setup section now points at flox rather than a manual `brew install`.
- Nothing here changes what a user of PostHog sees.

> [!NOTE]
> The release path carries no leading `v`. The vendor script's own usage comment shows `CODERABBIT_VERSION=v1.2.3`, and that form returns 404.

## How did you test this code?

The install function was exercised standalone, against a throwaway store, by extracting it from `on-activate.sh`:

<details>
<summary>Results</summary>

| Case | Result |
| --- | --- |
| First install | exit 0 in 1.4 s, `coderabbit --version` prints `0.7.6` |
| Second call | exit 0 in 7 ms, no download |
| Three concurrent calls | one binary, one stamp, `flock` serialized them |
| Pinned version that does not exist | exit 1, no stamp, no binary, only the lock file remains |

</details>

- All four published builds resolve: `darwin-arm64`, `darwin-x64`, `linux-arm64`, `linux-x64` at `0.7.6`.
- `bash -n` passes. `shellcheck -S warning` reports one finding, at line 39, which predates this change.
- Not run: a real `flox activate`. Interactive activation hangs in this session, per AGENTS.md. The block's placement among the background jobs and its reap step follow the pattern the removed Greptile install used, but the end-to-end activation is unverified.
- No new tests. `on-activate.sh` has no test harness, and the removed Greptile equivalent had none either.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The change is developer environment setup, and the matching agent guidance lives in the skill this stack's lower layer adds.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code (Opus 5), directed by the assignee.
- Skills invoked: `/stacking-prs`, `/writing-pr-descriptions`.
- The assignee asked whether #97510 installed the CLI. It did not, which is the gap this layer closes.
- #88409 installed the Greptile CLI the same way and #90504 removed all 57 lines. This block follows its store, lock, stamp, and symlink structure, and drops the npm and dev-sandbox parts, because a direct download runs no third-party code.
- Stacked rather than folded into #97510: the diff surfaces barely overlap, and `docs/internal/ci-things-already-tried.md` advises dividing by diff surface. The one shared file is the skill's setup section.
- Public artifact: nothing here draws on material that is not already public.
