### PR TITLE
fix(workflows): describe the cohort split warning as relative weights

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/steps/StepRandomCohortBranch.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepRandomCohortBranch.tsx
@@ -120,7 +120,6 @@ export function StepRandomCohortBranchConfiguration({
     const percentages = cohorts.map((cohort) => cohort.percentage)
     const totalPercentage = percentages.reduce((sum, percentage) => sum + percentage, 0)
     const isBalanced = cohortPercentagesAddUp(percentages)
-    const shortfall = 100 - totalPercentage
 
     return (
         <div className="flex flex-col gap-3">
@@ -156,9 +155,7 @@ export function StepRandomCohortBranchConfiguration({
 
             {cohorts.length > 0 && !isBalanced && (
                 <div className="text-sm text-orange-600">
-                    {shortfall > 0
-                        ? `These add up to ${formatPercentage(totalPercentage)}%. The remaining ${formatPercentage(shortfall)}% will go to the last cohort.`
-                        : `These add up to ${formatPercentage(totalPercentage)}%. Later cohorts will get less than their share, and some may never be used.`}
+                    {`These add up to ${formatPercentage(totalPercentage)}%. Traffic is split in proportion to these values, so 10% and 10% sends half to each. To hold back a share of traffic, add a cohort for it.`}
                 </div>
             )}
 

--- a/products/workflows/frontend/Workflows/hogflows/steps/utils.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/utils.test.ts
@@ -256,7 +256,7 @@ describe('utils', () => {
     describe('cohortPercentagesAddUp', () => {
         // Both directions of this have bitten: comparing against 100 exactly reports the balance
         // button's own output as unbalanced, while a tolerance wide enough to cover a hundredth of a
-        // percent hides shortfalls the runtime really does reroute to the last cohort.
+        // percent hides totals that really do miss 100.
         it.each([2, 3, 7, 8, 30, 99])('accepts the even split produced for %i cohorts', (count) => {
             expect(cohortPercentagesAddUp(normalizeCohortPercentages(count))).toBe(true)
         })

--- a/products/workflows/frontend/Workflows/hogflows/steps/utils.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/utils.ts
@@ -53,11 +53,9 @@ export function removeBranchEdge(branchEdges: HogFlowEdge[], conditionIndex: num
  * Percentages for an even N-way cohort split, summing to exactly 100.
  *
  * Shares are allocated in hundredths of a percent rather than whole percents, because whole percents
- * can't divide 100 evenly for most counts and the runtime routes any shortfall to the last cohort
- * (see getRandomCohort). Allocating in whole percents therefore gave 30 cohorts ten shares of 4% and
- * twenty of 3%, so a third of the branches carried 33% more than the rest. The leftover hundredths
- * are spread one each across the leading cohorts, which keeps every share within 0.01 of its fair
- * value.
+ * can't divide 100 evenly for most counts, and a total that misses 100 trips the editor's warning
+ * even though the runtime splits by relative weight. The leftover hundredths are spread one each
+ * across the leading cohorts, which keeps every share within 0.01 of its fair value.
  */
 export function normalizeCohortPercentages(count: number): number[] {
     if (count <= 0) {


### PR DESCRIPTION
## Problem

A workflow editor who sets a random cohort split to A = 10% and B = 10% is told the remaining 80% will go to the last cohort. The runtime sends half the runs to each cohort instead.

- The runtime has split traffic by relative weight since #75157.
- The warning below the cohort list predates that PR and still describes the old remainder-to-last-cohort routing.
- Editors who read the warning expect a holdout that never happens.

## Changes

- The warning now says traffic is split in proportion to the values, gives the 10/10 example, and tells the editor to add a cohort to hold back a share.
- Both directions (total under or over 100) get the same message, because relative weights make the direction irrelevant.
- Mechanical: two comments that still described the shortfall-to-last-cohort routing now describe the weight semantics.

Before:

> These add up to 20%. The remaining 80% will go to the last cohort.

After:

> These add up to 20%. Traffic is split in proportion to these values, so 10% and 10% sends half to each. To hold back a share of traffic, add a cohort for it.

No screenshot. The change swaps the one line of warning text quoted above and nothing else in the panel moves.

## How did you test this code?

- Typecheck and oxlint on the touched files.
- No tests changed in what they assert. The only test edit is a comment.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The runtime semantics are already documented in the serializer description and the workflow-authoring skill.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code, from a support escalation about a split that behaved as 50/50 rather than the 10/10/80 holdout the editor's warning implied. Skills invoked: `/writing-user-facing-copy`, `/writing-pr-descriptions`.

https://claude.ai/code/session_01LRMmdn9W7bJXjGi257ZHN5
