### PR TITLE
fix(capture): install rustls CryptoProvider in capture-apm-metrics

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2243,6 +2243,7 @@ dependencies = [
  "metrics",
  "opentelemetry-proto 0.29.0",
  "prost 0.13.5",
+ "rustls 0.23.37",
  "serde",
  "serde_json",
  "siphasher 1.0.2",

--- a/rust/capture-apm-metrics/Cargo.toml
+++ b/rust/capture-apm-metrics/Cargo.toml
@@ -17,6 +17,8 @@ capture = { path = "../capture" }
 capture-logs = { path = "../capture-logs" }
 common-compression = { path = "../common/compression" }
 common-redis = { path = "../common/redis" }
+# redis leaves the rustls provider to the binary, so `rediss://` needs one installed here.
+rustls = { workspace = true }
 tower-http = { workspace = true }
 envconfig = { workspace = true }
 bytes = { workspace = true }

--- a/rust/capture-apm-metrics/src/main.rs
+++ b/rust/capture-apm-metrics/src/main.rs
@@ -132,6 +132,11 @@ async fn start_series_label_gate(config: &Config) -> Arc<SeriesLabelGate> {
 
 #[tokio::main]
 async fn main() {
+    // Without this, the first TLS handshake to Valkey panics the task that made it.
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("failed to install rustls CryptoProvider");
+
     setup_tracing();
     info!("Starting up...");
 


### PR DESCRIPTION
## Problem

`capture-apm-metrics` crashes on its first TLS connection to Redis/Valkey (`rediss://`), instead of falling back to its local-only cache. The panic message points at rustls not finding a process-wide `CryptoProvider`:

```
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
```

## Changes

- Installs the `aws-lc-rs` rustls `CryptoProvider` at the top of `main()`, before any TLS use.
- Adds a direct `rustls` dependency (workspace version) so the binary can call the install API.

This mirrors the same fix already in place in `usage-ingestion`, which hits the identical gap: the `redis` crate leaves provider selection to the binary.

## How did you test this code?

- `cargo check -p capture-apm-metrics` passes.
- Did not reproduce the panic against a live `rediss://` endpoint; no automated test added since this is a one-line startup fix mirroring an existing, working pattern elsewhere in the workspace.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool used: Claude Code (PostHog Desktop cloud task).
- No repo skills were invoked; this is a small, mechanical fix following an existing sibling-crate pattern (`usage-ingestion`, `ingestion-consumer`, `personhog-router`).
- Decision: used the `aws_lc_rs` provider (not `ring`), matching the workspace-wide `rustls` feature selection and `usage-ingestion`'s redis-specific fix, rather than the `ring` provider used by crates whose TLS need comes from `kube`.
- No duplicate: searched open issues/PRs for "capture-apm-metrics rustls CryptoProvider" — found none.
- Public artifact: nothing in this PR beyond the panic message the user pasted, which is a generic rustls library message with no private data.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*