### PR TITLE
fix(hogvm): run match and extractRegex on re2

### DIFF
--- a/common/hogvm/python/stl/__init__.py
+++ b/common/hogvm/python/stl/__init__.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, Optional
 import pytz
 
 from ..objects import is_hog_callable, is_hog_closure, is_hog_error, new_hog_error, to_hog_interval
-from ..utils import HogVMException, _require_string, get_nested_value, like
+from ..utils import HogVMException, _compile_regex, _require_string, get_nested_value, like, regex_extract
 from .crypto import md5, sha1, sha1HmacChain, sha256, sha256HmacChain
 from .date import (
     formatDateTime,
@@ -273,7 +273,6 @@ def decodeURLComponent(args: list[Any], team: Optional["Team"], stdout: Optional
 def tryDecodeURLComponent(
     args: list[Any], team: Optional["Team"], stdout: Optional[list[str]], timeout: float
 ) -> Optional[str]:
-    import re
     import urllib.parse
 
     s = args[0]
@@ -947,37 +946,15 @@ def multiSearchAnyCaseInsensitive(args: list[Any], team, stdout, timeout):
 
 
 def extractRegex(args: list[Any], team: Optional["Team"], stdout: Optional[list[str]], timeout: float) -> str:
-    """
-    Extract substring matching a regex pattern.
-    Matches ClickHouse extract(haystack, pattern) behavior:
-    - Returns first capture group if pattern has groups
-    - Returns whole match if no capture groups
-    - Returns empty string if no match
-    """
-    if args[0] is None or args[1] is None:
-        return ""
-    haystack = str(args[0])
-    pattern = str(args[1])
-    try:
-        match = re.search(pattern, haystack)
-        if not match:
-            return ""
-        if match.lastindex and match.lastindex >= 1:
-            return match.group(1) or ""
-        return match.group(0) or ""
-    except re.error:
-        return ""
+    return regex_extract(args[0], args[1])
 
 
 def match(args: list[Any], team: Optional["Team"], stdout: Optional[list[str]], timeout: float) -> bool:
-    if args[1] is None or args[0] is None:
+    if args[0] is None or args[1] is None:
         return False
     input_string = _require_string(args[0], "input", "match")
     pattern = _require_string(args[1], "pattern", "match")
-    try:
-        return re.search(pattern, input_string) is not None
-    except re.error as e:
-        raise HogVMException(f"Invalid regex pattern: {e}") from e
+    return _compile_regex(pattern).search(input_string) is not None
 
 
 STL: dict[str, STLFunction] = {

--- a/common/hogvm/python/test/test_execute.py
+++ b/common/hogvm/python/test/test_execute.py
@@ -1215,12 +1215,13 @@ class TestBytecodeExecute:
             ("extractRegex", ""),
         ]
     )
-    def test_regex_functions_run_in_linear_time(self, fn_name, expected):
+    def test_regex_functions_run_in_linear_time(self, fn_name: str, expected: bool | str) -> None:
         # Python's re engine needs exponential time on this pattern, so this pins the engine choice.
+        # CPU time rather than wall clock, so a paused runner cannot fail the assertion on its own.
         subject = "a" * 26 + "!"
-        start = time.time()
+        start = time.process_time()
         result = STL[fn_name].fn([subject, "(a+)+$"], None, None, 5.0)
-        elapsed = time.time() - start
+        elapsed = time.process_time() - start
         assert result == expected
         assert elapsed < 1.0
 

--- a/common/hogvm/python/test/test_execute.py
+++ b/common/hogvm/python/test/test_execute.py
@@ -1205,6 +1205,10 @@ class TestBytecodeExecute:
         assert self._run("extractRegex(null, '\\\\w+')") == ""
         assert self._run("extractRegex('hello', null)") == ""
 
+        # A pattern with a group that captured nothing still returns the group, not the whole match
+        assert self._run("extractRegex('b', '(a)?b')") == ""
+        assert self._run("extractRegex('b', '(?:(a)|b)')") == ""
+
         # Complex pattern like ClickHouse sortableSemver uses
         assert self._run("extractRegex('v1.2.3-alpha', '(\\\\d+(\\\\.\\\\d+)+)')") == "1.2.3"
         assert self._run("extractRegex('version 10.20.30', '(\\\\d+(\\\\.\\\\d+)+)')") == "10.20.30"

--- a/common/hogvm/python/test/test_execute.py
+++ b/common/hogvm/python/test/test_execute.py
@@ -1225,6 +1225,21 @@ class TestBytecodeExecute:
         assert result == expected
         assert elapsed < 1.0
 
+    @parameterized.expand(
+        [
+            ("extractRegex", "café", r"\w+", "caf"),
+            ("extractRegex", "日本語", r"\w+", ""),
+            ("match", "Müller", r"^\w+$", False),
+            ("match", "١٢٣", r"\d+", False),
+        ]
+    )
+    def test_regex_character_classes_are_ascii_only(
+        self, fn_name: str, subject: str, pattern: str, expected: bool | str
+    ) -> None:
+        # The linear-time test cannot pin this, because another linear-time engine could restore the
+        # Unicode classes and still run fast. Python's re engine gives "café", a match, and true here.
+        assert STL[fn_name].fn([subject, pattern], None, None, 5.0) == expected
+
     def test_sortable_semver(self):
         # Basic semver parsing
         assert self._run("sortableSemver('1.2.3')") == [1, 2, 3]

--- a/common/hogvm/python/test/test_execute.py
+++ b/common/hogvm/python/test/test_execute.py
@@ -1,4 +1,5 @@
 import json
+import time
 from collections.abc import Callable
 from typing import Any, Optional, cast
 
@@ -86,7 +87,6 @@ class TestBytecodeExecute:
         assert self._run("match('test', 'x.*')") is False
         assert self._run("match('test', '')") is True
         assert self._run("match('', '')") is True
-        assert self._run("match('ab', '(?<=a)b')") is True
         assert self._run("'test' =~ 'e.*'") is True
         assert self._run("'test' !~ 'e.*'") is False
         assert self._run("'test' =~ '^e.*'") is False
@@ -118,6 +118,7 @@ class TestBytecodeExecute:
         [
             ("function_list_input", "match(['tool_call'], 'tool')", {}, "Function match requires input"),
             ("function_invalid_pattern", "match('tool_call', '[')", {}, "Invalid regex pattern"),
+            ("function_lookbehind_unsupported", "match('ab', '(?<=a)b')", {}, "Invalid regex pattern"),
             ("operator_list_input", "['tool_call'] =~ 'tool'", {}, "Function match requires input"),
             (
                 "operator_invalid_pattern",
@@ -1207,6 +1208,21 @@ class TestBytecodeExecute:
         # Complex pattern like ClickHouse sortableSemver uses
         assert self._run("extractRegex('v1.2.3-alpha', '(\\\\d+(\\\\.\\\\d+)+)')") == "1.2.3"
         assert self._run("extractRegex('version 10.20.30', '(\\\\d+(\\\\.\\\\d+)+)')") == "10.20.30"
+
+    @parameterized.expand(
+        [
+            ("match", False),
+            ("extractRegex", ""),
+        ]
+    )
+    def test_regex_functions_run_in_linear_time(self, fn_name, expected):
+        # Python's re engine needs exponential time on this pattern, so this pins the engine choice.
+        subject = "a" * 26 + "!"
+        start = time.time()
+        result = STL[fn_name].fn([subject, "(a+)+$"], None, None, 5.0)
+        elapsed = time.time() - start
+        assert result == expected
+        assert elapsed < 1.0
 
     def test_sortable_semver(self):
         # Basic semver parsing

--- a/common/hogvm/python/utils.py
+++ b/common/hogvm/python/utils.py
@@ -86,6 +86,24 @@ def regex_match(string: Any, pattern: Any, case_insensitive: bool = False) -> bo
     return _compile_regex(pattern, case_insensitive).search(string) is not None
 
 
+def regex_extract(string: Any, pattern: Any) -> str:
+    # Matches ClickHouse extract(): first capture group if the pattern has groups, else the whole
+    # match, else empty. re2 matches in linear time, unlike Python's backtracking re engine.
+    if string is None or pattern is None:
+        return ""
+    haystack = str(string)
+    try:
+        compiled = _compile_regex(str(pattern))
+    except HogVMException:
+        return ""
+    found = compiled.search(haystack)
+    if not found:
+        return ""
+    if found.lastindex and found.lastindex >= 1:
+        return found.group(1) or ""
+    return found.group(0) or ""
+
+
 def like(string: Any, pattern: Any, case_insensitive: bool = False) -> bool:
     pattern = re2.escape(pattern).replace("%", ".*").replace("_", ".")
     re_pattern = re2.compile(pattern, options=_CASE_INSENSITIVE_OPTS) if case_insensitive else re2.compile(pattern)

--- a/common/hogvm/python/utils.py
+++ b/common/hogvm/python/utils.py
@@ -102,7 +102,10 @@ def regex_extract(string: Any, pattern: Any) -> str:
     found = compiled.search(haystack)
     if not found:
         return ""
-    if found.lastindex and found.lastindex >= 1:
+    # Select on the pattern's static group count, not on which groups participated. A group that
+    # captured nothing still wins over the whole match, so `(a)?b` on "b" gives "". The Node and
+    # Rust VMs branch on the same static count.
+    if compiled.groups > 0:
         return found.group(1) or ""
     return found.group(0) or ""
 

--- a/common/hogvm/python/utils.py
+++ b/common/hogvm/python/utils.py
@@ -71,6 +71,9 @@ def _format_regex_error(error: Exception) -> str:
 
 
 def _compile_regex(pattern: str, case_insensitive: bool = False) -> Any:
+    # re2 matches in linear time, unlike Python's backtracking re engine. It also makes the character
+    # classes ASCII-only, so `\w+` extracts "caf" from "café" and `^\w+$` does not match "Müller".
+    # The =~ operator, like(), the Node VM and ClickHouse all use re2, so the Hog surfaces agree.
     try:
         return re2.compile(pattern, options=_CASE_INSENSITIVE_OPTS) if case_insensitive else re2.compile(pattern)
     except re2.error as e:
@@ -88,7 +91,7 @@ def regex_match(string: Any, pattern: Any, case_insensitive: bool = False) -> bo
 
 def regex_extract(string: Any, pattern: Any) -> str:
     # Matches ClickHouse extract(): first capture group if the pattern has groups, else the whole
-    # match, else empty. re2 matches in linear time, unlike Python's backtracking re engine.
+    # match, else empty.
     if string is None or pattern is None:
         return ""
     haystack = str(string)


### PR DESCRIPTION
## Problem

A Hog expression that calls `match()` or `extractRegex()` can take exponential time in the Python VM, while the same expression takes linear time in the Node VM.

- These two functions were the last in the Python VM to compile a caller-supplied pattern with Python's backtracking `re` engine.
- The VM checks its timeout between operations, so it cannot bound a single call to either one.
- Every neighbour already uses re2: the `=~` operator, `like`, the Node VM (`nodejs/src/cdp/utils/hog-exec.ts`), and ClickHouse.

## Changes

- `match()` and `extractRegex()` now match in linear time, for any pattern a person passes.
- `match()` now raises `Invalid regex pattern` for a pattern that uses lookaround or a backreference, because re2 supports neither.
- `extractRegex()` returns empty for such a pattern, rather than raising. It already did that for an invalid pattern, and ClickHouse `extract()` is re2-based and does the same.
- `regex_extract()` joins `regex_match()` in `common/hogvm/python/utils.py`. It keeps the ClickHouse `extract()` result rules: first capture group, else the whole match, else empty.
- `match()` compiles through `_compile_regex` rather than the shared `regex_match()` helper, to keep its own empty-pattern and null handling. See Agent context.
- Mechanical: `google-re2` is already a dependency, and `tryDecodeURLComponent` drops a local `import re` that shadowed the module import.

> [!WARNING]
> The lookaround change is user-visible, and the two functions report it differently. `match()` raises. `extractRegex()` returns empty, so a pattern that used lookaround to extract a value now yields empty rather than an error.
>
> No `.hog` file or Hog template in this repo uses lookaround or a backreference, so nothing here breaks. Stored user Hog could.

> [!NOTE]
> `common/hogvm/CHANGELOG.md` gets no entry. Its versions track the `@posthog/hogvm` npm package, which this Python-only change does not touch. Say if the semantics belong there anyway.

## How did you test this code?

- Added a parameterized test that pins linear time for both functions. It catches a return to a backtracking engine. No existing test caught that, because the current regex tests all use trivial patterns.
- Moved the `match('ab', '(?<=a)b')` assertion out of `test_bytecode_create` and into the existing regex-error test, since re2 rejects that pattern.
- Ran locally: the HogVM Python suite (`common/hogvm/python/test/`) and the HogQL suites that exercise these functions. CI reports the counts.
- Not run: repo-wide mypy, and the database-backed backend suites. `ty check` passed over the three changed files through lint-staged.
- No manual testing in the app. This change has no UI surface.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: PostHog Desktop, Claude Opus. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- Origin: an internal review of the HogVM standard library. Nothing from that review reaches this PR. The committed pattern is the textbook `(a+)+$` example, over a run of `a` characters.
- Delegating `match()` to the existing `regex_match()` helper read as tidier, but changed behavior. That helper treats an empty pattern as no match, while `match('test', '')` returns true and ClickHouse agrees. Hence the direct `_compile_regex` call.
- The first version of the new test timed the whole parse, compile and execute path. It failed when it ran first in a process, because about 1.4 s of one-time parser warmup fell inside the timed block. The test now calls the standard library function directly, where the engine choice lives. `test_bytecode_create` already covers the VM wiring.
- Patch coverage: the tests above cover the changed lines.
- No duplicate: an open-PR search found nothing changing these functions. #96636 edits the same file for standard library arity.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*


