### PR TITLE
fix(mcp): keep shared blob cache keys in one Redis Cluster slot

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5253,6 +5253,9 @@ importers:
       chokidar:
         specifier: ^3.6.0
         version: 3.6.0
+      cluster-key-slot:
+        specifier: ^1.1.2
+        version: 1.1.2
       dotenv:
         specifier: ^16.4.7
         version: 16.4.7

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -87,6 +87,7 @@
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
         "chokidar": "^3.6.0",
+        "cluster-key-slot": "^1.1.2",
         "dotenv": "^16.4.7",
         "msw": "^2.14.6",
         "oxfmt": "^0.33.0",

--- a/services/mcp/src/hono/cache/SharedBlobCache.ts
+++ b/services/mcp/src/hono/cache/SharedBlobCache.ts
@@ -79,7 +79,9 @@ export class SharedBlobCache {
         opts: SharedBlobCacheOptions = {}
     ) {
         // Separate layouts let old and new processes coexist during a rolling deploy.
-        const prefix = `mcp:shared-blob:${namespace}:v2`
+        // The hash tag keeps the pointer, blob, and lock in one Redis Cluster slot, so
+        // a script over two of them is accepted.
+        const prefix = `mcp:shared-blob:{${namespace}}:v3`
         this.currentKey = `${prefix}:current`
         this.blobKeyPrefix = `${prefix}:blob`
         this.lockKey = `${prefix}:lock`

--- a/services/mcp/tests/hono/context-mill-resource-cache.test.ts
+++ b/services/mcp/tests/hono/context-mill-resource-cache.test.ts
@@ -74,8 +74,8 @@ function createMockRedis(): MockRedis {
     }
 }
 
-const MANIFEST_CURRENT_KEY = 'mcp:shared-blob:context-mill:manifest:v2:current'
-const MANIFEST_LOCK_KEY = 'mcp:shared-blob:context-mill:manifest:v2:lock'
+const MANIFEST_CURRENT_KEY = 'mcp:shared-blob:{context-mill:manifest}:v3:current'
+const MANIFEST_LOCK_KEY = 'mcp:shared-blob:{context-mill:manifest}:v3:lock'
 
 function bodyKey(uri: string): string {
     const hash = createHash('sha256').update(uri).digest('hex')

--- a/services/mcp/tests/hono/helpers/shared-blob-redis-stubs.ts
+++ b/services/mcp/tests/hono/helpers/shared-blob-redis-stubs.ts
@@ -1,3 +1,4 @@
+import calculateSlot from 'cluster-key-slot'
 import { vi } from 'vitest'
 
 import type { RedisLike } from '@/hono/cache/RedisCache'
@@ -7,6 +8,7 @@ export function makeSharedBlobRedisStubs(store: Map<string, string>): Pick<Redis
         ttl: vi.fn(async (key: string) => (store.has(key) ? 60 : -2)),
         expire: vi.fn(async (key: string) => (store.has(key) ? 1 : 0)),
         eval: vi.fn(async (_script: string, numberOfKeys: number, ...args: (string | number)[]) => {
+            assertSingleSlot(args.slice(0, numberOfKeys).map(String))
             if (numberOfKeys === 1) {
                 const [key, token] = args.map(String)
                 return store.get(key!) === token ? Number(store.delete(key!)) : 0
@@ -18,5 +20,12 @@ export function makeSharedBlobRedisStubs(store: Map<string, string>): Pick<Redis
             store.set(key!, replacement!)
             return 1
         }),
+    }
+}
+
+// Redis Cluster rejects a multi-key command unless every key hashes to one slot.
+function assertSingleSlot(keys: string[]): void {
+    if (new Set(keys.map((key) => calculateSlot(key))).size > 1) {
+        throw new Error("CROSSSLOT Keys in request don't hash to the same slot")
     }
 }

--- a/services/mcp/tests/hono/resource-catalog.test.ts
+++ b/services/mcp/tests/hono/resource-catalog.test.ts
@@ -97,7 +97,7 @@ function makeEntry(suffix: string): ContextMillResource {
     }
 }
 
-const MANIFEST_CURRENT_KEY = 'mcp:shared-blob:context-mill:manifest:v2:current'
+const MANIFEST_CURRENT_KEY = 'mcp:shared-blob:{context-mill:manifest}:v3:current'
 
 describe('ResourceCatalog', () => {
     let redis: MockRedis

--- a/services/mcp/tests/hono/shared-blob-cache.test.ts
+++ b/services/mcp/tests/hono/shared-blob-cache.test.ts
@@ -69,8 +69,8 @@ function createMockRedis(): MockRedis {
 }
 
 const NAMESPACE = 'test-blob'
-const CURRENT_KEY = `mcp:shared-blob:${NAMESPACE}:v2:current`
-const LOCK_KEY = `mcp:shared-blob:${NAMESPACE}:v2:lock`
+const CURRENT_KEY = `mcp:shared-blob:{${NAMESPACE}}:v3:current`
+const LOCK_KEY = `mcp:shared-blob:{${NAMESPACE}}:v3:lock`
 
 describe('SharedBlobCache', () => {
     let redis: MockRedis

--- a/services/mcp/tests/unit/skill-archive-cache.test.ts
+++ b/services/mcp/tests/unit/skill-archive-cache.test.ts
@@ -46,15 +46,15 @@ function downloaded(bytes: Uint8Array = makeArchive(), etag?: string): SkillArch
     return { status: 'downloaded', bytes, etag }
 }
 
-const CURRENT_KEY = 'mcp:shared-blob:product-skills:v2:current'
-const LOCK_KEY = 'mcp:shared-blob:product-skills:v2:lock'
+const CURRENT_KEY = 'mcp:shared-blob:{product-skills}:v3:current'
+const LOCK_KEY = 'mcp:shared-blob:{product-skills}:v3:lock'
 
 function current(redis: MockRedis): { sha: string; etag?: string; validatedAt: number } {
     return JSON.parse(redis.store.get(CURRENT_KEY)!)
 }
 
 function bytesKey(redis: MockRedis): string {
-    return `mcp:shared-blob:product-skills:v2:blob:${current(redis).sha}`
+    return `mcp:shared-blob:{product-skills}:v3:blob:${current(redis).sha}`
 }
 
 function expireSharedCopy(redis: MockRedis): void {


### PR DESCRIPTION
## Problem

- The MCP server re-checks the shared skills archive against GitHub every 10 minutes. When GitHub answers that the archive is unchanged (304), that check fails every time in production.
- Production Redis for MCP runs in cluster mode. The 304 path updates the version pointer and the blob in one Lua script, and those two keys hash to different slots, so Redis rejects the script with `CROSSSLOT`.
- Result: the shared copy is only re-stamped when a new skills.zip is published, every stale poll logs `poll failed ... CROSSSLOT`, and `mcp_skill_archive_last_validated_timestamp_seconds` reads far older than it should. Skills still load and new releases are still picked up, because the download path writes one key per command.

## Changes

- The shared blob keys get a hash tag, `mcp:shared-blob:{<namespace>}:v3:...`, so the pointer, blob, and lock share one slot and the script is accepted.
- The layout version moves from v2 to v3 so old and new pods do not share keys during rollout. v2 keys expire on their own TTL.
- Tests only: the Redis stub now computes each key's real slot with the library ioredis uses, and rejects a multi-key script that mixes slots with the error Redis returns. Three tests update their expected key names.

## How did you test this code?

- With the stub change alone, four existing 304 tests fail with the production error. With the key change they pass.
- Not run: a real cluster-mode Redis. Local dev uses single-node Redis, which is why this did not show up before production.
- After deploy: `mcp_skill_archive_events_total{result="not_modified"}` should start counting and the CROSSSLOT log lines should stop.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Claude Fable 5.1). The MCP owner found the stale freshness metric while preparing an alert on it and directed the investigation and the fix. Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions. No open PR covers this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BQD6w8zeLoE4vmrTBdPiNs
