### PR TITLE
fix(cdp): clamp the janitor stall-backoff exponent before float8 overflow

### DIFF
--- a/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
@@ -2206,6 +2206,10 @@ describe('Cyclotron V2', () => {
             { touchCount: 1, baseMs: 10_000, maxMs: 600_000, minDeferMs: 4_000, maxDeferMs: 18_000 },
             { touchCount: 2, baseMs: 10_000, maxMs: 600_000, minDeferMs: 13_000, maxDeferMs: 38_000 },
             { touchCount: 2, baseMs: 10_000, maxMs: 5_000, minDeferMs: 2_000, maxDeferMs: 12_000 },
+            // Past 1023 touches, an unclamped POWER(2, touch_count) overflows float8 and the
+            // whole stall-reset UPDATE fails, so no stalled job on the queue recovers. The
+            // clamped exponent must land the row at the cap like any deep backoff.
+            { touchCount: 2_000, baseMs: 10_000, maxMs: 5_000, minDeferMs: 2_000, maxDeferMs: 12_000 },
         ])(
             'resetStalledJobs backs off repeat stalls exponentially, capped (touch=$touchCount, cap=$maxMs)',
             async ({ touchCount, baseMs, maxMs, minDeferMs, maxDeferMs }) => {
@@ -2221,7 +2225,9 @@ describe('Cyclotron V2', () => {
                 const before = Date.now()
                 const janitor = createJanitor({
                     stallTimeoutMs: 1_000,
-                    maxTouchCount: 100,
+                    // Above every touchCount case, so the poison-pill sweep (which runs before
+                    // the stall reset and would drop a non-invocation-queue row) never engages.
+                    maxTouchCount: 100_000,
                     stallBackoffBaseMs: baseMs,
                     stallBackoffMaxMs: maxMs,
                 })

--- a/nodejs/src/cdp/services/cyclotron-v2/janitor.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/janitor.ts
@@ -449,11 +449,15 @@ export class CyclotronV2Janitor {
         //      capped at max — half-jitter ([0.5, 1] x) on this part.
         // Disabled when stallBackoffBaseMs <= 0 — scheduled is left untouched
         // (immediate retry, the pre-backoff behavior).
+        // The exponent clamps at 30 because float8 POWER overflows past 2^1023,
+        // which would fail this UPDATE for every stalled job once one row's touch
+        // count grows past 1023. 2^30 * base already exceeds any real
+        // stallBackoffMaxMs, so the outer LEAST caps the result identically.
         const backoffEnabled = this.stallBackoffBaseMs > 0
         const backoffClause = backoffEnabled
             ? `, scheduled = NOW() + (
                    $4::float8 * random()
-                   + LEAST($2::float8 * (POWER(2, janitor_touch_count) - 1), $3::float8) * (0.5 + 0.5 * random())
+                   + LEAST($2::float8 * (POWER(2, LEAST(janitor_touch_count, 30)) - 1), $3::float8) * (0.5 + 0.5 * random())
                ) * INTERVAL '1 millisecond'`
             : ''
         const params: (Date | number)[] = backoffEnabled


### PR DESCRIPTION
## Problem

Once one stalled job's touch count passes 1023, the janitor's stall-reset UPDATE fails for every stalled job, so none of them recover.

- The backoff clause computes `POWER(2, janitor_touch_count)` in float8, which overflows past 2^1023.
- #97591 saturates the counter at 32767 instead of erroring, which makes touch counts that high reachable: a poison pill the janitor cannot record accrues touches without bound.

## Changes

- The exponent clamps at 30. 2^30 times the base already exceeds any real `stallBackoffMaxMs`, so the outer `LEAST` caps the delay identically and no retry schedule changes.
- Companion to #97591; the two merge cleanly in either order.

## How did you test this code?

- A new case in the existing parameterized backoff test: a stalled row with 2000 touches must reset and land at the backoff cap. Without the clamp, the UPDATE fails with `value out of range: overflow`.
- Mechanical test change: the test janitor's `maxTouchCount` rises above every case, so the poison-pill sweep does not delete the row before the stall reset runs.
- Not run locally (the suite needs the dev stack Postgres); CI runs it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code while investigating a stalled email consumer loop. Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions.
- Duplicate check: `gh pr list --search "cyclotron smallint"` found #97591, which covers the counter saturation. This PR carries only the overflow that PR does not touch; it started as a full saturation branch and was cut down to this delta after finding #97591.
