### PR TITLE
fix(mcp): feature_entitlement for access control tools

### DIFF
--- a/products/access_control/mcp/tools.yaml
+++ b/products/access_control/mcp/tools.yaml
@@ -12,7 +12,6 @@ tools:
     access-control-default-objects-list:
         operation: organizations_projects_access_control_default_objects_retrieve
         enabled: true
-        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:
@@ -30,10 +29,10 @@ tools:
                     Project id. If omitted, uses the active project.
                 optional: true
                 fallback: projectId
+        feature_entitlement: access_control
     access-control-default-properties-list:
         operation: organizations_projects_access_control_default_properties_retrieve
         enabled: true
-        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:
@@ -52,10 +51,10 @@ tools:
                     Project id. If omitted, uses the active project.
                 optional: true
                 fallback: projectId
+        feature_entitlement: access_control
     access-control-defaults-get:
         operation: organizations_projects_access_control_defaults_retrieve
         enabled: true
-        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:
@@ -79,13 +78,13 @@ tools:
                     Project id. If omitted, uses the active project.
                 optional: true
                 fallback: projectId
+        feature_entitlement: access_control
         response:
             exclude:
                 - can_edit
     access-control-member-objects-list:
         operation: organizations_projects_access_control_member_objects_retrieve
         enabled: true
-        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:
@@ -111,10 +110,10 @@ tools:
             member_id:
                 description: |
                     The organization membership id, as `organization_membership_id` in access-control-members-list.
+        feature_entitlement: access_control
     access-control-member-properties-list:
         operation: organizations_projects_access_control_member_properties_retrieve
         enabled: true
-        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:
@@ -140,10 +139,10 @@ tools:
             member_id:
                 description: |
                     The organization membership id, as `organization_membership_id` in access-control-members-list.
+        feature_entitlement: access_control
     access-control-members-list:
         operation: organizations_projects_access_control_members_retrieve
         enabled: true
-        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:
@@ -174,6 +173,7 @@ tools:
             member_id:
                 description: |
                     Optional. Narrow the result to one member, by organization membership id.
+        feature_entitlement: access_control
         response:
             exclude:
                 - project.minimum
@@ -183,7 +183,6 @@ tools:
     access-control-role-objects-list:
         operation: organizations_projects_access_control_role_objects_retrieve
         enabled: true
-        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:
@@ -205,10 +204,10 @@ tools:
                 description: |
                     The role id, as `role_id` in access-control-roles-list or an entry of `role_ids` in
                     access-control-members-list.
+        feature_entitlement: access_control
     access-control-role-properties-list:
         operation: organizations_projects_access_control_role_properties_retrieve
         enabled: true
-        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:
@@ -230,10 +229,10 @@ tools:
                 description: |
                     The role id, as `role_id` in access-control-roles-list or an entry of `role_ids` in
                     access-control-members-list.
+        feature_entitlement: access_control
     access-control-roles-list:
         operation: organizations_projects_access_control_roles_retrieve
         enabled: true
-        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:
@@ -261,6 +260,7 @@ tools:
             role_id:
                 description: |
                     Optional. Narrow the result to one role, by role id.
+        feature_entitlement: access_control
         response:
             exclude:
                 - project.minimum

--- a/products/access_control/mcp/tools.yaml
+++ b/products/access_control/mcp/tools.yaml
@@ -12,6 +12,7 @@ tools:
     access-control-default-objects-list:
         operation: organizations_projects_access_control_default_objects_retrieve
         enabled: true
+        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:
@@ -29,10 +30,10 @@ tools:
                     Project id. If omitted, uses the active project.
                 optional: true
                 fallback: projectId
-        feature_entitlement: access_control
     access-control-default-properties-list:
         operation: organizations_projects_access_control_default_properties_retrieve
         enabled: true
+        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:
@@ -51,10 +52,10 @@ tools:
                     Project id. If omitted, uses the active project.
                 optional: true
                 fallback: projectId
-        feature_entitlement: access_control
     access-control-defaults-get:
         operation: organizations_projects_access_control_defaults_retrieve
         enabled: true
+        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:
@@ -78,13 +79,13 @@ tools:
                     Project id. If omitted, uses the active project.
                 optional: true
                 fallback: projectId
-        feature_entitlement: access_control
         response:
             exclude:
                 - can_edit
     access-control-member-objects-list:
         operation: organizations_projects_access_control_member_objects_retrieve
         enabled: true
+        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:
@@ -110,10 +111,10 @@ tools:
             member_id:
                 description: |
                     The organization membership id, as `organization_membership_id` in access-control-members-list.
-        feature_entitlement: access_control
     access-control-member-properties-list:
         operation: organizations_projects_access_control_member_properties_retrieve
         enabled: true
+        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:
@@ -139,10 +140,10 @@ tools:
             member_id:
                 description: |
                     The organization membership id, as `organization_membership_id` in access-control-members-list.
-        feature_entitlement: access_control
     access-control-members-list:
         operation: organizations_projects_access_control_members_retrieve
         enabled: true
+        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:
@@ -173,7 +174,6 @@ tools:
             member_id:
                 description: |
                     Optional. Narrow the result to one member, by organization membership id.
-        feature_entitlement: access_control
         response:
             exclude:
                 - project.minimum
@@ -183,6 +183,7 @@ tools:
     access-control-role-objects-list:
         operation: organizations_projects_access_control_role_objects_retrieve
         enabled: true
+        feature_entitlement: role_based_access
         scopes:
             - access_control:read
         annotations:
@@ -204,10 +205,10 @@ tools:
                 description: |
                     The role id, as `role_id` in access-control-roles-list or an entry of `role_ids` in
                     access-control-members-list.
-        feature_entitlement: access_control
     access-control-role-properties-list:
         operation: organizations_projects_access_control_role_properties_retrieve
         enabled: true
+        feature_entitlement: role_based_access
         scopes:
             - access_control:read
         annotations:
@@ -229,10 +230,10 @@ tools:
                 description: |
                     The role id, as `role_id` in access-control-roles-list or an entry of `role_ids` in
                     access-control-members-list.
-        feature_entitlement: access_control
     access-control-roles-list:
         operation: organizations_projects_access_control_roles_retrieve
         enabled: true
+        feature_entitlement: role_based_access
         scopes:
             - access_control:read
         annotations:
@@ -260,7 +261,6 @@ tools:
             role_id:
                 description: |
                     Optional. Narrow the result to one role, by role id.
-        feature_entitlement: access_control
         response:
             exclude:
                 - project.minimum

--- a/products/access_control/mcp/tools.yaml
+++ b/products/access_control/mcp/tools.yaml
@@ -12,7 +12,6 @@ tools:
     access-control-default-objects-list:
         operation: organizations_projects_access_control_default_objects_retrieve
         enabled: true
-        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:
@@ -30,10 +29,10 @@ tools:
                     Project id. If omitted, uses the active project.
                 optional: true
                 fallback: projectId
+        feature_entitlement: access_control
     access-control-default-properties-list:
         operation: organizations_projects_access_control_default_properties_retrieve
         enabled: true
-        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:
@@ -52,10 +51,10 @@ tools:
                     Project id. If omitted, uses the active project.
                 optional: true
                 fallback: projectId
+        feature_entitlement: access_control
     access-control-defaults-get:
         operation: organizations_projects_access_control_defaults_retrieve
         enabled: true
-        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:
@@ -79,13 +78,13 @@ tools:
                     Project id. If omitted, uses the active project.
                 optional: true
                 fallback: projectId
+        feature_entitlement: access_control
         response:
             exclude:
                 - can_edit
     access-control-member-objects-list:
         operation: organizations_projects_access_control_member_objects_retrieve
         enabled: true
-        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:
@@ -111,10 +110,10 @@ tools:
             member_id:
                 description: |
                     The organization membership id, as `organization_membership_id` in access-control-members-list.
+        feature_entitlement: access_control
     access-control-member-properties-list:
         operation: organizations_projects_access_control_member_properties_retrieve
         enabled: true
-        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:
@@ -140,10 +139,10 @@ tools:
             member_id:
                 description: |
                     The organization membership id, as `organization_membership_id` in access-control-members-list.
+        feature_entitlement: access_control
     access-control-members-list:
         operation: organizations_projects_access_control_members_retrieve
         enabled: true
-        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:
@@ -174,6 +173,7 @@ tools:
             member_id:
                 description: |
                     Optional. Narrow the result to one member, by organization membership id.
+        feature_entitlement: access_control
         response:
             exclude:
                 - project.minimum
@@ -183,7 +183,6 @@ tools:
     access-control-role-objects-list:
         operation: organizations_projects_access_control_role_objects_retrieve
         enabled: true
-        feature_entitlement: role_based_access
         scopes:
             - access_control:read
         annotations:
@@ -205,10 +204,10 @@ tools:
                 description: |
                     The role id, as `role_id` in access-control-roles-list or an entry of `role_ids` in
                     access-control-members-list.
+        feature_entitlement: role_based_access
     access-control-role-properties-list:
         operation: organizations_projects_access_control_role_properties_retrieve
         enabled: true
-        feature_entitlement: role_based_access
         scopes:
             - access_control:read
         annotations:
@@ -230,10 +229,10 @@ tools:
                 description: |
                     The role id, as `role_id` in access-control-roles-list or an entry of `role_ids` in
                     access-control-members-list.
+        feature_entitlement: role_based_access
     access-control-roles-list:
         operation: organizations_projects_access_control_roles_retrieve
         enabled: true
-        feature_entitlement: role_based_access
         scopes:
             - access_control:read
         annotations:
@@ -261,6 +260,7 @@ tools:
             role_id:
                 description: |
                     Optional. Narrow the result to one role, by role id.
+        feature_entitlement: role_based_access
         response:
             exclude:
                 - project.minimum

--- a/products/access_control/mcp/tools.yaml
+++ b/products/access_control/mcp/tools.yaml
@@ -12,6 +12,7 @@ tools:
     access-control-default-objects-list:
         operation: organizations_projects_access_control_default_objects_retrieve
         enabled: true
+        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:
@@ -32,6 +33,7 @@ tools:
     access-control-default-properties-list:
         operation: organizations_projects_access_control_default_properties_retrieve
         enabled: true
+        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:
@@ -53,6 +55,7 @@ tools:
     access-control-defaults-get:
         operation: organizations_projects_access_control_defaults_retrieve
         enabled: true
+        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:
@@ -82,6 +85,7 @@ tools:
     access-control-member-objects-list:
         operation: organizations_projects_access_control_member_objects_retrieve
         enabled: true
+        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:
@@ -110,6 +114,7 @@ tools:
     access-control-member-properties-list:
         operation: organizations_projects_access_control_member_properties_retrieve
         enabled: true
+        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:
@@ -138,6 +143,7 @@ tools:
     access-control-members-list:
         operation: organizations_projects_access_control_members_retrieve
         enabled: true
+        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:
@@ -177,6 +183,7 @@ tools:
     access-control-role-objects-list:
         operation: organizations_projects_access_control_role_objects_retrieve
         enabled: true
+        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:
@@ -201,6 +208,7 @@ tools:
     access-control-role-properties-list:
         operation: organizations_projects_access_control_role_properties_retrieve
         enabled: true
+        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:
@@ -225,6 +233,7 @@ tools:
     access-control-roles-list:
         operation: organizations_projects_access_control_roles_retrieve
         enabled: true
+        feature_entitlement: access_control
         scopes:
             - access_control:read
         annotations:

--- a/products/access_control/skills/checking-member-access/SKILL.md
+++ b/products/access_control/skills/checking-member-access/SKILL.md
@@ -26,8 +26,9 @@ Not for changing rules. The read tools cannot write, and the settings page is wh
 
 ## Plan availability
 
-- Free and pay-as-you-go plans have no access control. Every level resolves to the PostHog default with
-  `source` `system_default`, and any rule the tools return has no effect. Say so, and stop.
+- Free and pay-as-you-go plans have no access control, and the access control tools are not offered to
+  them. If the tools are missing from the catalog, say that the plan does not include access control, and
+  stop.
 - Boost and Scale include the default levels and rules for single members on the project, on tools, on
   objects and on properties.
 - Roles exist on every plan, but role rules count for access only on Enterprise. On other plans a role

--- a/products/access_control/skills/checking-member-access/SKILL.md
+++ b/products/access_control/skills/checking-member-access/SKILL.md
@@ -27,12 +27,15 @@ Not for changing rules. The read tools cannot write, and the settings page is wh
 ## Plan availability
 
 - Free and pay-as-you-go plans have no access control, and the access control tools are not offered to
-  them. If the tools are missing from the catalog, say that the plan does not include access control and
-  suggest upgrading to the Boost plan. Link the plan comparison: https://posthog.com/platform-packages.
+  them. A missing tool has other causes too: a connection whose scopes do not include
+  `access_control:read` gets a scope error that names the scope, and a client can filter the catalog. So
+  when the tools are missing and no scope error explains it, say that the plan may not include access
+  control and that a filtered connection can hide the tools as well. Point at the Boost plan and the plan
+  comparison, https://posthog.com/platform-packages, as the fix when it is the plan.
 - Boost and Scale include the default levels and rules for single members on the project, on tools, on
   objects and on properties.
 - Roles exist on every plan, but role rules are an Enterprise feature: they can be set and are enforced
-  only there, and the three role access tools are offered only there. If the tools are missing, say that
+  only there, and the three role access tools are offered only there. If only the role tools are missing, say that
   role-based access control needs the Enterprise plan, with the same link. On other plans a member's
   roles never change the enforced level.
 - The tools do not say which plan the organization is on. A `source_subject` of `role` anywhere in a

--- a/products/access_control/skills/checking-member-access/SKILL.md
+++ b/products/access_control/skills/checking-member-access/SKILL.md
@@ -27,12 +27,13 @@ Not for changing rules. The read tools cannot write, and the settings page is wh
 ## Plan availability
 
 - Free and pay-as-you-go plans have no access control, and the access control tools are not offered to
-  them. If the tools are missing from the catalog, say that the plan does not include access control, and
-  stop.
+  them. If the tools are missing from the catalog, say that the plan does not include access control and
+  suggest upgrading to the Boost plan. Link the plan comparison: https://posthog.com/platform-packages.
 - Boost and Scale include the default levels and rules for single members on the project, on tools, on
   objects and on properties.
-- Roles exist on every plan, but role rules count for access only on Enterprise. On other plans a role
-  rule the tools return has no effect, and a member's roles never change the enforced level.
+- Roles exist on every plan, but role rules count for access only on Enterprise, and the three role access
+  tools are offered only there. If they are missing, say that role-based access control needs the
+  Enterprise plan, with the same link. On other plans a member's roles never change the enforced level.
 - The tools do not say which plan the organization is on. A `source_subject` of `role` anywhere in a
   `members-list` result proves that role rules count. Without that, ask the user whether the organization
   is on Enterprise before walking roles in step 4 of the workflow.

--- a/products/access_control/skills/checking-member-access/SKILL.md
+++ b/products/access_control/skills/checking-member-access/SKILL.md
@@ -27,15 +27,12 @@ Not for changing rules. The read tools cannot write, and the settings page is wh
 ## Plan availability
 
 - Free and pay-as-you-go plans have no access control, and the access control tools are not offered to
-  them. A missing tool has other causes too: a connection whose scopes do not include
-  `access_control:read` gets a scope error that names the scope, and a client can filter the catalog. So
-  when the tools are missing and no scope error explains it, say that the plan may not include access
-  control and that a filtered connection can hide the tools as well. Point at the Boost plan and the plan
-  comparison, https://posthog.com/platform-packages, as the fix when it is the plan.
+  them. If the tools are missing from the catalog, say that the plan does not include access control and
+  suggest upgrading to the Boost plan. Link the plan comparison: https://posthog.com/platform-packages.
 - Boost and Scale include the default levels and rules for single members on the project, on tools, on
   objects and on properties.
 - Roles exist on every plan, but role rules are an Enterprise feature: they can be set and are enforced
-  only there, and the three role access tools are offered only there. If only the role tools are missing, say that
+  only there, and the three role access tools are offered only there. If the tools are missing, say that
   role-based access control needs the Enterprise plan, with the same link. On other plans a member's
   roles never change the enforced level.
 - The tools do not say which plan the organization is on. A `source_subject` of `role` anywhere in a

--- a/products/access_control/skills/checking-member-access/SKILL.md
+++ b/products/access_control/skills/checking-member-access/SKILL.md
@@ -31,11 +31,12 @@ Not for changing rules. The read tools cannot write, and the settings page is wh
   suggest upgrading to the Boost plan. Link the plan comparison: https://posthog.com/platform-packages.
 - Boost and Scale include the default levels and rules for single members on the project, on tools, on
   objects and on properties.
-- Roles exist on every plan, but role rules count for access only on Enterprise, and the three role access
-  tools are offered only there. If they are missing, say that role-based access control needs the
-  Enterprise plan, with the same link. On other plans a member's roles never change the enforced level.
+- Roles exist on every plan, but role rules are an Enterprise feature: they can be set and are enforced
+  only there, and the three role access tools are offered only there. If the tools are missing, say that
+  role-based access control needs the Enterprise plan, with the same link. On other plans a member's
+  roles never change the enforced level.
 - The tools do not say which plan the organization is on. A `source_subject` of `role` anywhere in a
-  `members-list` result proves that role rules count. Without that, ask the user whether the organization
+  `members-list` result proves that role rules are enforced. Without that, ask the user whether the organization
   is on Enterprise before walking roles in step 4 of the workflow.
 
 ## How access resolves

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -577,6 +577,34 @@
             "readOnlyHint": false
         }
     },
+    "alert-destinations-create": {
+        "description": "Post this insight alert to a Slack channel as well as emailing its subscribed users. The Slack workspace must already be connected to the project — list the workspaces and their channels with integrations-channels-retrieve. An alert can have up to 5 destinations. The returned hog_function_ids identify the destination; pass them to alert-destinations-delete to remove it.",
+        "category": "Alerts",
+        "feature": "alerts",
+        "summary": "Send an alert to Slack",
+        "title": "Send an alert to Slack",
+        "required_scopes": ["alert:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "alert-destinations-delete": {
+        "description": "Remove a destination from an insight alert by passing the hog_function_ids that alert-destinations-create returned. The alert keeps its email recipients.",
+        "category": "Alerts",
+        "feature": "alerts",
+        "summary": "Stop sending an alert to Slack",
+        "title": "Stop sending an alert to Slack",
+        "required_scopes": ["alert:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "alert-get": {
         "description": "Get a specific alert by ID. Returns the full alert configuration including check results, threshold settings, detector_config (for anomaly detection alerts), and subscribed users. Check results include anomaly_scores, triggered_points, and triggered_dates for detector-based alerts. By default returns the last 5 checks. Use checks_date_from and checks_date_to (e.g. '-24h', '-7d') to get checks within a time window, and checks_limit to control the maximum returned (default 5, max 500). When date filters are provided without checks_limit, up to 500 checks are returned. Check history is retained for 14 days.",
         "category": "Alerts",
@@ -1227,6 +1255,20 @@
         "feature": "canvas",
         "summary": "Read canvas build status",
         "title": "Read canvas build status",
+        "required_scopes": ["canvas:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "canvas-connectors-retrieve": {
+        "description": "List the connector catalog a canvas can read live third-party data through with `ph.connectors.call`: every native provider (GitHub) and every MCP store server the authenticated user has connected, each with its tools, their argument schemas, and authoring docs. Use this before writing a canvas that shows pull requests, calendar events, issues, or any other data that must stay fresh per viewer, then declare each provider and tool you call in the project's `capabilities.connectors`. Calls run with the VIEWER's own connection at view time, never the author's, so results are never baked into the source. Only read-only tools may be declared. Pass `mcp_hosts` to include a server the user has not connected yet.",
+        "category": "Canvas",
+        "feature": "canvas",
+        "summary": "List canvas connectors",
+        "title": "List canvas connectors",
         "required_scopes": ["canvas:read"],
         "annotations": {
             "destructiveHint": false,
@@ -12450,6 +12492,48 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": false
+        }
+    },
+    "web-analytics-bot-rules-create": {
+        "description": "Add one bot rule so traffic matching it classifies as a bot. Set `key` to the event property to read (such as $raw_user_agent or $ip), `matcher` to 'contains' (case-insensitive substring), 'regex' (RE2), or 'cidr' (an IP network range, only with $ip), `pattern` to the value to match, and `name` to the label to report. Optionally set `category` to a built-in category like ai_crawler to relabel the traffic type. The rule is rejected if its pattern cannot run. Use this when a scraper is hitting the site that the built-in list misses.",
+        "category": "Web analytics",
+        "feature": "web_analytics",
+        "summary": "Create a custom bot rule",
+        "title": "Create a custom bot rule",
+        "required_scopes": ["web_analytics:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "web-analytics-bot-rules-destroy": {
+        "description": "Delete one bot rule by its `id` (from the list tool). The built-in bot list is unaffected.",
+        "category": "Web analytics",
+        "feature": "web_analytics",
+        "summary": "Delete a custom bot rule",
+        "title": "Delete a custom bot rule",
+        "required_scopes": ["web_analytics:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "web-analytics-bot-rules-list": {
+        "description": "List the project's own bot rules. Each rule names an event property, how to match it, a value, and the label reported when it matches. Rules extend PostHog's built-in bot list, so `Is bot` (isLikelyBot), `Bot name`, and `Traffic category` reflect them everywhere — insights, web analytics, session filters, and SQL.",
+        "category": "Web analytics",
+        "feature": "web_analytics",
+        "summary": "List custom bot rules",
+        "title": "List custom bot rules",
+        "required_scopes": ["web_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
         }
     },
     "web-analytics-path-cleaning-suggestions-apply": {

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -102,7 +102,7 @@
             "openWorldHint": true,
             "readOnlyHint": true
         },
-        "feature_entitlement": "access_control"
+        "feature_entitlement": "role_based_access"
     },
     "access-control-role-properties-list": {
         "description": "The property rules configured for a role: which person and event properties the role's members cannot see (`none`), can only read (`read`), or can read and write (`read_write`).",
@@ -117,7 +117,7 @@
             "openWorldHint": true,
             "readOnlyHint": true
         },
-        "feature_entitlement": "access_control"
+        "feature_entitlement": "role_based_access"
     },
     "access-control-roles-list": {
         "description": "For every role in the organization, the access it grants in the project: to the project itself and to each tool. Per entry, `access_level` is the role's own stored rule, `effective_access_level` is what the role's members get from it, and `inherited_access` says where that level comes from when the role has no rule of its own. Pass `role_id` for one role.",
@@ -132,7 +132,7 @@
             "openWorldHint": true,
             "readOnlyHint": true
         },
-        "feature_entitlement": "access_control"
+        "feature_entitlement": "role_based_access"
     },
     "account-relationship-definitions-create": {
         "description": "Create a Customer Analytics account relationship definition — a team-defined relationship type between a PostHog user and an account, such as CSM or Onboarding manager. Provide `name` (required, unique within the team), optional `description` explaining what the relationship means, and `is_single_holder` (default true) controlling whether only one user can hold the relationship per account at a time. Definitions are team-scoped and shared across all accounts; assign a user to a specific account with `accounts-relationships-create`.",

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -11,7 +11,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_entitlement": "access_control"
     },
     "access-control-default-properties-list": {
         "description": "Property rules that apply to everyone in the project without a rule of their own on that property: which person and event properties are hidden (`none`), read-only (`read`), or open (`read_write`). Every property is `read_write` unless a rule says otherwise.",
@@ -25,7 +26,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_entitlement": "access_control"
     },
     "access-control-defaults-get": {
         "description": "The access everyone in the project gets unless a rule of their own, or a role's rule, says otherwise: the default project level (member or admin) and the default level per tool (none, viewer, editor, manager), with the lowest and highest level each tool allows. Also lists which tools accept rules on single objects, such as one dashboard or one notebook. Start here to understand a project's baseline before checking a member or a role.",
@@ -39,7 +41,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_entitlement": "access_control"
     },
     "access-control-member-objects-list": {
         "description": "The rules configured for a member on single objects, for example a dashboard, a notebook or a warehouse table they are given access to, or blocked from, regardless of their tool-level access. Only the member's own rules are returned. An empty list means the member has no object rules of their own. Their tool-level access still applies.",
@@ -53,7 +56,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_entitlement": "access_control"
     },
     "access-control-member-properties-list": {
         "description": "The property rules configured for a member: which person and event properties they cannot see (`none`), can only read (`read`), or can read and write (`read_write`). Every property is `read_write` unless a rule says otherwise. Only the member's own rules are returned.",
@@ -67,7 +71,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_entitlement": "access_control"
     },
     "access-control-members-list": {
         "description": "For every organization member, the access enforced in the project: to the project itself and to each tool (dashboards, insights, feature flags, and so on). Per entry, `access_level` is the member's own stored rule (null when none), `effective_access_level` is what is enforced, and `inherited_access` says where that level comes from when it is not the member's own rule: `source_subject` is `role` or `default`, and `source` is `org_admin` when the member is an organization admin with full access to everything. Pass `member_id` (an `organization_membership_id`, from this tool or org-members-list) for one member. The checking-member-access skill explains how the levels combine.",
@@ -81,7 +86,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_entitlement": "access_control"
     },
     "access-control-role-objects-list": {
         "description": "The rules configured for a role on single objects, for example a dashboard, a notebook or a warehouse table the role's members are given access to, or blocked from, regardless of their tool-level access.",
@@ -95,7 +101,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_entitlement": "access_control"
     },
     "access-control-role-properties-list": {
         "description": "The property rules configured for a role: which person and event properties the role's members cannot see (`none`), can only read (`read`), or can read and write (`read_write`).",
@@ -109,7 +116,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_entitlement": "access_control"
     },
     "access-control-roles-list": {
         "description": "For every role in the organization, the access it grants in the project: to the project itself and to each tool. Per entry, `access_level` is the role's own stored rule, `effective_access_level` is what the role's members get from it, and `inherited_access` says where that level comes from when the role has no rule of its own. Pass `role_id` for one role.",
@@ -123,7 +131,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_entitlement": "access_control"
     },
     "account-relationship-definitions-create": {
         "description": "Create a Customer Analytics account relationship definition — a team-defined relationship type between a PostHog user and an account, such as CSM or Onboarding manager. Provide `name` (required, unique within the team), optional `description` explaining what the relationship means, and `is_single_holder` (default true) controlling whether only one user can hold the relationship per account at a time. Definitions are team-scoped and shared across all accounts; assign a user to a specific account with `accounts-relationships-create`.",
@@ -560,34 +569,6 @@
         "feature": "alerts",
         "summary": "Delete alert",
         "title": "Delete alert",
-        "required_scopes": ["alert:write"],
-        "annotations": {
-            "destructiveHint": true,
-            "idempotentHint": true,
-            "openWorldHint": true,
-            "readOnlyHint": false
-        }
-    },
-    "alert-destinations-create": {
-        "description": "Post this insight alert to a Slack channel as well as emailing its subscribed users. The Slack workspace must already be connected to the project — list the workspaces and their channels with integrations-channels-retrieve. An alert can have up to 5 destinations. The returned hog_function_ids identify the destination; pass them to alert-destinations-delete to remove it.",
-        "category": "Alerts",
-        "feature": "alerts",
-        "summary": "Send an alert to Slack",
-        "title": "Send an alert to Slack",
-        "required_scopes": ["alert:write"],
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": false,
-            "openWorldHint": true,
-            "readOnlyHint": false
-        }
-    },
-    "alert-destinations-delete": {
-        "description": "Remove a destination from an insight alert by passing the hog_function_ids that alert-destinations-create returned. The alert keeps its email recipients.",
-        "category": "Alerts",
-        "feature": "alerts",
-        "summary": "Stop sending an alert to Slack",
-        "title": "Stop sending an alert to Slack",
         "required_scopes": ["alert:write"],
         "annotations": {
             "destructiveHint": true,
@@ -1246,20 +1227,6 @@
         "feature": "canvas",
         "summary": "Read canvas build status",
         "title": "Read canvas build status",
-        "required_scopes": ["canvas:read"],
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": true,
-            "openWorldHint": true,
-            "readOnlyHint": true
-        }
-    },
-    "canvas-connectors-retrieve": {
-        "description": "List the connector catalog a canvas can read live third-party data through with `ph.connectors.call`: every native provider (GitHub) and every MCP store server the authenticated user has connected, each with its tools, their argument schemas, and authoring docs. Use this before writing a canvas that shows pull requests, calendar events, issues, or any other data that must stay fresh per viewer, then declare each provider and tool you call in the project's `capabilities.connectors`. Calls run with the VIEWER's own connection at view time, never the author's, so results are never baked into the source. Only read-only tools may be declared. Pass `mcp_hosts` to include a server the user has not connected yet.",
-        "category": "Canvas",
-        "feature": "canvas",
-        "summary": "List canvas connectors",
-        "title": "List canvas connectors",
         "required_scopes": ["canvas:read"],
         "annotations": {
             "destructiveHint": false,
@@ -12483,48 +12450,6 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": false
-        }
-    },
-    "web-analytics-bot-rules-create": {
-        "description": "Add one bot rule so traffic matching it classifies as a bot. Set `key` to the event property to read (such as $raw_user_agent or $ip), `matcher` to 'contains' (case-insensitive substring), 'regex' (RE2), or 'cidr' (an IP network range, only with $ip), `pattern` to the value to match, and `name` to the label to report. Optionally set `category` to a built-in category like ai_crawler to relabel the traffic type. The rule is rejected if its pattern cannot run. Use this when a scraper is hitting the site that the built-in list misses.",
-        "category": "Web analytics",
-        "feature": "web_analytics",
-        "summary": "Create a custom bot rule",
-        "title": "Create a custom bot rule",
-        "required_scopes": ["web_analytics:write"],
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": false,
-            "openWorldHint": true,
-            "readOnlyHint": false
-        }
-    },
-    "web-analytics-bot-rules-destroy": {
-        "description": "Delete one bot rule by its `id` (from the list tool). The built-in bot list is unaffected.",
-        "category": "Web analytics",
-        "feature": "web_analytics",
-        "summary": "Delete a custom bot rule",
-        "title": "Delete a custom bot rule",
-        "required_scopes": ["web_analytics:write"],
-        "annotations": {
-            "destructiveHint": true,
-            "idempotentHint": false,
-            "openWorldHint": true,
-            "readOnlyHint": false
-        }
-    },
-    "web-analytics-bot-rules-list": {
-        "description": "List the project's own bot rules. Each rule names an event property, how to match it, a value, and the label reported when it matches. Rules extend PostHog's built-in bot list, so `Is bot` (isLikelyBot), `Bot name`, and `Traffic category` reflect them everywhere — insights, web analytics, session filters, and SQL.",
-        "category": "Web analytics",
-        "feature": "web_analytics",
-        "summary": "List custom bot rules",
-        "title": "List custom bot rules",
-        "required_scopes": ["web_analytics:read"],
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": true,
-            "openWorldHint": true,
-            "readOnlyHint": true
         }
     },
     "web-analytics-path-cleaning-suggestions-apply": {

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -11,7 +11,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_entitlement": "access_control"
     },
     "access-control-default-properties-list": {
         "description": "Property rules that apply to everyone in the project without a rule of their own on that property: which person and event properties are hidden (`none`), read-only (`read`), or open (`read_write`). Every property is `read_write` unless a rule says otherwise.",
@@ -25,7 +26,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_entitlement": "access_control"
     },
     "access-control-defaults-get": {
         "description": "The access everyone in the project gets unless a rule of their own, or a role's rule, says otherwise: the default project level (member or admin) and the default level per tool (none, viewer, editor, manager), with the lowest and highest level each tool allows. Also lists which tools accept rules on single objects, such as one dashboard or one notebook. Start here to understand a project's baseline before checking a member or a role.",
@@ -39,7 +41,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_entitlement": "access_control"
     },
     "access-control-member-objects-list": {
         "description": "The rules configured for a member on single objects, for example a dashboard, a notebook or a warehouse table they are given access to, or blocked from, regardless of their tool-level access. Only the member's own rules are returned. An empty list means the member has no object rules of their own. Their tool-level access still applies.",
@@ -53,7 +56,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_entitlement": "access_control"
     },
     "access-control-member-properties-list": {
         "description": "The property rules configured for a member: which person and event properties they cannot see (`none`), can only read (`read`), or can read and write (`read_write`). Every property is `read_write` unless a rule says otherwise. Only the member's own rules are returned.",
@@ -67,7 +71,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_entitlement": "access_control"
     },
     "access-control-members-list": {
         "description": "For every organization member, the access enforced in the project: to the project itself and to each tool (dashboards, insights, feature flags, and so on). Per entry, `access_level` is the member's own stored rule (null when none), `effective_access_level` is what is enforced, and `inherited_access` says where that level comes from when it is not the member's own rule: `source_subject` is `role` or `default`, and `source` is `org_admin` when the member is an organization admin with full access to everything. Pass `member_id` (an `organization_membership_id`, from this tool or org-members-list) for one member. The checking-member-access skill explains how the levels combine.",
@@ -81,7 +86,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_entitlement": "access_control"
     },
     "access-control-role-objects-list": {
         "description": "The rules configured for a role on single objects, for example a dashboard, a notebook or a warehouse table the role's members are given access to, or blocked from, regardless of their tool-level access.",
@@ -95,7 +101,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_entitlement": "access_control"
     },
     "access-control-role-properties-list": {
         "description": "The property rules configured for a role: which person and event properties the role's members cannot see (`none`), can only read (`read`), or can read and write (`read_write`).",
@@ -109,7 +116,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_entitlement": "access_control"
     },
     "access-control-roles-list": {
         "description": "For every role in the organization, the access it grants in the project: to the project itself and to each tool. Per entry, `access_level` is the role's own stored rule, `effective_access_level` is what the role's members get from it, and `inherited_access` says where that level comes from when the role has no rule of its own. Pass `role_id` for one role.",
@@ -123,7 +131,8 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
+        },
+        "feature_entitlement": "access_control"
     },
     "account-relationship-definitions-create": {
         "description": "Create a Customer Analytics account relationship definition — a team-defined relationship type between a PostHog user and an account, such as CSM or Onboarding manager. Provide `name` (required, unique within the team), optional `description` explaining what the relationship means, and `is_single_holder` (default true) controlling whether only one user can hold the relationship per account at a time. Definitions are team-scoped and shared across all accounts; assign a user to a specific account with `accounts-relationships-create`.",
@@ -575,34 +584,6 @@
         "feature": "alerts",
         "summary": "Delete alert",
         "title": "Delete alert",
-        "required_scopes": ["alert:write"],
-        "annotations": {
-            "destructiveHint": true,
-            "idempotentHint": true,
-            "openWorldHint": true,
-            "readOnlyHint": false
-        }
-    },
-    "alert-destinations-create": {
-        "description": "Post this insight alert to a Slack channel as well as emailing its subscribed users. The Slack workspace must already be connected to the project — list the workspaces and their channels with integrations-channels-retrieve. An alert can have up to 5 destinations. The returned hog_function_ids identify the destination; pass them to alert-destinations-delete to remove it.",
-        "category": "Alerts",
-        "feature": "alerts",
-        "summary": "Send an alert to Slack",
-        "title": "Send an alert to Slack",
-        "required_scopes": ["alert:write"],
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": false,
-            "openWorldHint": true,
-            "readOnlyHint": false
-        }
-    },
-    "alert-destinations-delete": {
-        "description": "Remove a destination from an insight alert by passing the hog_function_ids that alert-destinations-create returned. The alert keeps its email recipients.",
-        "category": "Alerts",
-        "feature": "alerts",
-        "summary": "Stop sending an alert to Slack",
-        "title": "Stop sending an alert to Slack",
         "required_scopes": ["alert:write"],
         "annotations": {
             "destructiveHint": true,
@@ -1261,20 +1242,6 @@
         "feature": "canvas",
         "summary": "Read canvas build status",
         "title": "Read canvas build status",
-        "required_scopes": ["canvas:read"],
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": true,
-            "openWorldHint": true,
-            "readOnlyHint": true
-        }
-    },
-    "canvas-connectors-retrieve": {
-        "description": "List the connector catalog a canvas can read live third-party data through with `ph.connectors.call`: every native provider (GitHub) and every MCP store server the authenticated user has connected, each with its tools, their argument schemas, and authoring docs. Use this before writing a canvas that shows pull requests, calendar events, issues, or any other data that must stay fresh per viewer, then declare each provider and tool you call in the project's `capabilities.connectors`. Calls run with the VIEWER's own connection at view time, never the author's, so results are never baked into the source. Only read-only tools may be declared. Pass `mcp_hosts` to include a server the user has not connected yet.",
-        "category": "Canvas",
-        "feature": "canvas",
-        "summary": "List canvas connectors",
-        "title": "List canvas connectors",
         "required_scopes": ["canvas:read"],
         "annotations": {
             "destructiveHint": false,
@@ -13128,48 +13095,6 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": false
-        }
-    },
-    "web-analytics-bot-rules-create": {
-        "description": "Add one bot rule so traffic matching it classifies as a bot. Set `key` to the event property to read (such as $raw_user_agent or $ip), `matcher` to 'contains' (case-insensitive substring), 'regex' (RE2), or 'cidr' (an IP network range, only with $ip), `pattern` to the value to match, and `name` to the label to report. Optionally set `category` to a built-in category like ai_crawler to relabel the traffic type. The rule is rejected if its pattern cannot run. Use this when a scraper is hitting the site that the built-in list misses.",
-        "category": "Web analytics",
-        "feature": "web_analytics",
-        "summary": "Create a custom bot rule",
-        "title": "Create a custom bot rule",
-        "required_scopes": ["web_analytics:write"],
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": false,
-            "openWorldHint": true,
-            "readOnlyHint": false
-        }
-    },
-    "web-analytics-bot-rules-destroy": {
-        "description": "Delete one bot rule by its `id` (from the list tool). The built-in bot list is unaffected.",
-        "category": "Web analytics",
-        "feature": "web_analytics",
-        "summary": "Delete a custom bot rule",
-        "title": "Delete a custom bot rule",
-        "required_scopes": ["web_analytics:write"],
-        "annotations": {
-            "destructiveHint": true,
-            "idempotentHint": false,
-            "openWorldHint": true,
-            "readOnlyHint": false
-        }
-    },
-    "web-analytics-bot-rules-list": {
-        "description": "List the project's own bot rules. Each rule names an event property, how to match it, a value, and the label reported when it matches. Rules extend PostHog's built-in bot list, so `Is bot` (isLikelyBot), `Bot name`, and `Traffic category` reflect them everywhere — insights, web analytics, session filters, and SQL.",
-        "category": "Web analytics",
-        "feature": "web_analytics",
-        "summary": "List custom bot rules",
-        "title": "List custom bot rules",
-        "required_scopes": ["web_analytics:read"],
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": true,
-            "openWorldHint": true,
-            "readOnlyHint": true
         }
     },
     "web-analytics-path-cleaning-suggestions-apply": {

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -592,6 +592,34 @@
             "readOnlyHint": false
         }
     },
+    "alert-destinations-create": {
+        "description": "Post this insight alert to a Slack channel as well as emailing its subscribed users. The Slack workspace must already be connected to the project — list the workspaces and their channels with integrations-channels-retrieve. An alert can have up to 5 destinations. The returned hog_function_ids identify the destination; pass them to alert-destinations-delete to remove it.",
+        "category": "Alerts",
+        "feature": "alerts",
+        "summary": "Send an alert to Slack",
+        "title": "Send an alert to Slack",
+        "required_scopes": ["alert:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "alert-destinations-delete": {
+        "description": "Remove a destination from an insight alert by passing the hog_function_ids that alert-destinations-create returned. The alert keeps its email recipients.",
+        "category": "Alerts",
+        "feature": "alerts",
+        "summary": "Stop sending an alert to Slack",
+        "title": "Stop sending an alert to Slack",
+        "required_scopes": ["alert:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "alert-get": {
         "description": "Get a specific alert by ID. Returns the full alert configuration including check results, threshold settings, detector_config (for anomaly detection alerts), and subscribed users. Check results include anomaly_scores, triggered_points, and triggered_dates for detector-based alerts. By default returns the last 5 checks. Use checks_date_from and checks_date_to (e.g. '-24h', '-7d') to get checks within a time window, and checks_limit to control the maximum returned (default 5, max 500). When date filters are provided without checks_limit, up to 500 checks are returned. Check history is retained for 14 days.",
         "category": "Alerts",
@@ -1242,6 +1270,20 @@
         "feature": "canvas",
         "summary": "Read canvas build status",
         "title": "Read canvas build status",
+        "required_scopes": ["canvas:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "canvas-connectors-retrieve": {
+        "description": "List the connector catalog a canvas can read live third-party data through with `ph.connectors.call`: every native provider (GitHub) and every MCP store server the authenticated user has connected, each with its tools, their argument schemas, and authoring docs. Use this before writing a canvas that shows pull requests, calendar events, issues, or any other data that must stay fresh per viewer, then declare each provider and tool you call in the project's `capabilities.connectors`. Calls run with the VIEWER's own connection at view time, never the author's, so results are never baked into the source. Only read-only tools may be declared. Pass `mcp_hosts` to include a server the user has not connected yet.",
+        "category": "Canvas",
+        "feature": "canvas",
+        "summary": "List canvas connectors",
+        "title": "List canvas connectors",
         "required_scopes": ["canvas:read"],
         "annotations": {
             "destructiveHint": false,
@@ -13095,6 +13137,48 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": false
+        }
+    },
+    "web-analytics-bot-rules-create": {
+        "description": "Add one bot rule so traffic matching it classifies as a bot. Set `key` to the event property to read (such as $raw_user_agent or $ip), `matcher` to 'contains' (case-insensitive substring), 'regex' (RE2), or 'cidr' (an IP network range, only with $ip), `pattern` to the value to match, and `name` to the label to report. Optionally set `category` to a built-in category like ai_crawler to relabel the traffic type. The rule is rejected if its pattern cannot run. Use this when a scraper is hitting the site that the built-in list misses.",
+        "category": "Web analytics",
+        "feature": "web_analytics",
+        "summary": "Create a custom bot rule",
+        "title": "Create a custom bot rule",
+        "required_scopes": ["web_analytics:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "web-analytics-bot-rules-destroy": {
+        "description": "Delete one bot rule by its `id` (from the list tool). The built-in bot list is unaffected.",
+        "category": "Web analytics",
+        "feature": "web_analytics",
+        "summary": "Delete a custom bot rule",
+        "title": "Delete a custom bot rule",
+        "required_scopes": ["web_analytics:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "web-analytics-bot-rules-list": {
+        "description": "List the project's own bot rules. Each rule names an event property, how to match it, a value, and the label reported when it matches. Rules extend PostHog's built-in bot list, so `Is bot` (isLikelyBot), `Bot name`, and `Traffic category` reflect them everywhere — insights, web analytics, session filters, and SQL.",
+        "category": "Web analytics",
+        "feature": "web_analytics",
+        "summary": "List custom bot rules",
+        "title": "List custom bot rules",
+        "required_scopes": ["web_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
         }
     },
     "web-analytics-path-cleaning-suggestions-apply": {

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -102,7 +102,7 @@
             "openWorldHint": true,
             "readOnlyHint": true
         },
-        "feature_entitlement": "access_control"
+        "feature_entitlement": "role_based_access"
     },
     "access-control-role-properties-list": {
         "description": "The property rules configured for a role: which person and event properties the role's members cannot see (`none`), can only read (`read`), or can read and write (`read_write`).",
@@ -117,7 +117,7 @@
             "openWorldHint": true,
             "readOnlyHint": true
         },
-        "feature_entitlement": "access_control"
+        "feature_entitlement": "role_based_access"
     },
     "access-control-roles-list": {
         "description": "For every role in the organization, the access it grants in the project: to the project itself and to each tool. Per entry, `access_level` is the role's own stored rule, `effective_access_level` is what the role's members get from it, and `inherited_access` says where that level comes from when the role has no rule of its own. Pass `role_id` for one role.",
@@ -132,7 +132,7 @@
             "openWorldHint": true,
             "readOnlyHint": true
         },
-        "feature_entitlement": "access_control"
+        "feature_entitlement": "role_based_access"
     },
     "account-relationship-definitions-create": {
         "description": "Create a Customer Analytics account relationship definition — a team-defined relationship type between a PostHog user and an account, such as CSM or Onboarding manager. Provide `name` (required, unique within the team), optional `description` explaining what the relationship means, and `is_single_holder` (default true) controlling whether only one user can hold the relationship per account at a time. Definitions are team-scoped and shared across all accounts; assign a user to a specific account with `accounts-relationships-create`.",

--- a/services/mcp/tests/unit/tool-filtering.test.ts
+++ b/services/mcp/tests/unit/tool-filtering.test.ts
@@ -1213,3 +1213,36 @@ describe('Tool Filtering - Entitlements (activity log family)', () => {
         expect(unknown).toContain('advanced-activity-logs-list')
     })
 })
+
+describe('Tool Filtering - Entitlements (access control family)', () => {
+    const memberAndDefaultTools = [
+        'access-control-defaults-get',
+        'access-control-members-list',
+        'access-control-member-objects-list',
+        'access-control-member-properties-list',
+        'access-control-default-objects-list',
+        'access-control-default-properties-list',
+    ]
+    const roleTools = [
+        'access-control-roles-list',
+        'access-control-role-objects-list',
+        'access-control-role-properties-list',
+    ]
+
+    it.each(memberAndDefaultTools)('%s needs access_control', (tool) => {
+        expect(getToolsForFeatures({ availableFeatures: [], isCloud: true })).not.toContain(tool)
+        expect(getToolsForFeatures({ availableFeatures: ['access_control'], isCloud: true })).toContain(tool)
+    })
+
+    it.each(roleTools)('%s needs role_based_access, not just access_control', (tool) => {
+        expect(getToolsForFeatures({ availableFeatures: ['access_control'], isCloud: true })).not.toContain(tool)
+        expect(getToolsForFeatures({ availableFeatures: ['role_based_access'], isCloud: true })).toContain(tool)
+    })
+
+    it('fails open when entitlements are unknown', () => {
+        const unknown = getToolsForFeatures({ isCloud: true })
+        for (const tool of [...memberAndDefaultTools, ...roleTools]) {
+            expect(unknown).toContain(tool)
+        }
+    })
+})


### PR DESCRIPTION
## Problem

The nine access control MCP tools from #94553 are offered to every organization, but access control is a Boost, Scale and Enterprise feature. On a plan without it the settings page shows a paywall, while the tools still answer, with every level resolved to the PostHog default (`Editor` for resources, `Admin` for project)

## Changes

- Organizations without the `access_control` feature no longer see the six member and default tools in the MCP catalog. Each carries `feature_entitlement: access_control`, the same gate `platform_features` uses for `audit_logs` and `approvals`.
- The three role access tools, `access-control-roles-list`, `access-control-role-objects-list` and `access-control-role-properties-list`, gate on `role_based_access` instead. Role rules count for access only on Enterprise, and the general roles tools stay available on every plan.
- The gate is fail-open, like the backend's premium checks: self-hosted instances and sessions where the features cannot be resolved keep the tools.
- The `checking-member-access` skill says the tools are not offered on free and pay-as-you-go plans

## How did you test this code?

The MCP unit tests pass, including the tool definition checks. The entitlement predicate itself has existing unit coverage in `services/mcp`

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No
