### PR TITLE
fix(logs): cap volume/pattern bucket TTL to the team's own retention

### DIFF
--- a/posthog/clickhouse/hcl/golden/dev/logs.hcl
+++ b/posthog/clickhouse/hcl/golden/dev/logs.hcl
@@ -683,7 +683,7 @@ SQL
     primary_key  = ["team_id", "time_bucket", "service_name", "namespace", "environment", "severity_text", "pattern_version"]
     order_by     = ["team_id", "time_bucket", "service_name", "namespace", "environment", "severity_text", "pattern_version", "pattern"]
     partition_by = "toDate(time_bucket)"
-    ttl          = "time_bucket + toIntervalDay(42)"
+    ttl          = "time_bucket + toIntervalDay(least(retention_days, 42))"
     settings = {
       index_granularity   = "8192"
       ttl_only_drop_parts = "1"
@@ -715,6 +715,10 @@ SQL
     }
     column "log_count" {
       type = "SimpleAggregateFunction(sum, UInt64)"
+    }
+    column "retention_days" {
+      type    = "UInt16"
+      default = "42"
     }
     engine "replicated_aggregating_merge_tree" {
       zoo_path     = "/clickhouse/tables/noshard/posthog.logs_pattern_buckets"
@@ -751,6 +755,10 @@ SQL
     column "log_count" {
       type = "SimpleAggregateFunction(sum, UInt64)"
     }
+    column "retention_days" {
+      type    = "UInt16"
+      default = "42"
+    }
     engine "distributed" {
       cluster_name    = "logs"
       remote_database = "posthog"
@@ -761,7 +769,7 @@ SQL
   table "logs_volume_buckets" {
     order_by     = ["team_id", "time_bucket", "service_name", "namespace", "environment", "severity_text"]
     partition_by = "toDate(time_bucket)"
-    ttl          = "time_bucket + toIntervalDay(42)"
+    ttl          = "time_bucket + toIntervalDay(least(retention_days, 42))"
     settings = {
       index_granularity   = "8192"
       ttl_only_drop_parts = "1"
@@ -787,6 +795,10 @@ SQL
     }
     column "log_count" {
       type = "SimpleAggregateFunction(sum, UInt64)"
+    }
+    column "retention_days" {
+      type    = "UInt16"
+      default = "42"
     }
     engine "replicated_aggregating_merge_tree" {
       zoo_path     = "/clickhouse/tables/noshard/posthog.logs_volume_buckets"
@@ -816,6 +828,10 @@ SQL
     }
     column "log_count" {
       type = "SimpleAggregateFunction(sum, UInt64)"
+    }
+    column "retention_days" {
+      type    = "UInt16"
+      default = "42"
     }
     engine "distributed" {
       cluster_name    = "logs"

--- a/posthog/clickhouse/hcl/golden/local-multi/logs.hcl
+++ b/posthog/clickhouse/hcl/golden/local-multi/logs.hcl
@@ -1247,7 +1247,7 @@ SQL
     primary_key  = ["team_id", "time_bucket", "service_name", "namespace", "environment", "severity_text", "pattern_version"]
     order_by     = ["team_id", "time_bucket", "service_name", "namespace", "environment", "severity_text", "pattern_version", "pattern"]
     partition_by = "toDate(time_bucket)"
-    ttl          = "time_bucket + toIntervalDay(42)"
+    ttl          = "time_bucket + toIntervalDay(least(retention_days, 42))"
     settings = {
       index_granularity   = "8192"
       ttl_only_drop_parts = "1"
@@ -1279,6 +1279,10 @@ SQL
     }
     column "log_count" {
       type = "SimpleAggregateFunction(sum, UInt64)"
+    }
+    column "retention_days" {
+      type    = "UInt16"
+      default = "42"
     }
     engine "replicated_aggregating_merge_tree" {
       zoo_path     = "/clickhouse/tables/noshard/posthog.logs_pattern_buckets"
@@ -1315,6 +1319,10 @@ SQL
     column "log_count" {
       type = "SimpleAggregateFunction(sum, UInt64)"
     }
+    column "retention_days" {
+      type    = "UInt16"
+      default = "42"
+    }
     engine "distributed" {
       cluster_name    = "posthog_single_shard"
       remote_database = "posthog"
@@ -1325,7 +1333,7 @@ SQL
   table "logs_volume_buckets" {
     order_by     = ["team_id", "time_bucket", "service_name", "namespace", "environment", "severity_text"]
     partition_by = "toDate(time_bucket)"
-    ttl          = "time_bucket + toIntervalDay(42)"
+    ttl          = "time_bucket + toIntervalDay(least(retention_days, 42))"
     settings = {
       index_granularity   = "8192"
       ttl_only_drop_parts = "1"
@@ -1351,6 +1359,10 @@ SQL
     }
     column "log_count" {
       type = "SimpleAggregateFunction(sum, UInt64)"
+    }
+    column "retention_days" {
+      type    = "UInt16"
+      default = "42"
     }
     engine "replicated_aggregating_merge_tree" {
       zoo_path     = "/clickhouse/tables/noshard/posthog.logs_volume_buckets"
@@ -1380,6 +1392,10 @@ SQL
     }
     column "log_count" {
       type = "SimpleAggregateFunction(sum, UInt64)"
+    }
+    column "retention_days" {
+      type    = "UInt16"
+      default = "42"
     }
     engine "distributed" {
       cluster_name    = "posthog_single_shard"

--- a/posthog/clickhouse/hcl/golden/local-single/all.hcl
+++ b/posthog/clickhouse/hcl/golden/local-single/all.hcl
@@ -5768,7 +5768,7 @@ SQL
     primary_key  = ["team_id", "time_bucket", "service_name", "namespace", "environment", "severity_text", "pattern_version"]
     order_by     = ["team_id", "time_bucket", "service_name", "namespace", "environment", "severity_text", "pattern_version", "pattern"]
     partition_by = "toDate(time_bucket)"
-    ttl          = "time_bucket + toIntervalDay(42)"
+    ttl          = "time_bucket + toIntervalDay(least(retention_days, 42))"
     settings = {
       index_granularity   = "8192"
       ttl_only_drop_parts = "1"
@@ -5800,6 +5800,10 @@ SQL
     }
     column "log_count" {
       type = "SimpleAggregateFunction(sum, UInt64)"
+    }
+    column "retention_days" {
+      type    = "UInt16"
+      default = "42"
     }
     engine "replicated_aggregating_merge_tree" {
       zoo_path     = "/clickhouse/tables/noshard/posthog.logs_pattern_buckets"
@@ -5836,6 +5840,10 @@ SQL
     column "log_count" {
       type = "SimpleAggregateFunction(sum, UInt64)"
     }
+    column "retention_days" {
+      type    = "UInt16"
+      default = "42"
+    }
     engine "distributed" {
       cluster_name    = "posthog_single_shard"
       remote_database = "posthog"
@@ -5846,7 +5854,7 @@ SQL
   table "logs_volume_buckets" {
     order_by     = ["team_id", "time_bucket", "service_name", "namespace", "environment", "severity_text"]
     partition_by = "toDate(time_bucket)"
-    ttl          = "time_bucket + toIntervalDay(42)"
+    ttl          = "time_bucket + toIntervalDay(least(retention_days, 42))"
     settings = {
       index_granularity   = "8192"
       ttl_only_drop_parts = "1"
@@ -5872,6 +5880,10 @@ SQL
     }
     column "log_count" {
       type = "SimpleAggregateFunction(sum, UInt64)"
+    }
+    column "retention_days" {
+      type    = "UInt16"
+      default = "42"
     }
     engine "replicated_aggregating_merge_tree" {
       zoo_path     = "/clickhouse/tables/noshard/posthog.logs_volume_buckets"
@@ -5901,6 +5913,10 @@ SQL
     }
     column "log_count" {
       type = "SimpleAggregateFunction(sum, UInt64)"
+    }
+    column "retention_days" {
+      type    = "UInt16"
+      default = "42"
     }
     engine "distributed" {
       cluster_name    = "posthog_single_shard"

--- a/posthog/clickhouse/hcl/golden/prod-eu/logs.hcl
+++ b/posthog/clickhouse/hcl/golden/prod-eu/logs.hcl
@@ -833,7 +833,7 @@ SQL
     primary_key  = ["team_id", "time_bucket", "service_name", "namespace", "environment", "severity_text", "pattern_version"]
     order_by     = ["team_id", "time_bucket", "service_name", "namespace", "environment", "severity_text", "pattern_version", "pattern"]
     partition_by = "toDate(time_bucket)"
-    ttl          = "time_bucket + toIntervalDay(42)"
+    ttl          = "time_bucket + toIntervalDay(least(retention_days, 42))"
     settings = {
       index_granularity   = "8192"
       ttl_only_drop_parts = "1"
@@ -865,6 +865,10 @@ SQL
     }
     column "log_count" {
       type = "SimpleAggregateFunction(sum, UInt64)"
+    }
+    column "retention_days" {
+      type    = "UInt16"
+      default = "42"
     }
     engine "replicated_aggregating_merge_tree" {
       zoo_path     = "/clickhouse/tables/noshard/posthog.logs_pattern_buckets"
@@ -901,6 +905,10 @@ SQL
     column "log_count" {
       type = "SimpleAggregateFunction(sum, UInt64)"
     }
+    column "retention_days" {
+      type    = "UInt16"
+      default = "42"
+    }
     engine "distributed" {
       cluster_name    = "logs"
       remote_database = "posthog"
@@ -911,7 +919,7 @@ SQL
   table "logs_volume_buckets" {
     order_by     = ["team_id", "time_bucket", "service_name", "namespace", "environment", "severity_text"]
     partition_by = "toDate(time_bucket)"
-    ttl          = "time_bucket + toIntervalDay(42)"
+    ttl          = "time_bucket + toIntervalDay(least(retention_days, 42))"
     settings = {
       index_granularity   = "8192"
       ttl_only_drop_parts = "1"
@@ -937,6 +945,10 @@ SQL
     }
     column "log_count" {
       type = "SimpleAggregateFunction(sum, UInt64)"
+    }
+    column "retention_days" {
+      type    = "UInt16"
+      default = "42"
     }
     engine "replicated_aggregating_merge_tree" {
       zoo_path     = "/clickhouse/tables/noshard/posthog.logs_volume_buckets"
@@ -966,6 +978,10 @@ SQL
     }
     column "log_count" {
       type = "SimpleAggregateFunction(sum, UInt64)"
+    }
+    column "retention_days" {
+      type    = "UInt16"
+      default = "42"
     }
     engine "distributed" {
       cluster_name    = "logs"

--- a/posthog/clickhouse/hcl/golden/prod-us/logs.hcl
+++ b/posthog/clickhouse/hcl/golden/prod-us/logs.hcl
@@ -833,7 +833,7 @@ SQL
     primary_key  = ["team_id", "time_bucket", "service_name", "namespace", "environment", "severity_text", "pattern_version"]
     order_by     = ["team_id", "time_bucket", "service_name", "namespace", "environment", "severity_text", "pattern_version", "pattern"]
     partition_by = "toDate(time_bucket)"
-    ttl          = "time_bucket + toIntervalDay(42)"
+    ttl          = "time_bucket + toIntervalDay(least(retention_days, 42))"
     settings = {
       index_granularity   = "8192"
       ttl_only_drop_parts = "1"
@@ -865,6 +865,10 @@ SQL
     }
     column "log_count" {
       type = "SimpleAggregateFunction(sum, UInt64)"
+    }
+    column "retention_days" {
+      type    = "UInt16"
+      default = "42"
     }
     engine "replicated_aggregating_merge_tree" {
       zoo_path     = "/clickhouse/tables/noshard/posthog.logs_pattern_buckets"
@@ -901,6 +905,10 @@ SQL
     column "log_count" {
       type = "SimpleAggregateFunction(sum, UInt64)"
     }
+    column "retention_days" {
+      type    = "UInt16"
+      default = "42"
+    }
     engine "distributed" {
       cluster_name    = "logs"
       remote_database = "posthog"
@@ -911,7 +919,7 @@ SQL
   table "logs_volume_buckets" {
     order_by     = ["team_id", "time_bucket", "service_name", "namespace", "environment", "severity_text"]
     partition_by = "toDate(time_bucket)"
-    ttl          = "time_bucket + toIntervalDay(42)"
+    ttl          = "time_bucket + toIntervalDay(least(retention_days, 42))"
     settings = {
       index_granularity   = "8192"
       ttl_only_drop_parts = "1"
@@ -937,6 +945,10 @@ SQL
     }
     column "log_count" {
       type = "SimpleAggregateFunction(sum, UInt64)"
+    }
+    column "retention_days" {
+      type    = "UInt16"
+      default = "42"
     }
     engine "replicated_aggregating_merge_tree" {
       zoo_path     = "/clickhouse/tables/noshard/posthog.logs_volume_buckets"
@@ -966,6 +978,10 @@ SQL
     }
     column "log_count" {
       type = "SimpleAggregateFunction(sum, UInt64)"
+    }
+    column "retention_days" {
+      type    = "UInt16"
+      default = "42"
     }
     engine "distributed" {
       cluster_name    = "logs"

--- a/posthog/clickhouse/hcl/roles/logs/base/tables.hcl
+++ b/posthog/clickhouse/hcl/roles/logs/base/tables.hcl
@@ -663,7 +663,7 @@ database "posthog" {
   table "logs_volume_buckets" {
     order_by     = ["team_id", "time_bucket", "service_name", "namespace", "environment", "severity_text"]
     partition_by = "toDate(time_bucket)"
-    ttl          = "time_bucket + toIntervalDay(42)"
+    ttl          = "time_bucket + toIntervalDay(least(retention_days, 42))"
     settings = {
       index_granularity   = "8192"
       ttl_only_drop_parts = "1"
@@ -689,6 +689,14 @@ database "posthog" {
     }
     column "log_count" {
       type = "SimpleAggregateFunction(sum, UInt64)"
+    }
+    # The team's configured Logs retention (days) at write time, clamped to 42 by the TTL above —
+    # this table exists for anomaly detection's 6-week baseline, not to outlive the raw logs it was
+    # built from. Defaults to 42 so existing/unpopulated rows keep today's TTL until the writer
+    # backfills real per-team values.
+    column "retention_days" {
+      type    = "UInt16"
+      default = "42"
     }
     engine "replicated_aggregating_merge_tree" {
       zoo_path     = "/clickhouse/tables/noshard/posthog.logs_volume_buckets"
@@ -719,6 +727,10 @@ database "posthog" {
     column "log_count" {
       type = "SimpleAggregateFunction(sum, UInt64)"
     }
+    column "retention_days" {
+      type    = "UInt16"
+      default = "42"
+    }
     engine "distributed" {
       cluster_name    = "posthog_single_shard"
       remote_database = "posthog"
@@ -730,7 +742,7 @@ database "posthog" {
     order_by     = ["team_id", "time_bucket", "service_name", "namespace", "environment", "severity_text", "pattern_version", "pattern"]
     primary_key  = ["team_id", "time_bucket", "service_name", "namespace", "environment", "severity_text", "pattern_version"]
     partition_by = "toDate(time_bucket)"
-    ttl          = "time_bucket + toIntervalDay(42)"
+    ttl          = "time_bucket + toIntervalDay(least(retention_days, 42))"
     settings = {
       index_granularity   = "8192"
       ttl_only_drop_parts = "1"
@@ -762,6 +774,11 @@ database "posthog" {
     }
     column "log_count" {
       type = "SimpleAggregateFunction(sum, UInt64)"
+    }
+    # See logs_volume_buckets.retention_days — same clamp, same default.
+    column "retention_days" {
+      type    = "UInt16"
+      default = "42"
     }
     engine "replicated_aggregating_merge_tree" {
       zoo_path     = "/clickhouse/tables/noshard/posthog.logs_pattern_buckets"
@@ -797,6 +814,10 @@ database "posthog" {
     }
     column "log_count" {
       type = "SimpleAggregateFunction(sum, UInt64)"
+    }
+    column "retention_days" {
+      type    = "UInt16"
+      default = "42"
     }
     engine "distributed" {
       cluster_name    = "posthog_single_shard"

--- a/posthog/clickhouse/hcl/sql/dev/logs.sql
+++ b/posthog/clickhouse/hcl/sql/dev/logs.sql
@@ -199,8 +199,9 @@ CREATE TABLE posthog.logs_pattern_buckets (
   severity_text LowCardinality(String),
   pattern_version UInt8,
   pattern String,
-  log_count SimpleAggregateFunction(sum, UInt64)
-) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/noshard/posthog.logs_pattern_buckets', '{replica}-{shard}') PRIMARY KEY (team_id, time_bucket, service_name, namespace, environment, severity_text, pattern_version) ORDER BY (team_id, time_bucket, service_name, namespace, environment, severity_text, pattern_version, pattern) PARTITION BY toDate(time_bucket) TTL time_bucket + toIntervalDay(42) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+  log_count SimpleAggregateFunction(sum, UInt64),
+  retention_days UInt16 DEFAULT 42
+) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/noshard/posthog.logs_pattern_buckets', '{replica}-{shard}') PRIMARY KEY (team_id, time_bucket, service_name, namespace, environment, severity_text, pattern_version) ORDER BY (team_id, time_bucket, service_name, namespace, environment, severity_text, pattern_version, pattern) PARTITION BY toDate(time_bucket) TTL time_bucket + toIntervalDay(least(retention_days, 42)) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 CREATE TABLE posthog.logs_pattern_buckets_distributed (
   team_id Int32,
   time_bucket DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
@@ -210,7 +211,8 @@ CREATE TABLE posthog.logs_pattern_buckets_distributed (
   severity_text LowCardinality(String),
   pattern_version UInt8,
   pattern String,
-  log_count SimpleAggregateFunction(sum, UInt64)
+  log_count SimpleAggregateFunction(sum, UInt64),
+  retention_days UInt16 DEFAULT 42
 ) ENGINE = Distributed('logs', 'posthog', 'logs_pattern_buckets');
 CREATE TABLE posthog.logs_volume_buckets (
   team_id Int32,
@@ -219,8 +221,9 @@ CREATE TABLE posthog.logs_volume_buckets (
   namespace LowCardinality(String),
   environment LowCardinality(String),
   severity_text LowCardinality(String),
-  log_count SimpleAggregateFunction(sum, UInt64)
-) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/noshard/posthog.logs_volume_buckets', '{replica}-{shard}') ORDER BY (team_id, time_bucket, service_name, namespace, environment, severity_text) PARTITION BY toDate(time_bucket) TTL time_bucket + toIntervalDay(42) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+  log_count SimpleAggregateFunction(sum, UInt64),
+  retention_days UInt16 DEFAULT 42
+) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/noshard/posthog.logs_volume_buckets', '{replica}-{shard}') ORDER BY (team_id, time_bucket, service_name, namespace, environment, severity_text) PARTITION BY toDate(time_bucket) TTL time_bucket + toIntervalDay(least(retention_days, 42)) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 CREATE TABLE posthog.logs_volume_buckets_distributed (
   team_id Int32,
   time_bucket DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
@@ -228,7 +231,8 @@ CREATE TABLE posthog.logs_volume_buckets_distributed (
   namespace LowCardinality(String),
   environment LowCardinality(String),
   severity_text LowCardinality(String),
-  log_count SimpleAggregateFunction(sum, UInt64)
+  log_count SimpleAggregateFunction(sum, UInt64),
+  retention_days UInt16 DEFAULT 42
 ) ENGINE = Distributed('logs', 'posthog', 'logs_volume_buckets');
 CREATE TABLE posthog.metric_attributes (
   team_id Int32,

--- a/posthog/clickhouse/hcl/sql/local-multi/logs.sql
+++ b/posthog/clickhouse/hcl/sql/local-multi/logs.sql
@@ -312,8 +312,9 @@ CREATE TABLE posthog.logs_pattern_buckets (
   severity_text LowCardinality(String),
   pattern_version UInt8,
   pattern String,
-  log_count SimpleAggregateFunction(sum, UInt64)
-) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/noshard/posthog.logs_pattern_buckets', '{replica}-{shard}') PRIMARY KEY (team_id, time_bucket, service_name, namespace, environment, severity_text, pattern_version) ORDER BY (team_id, time_bucket, service_name, namespace, environment, severity_text, pattern_version, pattern) PARTITION BY toDate(time_bucket) TTL time_bucket + toIntervalDay(42) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+  log_count SimpleAggregateFunction(sum, UInt64),
+  retention_days UInt16 DEFAULT 42
+) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/noshard/posthog.logs_pattern_buckets', '{replica}-{shard}') PRIMARY KEY (team_id, time_bucket, service_name, namespace, environment, severity_text, pattern_version) ORDER BY (team_id, time_bucket, service_name, namespace, environment, severity_text, pattern_version, pattern) PARTITION BY toDate(time_bucket) TTL time_bucket + toIntervalDay(least(retention_days, 42)) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 CREATE TABLE posthog.logs_pattern_buckets_distributed (
   team_id Int32,
   time_bucket DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
@@ -323,7 +324,8 @@ CREATE TABLE posthog.logs_pattern_buckets_distributed (
   severity_text LowCardinality(String),
   pattern_version UInt8,
   pattern String,
-  log_count SimpleAggregateFunction(sum, UInt64)
+  log_count SimpleAggregateFunction(sum, UInt64),
+  retention_days UInt16 DEFAULT 42
 ) ENGINE = Distributed('posthog_single_shard', 'posthog', 'logs_pattern_buckets');
 CREATE TABLE posthog.logs_volume_buckets (
   team_id Int32,
@@ -332,8 +334,9 @@ CREATE TABLE posthog.logs_volume_buckets (
   namespace LowCardinality(String),
   environment LowCardinality(String),
   severity_text LowCardinality(String),
-  log_count SimpleAggregateFunction(sum, UInt64)
-) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/noshard/posthog.logs_volume_buckets', '{replica}-{shard}') ORDER BY (team_id, time_bucket, service_name, namespace, environment, severity_text) PARTITION BY toDate(time_bucket) TTL time_bucket + toIntervalDay(42) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+  log_count SimpleAggregateFunction(sum, UInt64),
+  retention_days UInt16 DEFAULT 42
+) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/noshard/posthog.logs_volume_buckets', '{replica}-{shard}') ORDER BY (team_id, time_bucket, service_name, namespace, environment, severity_text) PARTITION BY toDate(time_bucket) TTL time_bucket + toIntervalDay(least(retention_days, 42)) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 CREATE TABLE posthog.logs_volume_buckets_distributed (
   team_id Int32,
   time_bucket DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
@@ -341,7 +344,8 @@ CREATE TABLE posthog.logs_volume_buckets_distributed (
   namespace LowCardinality(String),
   environment LowCardinality(String),
   severity_text LowCardinality(String),
-  log_count SimpleAggregateFunction(sum, UInt64)
+  log_count SimpleAggregateFunction(sum, UInt64),
+  retention_days UInt16 DEFAULT 42
 ) ENGINE = Distributed('posthog_single_shard', 'posthog', 'logs_volume_buckets');
 CREATE TABLE posthog.metric_attributes (
   team_id Int32,

--- a/posthog/clickhouse/hcl/sql/local-single/all.sql
+++ b/posthog/clickhouse/hcl/sql/local-single/all.sql
@@ -1178,8 +1178,9 @@ CREATE TABLE posthog.logs_pattern_buckets (
   severity_text LowCardinality(String),
   pattern_version UInt8,
   pattern String,
-  log_count SimpleAggregateFunction(sum, UInt64)
-) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/noshard/posthog.logs_pattern_buckets', '{replica}-{shard}') PRIMARY KEY (team_id, time_bucket, service_name, namespace, environment, severity_text, pattern_version) ORDER BY (team_id, time_bucket, service_name, namespace, environment, severity_text, pattern_version, pattern) PARTITION BY toDate(time_bucket) TTL time_bucket + toIntervalDay(42) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+  log_count SimpleAggregateFunction(sum, UInt64),
+  retention_days UInt16 DEFAULT 42
+) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/noshard/posthog.logs_pattern_buckets', '{replica}-{shard}') PRIMARY KEY (team_id, time_bucket, service_name, namespace, environment, severity_text, pattern_version) ORDER BY (team_id, time_bucket, service_name, namespace, environment, severity_text, pattern_version, pattern) PARTITION BY toDate(time_bucket) TTL time_bucket + toIntervalDay(least(retention_days, 42)) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 CREATE TABLE posthog.logs_pattern_buckets_distributed (
   team_id Int32,
   time_bucket DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
@@ -1189,7 +1190,8 @@ CREATE TABLE posthog.logs_pattern_buckets_distributed (
   severity_text LowCardinality(String),
   pattern_version UInt8,
   pattern String,
-  log_count SimpleAggregateFunction(sum, UInt64)
+  log_count SimpleAggregateFunction(sum, UInt64),
+  retention_days UInt16 DEFAULT 42
 ) ENGINE = Distributed('posthog_single_shard', 'posthog', 'logs_pattern_buckets');
 CREATE TABLE posthog.logs_volume_buckets (
   team_id Int32,
@@ -1198,8 +1200,9 @@ CREATE TABLE posthog.logs_volume_buckets (
   namespace LowCardinality(String),
   environment LowCardinality(String),
   severity_text LowCardinality(String),
-  log_count SimpleAggregateFunction(sum, UInt64)
-) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/noshard/posthog.logs_volume_buckets', '{replica}-{shard}') ORDER BY (team_id, time_bucket, service_name, namespace, environment, severity_text) PARTITION BY toDate(time_bucket) TTL time_bucket + toIntervalDay(42) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+  log_count SimpleAggregateFunction(sum, UInt64),
+  retention_days UInt16 DEFAULT 42
+) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/noshard/posthog.logs_volume_buckets', '{replica}-{shard}') ORDER BY (team_id, time_bucket, service_name, namespace, environment, severity_text) PARTITION BY toDate(time_bucket) TTL time_bucket + toIntervalDay(least(retention_days, 42)) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 CREATE TABLE posthog.logs_volume_buckets_distributed (
   team_id Int32,
   time_bucket DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
@@ -1207,7 +1210,8 @@ CREATE TABLE posthog.logs_volume_buckets_distributed (
   namespace LowCardinality(String),
   environment LowCardinality(String),
   severity_text LowCardinality(String),
-  log_count SimpleAggregateFunction(sum, UInt64)
+  log_count SimpleAggregateFunction(sum, UInt64),
+  retention_days UInt16 DEFAULT 42
 ) ENGINE = Distributed('posthog_single_shard', 'posthog', 'logs_volume_buckets');
 CREATE TABLE posthog.message_assets_data (
   team_id Int64,

--- a/posthog/clickhouse/hcl/sql/prod-eu/logs.sql
+++ b/posthog/clickhouse/hcl/sql/prod-eu/logs.sql
@@ -244,8 +244,9 @@ CREATE TABLE posthog.logs_pattern_buckets (
   severity_text LowCardinality(String),
   pattern_version UInt8,
   pattern String,
-  log_count SimpleAggregateFunction(sum, UInt64)
-) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/noshard/posthog.logs_pattern_buckets', '{replica}-{shard}') PRIMARY KEY (team_id, time_bucket, service_name, namespace, environment, severity_text, pattern_version) ORDER BY (team_id, time_bucket, service_name, namespace, environment, severity_text, pattern_version, pattern) PARTITION BY toDate(time_bucket) TTL time_bucket + toIntervalDay(42) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+  log_count SimpleAggregateFunction(sum, UInt64),
+  retention_days UInt16 DEFAULT 42
+) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/noshard/posthog.logs_pattern_buckets', '{replica}-{shard}') PRIMARY KEY (team_id, time_bucket, service_name, namespace, environment, severity_text, pattern_version) ORDER BY (team_id, time_bucket, service_name, namespace, environment, severity_text, pattern_version, pattern) PARTITION BY toDate(time_bucket) TTL time_bucket + toIntervalDay(least(retention_days, 42)) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 CREATE TABLE posthog.logs_pattern_buckets_distributed (
   team_id Int32,
   time_bucket DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
@@ -255,7 +256,8 @@ CREATE TABLE posthog.logs_pattern_buckets_distributed (
   severity_text LowCardinality(String),
   pattern_version UInt8,
   pattern String,
-  log_count SimpleAggregateFunction(sum, UInt64)
+  log_count SimpleAggregateFunction(sum, UInt64),
+  retention_days UInt16 DEFAULT 42
 ) ENGINE = Distributed('logs', 'posthog', 'logs_pattern_buckets');
 CREATE TABLE posthog.logs_volume_buckets (
   team_id Int32,
@@ -264,8 +266,9 @@ CREATE TABLE posthog.logs_volume_buckets (
   namespace LowCardinality(String),
   environment LowCardinality(String),
   severity_text LowCardinality(String),
-  log_count SimpleAggregateFunction(sum, UInt64)
-) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/noshard/posthog.logs_volume_buckets', '{replica}-{shard}') ORDER BY (team_id, time_bucket, service_name, namespace, environment, severity_text) PARTITION BY toDate(time_bucket) TTL time_bucket + toIntervalDay(42) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+  log_count SimpleAggregateFunction(sum, UInt64),
+  retention_days UInt16 DEFAULT 42
+) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/noshard/posthog.logs_volume_buckets', '{replica}-{shard}') ORDER BY (team_id, time_bucket, service_name, namespace, environment, severity_text) PARTITION BY toDate(time_bucket) TTL time_bucket + toIntervalDay(least(retention_days, 42)) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 CREATE TABLE posthog.logs_volume_buckets_distributed (
   team_id Int32,
   time_bucket DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
@@ -273,7 +276,8 @@ CREATE TABLE posthog.logs_volume_buckets_distributed (
   namespace LowCardinality(String),
   environment LowCardinality(String),
   severity_text LowCardinality(String),
-  log_count SimpleAggregateFunction(sum, UInt64)
+  log_count SimpleAggregateFunction(sum, UInt64),
+  retention_days UInt16 DEFAULT 42
 ) ENGINE = Distributed('logs', 'posthog', 'logs_volume_buckets');
 CREATE TABLE posthog.metric_attributes (
   team_id Int32,

--- a/posthog/clickhouse/hcl/sql/prod-us/logs.sql
+++ b/posthog/clickhouse/hcl/sql/prod-us/logs.sql
@@ -244,8 +244,9 @@ CREATE TABLE posthog.logs_pattern_buckets (
   severity_text LowCardinality(String),
   pattern_version UInt8,
   pattern String,
-  log_count SimpleAggregateFunction(sum, UInt64)
-) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/noshard/posthog.logs_pattern_buckets', '{replica}-{shard}') PRIMARY KEY (team_id, time_bucket, service_name, namespace, environment, severity_text, pattern_version) ORDER BY (team_id, time_bucket, service_name, namespace, environment, severity_text, pattern_version, pattern) PARTITION BY toDate(time_bucket) TTL time_bucket + toIntervalDay(42) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+  log_count SimpleAggregateFunction(sum, UInt64),
+  retention_days UInt16 DEFAULT 42
+) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/noshard/posthog.logs_pattern_buckets', '{replica}-{shard}') PRIMARY KEY (team_id, time_bucket, service_name, namespace, environment, severity_text, pattern_version) ORDER BY (team_id, time_bucket, service_name, namespace, environment, severity_text, pattern_version, pattern) PARTITION BY toDate(time_bucket) TTL time_bucket + toIntervalDay(least(retention_days, 42)) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 CREATE TABLE posthog.logs_pattern_buckets_distributed (
   team_id Int32,
   time_bucket DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
@@ -255,7 +256,8 @@ CREATE TABLE posthog.logs_pattern_buckets_distributed (
   severity_text LowCardinality(String),
   pattern_version UInt8,
   pattern String,
-  log_count SimpleAggregateFunction(sum, UInt64)
+  log_count SimpleAggregateFunction(sum, UInt64),
+  retention_days UInt16 DEFAULT 42
 ) ENGINE = Distributed('logs', 'posthog', 'logs_pattern_buckets');
 CREATE TABLE posthog.logs_volume_buckets (
   team_id Int32,
@@ -264,8 +266,9 @@ CREATE TABLE posthog.logs_volume_buckets (
   namespace LowCardinality(String),
   environment LowCardinality(String),
   severity_text LowCardinality(String),
-  log_count SimpleAggregateFunction(sum, UInt64)
-) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/noshard/posthog.logs_volume_buckets', '{replica}-{shard}') ORDER BY (team_id, time_bucket, service_name, namespace, environment, severity_text) PARTITION BY toDate(time_bucket) TTL time_bucket + toIntervalDay(42) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+  log_count SimpleAggregateFunction(sum, UInt64),
+  retention_days UInt16 DEFAULT 42
+) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/noshard/posthog.logs_volume_buckets', '{replica}-{shard}') ORDER BY (team_id, time_bucket, service_name, namespace, environment, severity_text) PARTITION BY toDate(time_bucket) TTL time_bucket + toIntervalDay(least(retention_days, 42)) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 CREATE TABLE posthog.logs_volume_buckets_distributed (
   team_id Int32,
   time_bucket DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
@@ -273,7 +276,8 @@ CREATE TABLE posthog.logs_volume_buckets_distributed (
   namespace LowCardinality(String),
   environment LowCardinality(String),
   severity_text LowCardinality(String),
-  log_count SimpleAggregateFunction(sum, UInt64)
+  log_count SimpleAggregateFunction(sum, UInt64),
+  retention_days UInt16 DEFAULT 42
 ) ENGINE = Distributed('logs', 'posthog', 'logs_volume_buckets');
 CREATE TABLE posthog.metric_attributes (
   team_id Int32,

--- a/posthog/clickhouse/migrations/0321_volume_and_pattern_buckets_retention_ttl.py
+++ b/posthog/clickhouse/migrations/0321_volume_and_pattern_buckets_retention_ttl.py
@@ -1,0 +1,38 @@
+"""AUTO-GENERATED from the declarative HCL by posthog/clickhouse/hcl/codegen/gen_migration.py.
+Placement (node_roles) is derived from the node composition manifest; review before committing.
+"""
+
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+
+operations = [
+    run_sql_with_exceptions(
+        "ALTER TABLE posthog.logs_volume_buckets "
+        "ADD COLUMN IF NOT EXISTS retention_days UInt16 DEFAULT 42, "
+        "MODIFY TTL time_bucket + toIntervalDay(least(retention_days, 42))",
+        node_roles=[NodeRole.LOGS],
+        sharded=False,
+        is_alter_on_replicated_table=True,
+    ),
+    run_sql_with_exceptions(
+        "ALTER TABLE posthog.logs_volume_buckets_distributed ADD COLUMN IF NOT EXISTS retention_days UInt16 DEFAULT 42",
+        node_roles=[NodeRole.LOGS],
+        sharded=False,
+        is_alter_on_replicated_table=False,
+    ),
+    run_sql_with_exceptions(
+        "ALTER TABLE posthog.logs_pattern_buckets "
+        "ADD COLUMN IF NOT EXISTS retention_days UInt16 DEFAULT 42, "
+        "MODIFY TTL time_bucket + toIntervalDay(least(retention_days, 42))",
+        node_roles=[NodeRole.LOGS],
+        sharded=False,
+        is_alter_on_replicated_table=True,
+    ),
+    run_sql_with_exceptions(
+        "ALTER TABLE posthog.logs_pattern_buckets_distributed "
+        "ADD COLUMN IF NOT EXISTS retention_days UInt16 DEFAULT 42",
+        node_roles=[NodeRole.LOGS],
+        sharded=False,
+        is_alter_on_replicated_table=False,
+    ),
+]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0320_metric_series2_last_seen_index
+0321_volume_and_pattern_buckets_retention_ttl


### PR DESCRIPTION
## Problem

`logs_volume_buckets` and `logs_pattern_buckets` — the pre-aggregated rollups behind Logs anomaly detection — TTL out at a flat 42 days on every team, independent of that team's actual configured Logs retention (`team.logs_settings.retention_days`, default 14 days, up to 30 on the paid retention feature, and per-line ingest overrides can push it even higher). That mismatch cuts both ways: a team on 14-day retention keeps bucket rows for a window where the underlying raw log lines are already gone, and a team/line with a custom retention past 42 days would have raw data these rollups can no longer speak to. Either way, what the rollup reports can silently disagree with what `logs`/`log_attributes` can actually show for the same range.

This surfaced while investigating a candidate fix for the Logs facet rail's initial load, which fails today (`CHQueryErrorTooManyBytes`) for high-volume teams because it scans the raw `logs` table with no rollup at all — `logs_volume_buckets` is the natural rollup to move it onto, but not before its TTL tracks retention instead of a hardcoded constant.

## Changes

- `logs_volume_buckets` and `logs_pattern_buckets` (and their `_distributed` proxies) gain a `retention_days UInt16 DEFAULT 42` column.
- Both tables' TTL changes from `time_bucket + toIntervalDay(42)` to `time_bucket + toIntervalDay(least(retention_days, 42))`.
- Schema-only and behavior-preserving: nothing populates `retention_days` yet, so every row defaults to 42 and `least(42, 42)` keeps today's TTL. A follow-up PR will teach the volume-tick writer (`products/logs/backend/temporal/volume_tick/`) to populate the team's real retention at write time, the same way `logs34`/`log_attributes3` compute `original_expiry_timestamp` today.

## How did you test this code?

- `posthog/clickhouse/hcl/check.sh` passes (composition vs. golden, golden/sql freshness, duplicates baseline).
- Regenerated `golden/` and `sql/` via `gen-golden.sh`/`gen-sql.sh`, and the migration via `codegen/gen_migration.py --auto`; added the repo's required `IF NOT EXISTS`/`IF EXISTS` guards by hand since the generator omits them.
- Did not run this against a live ClickHouse cluster — no cluster available in this environment. No application code changes, so no test suite applies.

## Docs update

None — internal schema change, no user-facing or documented behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated with Claude Code (Sonnet 5) while debugging why the Logs product's initial facet load 500s for a high-volume team in prod-us. Skills invoked: `/clickhouse-migrations`.

Decisions made along the way:
- Considered a live ClickHouse dictionary sourced from Postgres team settings to make TTL fully dynamic, but no such Postgres-sourced dictionary exists anywhere in this codebase yet — building one is a separate, much larger change. A stored column populated at write time matches the existing `logs34`/`log_attributes3` pattern and is far lower risk.
- `DEFAULT 42` on the new column was chosen specifically so this migration is a no-op until the writer is updated, per the repo's "migration-only PR" rule.

No duplicate: searched `gh pr list --state open --search "logs_volume_buckets retention"` and `"logs facet TTL"` — nothing matches this change (closest related PRs, e.g. #89927, address facet-request batching, not this TTL/retention mismatch).

Public artifact: this description and the diff are original analysis and code from this session; no customer data, ticket contents, or Slack thread material is included.