### PR TITLE
feat(insights): add horizontal bar charts to SQL insights

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -1131,17 +1131,17 @@ jobs:
                   # deploy and leaves triagers with no report on a red run. Trace zips and videos
                   # can cross that, so drop them from the copy we publish; the full attachments
                   # stay in the uploaded playwright-test-results artifact. Prune at 24 MiB for margin.
-                  # Guarded and non-fatal so a missing/partial report dir still reaches the deploy.
+                  # Guarded and non-fatal so a missing or partial report dir skips the deployment.
                   if [ -d playwright/playwright-report ]; then
                       find playwright/playwright-report -type f -size +24M -printf 'Pruning oversized report file (%s bytes): %p\n' -delete || true
-                  fi
-                  npx --yes wrangler@3 pages deploy playwright/playwright-report \
-                    --project-name=playwright-report \
-                    --branch="$BRANCH" \
-                    --commit-dirty=true 2>&1 | tee /tmp/wrangler-output.txt
-                  URL=$(grep -oP 'https://\S+\.pages\.dev' /tmp/wrangler-output.txt | tail -1 || true)
-                  if [ -n "$URL" ]; then
-                      echo "deployment-url=$URL" >> $GITHUB_OUTPUT
+                      npx --yes wrangler@3 pages deploy playwright/playwright-report \
+                        --project-name=playwright-report \
+                        --branch="$BRANCH" \
+                        --commit-dirty=true 2>&1 | tee /tmp/wrangler-output.txt
+                      URL=$(grep -oP 'https://\S+\.pages\.dev' /tmp/wrangler-output.txt | tail -1 || true)
+                      if [ -n "$URL" ]; then
+                          echo "deployment-url=$URL" >> $GITHUB_OUTPUT
+                      fi
                   fi
 
             - name: Write report URL to job summary

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -1131,17 +1131,17 @@ jobs:
                   # deploy and leaves triagers with no report on a red run. Trace zips and videos
                   # can cross that, so drop them from the copy we publish; the full attachments
                   # stay in the uploaded playwright-test-results artifact. Prune at 24 MiB for margin.
-                  # Guarded and non-fatal so a missing or partial report dir skips the deployment.
+                  # Guarded and non-fatal so a missing/partial report dir still reaches the deploy.
                   if [ -d playwright/playwright-report ]; then
                       find playwright/playwright-report -type f -size +24M -printf 'Pruning oversized report file (%s bytes): %p\n' -delete || true
-                      npx --yes wrangler@3 pages deploy playwright/playwright-report \
-                        --project-name=playwright-report \
-                        --branch="$BRANCH" \
-                        --commit-dirty=true 2>&1 | tee /tmp/wrangler-output.txt
-                      URL=$(grep -oP 'https://\S+\.pages\.dev' /tmp/wrangler-output.txt | tail -1 || true)
-                      if [ -n "$URL" ]; then
-                          echo "deployment-url=$URL" >> $GITHUB_OUTPUT
-                      fi
+                  fi
+                  npx --yes wrangler@3 pages deploy playwright/playwright-report \
+                    --project-name=playwright-report \
+                    --branch="$BRANCH" \
+                    --commit-dirty=true 2>&1 | tee /tmp/wrangler-output.txt
+                  URL=$(grep -oP 'https://\S+\.pages\.dev' /tmp/wrangler-output.txt | tail -1 || true)
+                  if [ -n "$URL" ]; then
+                      echo "deployment-url=$URL" >> $GITHUB_OUTPUT
                   fi
 
             - name: Write report URL to job summary

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -3160,6 +3160,10 @@ snapshots:
         hash: v1.k794b7964.3958ab3fd470dfbf3a3dde5536bdbccdfd5205289f25a3ba5f3d98e069fdc4e7.WqKR9SVpum4z1_KyM3TXG6nN9BLC7cUiDWp0w0vpYms
     insights-sqlbargraph--grouped-bar-with-negative-values--light:
         hash: v1.k794b7964.f650a19c898a1b45659a824ca56b78b832d3229e15216e775abf225c39fc76b7.0GEkJRi-qzoYtdTtlPgeJD1FLrEu4N19aOMCQ3eMdoA
+    insights-sqlbargraph--horizontal-bar--dark:
+        hash: v1.k794b7964.198d11e486296652fca6921ecf76d8627a8257f3c94df2a2198919c87b76b502.fMwrM7mMAlzwrf5aFt-6YLfILYVbyM4yu9qhyUT8MbQ
+    insights-sqlbargraph--horizontal-bar--light:
+        hash: v1.k794b7964.eb99bf633cae565be567f33a544ce22c9ffe728585e64b1ca23b7933df751e6d.RuuY0Z82oyFutR0tkY7wZGvOH2_oKY-E6mwehd2wky4
     insights-sqlbargraph--stacked-bar--dark:
         hash: v1.k794b7964.213a5a22d4f777cf9f8ffa14d648b85b5b1949d0a2c96c476be9011736b5183b.liwM0IzwJRoqi0PSOuGNiaWpcLTPexevSaGc3FyxYHI
     insights-sqlbargraph--stacked-bar--light:

--- a/frontend/src/lib/components/Cards/InsightCard/sqlVisualizationSupport.test.ts
+++ b/frontend/src/lib/components/Cards/InsightCard/sqlVisualizationSupport.test.ts
@@ -139,8 +139,8 @@ describe('dashboard SQL visualization support', () => {
             columns,
             response.result.length
         )
-        expect(saved.chartSettings?.xAxis?.column).toBe('day')
-        expect(saved.chartSettings?.yAxis?.map((series) => series.column)).toEqual(['total'])
+        expect(saved.chartSettings!.xAxis!.column).toBe('day')
+        expect(saved.chartSettings!.yAxis!.map((series) => series.column)).toEqual(['total'])
     })
 
     it('does not offer Auto when it resolves to a type the card cannot set up', () => {

--- a/frontend/src/lib/components/Cards/InsightCard/sqlVisualizationSupport.test.ts
+++ b/frontend/src/lib/components/Cards/InsightCard/sqlVisualizationSupport.test.ts
@@ -118,6 +118,31 @@ describe('dashboard SQL visualization support', () => {
         }
     )
 
+    it('sets up a dashboard horizontal bar chart from category and numeric columns', () => {
+        const response = responses['date and numeric']
+        const columns = columnsFromResponse(response)
+        const autoVisualizationType = getAutoVisualizationType(columns, response.result.length)
+
+        expect(
+            sqlVisualizationDisabledReason(
+                ChartDisplayType.ActionsBarValue,
+                baseQuery,
+                columns,
+                response.result.length,
+                autoVisualizationType
+            )
+        ).toBeUndefined()
+
+        const saved = applyVisualizationType(
+            baseQuery,
+            ChartDisplayType.ActionsBarValue,
+            columns,
+            response.result.length
+        )
+        expect(saved.chartSettings?.xAxis?.column).toBe('day')
+        expect(saved.chartSettings?.yAxis?.map((series) => series.column)).toEqual(['total'])
+    })
+
     it('does not offer Auto when it resolves to a type the card cannot set up', () => {
         const response = responses['two strings and a numeric, which Auto resolves to a 2d heatmap']
         const columns = columnsFromResponse(response)

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlBarGraph.stories.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlBarGraph.stories.tsx
@@ -90,3 +90,13 @@ export const GroupedBarWithNegativeValues: Story = {
             chartSettings: baseSettings,
         }),
 }
+
+export const HorizontalBar: Story = {
+    render: () =>
+        render({
+            xData,
+            yData: positiveSeries,
+            visualizationType: ChartDisplayType.ActionsBarValue,
+            chartSettings: { ...baseSettings, showValuesOnSeries: true },
+        }),
+}

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlBarGraph.test.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlBarGraph.test.tsx
@@ -94,8 +94,8 @@ describe('SqlBarGraph', () => {
             expect(
                 getHogChart()
                     .xTicks()
-                    .every((tick) => tick.startsWith('$'))
-            ).toBe(true)
+                    .map((tick) => tick.startsWith('$'))
+            ).not.toContain(false)
         })
 
         it('renders percentage y-axis ticks for the 100%-stacked layout', async () => {

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlBarGraph.test.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlBarGraph.test.tsx
@@ -67,6 +67,7 @@ describe('SqlBarGraph', () => {
     describe('bar layouts', () => {
         it.each([
             { name: 'grouped', display: ChartDisplayType.ActionsBar, extra: {} },
+            { name: 'horizontal', display: ChartDisplayType.ActionsBarValue, extra: {} },
             { name: 'stacked', display: ChartDisplayType.ActionsStackedBar, extra: {} },
             {
                 name: 'percent (100% stacked)',
@@ -78,6 +79,23 @@ describe('SqlBarGraph', () => {
 
             await screen.findByLabelText(/chart with 2 data series/i)
             await waitFor(() => expect(getHogChart().yTicks().length).toBeGreaterThan(0))
+        })
+
+        it('renders category labels on the vertical axis for horizontal bars', async () => {
+            renderBar(
+                ChartDisplayType.ActionsBarValue,
+                { yAxis: [{ column: 'a', settings: { formatting: { prefix: '$' } } }] },
+                barFixture([{ name: 'a', valueAt: (i) => (i + 1) * 1000 }])
+            )
+
+            await screen.findByLabelText(/chart with/i)
+            await waitFor(() => expect(getHogChart().xTicks().length).toBeGreaterThan(0))
+            expect(getHogChart().yTicks()).toContain('Oct 1, 2025')
+            expect(
+                getHogChart()
+                    .xTicks()
+                    .every((tick) => tick.startsWith('$'))
+            ).toBe(true)
         })
 
         it('renders percentage y-axis ticks for the 100%-stacked layout', async () => {
@@ -191,9 +209,12 @@ describe('SqlBarGraph', () => {
     })
 
     describe('goal lines', () => {
-        it('renders a goal line as a horizontal reference line', async () => {
+        it.each([
+            [ChartDisplayType.ActionsBar, 'horizontal'],
+            [ChartDisplayType.ActionsBarValue, 'vertical'],
+        ] as const)('renders a goal line on the value axis for %s', async (display, orientation) => {
             renderBar(
-                ChartDisplayType.ActionsBar,
+                display,
                 { yAxis: [{ column: 'a' }], goalLines: [{ label: 'Target', value: 250, displayIfCrossed: true }] },
                 barFixture([{ name: 'a', valueAt: (i) => (i + 1) * 100 }])
             )
@@ -201,7 +222,7 @@ describe('SqlBarGraph', () => {
             await screen.findByLabelText(/chart with/i)
             const lines = getHogChart().referenceLines()
             expect(lines.map((l) => l.label)).toEqual(['Target'])
-            expect(lines[0].orientation).toBe('horizontal')
+            expect(lines[0].orientation).toBe(orientation)
         })
     })
 })

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlBarGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlBarGraph.tsx
@@ -1,51 +1,97 @@
 import clsx from 'clsx'
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 
-import { TimeSeriesBarChart, type PointClickData } from '@posthog/quill-charts'
+import {
+    BarChart,
+    ReferenceLines,
+    TimeSeriesBarChart,
+    ValueLabels,
+    type PointClickData,
+    type ValueLabelContext,
+} from '@posthog/quill-charts'
 
 import { AnnotationsLayer } from 'lib/components/AnnotationsOverlay/AnnotationsLayer'
 
+import { ChartDisplayType } from '~/types'
+
 import { makeChartErrorHandler } from 'products/product_analytics/frontend/insights/trends/shared/chartErrorHandler'
+import { goalLinesToReferenceLines } from 'products/product_analytics/frontend/insights/trends/shared/goalLinesAdapter'
 
 import { type SqlChartProps } from './SqlChart'
-import { type SqlLineSeriesMeta, buildBarChartConfig } from './sqlLineGraphAdapter'
+import {
+    type SqlBarGraphConfig,
+    type SqlLineSeriesMeta,
+    buildBarChartConfig,
+    buildBarValueChartConfig,
+    formatSqlSeriesValue,
+} from './sqlLineGraphAdapter'
 import { useSqlChartModel } from './useSqlChartModel'
 
 const handleChartError = makeChartErrorHandler('sql-bar-chart')
 
 export const SqlBarGraph = (props: SqlChartProps): JSX.Element => {
     const { onPointClick: onPointClickProp } = props
-    const model = useSqlChartModel(props, buildBarChartConfig)
+    const isHorizontal = props.visualizationType === ChartDisplayType.ActionsBarValue
+    const model = useSqlChartModel<SqlBarGraphConfig>(
+        props,
+        isHorizontal ? buildBarValueChartConfig : buildBarChartConfig
+    )
 
     const onPointClick = useCallback(
         (data: PointClickData<SqlLineSeriesMeta>) => {
-            onPointClickProp?.(data.series.key, data.dataIndex, data.label)
+            onPointClickProp?.(data.series.key, data.dataIndex, String(props.xData?.data[data.dataIndex] ?? data.label))
         },
-        [onPointClickProp]
+        [onPointClickProp, props.xData]
+    )
+
+    const series = model?.series
+    const referenceLines = useMemo(
+        () => (series && isHorizontal ? goalLinesToReferenceLines(props.goalLines, series, 'horizontal') : []),
+        [isHorizontal, series, props.goalLines]
+    )
+
+    const valueLabelFormatter = useCallback(
+        (_value: number, seriesIndex: number, _dataIndex: number, context: ValueLabelContext): string =>
+            formatSqlSeriesValue(context.rawValue, series?.[seriesIndex]?.meta?.settings),
+        [series]
     )
 
     return (
         <div
-            className={clsx(
-                props.className,
-                'rounded bg-surface-primary w-full grow relative overflow-hidden flex flex-col',
-                { 'h-[60vh]': props.presetChartHeight, 'h-full': !props.presetChartHeight }
-            )}
+            className={clsx(props.className, 'rounded bg-surface-primary w-full grow relative flex flex-col', {
+                'h-[60vh]': props.presetChartHeight,
+                'h-full': !props.presetChartHeight,
+                'overflow-y-auto': isHorizontal && !props.embedded,
+                'overflow-hidden': !isHorizontal || props.embedded,
+            })}
         >
-            {model && (
-                <TimeSeriesBarChart
-                    series={model.series}
-                    labels={model.labels}
-                    theme={model.theme}
-                    config={model.config}
-                    onPointClick={onPointClickProp ? onPointClick : undefined}
-                    onError={handleChartError}
-                >
-                    {props.showAnnotations && props.insightNumericId && (
-                        <AnnotationsLayer insightNumericId={props.insightNumericId} dates={model.labels} />
-                    )}
-                </TimeSeriesBarChart>
-            )}
+            {model &&
+                (isHorizontal ? (
+                    <BarChart
+                        series={model.series}
+                        labels={model.labels}
+                        theme={model.theme}
+                        config={model.config}
+                        onPointClick={onPointClickProp ? onPointClick : undefined}
+                        onError={handleChartError}
+                    >
+                        <ReferenceLines lines={referenceLines} />
+                        {props.chartSettings.showValuesOnSeries && <ValueLabels valueFormatter={valueLabelFormatter} />}
+                    </BarChart>
+                ) : (
+                    <TimeSeriesBarChart
+                        series={model.series}
+                        labels={model.labels}
+                        theme={model.theme}
+                        config={model.config}
+                        onPointClick={onPointClickProp ? onPointClick : undefined}
+                        onError={handleChartError}
+                    >
+                        {props.showAnnotations && props.insightNumericId && (
+                            <AnnotationsLayer insightNumericId={props.insightNumericId} dates={model.labels} />
+                        )}
+                    </TimeSeriesBarChart>
+                ))}
         </div>
     )
 }

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlBarGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlBarGraph.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { useCallback, useMemo } from 'react'
+import { useCallback } from 'react'
 
 import {
     BarChart,
@@ -15,7 +15,6 @@ import { AnnotationsLayer } from 'lib/components/AnnotationsOverlay/AnnotationsL
 import { ChartDisplayType } from '~/types'
 
 import { makeChartErrorHandler } from 'products/product_analytics/frontend/insights/trends/shared/chartErrorHandler'
-import { goalLinesToReferenceLines } from 'products/product_analytics/frontend/insights/trends/shared/goalLinesAdapter'
 
 import { type SqlChartProps } from './SqlChart'
 import {
@@ -45,10 +44,6 @@ export const SqlBarGraph = (props: SqlChartProps): JSX.Element => {
     )
 
     const series = model?.series
-    const referenceLines = useMemo(
-        () => (series && isHorizontal ? goalLinesToReferenceLines(props.goalLines, series, 'horizontal') : []),
-        [isHorizontal, series, props.goalLines]
-    )
 
     const valueLabelFormatter = useCallback(
         (_value: number, seriesIndex: number, _dataIndex: number, context: ValueLabelContext): string =>
@@ -75,7 +70,7 @@ export const SqlBarGraph = (props: SqlChartProps): JSX.Element => {
                         onPointClick={onPointClickProp ? onPointClick : undefined}
                         onError={handleChartError}
                     >
-                        <ReferenceLines lines={referenceLines} />
+                        <ReferenceLines lines={model.config.referenceLines ?? []} />
                         {props.chartSettings.showValuesOnSeries && <ValueLabels valueFormatter={valueLabelFormatter} />}
                     </BarChart>
                 ) : (

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlChart.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlChart.test.ts
@@ -1,7 +1,7 @@
 import { ChartDisplayType } from '~/types'
 
 import { AxisSeries, AxisSeriesSettings } from '../../dataVisualizationLogic'
-import { SqlChartProps, sqlChartComponentFor } from './SqlChart'
+import { SqlChartProps, isSqlChartVisualizationType, sqlChartComponentFor } from './SqlChart'
 
 const baseProps = (visualizationType: ChartDisplayType): SqlChartProps => ({
     xData: null,
@@ -23,6 +23,16 @@ const mixedYData: AxisSeries<number | null>[] = [
 ]
 
 describe('sqlChartComponentFor', () => {
+    it.each([
+        ChartDisplayType.ActionsLineGraph,
+        ChartDisplayType.ActionsBar,
+        ChartDisplayType.ActionsBarValue,
+        ChartDisplayType.ActionsAreaGraph,
+        ChartDisplayType.ActionsStackedBar,
+    ])('routes %s through SqlChart', (visualizationType) => {
+        expect(isSqlChartVisualizationType(visualizationType)).toBe(true)
+    })
+
     it.each([
         ['line', ChartDisplayType.ActionsLineGraph, 'SqlLineGraph'],
         ['bar', ChartDisplayType.ActionsBar, 'SqlBarGraph'],

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlChart.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlChart.test.ts
@@ -26,6 +26,7 @@ describe('sqlChartComponentFor', () => {
     it.each([
         ['line', ChartDisplayType.ActionsLineGraph, 'SqlLineGraph'],
         ['bar', ChartDisplayType.ActionsBar, 'SqlBarGraph'],
+        ['horizontal bar', ChartDisplayType.ActionsBarValue, 'SqlBarGraph'],
         // Pie is not routed here — it has its own wrapper (see PieChart.test.tsx).
         ['pie (handled by the PieChart wrapper, not here)', ChartDisplayType.ActionsPie, 'SqlLineGraph'],
     ])('routes %s to the right component', (_name, visualizationType, expected) => {
@@ -37,6 +38,13 @@ describe('sqlChartComponentFor', () => {
         ['a line-base chart', ChartDisplayType.ActionsLineGraph],
     ])('routes mixed bar + line series on %s to SqlComboGraph', (_name, visualizationType) => {
         expect(sqlChartComponentFor({ ...baseProps(visualizationType), yData: mixedYData }).name).toBe('SqlComboGraph')
+    })
+
+    it('keeps horizontal bars when a series has a saved line display type', () => {
+        const lineSeries = [ySeries('a', { display: { displayType: 'line' } })]
+        expect(sqlChartComponentFor({ ...baseProps(ChartDisplayType.ActionsBarValue), yData: lineSeries }).name).toBe(
+            'SqlBarGraph'
+        )
     })
 
     it('routes an all-bar line chart to SqlBarGraph', () => {

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlChart.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlChart.tsx
@@ -18,6 +18,7 @@ export type SqlChartProps = {
     goalLines?: GoalLine[]
     insightNumericId?: number | 'new'
     showAnnotations?: boolean
+    embedded?: boolean
     className?: string
     /** Called when the user clicks a data point. Receives the series key, x-axis index, and label.
      *  When provided, the SQL chart shows a "click to inspect" hint in the tooltip. */

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlChart.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlChart.tsx
@@ -8,6 +8,17 @@ import { SqlComboGraph } from './SqlComboGraph'
 import { SqlLineGraph } from './SqlLineGraph'
 import { sqlChartKind } from './sqlLineGraphAdapter'
 
+const SQL_CHART_VISUALIZATION_TYPES: ChartDisplayType[] = [
+    ChartDisplayType.ActionsLineGraph,
+    ChartDisplayType.ActionsBar,
+    ChartDisplayType.ActionsBarValue,
+    ChartDisplayType.ActionsAreaGraph,
+    ChartDisplayType.ActionsStackedBar,
+]
+
+export const isSqlChartVisualizationType = (visualizationType: ChartDisplayType): boolean =>
+    SQL_CHART_VISUALIZATION_TYPES.includes(visualizationType)
+
 export type SqlChartProps = {
     xData: AxisSeries<string> | null
     yData: AxisSeries<number | null>[] | AxisBreakdownSeries<number | null>[]

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.test.ts
@@ -971,6 +971,10 @@ describe('sqlLineGraphAdapter', () => {
                 visualizationType: ChartDisplayType.ActionsBarValue,
                 ySeriesData: [ySeries('revenue', [1200, 1800], { formatting: { prefix: '$' } })],
                 goalLines: [{ label: 'Target', value: 2000 }],
+                series: buildSeries(
+                    [ySeries('revenue', [1200, 1800], { formatting: { prefix: '$' } })],
+                    ChartDisplayType.ActionsBarValue
+                ),
                 embedded: true,
             })
 
@@ -985,9 +989,29 @@ describe('sqlLineGraphAdapter', () => {
                 maxCategoryLabelWidth: MAX_CATEGORY_LABEL_WIDTH,
                 bars: { fitToHeight: true, valueDomain: { include: [2000] } },
             })
-            expect(config.xTickFormatter?.('0', 0)).toBe('/pricing')
-            expect(config.yTickFormatter?.(1200)).toBe('$1200')
-            expect(config.tooltip?.labelFormatter?.('1')).toBe('/signup')
+            expect(config.xTickFormatter!('0', 0)).toBe('/pricing')
+            expect(config.yTickFormatter!(1200)).toBe('$1200')
+            expect(config.tooltip!.labelFormatter!('1')).toBe('/signup')
+            expect(config.referenceLines).toEqual([
+                expect.objectContaining({ label: 'Target', value: 2000, axisOrientation: 'horizontal' }),
+            ])
+        })
+
+        it.each([
+            { category: null, label: '0', expected: '[No value]' },
+            { category: undefined, label: '0', expected: '[No value]' },
+            { category: 42, label: '0', expected: '42' },
+            { category: '/pricing', label: 'invalid', expected: 'invalid' },
+        ])('formats $expected when a category is $category', ({ category, label, expected }) => {
+            const config = buildBarValueChartConfig({
+                xData: { ...xData, data: [category] as unknown as string[] },
+                chartSettings: {},
+                timezone: 'UTC',
+                visualizationType: ChartDisplayType.ActionsBarValue,
+            })
+
+            expect(config.xTickFormatter!(label, 0)).toBe(expected)
+            expect(config.tooltip!.labelFormatter!(label)).toBe(expected)
         })
     })
 

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.test.ts
@@ -21,6 +21,7 @@ import {
     type SqlLineYSeries,
     barLayoutForDisplay,
     buildBarChartConfig,
+    buildBarValueChartConfig,
     buildComboChartConfig,
     buildLineChartConfig,
     buildSeries,
@@ -75,6 +76,7 @@ describe('sqlLineGraphAdapter', () => {
             ['line graph', ChartDisplayType.ActionsLineGraph, 'line'],
             ['area graph', ChartDisplayType.ActionsAreaGraph, 'line'],
             ['bar graph', ChartDisplayType.ActionsBar, 'bar'],
+            ['horizontal bar graph', ChartDisplayType.ActionsBarValue, 'bar'],
             ['stacked bar graph', ChartDisplayType.ActionsStackedBar, 'bar'],
             // Pie never reaches dispatch — PieChart wraps it separately.
             ['pie graph', ChartDisplayType.ActionsPie, 'line'],
@@ -211,6 +213,7 @@ describe('sqlLineGraphAdapter', () => {
             ['auto on a line graph is a line', ChartDisplayType.ActionsLineGraph, {}, 'line'],
             ['auto on an area graph is an area', ChartDisplayType.ActionsAreaGraph, {}, 'area'],
             ['auto on a bar graph is a bar', ChartDisplayType.ActionsBar, {}, 'bar'],
+            ['auto on a horizontal bar graph is a bar', ChartDisplayType.ActionsBarValue, {}, 'bar'],
             ['auto on a stacked bar graph is a bar', ChartDisplayType.ActionsStackedBar, {}, 'bar'],
             [
                 "the 'auto' display type defers to the chart type",
@@ -946,6 +949,45 @@ describe('sqlLineGraphAdapter', () => {
                 { id: 'left', position: 'left', scale: 'linear' },
                 { id: 'right', position: 'right', scale: 'linear' },
             ])
+        })
+    })
+
+    describe('buildBarValueChartConfig', () => {
+        const xData: AxisSeries<string> = {
+            column: { name: 'path', type: { name: 'STRING', isNumerical: false }, label: 'path', dataIndex: 0 },
+            data: ['/pricing', '/signup'],
+        }
+
+        it('maps SQL category and value settings onto horizontal chart axes', () => {
+            const config = buildBarValueChartConfig({
+                xData,
+                chartSettings: {
+                    xAxisLabel: 'Page',
+                    showXAxisTicks: false,
+                    showXAxisBorder: false,
+                    leftYAxisSettings: { label: 'Revenue', showTicks: false },
+                },
+                timezone: 'UTC',
+                visualizationType: ChartDisplayType.ActionsBarValue,
+                ySeriesData: [ySeries('revenue', [1200, 1800], { formatting: { prefix: '$' } })],
+                goalLines: [{ label: 'Target', value: 2000 }],
+                embedded: true,
+            })
+
+            expect(config).toMatchObject({
+                axisOrientation: 'horizontal',
+                barLayout: 'grouped',
+                hideXAxis: true,
+                hideYAxis: true,
+                xAxisLabel: 'Revenue',
+                yAxisLabel: 'Page',
+                showAxisLines: { x: true, y: false },
+                maxCategoryLabelWidth: MAX_CATEGORY_LABEL_WIDTH,
+                bars: { fitToHeight: true, valueDomain: { include: [2000] } },
+            })
+            expect(config.xTickFormatter?.('0', 0)).toBe('/pricing')
+            expect(config.yTickFormatter?.(1200)).toBe('$1200')
+            expect(config.tooltip?.labelFormatter?.('1')).toBe('/signup')
         })
     })
 

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.ts
@@ -4,6 +4,7 @@ import {
     type AxisLinesConfig,
     type BarChartConfig,
     type ChartLegendConfig,
+    type ReferenceLineProps,
     type Series,
     type SeriesType,
     type TimeSeriesBarChartConfig,
@@ -324,6 +325,7 @@ interface BuildConfigArgs {
     timezone: string
     goalLines?: GoalLine[]
     ySeriesData?: SqlLineYSeries[] | null
+    series?: Series<SqlLineSeriesMeta>[]
     embedded?: boolean
     /** Wraps each legend row, e.g. with the series right-click menu. Passed straight through to
      *  quill so this module stays free of JSX. */
@@ -334,7 +336,8 @@ export interface BuildBarConfigArgs extends BuildConfigArgs {
     visualizationType: ChartDisplayType
 }
 
-export type SqlBarGraphConfig = BarChartConfig & TimeSeriesBarChartConfig & { yAxis?: YAxisConfig }
+export type SqlBarGraphConfig = BarChartConfig &
+    TimeSeriesBarChartConfig & { yAxis?: YAxisConfig; referenceLines?: ReferenceLineProps[] }
 
 const SQL_BAR_TICK_LABEL_ROTATION = -45
 
@@ -529,8 +532,8 @@ export function buildBarValueChartConfig({
     chartSettings,
     timezone,
     goalLines,
-    visualizationType,
     ySeriesData,
+    series,
     legendRenderItem,
     embedded,
 }: BuildBarConfigArgs): SqlBarGraphConfig {
@@ -538,20 +541,25 @@ export function buildBarValueChartConfig({
     const valueAxis = buildYAxisConfig(chartSettings.leftYAxisSettings, ySeriesData ?? [], chartSettings.yAxisAtZero)
     const dateLabelFormatter = buildSqlDateLabelFormatter(xData, timezone)
     const categoryLabelFormatter = (label: string): string => {
-        const value = String(xData.data[Number(label)] ?? label)
-        return dateLabelFormatter?.(value) ?? value
+        const index = Number(label)
+        if (!Number.isInteger(index) || index < 0 || index >= xData.data.length) {
+            return label
+        }
+        const value = xData.data[index]
+        if (value == null) {
+            return '[No value]'
+        }
+        const stringValue = String(value)
+        return dateLabelFormatter?.(stringValue) ?? stringValue
     }
-    const referenceLines = goalLinesToReferenceLines(
-        goalLines,
-        buildSeries(ySeriesData ?? [], visualizationType),
-        'horizontal'
-    )
+    const referenceLines = goalLinesToReferenceLines(goalLines, series ?? [], 'horizontal')
     const referenceLineValues = referenceLines.flatMap((line) => (typeof line.value === 'number' ? [line.value] : []))
 
     return {
         axisOrientation: 'horizontal',
         barLayout: 'grouped',
         barCornerRadius: 4,
+        referenceLines,
         xTickFormatter: categoryLabelFormatter,
         yTickFormatter: valueAxis.tickFormatter,
         yScaleType: valueAxis.scale,

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.ts
@@ -2,6 +2,7 @@ import { lemonToast } from '@posthog/lemon-ui'
 import {
     MAX_CATEGORY_LABEL_WIDTH,
     type AxisLinesConfig,
+    type BarChartConfig,
     type ChartLegendConfig,
     type Series,
     type SeriesType,
@@ -23,7 +24,10 @@ import { ChartSettings, GoalLine, YAxisSettings } from '~/queries/schema/schema-
 import { ChartDisplayType } from '~/types'
 
 import { chartStyleCurve } from 'products/product_analytics/frontend/insights/shared/chartStyleAdapter'
-import { schemaGoalLinesToConfigs } from 'products/product_analytics/frontend/insights/trends/shared/goalLinesAdapter'
+import {
+    goalLinesToReferenceLines,
+    schemaGoalLinesToConfigs,
+} from 'products/product_analytics/frontend/insights/trends/shared/goalLinesAdapter'
 
 import { AxisSeries, AxisSeriesSettings, formatDataWithSettings } from '../../dataVisualizationLogic'
 import { AxisBreakdownSeries } from '../seriesBreakdownLogic'
@@ -44,6 +48,10 @@ export function seriesDisplayType(
     visualizationType: ChartDisplayType,
     settings: AxisSeriesSettings | undefined
 ): SeriesType {
+    if (visualizationType === ChartDisplayType.ActionsBarValue) {
+        return 'bar'
+    }
+
     const displayType = settings?.display?.displayType
     if (displayType === 'bar') {
         return 'bar'
@@ -116,7 +124,9 @@ export type SqlChartKindProps = Pick<SqlChartProps, 'visualizationType' | 'yData
  */
 export function sqlChartKind({ visualizationType, yData, chartSettings }: SqlChartKindProps): SqlChartKind {
     const isBarBase =
-        visualizationType === ChartDisplayType.ActionsBar || visualizationType === ChartDisplayType.ActionsStackedBar
+        visualizationType === ChartDisplayType.ActionsBar ||
+        visualizationType === ChartDisplayType.ActionsBarValue ||
+        visualizationType === ChartDisplayType.ActionsStackedBar
     const isLineBase =
         visualizationType === ChartDisplayType.ActionsLineGraph ||
         visualizationType === ChartDisplayType.ActionsAreaGraph
@@ -219,7 +229,9 @@ export function buildSeries(yData: SqlLineYSeries[], visualizationType: ChartDis
             ...(settings?.formatting?.style === 'percent' ? { visibility: { total: false } } : {}),
             // Only pin an explicit color; otherwise let quill assign palette colors by index.
             ...(color ? { color } : {}),
-            ...(settings?.display?.yAxisPosition === 'right' ? { yAxisId: 'right' } : {}),
+            ...(visualizationType !== ChartDisplayType.ActionsBarValue && settings?.display?.yAxisPosition === 'right'
+                ? { yAxisId: 'right' }
+                : {}),
             ...(type !== 'bar' && isAreaSeries(visualizationType, settings)
                 ? { fill: { opacity: AREA_FILL_OPACITY } }
                 : {}),
@@ -312,6 +324,7 @@ interface BuildConfigArgs {
     timezone: string
     goalLines?: GoalLine[]
     ySeriesData?: SqlLineYSeries[] | null
+    embedded?: boolean
     /** Wraps each legend row, e.g. with the series right-click menu. Passed straight through to
      *  quill so this module stays free of JSX. */
     legendRenderItem?: ChartLegendConfig['renderItem']
@@ -320,6 +333,8 @@ interface BuildConfigArgs {
 export interface BuildBarConfigArgs extends BuildConfigArgs {
     visualizationType: ChartDisplayType
 }
+
+export type SqlBarGraphConfig = BarChartConfig & TimeSeriesBarChartConfig & { yAxis?: YAxisConfig }
 
 const SQL_BAR_TICK_LABEL_ROTATION = -45
 
@@ -388,10 +403,10 @@ function buildLegendConfig(
 
 /** The X/Y axis-border toggles map onto quill's per-edge axis lines — undefined when both are on
  *  (the default), so the app-level style default still applies. */
-function buildAxisLinesConfig(chartSettings: ChartSettings): AxisLinesConfig | undefined {
+function buildAxisLinesConfig(chartSettings: ChartSettings, horizontal = false): AxisLinesConfig | undefined {
     const x = chartSettings.showXAxisBorder ?? true
     const y = chartSettings.showYAxisBorder ?? true
-    return x && y ? undefined : { x, y }
+    return x && y ? undefined : horizontal ? { x: y, y: x } : { x, y }
 }
 
 /**
@@ -465,7 +480,7 @@ export function buildBarChartConfig({
     visualizationType,
     ySeriesData,
     legendRenderItem,
-}: BuildBarConfigArgs): TimeSeriesBarChartConfig & { yAxis?: YAxisConfig } {
+}: BuildBarConfigArgs): SqlBarGraphConfig {
     const barLayout = barLayoutForDisplay(visualizationType, chartSettings)
     const labelFormatter = buildSqlDateLabelFormatter(xData, timezone)
     const leftSeries = seriesForAxis(ySeriesData, 'left')
@@ -505,6 +520,56 @@ export function buildBarChartConfig({
         tooltip: {
             ...buildSqlTooltipConfig(chartSettings, ySeriesData),
             ...(labelFormatter ? { labelFormatter } : {}),
+        },
+    }
+}
+
+export function buildBarValueChartConfig({
+    xData,
+    chartSettings,
+    timezone,
+    goalLines,
+    visualizationType,
+    ySeriesData,
+    legendRenderItem,
+    embedded,
+}: BuildBarConfigArgs): SqlBarGraphConfig {
+    const categoryAxis = buildXAxisConfig(xData, chartSettings, timezone)
+    const valueAxis = buildYAxisConfig(chartSettings.leftYAxisSettings, ySeriesData ?? [], chartSettings.yAxisAtZero)
+    const dateLabelFormatter = buildSqlDateLabelFormatter(xData, timezone)
+    const categoryLabelFormatter = (label: string): string => {
+        const value = String(xData.data[Number(label)] ?? label)
+        return dateLabelFormatter?.(value) ?? value
+    }
+    const referenceLines = goalLinesToReferenceLines(
+        goalLines,
+        buildSeries(ySeriesData ?? [], visualizationType),
+        'horizontal'
+    )
+    const referenceLineValues = referenceLines.flatMap((line) => (typeof line.value === 'number' ? [line.value] : []))
+
+    return {
+        axisOrientation: 'horizontal',
+        barLayout: 'grouped',
+        barCornerRadius: 4,
+        xTickFormatter: categoryLabelFormatter,
+        yTickFormatter: valueAxis.tickFormatter,
+        yScaleType: valueAxis.scale,
+        hideXAxis: valueAxis.hide,
+        hideYAxis: categoryAxis.hide,
+        xAxisLabel: valueAxis.label,
+        yAxisLabel: categoryAxis.label,
+        showGrid: valueAxis.showGrid,
+        showAxisLines: buildAxisLinesConfig(chartSettings, true),
+        maxCategoryLabelWidth: MAX_CATEGORY_LABEL_WIDTH,
+        bars: {
+            fitToHeight: embedded,
+            valueDomain: referenceLineValues.length ? { include: referenceLineValues } : undefined,
+        },
+        legend: buildLegendConfig(chartSettings, legendRenderItem),
+        tooltip: {
+            ...buildSqlTooltipConfig(chartSettings, ySeriesData),
+            labelFormatter: categoryLabelFormatter,
         },
     }
 }

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/useSqlChartModel.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/useSqlChartModel.ts
@@ -7,6 +7,8 @@ import { useChartTheme, useChartConfig } from 'lib/charts/hooks'
 import { useChartLegendSeriesMenu } from 'lib/components/ChartLegendSeriesMenu/useChartLegendSeriesMenu'
 import { teamLogic } from 'scenes/teamLogic'
 
+import { ChartDisplayType } from '~/types'
+
 import { SqlChartProps } from './SqlChart'
 import {
     type BuildBarConfigArgs,
@@ -25,7 +27,7 @@ export interface SqlChartModel<TConfig> {
 }
 
 export function useSqlChartModel<TConfig extends object>(
-    { xData, yData, visualizationType, chartSettings, dashboardId, goalLines }: SqlChartProps,
+    { xData, yData, visualizationType, chartSettings, dashboardId, goalLines, embedded }: SqlChartProps,
     buildConfig: (args: BuildBarConfigArgs) => TConfig
 ): SqlChartModel<TConfig> | null {
     const { timezone } = useValues(teamLogic)
@@ -58,14 +60,33 @@ export function useSqlChartModel<TConfig extends object>(
                       visualizationType,
                       ySeriesData,
                       legendRenderItem,
+                      embedded,
                   })
                 : undefined,
-        [xData, chartSettings, timezone, goalLines, visualizationType, buildConfig, ySeriesData, legendRenderItem]
+        [
+            xData,
+            chartSettings,
+            timezone,
+            goalLines,
+            visualizationType,
+            buildConfig,
+            ySeriesData,
+            legendRenderItem,
+            embedded,
+        ]
+    )
+
+    const labels = useMemo(
+        () =>
+            visualizationType === ChartDisplayType.ActionsBarValue
+                ? (xData?.data.map((_, index) => String(index)) ?? [])
+                : (xData?.data ?? []),
+        [visualizationType, xData]
     )
 
     if (!xData || !ySeriesData || series.length === 0 || !config) {
         return null
     }
 
-    return { series, labels: xData.data, theme, config }
+    return { series, labels, theme, config }
 }

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/useSqlChartModel.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/useSqlChartModel.ts
@@ -59,6 +59,7 @@ export function useSqlChartModel<TConfig extends object>(
                       goalLines,
                       visualizationType,
                       ySeriesData,
+                      series,
                       legendRenderItem,
                       embedded,
                   })
@@ -71,6 +72,7 @@ export function useSqlChartModel<TConfig extends object>(
             visualizationType,
             buildConfig,
             ySeriesData,
+            series,
             legendRenderItem,
             embedded,
         ]

--- a/frontend/src/queries/nodes/DataVisualization/Components/DisplayTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/DisplayTab.tsx
@@ -67,8 +67,10 @@ export const DisplayTab = (): JSX.Element => {
     const isScatterPlot = effectiveVisualizationType === ChartDisplayType.ScatterPlot
     const isBoxPlot = effectiveVisualizationType === ChartDisplayType.BoxPlot
     const isMetric = effectiveVisualizationType === ChartDisplayType.Metric
+    const isHorizontalBarChart = effectiveVisualizationType === ChartDisplayType.ActionsBarValue
     // Scatter and box plots have a single Y axis, so there is no separate right axis to configure.
     const isSingleAxisChart = isScatterPlot || isBoxPlot
+    const supportsRightYAxis = !isSingleAxisChart && !isHorizontalBarChart
     const isLineChart =
         effectiveVisualizationType === ChartDisplayType.ActionsLineGraph ||
         effectiveVisualizationType === ChartDisplayType.ActionsAreaGraph
@@ -80,7 +82,11 @@ export const DisplayTab = (): JSX.Element => {
             effectiveVisualizationType === ChartDisplayType.ActionsStackedBar)
 
     const renderYAxisSettings = (name: 'leftYAxisSettings' | 'rightYAxisSettings'): JSX.Element => {
-        const leftPlaceholder = isSingleAxisChart ? 'Y-axis label' : 'Left Y-axis label'
+        const leftPlaceholder = isHorizontalBarChart
+            ? 'X-axis label'
+            : supportsRightYAxis
+              ? 'Left Y-axis label'
+              : 'Y-axis label'
         const labelPlaceholder = name === 'leftYAxisSettings' ? leftPlaceholder : 'Right Y-axis label'
 
         return (
@@ -373,11 +379,13 @@ export const DisplayTab = (): JSX.Element => {
                                             </div>
                                         )}
                                         <div className="flex flex-col gap-1">
-                                            <LemonLabel>X-axis label</LemonLabel>
+                                            <LemonLabel>
+                                                {isHorizontalBarChart ? 'Y-axis label' : 'X-axis label'}
+                                            </LemonLabel>
                                             <LemonInput
                                                 data-attr="data-visualization-x-axis-label-input"
                                                 value={chartSettings.xAxisLabel ?? ''}
-                                                placeholder="X-axis label"
+                                                placeholder={isHorizontalBarChart ? 'Y-axis label' : 'X-axis label'}
                                                 onChange={(value) => {
                                                     updateChartSettings({ xAxisLabel: value })
                                                 }}
@@ -385,7 +393,11 @@ export const DisplayTab = (): JSX.Element => {
                                         </div>
                                         <LemonSwitch
                                             className="flex-1 w-full"
-                                            label="Show X-axis tick labels"
+                                            label={
+                                                isHorizontalBarChart
+                                                    ? 'Show Y-axis tick labels'
+                                                    : 'Show X-axis tick labels'
+                                            }
                                             checked={chartSettings.showXAxisTicks ?? true}
                                             onChange={(value) => {
                                                 updateChartSettings({ showXAxisTicks: value })
@@ -397,7 +409,11 @@ export const DisplayTab = (): JSX.Element => {
                                             <>
                                                 <LemonSwitch
                                                     className="flex-1 w-full"
-                                                    label="Show X-axis border"
+                                                    label={
+                                                        isHorizontalBarChart
+                                                            ? 'Show Y-axis border'
+                                                            : 'Show X-axis border'
+                                                    }
                                                     checked={chartSettings.showXAxisBorder ?? true}
                                                     onChange={(value) => {
                                                         updateChartSettings({ showXAxisBorder: value })
@@ -405,7 +421,11 @@ export const DisplayTab = (): JSX.Element => {
                                                 />
                                                 <LemonSwitch
                                                     className="flex-1 w-full"
-                                                    label="Show Y-axis border"
+                                                    label={
+                                                        isHorizontalBarChart
+                                                            ? 'Show X-axis border'
+                                                            : 'Show Y-axis border'
+                                                    }
                                                     checked={chartSettings.showYAxisBorder ?? true}
                                                     onChange={(value) => {
                                                         updateChartSettings({ showYAxisBorder: value })
@@ -454,13 +474,12 @@ export const DisplayTab = (): JSX.Element => {
                     !isPieChart
                         ? {
                               key: 'left-y-axis',
-                              header: isSingleAxisChart ? 'Y-axis' : 'Left Y-axis',
+                              header: isHorizontalBarChart ? 'X-axis' : supportsRightYAxis ? 'Left Y-axis' : 'Y-axis',
                               className: 'p-2 flex flex-col gap-2',
                               content: renderYAxisSettings('leftYAxisSettings'),
                           }
                         : null,
-                    // A scatter has one gutter per axis, so there is no second Y axis to configure.
-                    !isPieChart && !isSingleAxisChart
+                    !isPieChart && supportsRightYAxis
                         ? {
                               key: 'right-y-axis',
                               header: 'Right Y-axis',

--- a/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
@@ -504,9 +504,9 @@ export const YSeriesDisplayTab = ({ ySeriesLogicProps }: { ySeriesLogicProps: YS
     const { updateSeriesIndex } = useActions(dataVisualizationLogic)
 
     const isPieChart = effectiveVisualizationType === ChartDisplayType.ActionsPie
-    // Pie, metric, and scatter charts do not use these series controls.
     const hideChartSpecificOptions =
         isPieChart ||
+        effectiveVisualizationType === ChartDisplayType.ActionsBarValue ||
         effectiveVisualizationType === ChartDisplayType.Metric ||
         effectiveVisualizationType === ChartDisplayType.ScatterPlot
     const showColorPicker = !showTableSettings && !selectedSeriesBreakdownColumn

--- a/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.test.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.test.tsx
@@ -82,12 +82,15 @@ describe('TableDisplay', () => {
         cleanup()
     })
 
-    it('offers box plots and saves the selected display', async () => {
-        const query = renderTableDisplay('table-display-box-plot')
+    it.each([
+        ['Box plot', ChartDisplayType.BoxPlot],
+        ['Horizontal bar chart', ChartDisplayType.ActionsBarValue],
+    ])('offers %s and saves the selected display', async (label, display) => {
+        const query = renderTableDisplay(`table-display-${display}`)
 
-        await selectDisplay('Box plot')
+        await selectDisplay(label)
 
-        await waitFor(() => expect(query().display).toBe(ChartDisplayType.BoxPlot))
+        await waitFor(() => expect(query().display).toBe(display))
     })
 
     it('offers metrics behind the feature flag and saves one Y-series', async () => {

--- a/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.tsx
@@ -23,7 +23,7 @@ const DISPLAY_TYPE_LABELS: Record<ChartDisplayType, string> = {
     [ChartDisplayType.Metric]: 'Metric',
     [ChartDisplayType.ActionsPie]: 'Pie chart',
     [ChartDisplayType.ActionsDonut]: 'Donut chart',
-    [ChartDisplayType.ActionsBarValue]: 'Value chart',
+    [ChartDisplayType.ActionsBarValue]: 'Horizontal bar chart',
     [ChartDisplayType.ActionsTable]: 'Table',
     [ChartDisplayType.WorldMap]: 'World map',
     [ChartDisplayType.CalendarHeatmap]: 'Calendar heatmap',
@@ -106,6 +106,15 @@ export function getTableDisplayOptions(
                     value: ChartDisplayType.ActionsBar,
                     icon: <IconGraph />,
                     label: 'Bar chart',
+                },
+                {
+                    value: ChartDisplayType.ActionsBarValue,
+                    icon: <IconGraph className="rotate-90" />,
+                    label: 'Horizontal bar chart',
+                    disabledReason:
+                        numericalColumns.length === 0 || columns.every((column) => column.type.isNumerical)
+                            ? 'Requires a category column and a numeric column'
+                            : undefined,
                 },
                 {
                     value: ChartDisplayType.ActionsStackedBar,

--- a/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
@@ -36,7 +36,7 @@ import { Reload } from '../DataNode/Reload'
 import { QueryFeature } from '../DataTable/queryFeatures'
 import { PieChart } from './Components/Charts/PieChart'
 import { SqlBoxPlot } from './Components/Charts/SqlBoxPlot'
-import { SqlChart } from './Components/Charts/SqlChart'
+import { isSqlChartVisualizationType, SqlChart } from './Components/Charts/SqlChart'
 import { SqlMetricCard } from './Components/Charts/SqlMetricCard'
 import { SqlScatterGraph } from './Components/Charts/SqlScatterGraph'
 import { TwoDimensionalHeatmap } from './Components/Heatmap/TwoDimensionalHeatmap'
@@ -260,13 +260,7 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
                 embedded={props.embedded}
             />
         )
-    } else if (
-        effectiveVisualizationType === ChartDisplayType.ActionsLineGraph ||
-        effectiveVisualizationType === ChartDisplayType.ActionsBar ||
-        effectiveVisualizationType === ChartDisplayType.ActionsBarValue ||
-        effectiveVisualizationType === ChartDisplayType.ActionsAreaGraph ||
-        effectiveVisualizationType === ChartDisplayType.ActionsStackedBar
-    ) {
+    } else if (isSqlChartVisualizationType(effectiveVisualizationType)) {
         const _xData = seriesBreakdownData.xData.data.length ? seriesBreakdownData.xData : xData
         const _yData = seriesBreakdownData.xData.data.length ? seriesBreakdownData.seriesData : yData
         component = (

--- a/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
@@ -263,6 +263,7 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
     } else if (
         effectiveVisualizationType === ChartDisplayType.ActionsLineGraph ||
         effectiveVisualizationType === ChartDisplayType.ActionsBar ||
+        effectiveVisualizationType === ChartDisplayType.ActionsBarValue ||
         effectiveVisualizationType === ChartDisplayType.ActionsAreaGraph ||
         effectiveVisualizationType === ChartDisplayType.ActionsStackedBar
     ) {
@@ -281,6 +282,7 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
                     insightNumericId={insight?.id || 'new'}
                     showAnnotations={!props.inSharedMode && isDateXAxis && chartSettings.showAnnotations === true}
                     presetChartHeight={presetChartHeight}
+                    embedded={props.embedded}
                 />
             </BindLogic>
         )

--- a/frontend/src/queries/nodes/DataVisualization/sqlVisualizationSupport.ts
+++ b/frontend/src/queries/nodes/DataVisualization/sqlVisualizationSupport.ts
@@ -18,7 +18,7 @@ const VISUALIZATION_SUPPORT: Record<ChartDisplayType, VisualizationSupport> = {
     [ChartDisplayType.ActionsLineGraphCumulative]: 'axes',
     [ChartDisplayType.ScatterPlot]: 'manual',
     [ChartDisplayType.TwoDimensionalHeatmap]: 'manual',
-    [ChartDisplayType.ActionsBarValue]: 'manual',
+    [ChartDisplayType.ActionsBarValue]: 'axes',
     [ChartDisplayType.Metric]: 'axes',
     [ChartDisplayType.WorldMap]: 'manual',
     [ChartDisplayType.CalendarHeatmap]: 'manual',

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -985,6 +985,7 @@ function InternalDataTableVisualization(
     } else if (
         effectiveVisualizationType === ChartDisplayType.ActionsLineGraph ||
         effectiveVisualizationType === ChartDisplayType.ActionsBar ||
+        effectiveVisualizationType === ChartDisplayType.ActionsBarValue ||
         effectiveVisualizationType === ChartDisplayType.ActionsAreaGraph ||
         effectiveVisualizationType === ChartDisplayType.ActionsStackedBar
     ) {
@@ -1003,6 +1004,7 @@ function InternalDataTableVisualization(
                     insightNumericId={editingInsight?.id || 'new'}
                     showAnnotations={isDateXAxis && chartSettings.showAnnotations === true}
                     presetChartHeight={presetChartHeight}
+                    embedded={props.embedded}
                 />
             </BindLogic>
         )

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -48,7 +48,7 @@ import { QueryExecutionDetails } from '~/queries/nodes/DataNode/QueryExecutionDe
 import { DataTableRow } from '~/queries/nodes/DataTable/dataTableLogic'
 import { PieChart } from '~/queries/nodes/DataVisualization/Components/Charts/PieChart'
 import { SqlBoxPlot } from '~/queries/nodes/DataVisualization/Components/Charts/SqlBoxPlot'
-import { SqlChart } from '~/queries/nodes/DataVisualization/Components/Charts/SqlChart'
+import { isSqlChartVisualizationType, SqlChart } from '~/queries/nodes/DataVisualization/Components/Charts/SqlChart'
 import { SqlMetricCard } from '~/queries/nodes/DataVisualization/Components/Charts/SqlMetricCard'
 import { SqlScatterGraph } from '~/queries/nodes/DataVisualization/Components/Charts/SqlScatterGraph'
 import { TwoDimensionalHeatmap } from '~/queries/nodes/DataVisualization/Components/Heatmap/TwoDimensionalHeatmap'
@@ -982,13 +982,7 @@ function InternalDataTableVisualization(
                 embedded
             />
         )
-    } else if (
-        effectiveVisualizationType === ChartDisplayType.ActionsLineGraph ||
-        effectiveVisualizationType === ChartDisplayType.ActionsBar ||
-        effectiveVisualizationType === ChartDisplayType.ActionsBarValue ||
-        effectiveVisualizationType === ChartDisplayType.ActionsAreaGraph ||
-        effectiveVisualizationType === ChartDisplayType.ActionsStackedBar
-    ) {
+    } else if (isSqlChartVisualizationType(effectiveVisualizationType)) {
         const _xData = seriesBreakdownData.xData.data.length ? seriesBreakdownData.xData : xData
         const _yData = seriesBreakdownData.xData.data.length ? seriesBreakdownData.seriesData : yData
         component = (


### PR DESCRIPTION
## Problem

SQL insight users can choose vertical bars, but they cannot compare categories with horizontal bars.

This layer follows [#96725](https://github.com/PostHog/posthog/pull/96725), which adds metric chart support.

## Changes

- Adds a horizontal bar option when a query returns a category column and a numeric column.
- Renders SQL data with the existing Quill bar chart, including formatting, legends, values, and goal lines.
- Uses horizontal axis names in the settings panel.
- Fits rows inside dashboard tiles and scrolls long charts on the insight page.

![sql-horizontal-bar-viewport](https://raw.githubusercontent.com/PostHog/pr-assets/d8d8c035357653fa0e5799ec8dfc359309ea32b5/2026/09/f86575af-e000-46f7-a022-6218adc08f4d.png)

## How did you test this code?

- Targeted Jest suites cover selection, dashboard setup, renderer routing, axis mapping, goal lines, and chart controls.
- `pnpm --filter=@posthog/frontend typescript:check`
- Playwright rendered the Storybook story at 760 px and 500 px widths.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Not needed. The existing SQL insight controls now support another shared chart type.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Desktop made the change. Explore subagents reviewed the data flow and the final diff. Playwright checked the Storybook story.

Skills used: `/working-with-charts`, `/writing-ui-components`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, `/stacking-prs`, `/running-ci-preflight`, `/writing-pr-descriptions`, and `/writing-simplified-technical-english`.

The open PR search found no duplicate horizontal SQL bar chart change. The committed fixtures use repository data only.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
