### PR TITLE
feat(customer-analytics): accept project secret API key on account GET

### DIFF
--- a/products/customer_analytics/backend/presentation/views/account_actions.py
+++ b/products/customer_analytics/backend/presentation/views/account_actions.py
@@ -25,7 +25,7 @@ from products.customer_analytics.backend.facade import (
 ACCOUNT_ACTION_AUTH_COUNTER = Counter(
     "posthog_customer_analytics_account_action_auth_total",
     "Successful authentications on the account routes called by CDP workflow actions, by auth method",
-    labelnames=["auth_method", "http_method"],  # auth_method: secret_api_token | scoped_jwt
+    labelnames=["auth_method", "http_method"],  # auth_method: secret_api_token | project_secret_api_key | scoped_jwt
 )
 
 

--- a/products/customer_analytics/backend/presentation/views/external.py
+++ b/products/customer_analytics/backend/presentation/views/external.py
@@ -6,6 +6,7 @@ authenticate via the team secret API token passed as a Bearer token in the
 Authorization header. The bulk account list instead authenticates via a project
 secret API key carrying the ``account:read`` scope, because the team token is
 readable by every project member and must not unlock a team-wide account export.
+The single-account GET accepts either credential; its writes stay team-token only.
 
 The team token deliberately grants single-account writes (create, tags,
 relationships, custom property values) without per-user ``account`` scope checks:
@@ -31,7 +32,7 @@ from django.http import HttpRequest
 import structlog
 import posthoganalytics
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import OpenApiResponse, extend_schema
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
 from rest_framework import serializers, status
 from rest_framework.permissions import AllowAny
 from rest_framework.request import Request
@@ -49,7 +50,6 @@ from products.customer_analytics.backend.facade import api as facade
 from products.customer_analytics.backend.facade.constants import CUSTOMER_ANALYTICS_CSP_FLAG
 from products.customer_analytics.backend.presentation.views.account_actions import (
     ACCOUNT_ACTION_AUTH_COUNTER,
-    ExternalAccountCreateSerializer,
     ExternalAccountCustomPropertiesSerializer,
     handle_account_create,
     handle_account_get,
@@ -60,7 +60,7 @@ from products.customer_analytics.backend.presentation.views.account_actions impo
 logger = structlog.get_logger(__name__)
 
 EXTERNAL_ACCOUNT_LIST_MAX_LIMIT = 100
-EXTERNAL_ACCOUNT_LIST_REQUIRED_SCOPE = "account:read"
+EXTERNAL_ACCOUNT_READ_SCOPE = "account:read"
 
 
 class _ExternalAccountThrottle(SimpleRateThrottle):
@@ -81,6 +81,16 @@ class ExternalAccountBurstThrottle(_ExternalAccountThrottle):
 class ExternalAccountSustainedThrottle(_ExternalAccountThrottle):
     scope = "external_account_sustained"
     rate = "600/hour"
+
+
+class ExternalAccountTeamBurstThrottle(ProjectSecretApiKeyTeamRateThrottle):
+    scope = "external_account_psak_team_burst"
+    rate = ExternalAccountBurstThrottle.rate
+
+
+class ExternalAccountTeamSustainedThrottle(ProjectSecretApiKeyTeamRateThrottle):
+    scope = "external_account_psak_team_sustained"
+    rate = ExternalAccountSustainedThrottle.rate
 
 
 class ExternalAccountListBurstThrottle(PersonalOrProjectSecretApiKeyRateThrottle):
@@ -116,7 +126,11 @@ def _customer_analytics_enabled(team: Team) -> bool:
     )
 
 
-class ExternalAccountListAuthentication(ProjectSecretAPIKeyAuthentication):
+class ExternalAccountProjectSecretAPIKeyAuthentication(ProjectSecretAPIKeyAuthentication):
+    """Returns None instead of raising when the key's team lacks customer analytics, so a
+    key for a disabled team is indistinguishable from an unknown token and the response
+    cannot reveal that the key exists or which scopes it carries."""
+
     def authenticate(self, request: HttpRequest | Request) -> tuple[Any, None] | None:
         result = super().authenticate(request)
         if result is None or not _customer_analytics_enabled(self.project_secret_api_key.team):
@@ -159,16 +173,27 @@ def _authenticate_psak_team(request: Request) -> tuple[Team, None] | tuple[None,
 
     key_scopes = set(get_authenticator_scopes(authenticator) or [])
     valid_scopes = {
-        EXTERNAL_ACCOUNT_LIST_REQUIRED_SCOPE,
-        EXTERNAL_ACCOUNT_LIST_REQUIRED_SCOPE.replace(":read", ":write"),
+        EXTERNAL_ACCOUNT_READ_SCOPE,
+        EXTERNAL_ACCOUNT_READ_SCOPE.replace(":read", ":write"),
     }
     if "*" not in key_scopes and key_scopes.isdisjoint(valid_scopes):
         return None, Response(
-            {"error": f"API key missing required scope '{EXTERNAL_ACCOUNT_LIST_REQUIRED_SCOPE}'"},
+            {"error": f"API key missing required scope '{EXTERNAL_ACCOUNT_READ_SCOPE}'"},
             status=status.HTTP_403_FORBIDDEN,
         )
 
     return psak.team, None
+
+
+def _authenticate_team_for_write(request: Request) -> tuple[Team, None] | tuple[None, Response]:
+    """Writes stay team-token only. A project secret API key is rejected explicitly, because
+    the team-token lookup treats it as an unknown token and answers 401 instead of 403."""
+    if is_authenticated_via_project_secret_api_key(request):
+        return None, Response(
+            {"error": "Project secret API keys can only read accounts on this route"},
+            status=status.HTTP_403_FORBIDDEN,
+        )
+    return _authenticate_team(request)
 
 
 class ExternalAccountAssignmentSerializer(serializers.Serializer):
@@ -220,20 +245,66 @@ class ExternalAccountView(APIView):
     POST /api/customer_analytics/external/account — Create an account (no-op if it already exists)
     PATCH /api/customer_analytics/external/account — Update an account's relationships, tags, and churn state
 
-    Authenticated via Bearer token (team secret_api_token) in Authorization header.
+    GET accepts either the team secret_api_token or a project secret API key with the
+    ``account:read`` scope as a Bearer token. POST and PATCH accept only the team
+    secret_api_token.
     """
 
-    authentication_classes: list = []
+    authentication_classes = [ExternalAccountProjectSecretAPIKeyAuthentication]
     permission_classes = [AllowAny]
-    throttle_classes = [ExternalAccountBurstThrottle, ExternalAccountSustainedThrottle]
+    throttle_classes = [
+        ExternalAccountBurstThrottle,
+        ExternalAccountSustainedThrottle,
+        ExternalAccountTeamBurstThrottle,
+        ExternalAccountTeamSustainedThrottle,
+    ]
+    # Opts the route into the OpenAPI spec and generated types; the schema preprocessor drops
+    # views without a scope_object. Authorization itself stays in the manual Bearer checks above.
+    scope_object = "account"
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                "external_id",
+                OpenApiTypes.STR,
+                OpenApiParameter.QUERY,
+                required=True,
+                description="External account key: the group key the account is linked to.",
+            )
+        ],
+        responses={
+            200: OpenApiResponse(response=ExternalAccountSerializer, description="The account."),
+            400: OpenApiResponse(response=ExternalAccountErrorSerializer, description="Missing external_id."),
+            401: OpenApiResponse(
+                response=ExternalAccountErrorSerializer, description="Missing or invalid Bearer token."
+            ),
+            403: OpenApiResponse(
+                response=ExternalAccountErrorSerializer,
+                description="Project secret API key does not carry the account:read scope.",
+            ),
+            404: OpenApiResponse(
+                response=ExternalAccountErrorSerializer, description="No account with that external_id."
+            ),
+        },
+        summary="Get an external customer analytics account",
+        description=(
+            "Fetch one account by external ID with its properties, tags, active relationship assignments "
+            "and custom property values. Accepts the team secret API token or a project secret API key with "
+            "the `account:read` scope."
+        ),
+    )
     def get(self, request: Request) -> Response:
-        team, error = _authenticate_team(request)
+        if is_authenticated_via_project_secret_api_key(request):
+            team, error = _authenticate_psak_team(request)
+            auth_method = "project_secret_api_key"
+        else:
+            team, error = _authenticate_team(request)
+            auth_method = "secret_api_token"
         if error:
             return error
 
         assert team is not None
-        ACCOUNT_ACTION_AUTH_COUNTER.labels(auth_method="secret_api_token", http_method="get").inc()
+        ACCOUNT_ACTION_AUTH_COUNTER.labels(auth_method=auth_method, http_method="get").inc()
 
         external_id = request.query_params.get("external_id", "").strip()
         if not external_id:
@@ -241,21 +312,12 @@ class ExternalAccountView(APIView):
 
         return handle_account_get(team, external_id)
 
-    @extend_schema(
-        request=ExternalAccountCreateSerializer,
-        responses={
-            201: OpenApiResponse(response=ExternalAccountSerializer, description="Account created."),
-            200: OpenApiResponse(
-                response=ExternalAccountSerializer, description="Account already existed — creation skipped."
-            ),
-            400: OpenApiResponse(response=ExternalAccountErrorSerializer, description="Invalid request body."),
-            401: OpenApiResponse(
-                response=ExternalAccountErrorSerializer, description="Missing or invalid Bearer token."
-            ),
-        },
-    )
+    # The write operations stay out of the generated schema. drf-spectacular renders a PATCH body
+    # as fully optional although this route requires external_id, and validation failures return
+    # field-keyed errors that ExternalAccountErrorSerializer does not describe.
+    @extend_schema(exclude=True)
     def post(self, request: Request) -> Response:
-        team, error = _authenticate_team(request)
+        team, error = _authenticate_team_for_write(request)
         if error:
             return error
 
@@ -263,8 +325,9 @@ class ExternalAccountView(APIView):
         ACCOUNT_ACTION_AUTH_COUNTER.labels(auth_method="secret_api_token", http_method="post").inc()
         return handle_account_create(request, team)
 
+    @extend_schema(exclude=True)
     def patch(self, request: Request) -> Response:
-        team, error = _authenticate_team(request)
+        team, error = _authenticate_team_for_write(request)
         if error:
             return error
 
@@ -376,7 +439,7 @@ class ExternalAccountListView(APIView):
     explicit scope.
     """
 
-    authentication_classes = [ExternalAccountListAuthentication]
+    authentication_classes = [ExternalAccountProjectSecretAPIKeyAuthentication]
     permission_classes = [AllowAny]
     throttle_classes = [
         ExternalAccountListBurstThrottle,

--- a/products/customer_analytics/backend/test/test_external.py
+++ b/products/customer_analytics/backend/test/test_external.py
@@ -5,6 +5,7 @@ from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
 from django.apps import apps
+from django.core.cache import cache
 
 from parameterized import parameterized
 from rest_framework import status
@@ -13,6 +14,7 @@ from rest_framework.test import APIClient
 from posthog.models import Organization, Team, User
 from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.models.utils import generate_random_token_secret
+from posthog.test.api_keys import create_project_secret_api_key
 from posthog.test.persons import create_group
 
 from products.customer_analytics.backend.models import (
@@ -75,6 +77,10 @@ class TestExternalAccountAPI(APIBaseTest):
             .values_list("user_id", flat=True)
         )
 
+    def _create_psak_token(self, scopes, team=None, label="external-account"):
+        _, token = create_project_secret_api_key(team or self.team, label=label, scopes=scopes)
+        return token
+
     # -- Authentication ---------------------------------------------------
 
     def test_get_requires_auth(self):
@@ -106,9 +112,54 @@ class TestExternalAccountAPI(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_rejects_team_without_customer_analytics_enabled(self):
+        read_psak = self._create_psak_token(scopes=["account:read"], label="read")
+        wrong_scope_psak = self._create_psak_token(scopes=["endpoint:read"], label="wrong-scope")
         self.mock_csp_enabled.return_value = False
-        response = self._get()
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        for token in [self.team.secret_api_token, read_psak, wrong_scope_psak]:
+            with self.subTest(token=token):
+                response = self._get(token=token)
+                self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+                self.assertEqual(response.json(), {"error": "Invalid API key"})
+
+    def test_get_accepts_project_secret_api_key_with_account_read_scope(self):
+        response = self._get(token=self._create_psak_token(scopes=["account:read"]))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["id"], str(self.account.id))
+
+    def test_get_rejects_project_secret_api_key_without_account_scope(self):
+        response = self._get(token=self._create_psak_token(scopes=["endpoint:read"]))
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @parameterized.expand(
+        [
+            ("post_read_scope", "_post", ["account:read"], {"external_id": "acme-2"}),
+            ("post_write_scope", "_post", ["account:write"], {"external_id": "acme-2"}),
+            ("patch_read_scope", "_patch", ["account:read"], {"external_id": "acme-1", "churned_at": "2026-08-01"}),
+        ]
+    )
+    def test_writes_reject_project_secret_api_key(self, _name, request_method, scopes, payload):
+        token = self._create_psak_token(scopes=scopes)
+        response = getattr(self, request_method)(payload, token=token)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertFalse(Account.objects.for_team(self.team.id).filter(external_id="acme-2").exists())
+        self.account.refresh_from_db()
+        self.assertIsNone(self.account.churned_at)
+
+    def test_project_secret_api_keys_share_a_team_rate_limit(self):
+        cache.clear()
+        self.addCleanup(cache.clear)
+        first_token = self._create_psak_token(scopes=["account:read"], label="first")
+        second_token = self._create_psak_token(scopes=["account:read"], label="second")
+
+        with (
+            patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True),
+            patch(
+                "products.customer_analytics.backend.presentation.views.external.ExternalAccountTeamBurstThrottle.rate",
+                "1/minute",
+            ),
+        ):
+            self.assertEqual(self._get(token=first_token).status_code, status.HTTP_200_OK)
+            self.assertEqual(self._get(token=second_token).status_code, status.HTTP_429_TOO_MANY_REQUESTS)
 
     # -- GET account ------------------------------------------------------
 
@@ -174,9 +225,11 @@ class TestExternalAccountAPI(APIBaseTest):
         other_team = Team.objects.create(organization=self.organization, name="Other")
         other_team.secret_api_token = generate_random_token_secret()
         other_team.save(update_fields=["secret_api_token"])
+        other_team_psak = self._create_psak_token(scopes=["account:read"], team=other_team)
 
-        response = self._get(token=other_team.secret_api_token)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        for token in [other_team.secret_api_token, other_team_psak]:
+            with self.subTest(token=token):
+                self.assertEqual(self._get(token=token).status_code, status.HTTP_404_NOT_FOUND)
 
     # -- PATCH account ----------------------------------------------------
 

--- a/products/customer_analytics/backend/test/test_external_list.py
+++ b/products/customer_analytics/backend/test/test_external_list.py
@@ -12,8 +12,8 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from posthog.models import Organization, OrganizationMembership, Team, User
-from posthog.models.project_secret_api_key import ProjectSecretAPIKey
-from posthog.models.utils import generate_random_token_secret, hash_key_value, mask_key_value
+from posthog.models.utils import generate_random_token_secret
+from posthog.test.api_keys import create_project_secret_api_key
 
 from products.customer_analytics.backend.models import AccountRelationship, AccountRelationshipDefinition
 from products.customer_analytics.backend.test.factories import create_account
@@ -37,14 +37,7 @@ class TestExternalAccountListAPI(APIBaseTest):
         self.addCleanup(csp_enabled.stop)
 
     def _create_psak_token(self, scopes, label="external-list"):
-        token = generate_random_token_secret()
-        ProjectSecretAPIKey.objects.create(
-            team=self.team,
-            label=label,
-            mask_value=mask_key_value(token),
-            secure_value=hash_key_value(token),
-            scopes=scopes,
-        )
+        _, token = create_project_secret_api_key(self.team, label=label, scopes=scopes)
         return token
 
     def _create_definition(self, name, **kwargs):

--- a/products/customer_analytics/frontend/generated/api.schemas.ts
+++ b/products/customer_analytics/frontend/generated/api.schemas.ts
@@ -7,6 +7,63 @@
  * PostHog API - generated
  * OpenAPI spec version: 1.0.0
  */
+/**
+ * Typed account properties: external-system ids. Role assignments live under `relationships`.
+ */
+export type ExternalAccountApiProperties = { [key: string]: unknown }
+
+export interface ExternalAccountAssignmentApi {
+    /** PostHog user id of the assigned user. */
+    user_id: number
+    /** Email address of the assigned user. */
+    email: string
+}
+
+/**
+ * Active relationship assignments keyed by definition name (e.g. 'CSM'). Definitions with no active assignment are omitted.
+ */
+export type ExternalAccountApiRelationships = { [key: string]: ExternalAccountAssignmentApi[] }
+
+/**
+ * Every team custom property definition keyed by name, with the account's active value or null.
+ */
+export type ExternalAccountApiCustomProperties = { [key: string]: unknown }
+
+export interface ExternalAccountApi {
+    /** Account UUID. */
+    id: string
+    /**
+     * External account key — the group key the account is linked to.
+     * @nullable
+     */
+    external_id: string | null
+    /** Human-readable account name. */
+    name: string
+    /**
+     * When the account churned, or null if it has not churned.
+     * @nullable
+     */
+    churned_at: string | null
+    /**
+     * When Track Rules ignored the account, or null if it is tracked.
+     * @nullable
+     */
+    ignored_at: string | null
+    /** Typed account properties: external-system ids. Role assignments live under `relationships`. */
+    properties: ExternalAccountApiProperties
+    /** Tag names on the account, sorted alphabetically. */
+    tags: string[]
+    /** Active relationship assignments keyed by definition name (e.g. 'CSM'). Definitions with no active assignment are omitted. */
+    relationships: ExternalAccountApiRelationships
+    /** Every team custom property definition keyed by name, with the account's active value or null. */
+    custom_properties: ExternalAccountApiCustomProperties
+}
+
+export interface ExternalAccountErrorApi {
+    /** What went wrong with the request. */
+    error: string
+}
+
 export interface ExternalAccountListAssignmentApi {
     /** PostHog user id of the assigned user. */
     user_id: number
@@ -3960,6 +4017,13 @@ export interface UserCustomerAnalyticsConfigApi {
 export interface PatchedUserCustomerAnalyticsConfigUpdateApi {
     /** Complete ordered list of account properties to pin. Omit to keep the current pins; pass an empty list to clear them. */
     pinned_properties?: PinnedAccountPropertyApi[]
+}
+
+export type CustomerAnalyticsExternalAccountRetrieveParams = {
+    /**
+     * External account key: the group key the account is linked to.
+     */
+    external_id: string
 }
 
 export type CustomerAnalyticsExternalAccountsRetrieveParams = {

--- a/products/customer_analytics/frontend/generated/api.ts
+++ b/products/customer_analytics/frontend/generated/api.ts
@@ -48,6 +48,7 @@ import type {
     CustomPropertyValueApi,
     CustomPropertyValueSuggestionsResponseApi,
     CustomPropertyValueWriteApi,
+    CustomerAnalyticsExternalAccountRetrieveParams,
     CustomerAnalyticsExternalAccountsRetrieveParams,
     CustomerJourneyApi,
     CustomerJourneysListParams,
@@ -63,6 +64,7 @@ import type {
     EventStreamApi,
     EventStreamMemberWriteApi,
     EventStreamTestMessageApi,
+    ExternalAccountApi,
     ExternalAccountListPageApi,
     FeatureRequestAddAccountApi,
     FeatureRequestApi,
@@ -130,6 +132,38 @@ type NonReadonly<T> = [T] extends [UnionToIntersection<T>]
           [P in keyof Writable<T>]: T[P] extends object ? NonReadonly<NonNullable<T[P]>> : T[P]
       }
     : DistributeReadOnlyOverUnions<T>
+
+export const getCustomerAnalyticsExternalAccountRetrieveUrl = (
+    params: CustomerAnalyticsExternalAccountRetrieveParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : String(value))
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/customer_analytics/external/account?${stringifiedParams}`
+        : `/api/customer_analytics/external/account`
+}
+
+/**
+ * Fetch one account by external ID with its properties, tags, active relationship assignments and custom property values. Accepts the team secret API token or a project secret API key with the `account:read` scope.
+ * @summary Get an external customer analytics account
+ */
+export const customerAnalyticsExternalAccountRetrieve = async (
+    params: CustomerAnalyticsExternalAccountRetrieveParams,
+    options?: RequestInit
+): Promise<ExternalAccountApi> => {
+    return apiMutator<ExternalAccountApi>(getCustomerAnalyticsExternalAccountRetrieveUrl(params), {
+        ...options,
+        method: 'GET',
+    })
+}
 
 export const getCustomerAnalyticsExternalAccountsRetrieveUrl = (
     params?: CustomerAnalyticsExternalAccountsRetrieveParams

--- a/products/customer_analytics/mcp/tools.yaml
+++ b/products/customer_analytics/mcp/tools.yaml
@@ -787,6 +787,9 @@ tools:
     customer-analytics-accounts-table-query-create:
         operation: customer_analytics_accounts_table_query_create
         enabled: false
+    customer-analytics-external-account-retrieve:
+        operation: customer_analytics_external_account_retrieve
+        enabled: false
     customer-analytics-external-accounts-retrieve:
         operation: customer_analytics_external_accounts_retrieve
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -36665,6 +36665,63 @@ export namespace Schemas {
       readonly user_access_level: string | null;
     }
 
+    /**
+     * Typed account properties: external-system ids. Role assignments live under `relationships`.
+     */
+    export type ExternalAccountProperties = {[key: string]: unknown};
+
+    export interface ExternalAccountAssignment {
+      /** PostHog user id of the assigned user. */
+      user_id: number;
+      /** Email address of the assigned user. */
+      email: string;
+    }
+
+    /**
+     * Active relationship assignments keyed by definition name (e.g. 'CSM'). Definitions with no active assignment are omitted.
+     */
+    export type ExternalAccountRelationships = {[key: string]: ExternalAccountAssignment[]};
+
+    /**
+     * Every team custom property definition keyed by name, with the account's active value or null.
+     */
+    export type ExternalAccountCustomProperties = {[key: string]: unknown};
+
+    export interface ExternalAccount {
+      /** Account UUID. */
+      id: string;
+      /**
+         * External account key — the group key the account is linked to.
+         * @nullable
+         */
+      external_id: string | null;
+      /** Human-readable account name. */
+      name: string;
+      /**
+         * When the account churned, or null if it has not churned.
+         * @nullable
+         */
+      churned_at: string | null;
+      /**
+         * When Track Rules ignored the account, or null if it is tracked.
+         * @nullable
+         */
+      ignored_at: string | null;
+      /** Typed account properties: external-system ids. Role assignments live under `relationships`. */
+      properties: ExternalAccountProperties;
+      /** Tag names on the account, sorted alphabetically. */
+      tags: string[];
+      /** Active relationship assignments keyed by definition name (e.g. 'CSM'). Definitions with no active assignment are omitted. */
+      relationships: ExternalAccountRelationships;
+      /** Every team custom property definition keyed by name, with the account's active value or null. */
+      custom_properties: ExternalAccountCustomProperties;
+    }
+
+    export interface ExternalAccountError {
+      /** What went wrong with the request. */
+      error: string;
+    }
+
     export interface ExternalAccountListAssignment {
       /** PostHog user id of the assigned user. */
       user_id: number;
@@ -91982,6 +92039,13 @@ export namespace Schemas {
      * @maxItems 50
      */
     cohort_ids: number[];
+    };
+
+    export type CustomerAnalyticsExternalAccountRetrieveParams = {
+    /**
+     * External account key: the group key the account is linked to.
+     */
+    external_id: string;
     };
 
     export type CustomerAnalyticsExternalAccountsRetrieveParams = {


### PR DESCRIPTION
## Problem

- An engineer wiring a service to look up one customer analytics account by external ID has to hand that service the team secret token, which also lets it create and update accounts on the same route.
- The bulk account list already accepts a project secret API key with the `account:read` scope. The single-account GET did not.

## Changes

- `GET /api/customer_analytics/external/account` now accepts a project secret API key with the `account:read` scope, in addition to the team secret token.
- POST and PATCH on that route reject a project secret API key with a 403, so the key stays read-only.
- A key for a team without customer analytics enabled gets the same 401 body as an unknown token, matching the list view, so the response does not reveal that the key exists.
- Project secret API key requests share a per-team throttle on the route, alongside the existing per-token throttle.
- The GET operation now appears in the generated OpenAPI types for the frontend and MCP clients. The view sets `scope_object`, and the generated files are regenerated output.
- POST and PATCH stay out of the generated schema. drf-spectacular renders a PATCH body as fully optional although the route requires `external_id`, and validation failures return field-keyed errors that the error serializer does not describe.

No visible UI changes.

## How did you test this code?

New cases in `test_external.py`, each named for the regression it catches:

- A key with `account:read` reads the account. Catches removing the authenticator or the key branch from the GET.
- A key without the scope gets a 403. Catches the GET skipping the scope check.
- POST and PATCH with a key get a 403 and change nothing, for read and write scopes. Catches a key reaching a write.
- Another team's key gets a 404. Catches resolving the team from anything but the key.
- With the feature disabled, the team token, a read key, and a wrong-scope key all get the unknown-token 401 body. Catches wiring the ungated authenticator.
- Two keys share one team rate limit. Catches dropping the team throttle.

Both external test files now use the shared `create_project_secret_api_key` helper instead of a local copy.

Ran locally: the two external test files, ruff, mypy on the touched files, `hogli build:openapi` with no drf-spectacular warnings, and `hogli ci:preflight`. Not run: repo-wide mypy and the frontend typecheck against the regenerated types, which CI covers.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No docs describe the external account route.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tools: Claude Code with Claude Fable 5.1, then the code-reviewer and code-simplifier agents and a Codex review before the commit.
- Skills invoked: /improving-drf-endpoints, /adding-project-secret-api-key-auth, /writing-tests, /writing-code-comments, /writing-user-facing-copy, /writing-pr-descriptions.
- The first draft added the GET schema without `scope_object`, so the schema never reached the spec. The code-reviewer caught it. Adding `scope_object` then exposed POST and PATCH, whose generated contracts were inaccurate, which the Codex review caught, so they are excluded.
- Duplicate check: `gh pr list --state open --search "project secret API key customer analytics external account"` found no related PR.
- Public artifact: nothing in the diff or this description draws on material outside this repository. Test data is invented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GX2Tq8CpuzJpkYtnXjmySf
