### PR TITLE
fix(api): log the api query budget refusals through a logger that is not clamped to warning

### DIFF
--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -179,6 +179,9 @@ from products.access_control.backend.facade.user_access_control import (
 from products.web_analytics.backend.hogql_queries.first_pageview_flag import resolve_first_pageview_filters_modifier
 
 logger = structlog.get_logger(__name__)
+# Named so posthog/settings/logs.py can opt it into INFO: the posthoganalytics SDK clamps the
+# "posthog" logger tree to WARNING, which would drop the budget line under __name__.
+budget_logger = structlog.get_logger("posthog.api_queries_budget")
 
 QUERY_EXECUTION_TOTAL = Counter(
     "posthog_query_execution_total",
@@ -2537,7 +2540,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         enforced = _api_queries_budget_enforcement_enabled(self.team)
         outcome = "enforced" if enforced else "observed"
         API_QUERIES_BUDGET_LIMITED_COUNTER.labels(outcome=outcome).inc()
-        logger.info(
+        budget_logger.info(
             "api_queries_budget_limited",
             organization_id=str(self.team.organization_id),
             team_id=self.team.pk,

--- a/posthog/settings/logs.py
+++ b/posthog/settings/logs.py
@@ -177,6 +177,8 @@ LOGGING: dict[str, Any] = {
         # at client init, so the source-registry prewarm's INFO lifecycle logs need an
         # explicit level to be visible.
         "posthog.warehouse_source_prewarm": {"level": "INFO", "handlers": ["console"], "propagate": False},
+        # Same clamp: the api query budget logs the team and balance behind every would-be 429 at INFO.
+        "posthog.api_queries_budget": {"level": "INFO", "handlers": ["console"], "propagate": False},
         "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.load": {
             "level": "DEBUG",
             "handlers": ["console"],


### PR DESCRIPTION
## Problem

The `api_queries_budget_limited` log line, which names the team and balance behind every would-be 429, never reaches Loki. The posthoganalytics SDK clamps the `posthog` logger tree to WARNING at client init, and the query runner logs the line at INFO under its module name. The counters and the balance histogram work, so shadow mode shows how many checks would be refused, but not which teams.

## Changes

- The budget line logs through a dedicated `posthog.api_queries_budget` logger, opted into INFO in the logging config the same way `posthog.warehouse_source_prewarm` is.
- Nothing else changes: the metrics, the 429, and the headers are untouched.

## How did you test this code?

- `posthog/hogql_queries/test/test_api_queries_budget.py` still passes. The change is a logger name and a config entry, and the first shadow-mode line in Loki after deploy is the check.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5.1) found the gap while checking https://github.com/PostHog/posthog/pull/95375 in production, session https://claude.ai/code/session_01FqmSQ8ar12jzR6e6MM5v3K. Skills invoked: /writing-code-comments, /writing-pr-descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqmSQ8ar12jzR6e6MM5v3K