### PR TITLE
feat(cdp): reserve retry slots for tier-cap-denied emails

### DIFF
--- a/nodejs/src/cdp/services/messaging/email.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.test.ts
@@ -17,7 +17,7 @@ import { TeamWorkflowsConfigService } from '../managers/team-workflows-config.se
 import { RateLimiterService } from '../rate-limiter/rate-limiter.service'
 import { selectEmailSenderIntegrationId } from './email-sender-selection'
 import { EmailSuppressionService, emailSuppressionConfigFromEnv } from './email-suppression.service'
-import { EmailService, parseAddressList, sanitizeEmailSubject } from './email.service'
+import { EmailService, parseAddressList, sanitizeEmailSubject, teamEmailCapBuckets } from './email.service'
 import { MailDevAPI } from './helpers/maildev'
 import { EmailTrackingCodeSigner } from './helpers/tracking-code'
 
@@ -796,6 +796,99 @@ describe('EmailService', () => {
                 )
                 expect(result.finished).toBe(true)
                 expect(cappedSendSpy).toHaveBeenCalled()
+            })
+
+            // Reproduces the tier-cap face of the 2026-09 email queue incident against the real
+            // limiter: a capped team's denied backlog used to park at the shared deficit horizon,
+            // wake as a herd, and rotate head-of-queue starvation across teams.
+            it('spreads a capped team over distinct slots while another team keeps sending', async () => {
+                const hourlyCap = 360
+                const dailyCap = 8640
+                const redis = createRedisV2PoolFromConfig({
+                    connection: hub.CDP_REDIS_HOST
+                        ? {
+                              url: hub.CDP_REDIS_HOST,
+                              options: { port: hub.CDP_REDIS_PORT, password: hub.CDP_REDIS_PASSWORD },
+                          }
+                        : { url: hub.REDIS_URL },
+                    poolMinSize: hub.REDIS_POOL_MIN_SIZE,
+                    poolMaxSize: hub.REDIS_POOL_MAX_SIZE,
+                })
+                const limiter = new RateLimiterService(redis, { name: 'team-email-incident-test' })
+                const configService = new TeamWorkflowsConfigService(hub.postgres, hub.pubSub)
+                jest.spyOn(configService, 'getEmailSendingTier').mockResolvedValue(0)
+                const enforcedService = new EmailService(
+                    {
+                        sesAccessKeyId: hub.SES_ACCESS_KEY_ID,
+                        sesSecretAccessKey: hub.SES_SECRET_ACCESS_KEY,
+                        sesRegion: hub.SES_REGION,
+                        sesEndpoint: hub.SES_ENDPOINT,
+                        sesTrackedConfigurationSet: hub.SES_TRACKED_CONFIGURATION_SET,
+                        sesUntrackedConfigurationSet: hub.SES_UNTRACKED_CONFIGURATION_SET,
+                        teamEmailCapMode: 'enforce',
+                        teamEmailTierHourlyCaps: [hourlyCap],
+                        teamEmailTierDailyCaps: [dailyCap],
+                    },
+                    hub.integrationManager,
+                    configService,
+                    hub.ENCRYPTION_SALT_KEYS,
+                    hub.SITE_URL,
+                    new EmailTrackingCodeSigner(hub.ENCRYPTION_SALT_KEYS, hub.CDP_EMAIL_TRACKING_URL),
+                    new EmailSuppressionService(hub.postgres, emailSuppressionConfigFromEnv()),
+                    new RecipientsManagerService(hub.postgres),
+                    undefined,
+                    null,
+                    limiter
+                )
+                const enforcedSendSpy = jest.spyOn(enforcedService.sesV2Client!, 'send') as any
+                enforcedSendSpy.mockResolvedValue({ MessageId: 'test-message-id' })
+
+                // Drain the capped team's hourly bucket so every send below is a denial. The
+                // 0.1 tokens/s refill makes the slot spacing 10s, far above test wall-clock.
+                const buckets = teamEmailCapBuckets(team.id, hourlyCap, dailyCap)
+                await limiter.claimUpTo({
+                    key: buckets[0].key,
+                    requested: hourlyCap,
+                    capacity: buckets[0].capacity,
+                    refillPerSecond: buckets[0].refillPerSecond,
+                })
+
+                const parkedAt: number[] = []
+                for (let i = 0; i < 4; i++) {
+                    const denied = await enforcedService.executeSendEmail(invocation)
+                    expect(denied.finished).toBe(false)
+                    parkedAt.push(denied.invocation.queueScheduledAt!.toMillis())
+                }
+                // Distinct slots one token interval apart, not a herd at the shared horizon.
+                for (let i = 1; i < parkedAt.length; i++) {
+                    const gapMs = parkedAt[i] - parkedAt[i - 1]
+                    expect(gapMs).toBeGreaterThan(9_000)
+                    expect(gapMs).toBeLessThan(11_000)
+                }
+
+                // A second team's buckets are cold, so its send goes straight out. Tier caps
+                // isolate per team; the capped team's backlog must not reach anyone else.
+                const otherTeam = (await createTestTeamFixture(hub.postgres)).team
+                await insertIntegration(hub.postgres, otherTeam.id, {
+                    id: otherTeam.id + 1,
+                    kind: 'email',
+                    config: {
+                        email: 'test@posthog.com',
+                        name: 'Test User',
+                        domain: 'posthog.com',
+                        verified: true,
+                        provider: 'ses',
+                    },
+                })
+                const other = createExampleInvocation({ team_id: otherTeam.id, id: 'function-other-team' })
+                other.id = 'invocation-other-team'
+                other.state.vmState = { stack: [] } as any
+                other.queueParameters = createEmailParams()
+                other.queueParameters.from = { integrationId: otherTeam.id + 1 }
+                const otherResult = await enforcedService.executeSendEmail(other)
+
+                expect(otherResult.finished).toBe(true)
+                expect(enforcedSendSpy).toHaveBeenCalledTimes(1)
             })
         })
     })

--- a/nodejs/src/cdp/services/messaging/email.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.test.ts
@@ -787,6 +787,13 @@ describe('EmailService', () => {
 
                 const result = await cappedService.executeSendEmail(invocation)
 
+                // The reservation horizon must reach the limiter, or denials fall back to
+                // shared-horizon wakes and a denied backlog re-herds.
+                expect(claimAllOrNothingPair).toHaveBeenCalledWith(
+                    expect.anything(),
+                    expect.any(Number),
+                    60 * 60 * 1000
+                )
                 expect(result.finished).toBe(true)
                 expect(cappedSendSpy).toHaveBeenCalled()
             })

--- a/nodejs/src/cdp/services/messaging/email.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.test.ts
@@ -747,10 +747,20 @@ describe('EmailService', () => {
             })
 
             it.each([
-                ['parks the send until the reported refill horizon', 30 * 60 * 1000, 30 * 60 * 1000],
-                ['clamps the wake to one hour on a longer horizon', 24 * 60 * 60 * 1000, 60 * 60 * 1000],
-            ])('%s', async (_name, retryAfterMs, clampedBaseMs) => {
-                claimAllOrNothingPair.mockResolvedValue({ granted: false, deniedIndex: 1, retryAfterMs })
+                // A reserved slot is exclusive and is parked on exactly; spreading it would
+                // collide it with the slot in front.
+                ['parks exactly on a reserved slot', 30 * 60 * 1000, true, 30 * 60 * 1000, 30 * 60 * 1000],
+                // Past the horizon nothing is reserved: every overflow caller gets the same
+                // wake back and spreads itself 1x-2x across the horizon.
+                [
+                    'spreads an overflow wake across the horizon',
+                    60 * 60 * 1000,
+                    false,
+                    60 * 60 * 1000,
+                    2 * 60 * 60 * 1000,
+                ],
+            ])('%s', async (_name, retryAfterMs, reserved, minMs, maxMs) => {
+                claimAllOrNothingPair.mockResolvedValue({ granted: false, deniedIndex: 1, retryAfterMs, reserved })
 
                 const before = Date.now()
                 const result = await cappedService.executeSendEmail(invocation)
@@ -761,16 +771,20 @@ describe('EmailService', () => {
                 // The reschedule must carry the email payload forward, same as the workflow limit.
                 expect(result.invocation.queueParameters).toEqual(invocation.queueParameters)
                 const scheduledMs = result.invocation.queueScheduledAt!.toMillis()
-                // Jitter is 1x-2x the clamped horizon; the slack absorbs scheduler overhead.
-                expect(scheduledMs).toBeGreaterThanOrEqual(before + clampedBaseMs)
-                expect(scheduledMs).toBeLessThan(before + 2 * clampedBaseMs + 5000)
+                expect(scheduledMs).toBeGreaterThanOrEqual(before + minMs)
+                expect(scheduledMs).toBeLessThan(before + maxMs + 5000)
             })
 
             it('retries on the token bucket cadence when the limiter reports no horizon', async () => {
                 // A Valkey fault denies with no horizon. Parking on the daily cap's pacing
                 // interval would hold the email long after the limiter recovered.
                 jest.spyOn(Math, 'random').mockReturnValue(0)
-                claimAllOrNothingPair.mockResolvedValue({ granted: false, deniedIndex: null, retryAfterMs: null })
+                claimAllOrNothingPair.mockResolvedValue({
+                    granted: false,
+                    deniedIndex: null,
+                    retryAfterMs: null,
+                    reserved: false,
+                })
 
                 const before = Date.now()
                 const result = await cappedService.executeSendEmail(invocation)
@@ -783,7 +797,12 @@ describe('EmailService', () => {
             })
 
             it('sends when the claim is granted', async () => {
-                claimAllOrNothingPair.mockResolvedValue({ granted: true, deniedIndex: null, retryAfterMs: null })
+                claimAllOrNothingPair.mockResolvedValue({
+                    granted: true,
+                    deniedIndex: null,
+                    retryAfterMs: null,
+                    reserved: false,
+                })
 
                 const result = await cappedService.executeSendEmail(invocation)
 

--- a/nodejs/src/cdp/services/messaging/email.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.test.ts
@@ -817,9 +817,9 @@ describe('EmailService', () => {
                 expect(cappedSendSpy).toHaveBeenCalled()
             })
 
-            // Reproduces the tier-cap face of the 2026-09 email queue incident against the real
-            // limiter: a capped team's denied backlog used to park at the shared deficit horizon,
-            // wake as a herd, and rotate head-of-queue starvation across teams.
+            // A team over its tier cap must not slow anyone else down: its denied sends get
+            // their own future slots instead of all waking together, and another team's send
+            // goes straight out. Runs against the real limiter.
             it('spreads a capped team over distinct slots while another team keeps sending', async () => {
                 const hourlyCap = 360
                 const dailyCap = 8640
@@ -833,7 +833,7 @@ describe('EmailService', () => {
                     poolMinSize: hub.REDIS_POOL_MIN_SIZE,
                     poolMaxSize: hub.REDIS_POOL_MAX_SIZE,
                 })
-                const limiter = new RateLimiterService(redis, { name: 'team-email-incident-test' })
+                const limiter = new RateLimiterService(redis, { name: 'team-email-cap-test' })
                 const configService = new TeamWorkflowsConfigService(hub.postgres, hub.pubSub)
                 jest.spyOn(configService, 'getEmailSendingTier').mockResolvedValue(0)
                 const enforcedService = new EmailService(

--- a/nodejs/src/cdp/services/messaging/email.service.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.ts
@@ -663,7 +663,7 @@ export class EmailService {
             }
             const denied = buckets[claim.deniedIndex ?? 1]
             teamEmailCapDelayedTotal.inc({ tier: String(tier), bucket: denied.name, mode })
-            const retryDelayMs = pickReservedRetryDelayMs(claim.retryAfterMs, denied.refillPerSecond)
+            const retryDelayMs = pickReservedRetryDelayMs(claim.retryAfterMs, denied.refillPerSecond, claim.reserved)
             emailReservedParkMs.labels('team-email').observe(retryDelayMs)
             return {
                 retryDelayMs,

--- a/nodejs/src/cdp/services/messaging/email.service.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.ts
@@ -118,18 +118,6 @@ function pickTokenBucketRetryDelayMs(refillPerSecond: number): number {
 const CAP_RETRY_MIN_MS = 1_000
 const CAP_RETRY_MAX_MS = 60 * 60 * 1_000
 
-function pickCapRetryDelayMs(retryAfterMs: number | null, refillPerSecond: number): number {
-    // A denial with no horizon means the limiter itself failed, not that the cap was reached.
-    // Valkey recovers in seconds, but a daily cap paces in hours, so that bucket's refill is the
-    // wrong clock for this wake. Use the token-bucket cadence, which has a much shorter ceiling.
-    if (retryAfterMs === null) {
-        return pickTokenBucketRetryDelayMs(refillPerSecond)
-    }
-    // The 1x-2x jitter spreads re-claims so a parked backlog does not wake on the same instant.
-    const clampedMs = Math.min(Math.max(retryAfterMs, CAP_RETRY_MIN_MS), CAP_RETRY_MAX_MS)
-    return Math.floor(clampedMs * (1 + Math.random()))
-}
-
 // How far denied sends park. Everything at or below the top bucket is a real slot.
 // Above the top bucket is overflow: the backlog is deeper than one hour of refill.
 // A sustained rate up there means a team queues more email than its limit can send.
@@ -665,14 +653,20 @@ export class EmailService {
             // Both buckets in one atomic claim, granted whole or not at all. A denial consumes
             // nothing, so a rescheduled multi-recipient send cannot burn the partial refill on
             // every retry and starve the team's other emails while never sending itself.
-            const claim = await this.teamEmailRateLimiter.claimAllOrNothingPair([buckets[0], buckets[1]], requested)
+            const claim = await this.teamEmailRateLimiter.claimAllOrNothingPair(
+                [buckets[0], buckets[1]],
+                requested,
+                CAP_RETRY_MAX_MS
+            )
             if (claim.granted) {
                 return null
             }
             const denied = buckets[claim.deniedIndex ?? 1]
             teamEmailCapDelayedTotal.inc({ tier: String(tier), bucket: denied.name, mode })
+            const retryDelayMs = pickReservedRetryDelayMs(claim.retryAfterMs, denied.refillPerSecond)
+            emailReservedParkMs.labels('team-email').observe(retryDelayMs)
             return {
-                retryDelayMs: pickCapRetryDelayMs(claim.retryAfterMs, denied.refillPerSecond),
+                retryDelayMs,
                 label: denied.label,
             }
         }

--- a/nodejs/src/cdp/services/rate-limiter/rate-limiter.service.test.ts
+++ b/nodejs/src/cdp/services/rate-limiter/rate-limiter.service.test.ts
@@ -276,10 +276,9 @@ describe('RateLimiterService', () => {
         })
 
         it('hands successive reserved denials distinct, later slots, paced by the slower bucket', async () => {
-            // Both buckets are short. The slower one (0.5/s) decides: the first caller waits
-            // only its 40s deficit, the caller behind it chains a further requested/refill
-            // (60s) on top, so denied callers park at distinct times instead of all waking
-            // at the shared deficit horizon and re-herding.
+            // Both buckets are short, so the slower one (0.5/s) sets the pace. The first
+            // caller waits 40s (its missing tokens). The next one gets the slot after
+            // that, a full 60s later. Nobody wakes at the same time.
             const buckets: [
                 { key: string; capacity: number; refillPerSecond: number },
                 { key: string; capacity: number; refillPerSecond: number },
@@ -292,7 +291,7 @@ describe('RateLimiterService', () => {
 
             expect(first.granted).toBe(false)
             expect(first.reserved).toBe(true)
-            // Cold cursor: the first slot is the 40s deficit, not a full 60s spacing.
+            // First in line pays only the 40s shortfall, not a full 60s slot.
             expect(first.retryAfterMs).toBe(40_000)
             expect(second.reserved).toBe(true)
             expect(second.retryAfterMs!).toBeGreaterThan(first.retryAfterMs!)
@@ -307,9 +306,8 @@ describe('RateLimiterService', () => {
                 { key: `${KEY_A}/resv-cap`, capacity: 50, refillPerSecond: 0 },
                 { key: `${KEY_B}/resv-cap`, capacity: 10, refillPerSecond: 2 },
             ]
-            // The 10s deficit slot fits the 20s horizon; the next slot (deficit + 15s
-            // spacing) does not, so everyone after the first gets the horizon back,
-            // un-reserved, and must spread its own wake.
+            // The first slot (10s) fits inside the 20s horizon. The next one would not,
+            // so everyone after the first just gets "come back in 20s" with no slot.
             const first = await limiter.claimAllOrNothingPair(buckets, 30, 20_000)
             const second = await limiter.claimAllOrNothingPair(buckets, 30, 20_000)
             const third = await limiter.claimAllOrNothingPair(buckets, 30, 20_000)

--- a/nodejs/src/cdp/services/rate-limiter/rate-limiter.service.test.ts
+++ b/nodejs/src/cdp/services/rate-limiter/rate-limiter.service.test.ts
@@ -209,7 +209,7 @@ describe('RateLimiterService', () => {
                 ],
                 30
             )
-            expect(claim).toEqual({ granted: true, deniedIndex: null, retryAfterMs: null })
+            expect(claim).toEqual({ granted: true, deniedIndex: null, retryAfterMs: null, reserved: false })
             // Both pools were charged: the remainder is all that is left to claim.
             expect(await limiter.claimUpTo({ key: KEY_A, requested: 50, capacity: 50, refillPerSecond: 0 })).toBe(20)
             expect(await limiter.claimUpTo({ key: KEY_B, requested: 100, capacity: 100, refillPerSecond: 0 })).toBe(70)
@@ -227,7 +227,7 @@ describe('RateLimiterService', () => {
                 30
             )
             // refillPerSecond 0 means the missing tokens never accrue, so no horizon is reported.
-            expect(claim).toEqual({ granted: false, deniedIndex: 1, retryAfterMs: null })
+            expect(claim).toEqual({ granted: false, deniedIndex: 1, retryAfterMs: null, reserved: false })
             expect(await limiter.claimUpTo({ key: KEY_A, requested: 50, capacity: 50, refillPerSecond: 0 })).toBe(50)
             expect(await limiter.claimUpTo({ key: KEY_B, requested: 10, capacity: 10, refillPerSecond: 0 })).toBe(10)
         })
@@ -242,7 +242,7 @@ describe('RateLimiterService', () => {
                 ],
                 30
             )
-            expect(claim).toEqual({ granted: false, deniedIndex: 1, retryAfterMs: 10_000 })
+            expect(claim).toEqual({ granted: false, deniedIndex: 1, retryAfterMs: 10_000, reserved: false })
         })
 
         it('reports the slower bucket when both are short', async () => {
@@ -256,7 +256,7 @@ describe('RateLimiterService', () => {
                 ],
                 30
             )
-            expect(claim).toEqual({ granted: false, deniedIndex: 0, retryAfterMs: 40_000 })
+            expect(claim).toEqual({ granted: false, deniedIndex: 0, retryAfterMs: 40_000, reserved: false })
         })
 
         it('fails closed when the Lua call throws', async () => {
@@ -272,14 +272,14 @@ describe('RateLimiterService', () => {
                 ],
                 5
             )
-            expect(claim).toEqual({ granted: false, deniedIndex: null, retryAfterMs: null })
+            expect(claim).toEqual({ granted: false, deniedIndex: null, retryAfterMs: null, reserved: false })
         })
 
         it('hands successive reserved denials distinct, later slots, paced by the slower bucket', async () => {
-            // Both buckets are short. The slower one (0.5/s) sets the pace: its slot spacing is
-            // requested/refill = 60s, and each denial advances the cursor by one slot, so three
-            // denied callers park at three different times instead of all waking at the shared
-            // 40s deficit horizon and re-herding.
+            // Both buckets are short. The slower one (0.5/s) decides: the first caller waits
+            // only its 40s deficit, the caller behind it chains a further requested/refill
+            // (60s) on top, so denied callers park at distinct times instead of all waking
+            // at the shared deficit horizon and re-herding.
             const buckets: [
                 { key: string; capacity: number; refillPerSecond: number },
                 { key: string; capacity: number; refillPerSecond: number },
@@ -291,10 +291,12 @@ describe('RateLimiterService', () => {
             const second = await limiter.claimAllOrNothingPair(buckets, 30, 600_000)
 
             expect(first.granted).toBe(false)
-            // Cold cursor: the first slot is one spacing (60s) out, past the 40s deficit.
-            expect(first.retryAfterMs).toBe(60_000)
+            expect(first.reserved).toBe(true)
+            // Cold cursor: the first slot is the 40s deficit, not a full 60s spacing.
+            expect(first.retryAfterMs).toBe(40_000)
+            expect(second.reserved).toBe(true)
             expect(second.retryAfterMs!).toBeGreaterThan(first.retryAfterMs!)
-            expect(second.retryAfterMs!).toBeLessThanOrEqual(120_000)
+            expect(second.retryAfterMs!).toBeLessThanOrEqual(100_000)
         })
 
         it('stops advancing the reservation cursor at the horizon', async () => {
@@ -305,15 +307,19 @@ describe('RateLimiterService', () => {
                 { key: `${KEY_A}/resv-cap`, capacity: 50, refillPerSecond: 0 },
                 { key: `${KEY_B}/resv-cap`, capacity: 10, refillPerSecond: 2 },
             ]
-            // Slot spacing is 15s with a 20s horizon: the first denial reserves the one slot
-            // inside the horizon, everyone after gets the horizon back unchanged and re-contends.
+            // The 10s deficit slot fits the 20s horizon; the next slot (deficit + 15s
+            // spacing) does not, so everyone after the first gets the horizon back,
+            // un-reserved, and must spread its own wake.
             const first = await limiter.claimAllOrNothingPair(buckets, 30, 20_000)
             const second = await limiter.claimAllOrNothingPair(buckets, 30, 20_000)
             const third = await limiter.claimAllOrNothingPair(buckets, 30, 20_000)
 
-            expect(first.retryAfterMs).toBe(15_000)
+            expect(first.retryAfterMs).toBe(10_000)
+            expect(first.reserved).toBe(true)
             expect(second.retryAfterMs).toBe(20_000)
+            expect(second.reserved).toBe(false)
             expect(third.retryAfterMs).toBe(20_000)
+            expect(third.reserved).toBe(false)
         })
     })
 

--- a/nodejs/src/cdp/services/rate-limiter/rate-limiter.service.test.ts
+++ b/nodejs/src/cdp/services/rate-limiter/rate-limiter.service.test.ts
@@ -319,6 +319,32 @@ describe('RateLimiterService', () => {
             expect(third.retryAfterMs).toBe(20_000)
             expect(third.reserved).toBe(false)
         })
+
+        it('keeps one reservation line when the slower bucket changes', async () => {
+            const buckets: [
+                { key: string; capacity: number; refillPerSecond: number },
+                { key: string; capacity: number; refillPerSecond: number },
+            ] = [
+                { key: `${KEY_A}/line`, capacity: 10, refillPerSecond: 2 },
+                { key: `${KEY_B}/line`, capacity: 100, refillPerSecond: 0.5 },
+            ]
+            // The second bucket still covers the request, so the first one (10s
+            // shortfall, 15s spacing) sets the pace for the first two denials.
+            const first = await limiter.claimAllOrNothingPair(buckets, 30, 600_000)
+            const second = await limiter.claimAllOrNothingPair(buckets, 30, 600_000)
+
+            // Now drain the second bucket so it becomes the slower one. The line has
+            // to continue behind the parked sends. A cursor kept only on the bucket
+            // that is currently slower would start a fresh line here and hand this
+            // send a slot at ~16s, ahead of the send already parked at ~25s.
+            await limiter.claimUpTo({ key: buckets[1].key, requested: 78, capacity: 100, refillPerSecond: 0.5 })
+            const third = await limiter.claimAllOrNothingPair(buckets, 30, 600_000)
+
+            expect(first.reserved).toBe(true)
+            expect(second.retryAfterMs!).toBeGreaterThan(first.retryAfterMs!)
+            expect(third.reserved).toBe(true)
+            expect(third.retryAfterMs!).toBeGreaterThan(second.retryAfterMs!)
+        })
     })
 
     describe('claimOrReserve', () => {

--- a/nodejs/src/cdp/services/rate-limiter/rate-limiter.service.test.ts
+++ b/nodejs/src/cdp/services/rate-limiter/rate-limiter.service.test.ts
@@ -274,6 +274,47 @@ describe('RateLimiterService', () => {
             )
             expect(claim).toEqual({ granted: false, deniedIndex: null, retryAfterMs: null })
         })
+
+        it('hands successive reserved denials distinct, later slots, paced by the slower bucket', async () => {
+            // Both buckets are short. The slower one (0.5/s) sets the pace: its slot spacing is
+            // requested/refill = 60s, and each denial advances the cursor by one slot, so three
+            // denied callers park at three different times instead of all waking at the shared
+            // 40s deficit horizon and re-herding.
+            const buckets: [
+                { key: string; capacity: number; refillPerSecond: number },
+                { key: string; capacity: number; refillPerSecond: number },
+            ] = [
+                { key: `${KEY_A}/resv`, capacity: 10, refillPerSecond: 2 },
+                { key: `${KEY_B}/resv`, capacity: 10, refillPerSecond: 0.5 },
+            ]
+            const first = await limiter.claimAllOrNothingPair(buckets, 30, 600_000)
+            const second = await limiter.claimAllOrNothingPair(buckets, 30, 600_000)
+
+            expect(first.granted).toBe(false)
+            // Cold cursor: the first slot is one spacing (60s) out, past the 40s deficit.
+            expect(first.retryAfterMs).toBe(60_000)
+            expect(second.retryAfterMs!).toBeGreaterThan(first.retryAfterMs!)
+            expect(second.retryAfterMs!).toBeLessThanOrEqual(120_000)
+        })
+
+        it('stops advancing the reservation cursor at the horizon', async () => {
+            const buckets: [
+                { key: string; capacity: number; refillPerSecond: number },
+                { key: string; capacity: number; refillPerSecond: number },
+            ] = [
+                { key: `${KEY_A}/resv-cap`, capacity: 50, refillPerSecond: 0 },
+                { key: `${KEY_B}/resv-cap`, capacity: 10, refillPerSecond: 2 },
+            ]
+            // Slot spacing is 15s with a 20s horizon: the first denial reserves the one slot
+            // inside the horizon, everyone after gets the horizon back unchanged and re-contends.
+            const first = await limiter.claimAllOrNothingPair(buckets, 30, 20_000)
+            const second = await limiter.claimAllOrNothingPair(buckets, 30, 20_000)
+            const third = await limiter.claimAllOrNothingPair(buckets, 30, 20_000)
+
+            expect(first.retryAfterMs).toBe(15_000)
+            expect(second.retryAfterMs).toBe(20_000)
+            expect(third.retryAfterMs).toBe(20_000)
+        })
     })
 
     describe('claimOrReserve', () => {

--- a/nodejs/src/cdp/services/rate-limiter/rate-limiter.service.ts
+++ b/nodejs/src/cdp/services/rate-limiter/rate-limiter.service.ts
@@ -139,15 +139,18 @@ return {0, math.ceil(slotAt - now), 1}
 //   ARGV[2..4]   = capacity, refill/sec, TTL seconds for KEYS[1]
 //   ARGV[5..7]   = capacity, refill/sec, TTL seconds for KEYS[2]
 //   ARGV[8]      = reserve-on-deny horizon in ms; 0 disables reservation.
-// Returns {1, 0, 0} when granted. On denial: {0, i, retryAfterMs}, where i is the
-// first bucket (1-based) that came up short. With ARGV[8] = 0, retryAfterMs is only
-// how long until BOTH buckets have their missing tokens back (the slower one
-// decides). Every denied caller gets that same answer, so they all wake together.
-// With ARGV[8] > 0 the denial also books the caller a slot on the slowest short
-// bucket, the same ticket-at-a-counter idea as the claim-up-to script above, and
-// retryAfterMs is the caller's own slot. Slots never go out past ARGV[8]. A slot is
-// a place in line, not a promise: the wake still has to claim. A bucket that never
-// refills has no horizon, and then the denial reports none and books nothing.
+// Returns {1, 0, 0, 0} when granted. On denial: {0, i, retryAfterMs, reserved},
+// where i is the first bucket (1-based) that came up short. With ARGV[8] = 0,
+// retryAfterMs is only how long until BOTH buckets have their missing tokens back
+// (the slower one decides). Every denied caller gets that same answer, so they all
+// wake together. With ARGV[8] > 0 the denial also books the caller a slot on the
+// slowest short bucket, the same ticket-at-a-counter idea as the claim-up-to script
+// above: the first denied caller waits only for the missing tokens, everyone after
+// gets the next slot, one interval later. Slots never go out past ARGV[8]; past
+// that the caller gets ARGV[8] back with reserved=0 and asks again when it wakes.
+// A slot is a place in line, not a promise: the wake still has to claim. A bucket
+// that never refills has no horizon, and then the denial reports none and books
+// nothing.
 const CLAIM_ALL_OR_NOTHING_PAIR_LUA = `
 local time = redis.call('TIME')
 local now = tonumber(time[1]) * 1000 + math.floor(tonumber(time[2]) / 1000)
@@ -200,27 +203,30 @@ end
 
 if deniedIndex > 0 then
     if not horizonKnown then
-        return {0, deniedIndex, 0}
+        return {0, deniedIndex, 0, 0}
     end
     if reserveOnDenyMaxMs <= 0 then
-        return {0, deniedIndex, retryAfterMs}
+        return {0, deniedIndex, retryAfterMs, 0}
     end
-    local slotMs = (requested / slowRefill) * 1000
+    -- First in line waits only for the pair's shortfall (retryAfterMs is the slower
+    -- bucket's deficit); callers behind a live cursor chain a further requested/refill
+    -- of the slowest bucket each. Same shape as the claim-up-to script above.
     local rawResv = redis.call('hget', KEYS[slowIndex], 'resv')
-    local base = now
+    local slotAt
     if rawResv ~= false and tonumber(rawResv) > now then
-        base = tonumber(rawResv)
+        slotAt = tonumber(rawResv) + (requested / slowRefill) * 1000
+    else
+        slotAt = now + retryAfterMs
     end
-    local slotAt = base + slotMs
     if slotAt - now < retryAfterMs then
         slotAt = now + retryAfterMs
     end
     if slotAt - now > reserveOnDenyMaxMs then
-        return {0, deniedIndex, reserveOnDenyMaxMs}
+        return {0, deniedIndex, reserveOnDenyMaxMs, 0}
     end
     redis.call('hset', KEYS[slowIndex], 'resv', slotAt)
     redis.call('expire', KEYS[slowIndex], slowTtl)
-    return {0, deniedIndex, math.ceil(slotAt - now)}
+    return {0, deniedIndex, math.ceil(slotAt - now), 1}
 end
 
 for i = 1, 2 do
@@ -229,7 +235,7 @@ for i = 1, 2 do
     redis.call('expire', KEYS[i], ttlSeconds)
 end
 
-return {1, 0, 0}
+return {1, 0, 0, 0}
 `
 
 export interface RateLimiterConfig {
@@ -379,7 +385,7 @@ export class RateLimiterService {
         buckets: [Omit<ClaimRequest, 'requested'>, Omit<ClaimRequest, 'requested'>],
         requested: number,
         reserveOnDenyMs: number = 0
-    ): Promise<{ granted: boolean; deniedIndex: 0 | 1 | null; retryAfterMs: number | null }> {
+    ): Promise<{ granted: boolean; deniedIndex: 0 | 1 | null; retryAfterMs: number | null; reserved: boolean }> {
         const endTimer = claimLatency.startTimer({ limiter: this.config.name })
         try {
             const result = await this.valkey.useClient(
@@ -401,23 +407,26 @@ export class RateLimiterService {
                     )
             )
 
-            const [granted, deniedBucket, retryAfterMs] = Array.isArray(result) ? result.map(Number) : [NaN, NaN, NaN]
+            const [granted, deniedBucket, retryAfterMs, reserved] = Array.isArray(result)
+                ? result.map(Number)
+                : [NaN, NaN, NaN, 0]
             if (granted !== 0 && granted !== 1) {
                 logger.warn('🪙', `RateLimiterService(${this.config.name}) pair claim returned invalid result`, {
                     keys: [buckets[0].key, buckets[1].key],
                     raw: result,
                 })
                 claimCounter.inc({ limiter: this.config.name, result: 'valkey_error' })
-                return { granted: false, deniedIndex: null, retryAfterMs: null }
+                return { granted: false, deniedIndex: null, retryAfterMs: null, reserved: false }
             }
 
             claimCounter.inc({ limiter: this.config.name, result: granted === 1 ? 'granted_full' : 'denied' })
             return granted === 1
-                ? { granted: true, deniedIndex: null, retryAfterMs: null }
+                ? { granted: true, deniedIndex: null, retryAfterMs: null, reserved: false }
                 : {
                       granted: false,
                       deniedIndex: deniedBucket === 2 ? 1 : 0,
                       retryAfterMs: Number.isFinite(retryAfterMs) && retryAfterMs > 0 ? retryAfterMs : null,
+                      reserved: reserved === 1,
                   }
         } catch (err) {
             logger.warn('🪙', `RateLimiterService(${this.config.name}) pair claim threw`, {
@@ -425,7 +434,7 @@ export class RateLimiterService {
                 error: String(err),
             })
             claimCounter.inc({ limiter: this.config.name, result: 'valkey_error' })
-            return { granted: false, deniedIndex: null, retryAfterMs: null }
+            return { granted: false, deniedIndex: null, retryAfterMs: null, reserved: false }
         } finally {
             endTimer()
         }

--- a/nodejs/src/cdp/services/rate-limiter/rate-limiter.service.ts
+++ b/nodejs/src/cdp/services/rate-limiter/rate-limiter.service.ts
@@ -138,21 +138,29 @@ return {0, math.ceil(slotAt - now), 1}
 //   ARGV[1]      = requested tokens (integer)
 //   ARGV[2..4]   = capacity, refill/sec, TTL seconds for KEYS[1]
 //   ARGV[5..7]   = capacity, refill/sec, TTL seconds for KEYS[2]
+//   ARGV[8]      = reserve-on-deny horizon in ms; 0 disables reservation.
 // Returns {1, 0, 0} when granted. On denial: {0, i, retryAfterMs}, where i is the
-// first bucket (1-based) that came up short and retryAfterMs is how long until BOTH
-// buckets have their missing tokens back (the slower one decides). That is a lower
-// bound, not a reservation: other callers can take those tokens first, so the wake
-// still has to claim. A bucket that never refills has no horizon, and then the
-// denial reports none.
+// first bucket (1-based) that came up short. With ARGV[8] = 0, retryAfterMs is only
+// how long until BOTH buckets have their missing tokens back (the slower one
+// decides). Every denied caller gets that same answer, so they all wake together.
+// With ARGV[8] > 0 the denial also books the caller a slot on the slowest short
+// bucket, the same ticket-at-a-counter idea as the claim-up-to script above, and
+// retryAfterMs is the caller's own slot. Slots never go out past ARGV[8]. A slot is
+// a place in line, not a promise: the wake still has to claim. A bucket that never
+// refills has no horizon, and then the denial reports none and books nothing.
 const CLAIM_ALL_OR_NOTHING_PAIR_LUA = `
 local time = redis.call('TIME')
 local now = tonumber(time[1]) * 1000 + math.floor(tonumber(time[2]) / 1000)
 local requested = tonumber(ARGV[1])
+local reserveOnDenyMaxMs = tonumber(ARGV[8])
 
 local available = {}
 local deniedIndex = 0
 local retryAfterMs = 0
 local horizonKnown = true
+local slowIndex = 0
+local slowRefill = 0
+local slowTtl = 0
 for i = 1, 2 do
     local capacity = tonumber(ARGV[(i - 1) * 3 + 2])
     local refillPerSecond = tonumber(ARGV[(i - 1) * 3 + 3])
@@ -179,6 +187,9 @@ for i = 1, 2 do
             local bucketRetryMs = math.ceil(((requested - avail) / refillPerSecond) * 1000)
             if bucketRetryMs > retryAfterMs then
                 retryAfterMs = bucketRetryMs
+                slowIndex = i
+                slowRefill = refillPerSecond
+                slowTtl = tonumber(ARGV[(i - 1) * 3 + 4])
             end
         else
             horizonKnown = false
@@ -191,7 +202,25 @@ if deniedIndex > 0 then
     if not horizonKnown then
         return {0, deniedIndex, 0}
     end
-    return {0, deniedIndex, retryAfterMs}
+    if reserveOnDenyMaxMs <= 0 then
+        return {0, deniedIndex, retryAfterMs}
+    end
+    local slotMs = (requested / slowRefill) * 1000
+    local rawResv = redis.call('hget', KEYS[slowIndex], 'resv')
+    local base = now
+    if rawResv ~= false and tonumber(rawResv) > now then
+        base = tonumber(rawResv)
+    end
+    local slotAt = base + slotMs
+    if slotAt - now < retryAfterMs then
+        slotAt = now + retryAfterMs
+    end
+    if slotAt - now > reserveOnDenyMaxMs then
+        return {0, deniedIndex, reserveOnDenyMaxMs}
+    end
+    redis.call('hset', KEYS[slowIndex], 'resv', slotAt)
+    redis.call('expire', KEYS[slowIndex], slowTtl)
+    return {0, deniedIndex, math.ceil(slotAt - now)}
 end
 
 for i = 1, 2 do
@@ -328,14 +357,16 @@ export class RateLimiterService {
     }
 
     /**
-     * Atomically claim `requested` tokens from BOTH buckets, or neither. A denial consumes
-     * nothing, so a caller that retries a multi-token claim cannot drain the buckets while never
+     * Atomically claim `requested` tokens from BOTH buckets, or neither. A denial consumes no
+     * tokens, so a caller that retries a multi-token claim cannot drain the buckets while never
      * succeeding. Returns which bucket denied (index into `buckets`), or null when granted.
-     * A denial also carries `retryAfterMs`, the time until every short bucket's refill has
-     * accrued its missing tokens. Both buckets are measured, so a pair that is short on the
-     * hourly and the daily bucket reports the slower one. It is a lower bound (competing callers
-     * may take the tokens first), so callers use it to schedule the retry, never to skip the
-     * re-claim.
+     * A denial also carries `retryAfterMs`. Both buckets are measured, so a pair that is short
+     * on the hourly and the daily bucket paces on the slower one. With `reserveOnDenyMs` = 0
+     * that is only the deficit horizon, a shared lower bound. With `reserveOnDenyMs` > 0 the
+     * denial also reserves the caller's place in line on the slowest short bucket (see
+     * claimOrReserve), so each denied caller parks for a distinct slot, never earlier than the
+     * deficit horizon and never further out than `reserveOnDenyMs`. The slot is a place in
+     * line, not a guarantee — the wake must still claim.
      * Runtime errors deny with `deniedIndex: null` and `retryAfterMs: null` — fail-closed, like
      * claimUpTo.
      *
@@ -346,7 +377,8 @@ export class RateLimiterService {
      */
     public async claimAllOrNothingPair(
         buckets: [Omit<ClaimRequest, 'requested'>, Omit<ClaimRequest, 'requested'>],
-        requested: number
+        requested: number,
+        reserveOnDenyMs: number = 0
     ): Promise<{ granted: boolean; deniedIndex: 0 | 1 | null; retryAfterMs: number | null }> {
         const endTimer = claimLatency.startTimer({ limiter: this.config.name })
         try {
@@ -364,7 +396,8 @@ export class RateLimiterService {
                         String(buckets[0].ttlSeconds ?? 3600),
                         String(buckets[1].capacity),
                         String(buckets[1].refillPerSecond),
-                        String(buckets[1].ttlSeconds ?? 3600)
+                        String(buckets[1].ttlSeconds ?? 3600),
+                        String(reserveOnDenyMs)
                     )
             )
 

--- a/nodejs/src/cdp/services/rate-limiter/rate-limiter.service.ts
+++ b/nodejs/src/cdp/services/rate-limiter/rate-limiter.service.ts
@@ -208,9 +208,9 @@ if deniedIndex > 0 then
     if reserveOnDenyMaxMs <= 0 then
         return {0, deniedIndex, retryAfterMs, 0}
     end
-    -- First in line waits only for the pair's shortfall (retryAfterMs is the slower
-    -- bucket's deficit); callers behind a live cursor chain a further requested/refill
-    -- of the slowest bucket each. Same shape as the claim-up-to script above.
+    -- First in line: wait only for the pair's shortfall (that is retryAfterMs).
+    -- Behind someone: take the slot after theirs, one interval of the slowest
+    -- bucket later. Same idea as the claim-up-to script above.
     local rawResv = redis.call('hget', KEYS[slowIndex], 'resv')
     local slotAt
     if rawResv ~= false and tonumber(rawResv) > now then
@@ -366,13 +366,12 @@ export class RateLimiterService {
      * Atomically claim `requested` tokens from BOTH buckets, or neither. A denial consumes no
      * tokens, so a caller that retries a multi-token claim cannot drain the buckets while never
      * succeeding. Returns which bucket denied (index into `buckets`), or null when granted.
-     * A denial also carries `retryAfterMs`. Both buckets are measured, so a pair that is short
-     * on the hourly and the daily bucket paces on the slower one. With `reserveOnDenyMs` = 0
-     * that is only the deficit horizon, a shared lower bound. With `reserveOnDenyMs` > 0 the
-     * denial also reserves the caller's place in line on the slowest short bucket (see
-     * claimOrReserve), so each denied caller parks for a distinct slot, never earlier than the
-     * deficit horizon and never further out than `reserveOnDenyMs`. The slot is a place in
-     * line, not a guarantee — the wake must still claim.
+     * A denial also says when to come back (`retryAfterMs`), paced by the slower of the two
+     * buckets. With `reserveOnDenyMs` = 0 that is a shared answer and every denied caller gets
+     * the same one. With `reserveOnDenyMs` > 0 the denial books the caller its own slot in
+     * line instead, like claimOrReserve does, never further out than `reserveOnDenyMs`.
+     * `reserved` tells the caller which of the two it got. A slot is a place in line, not a
+     * promise: the wake still has to claim.
      * Runtime errors deny with `deniedIndex: null` and `retryAfterMs: null` — fail-closed, like
      * claimUpTo.
      *

--- a/nodejs/src/cdp/services/rate-limiter/rate-limiter.service.ts
+++ b/nodejs/src/cdp/services/rate-limiter/rate-limiter.service.ts
@@ -161,9 +161,7 @@ local available = {}
 local deniedIndex = 0
 local retryAfterMs = 0
 local horizonKnown = true
-local slowIndex = 0
 local slowRefill = 0
-local slowTtl = 0
 for i = 1, 2 do
     local capacity = tonumber(ARGV[(i - 1) * 3 + 2])
     local refillPerSecond = tonumber(ARGV[(i - 1) * 3 + 3])
@@ -190,9 +188,7 @@ for i = 1, 2 do
             local bucketRetryMs = math.ceil(((requested - avail) / refillPerSecond) * 1000)
             if bucketRetryMs > retryAfterMs then
                 retryAfterMs = bucketRetryMs
-                slowIndex = i
                 slowRefill = refillPerSecond
-                slowTtl = tonumber(ARGV[(i - 1) * 3 + 4])
             end
         else
             horizonKnown = false
@@ -211,10 +207,23 @@ if deniedIndex > 0 then
     -- First in line: wait only for the pair's shortfall (that is retryAfterMs).
     -- Behind someone: take the slot after theirs, one interval of the slowest
     -- bucket later. Same idea as the claim-up-to script above.
-    local rawResv = redis.call('hget', KEYS[slowIndex], 'resv')
+    -- There is ONE line for the pair, kept on both keys: the base is the later of
+    -- the two cursors and the new slot is written back to both. Keeping the line
+    -- on only the currently slower bucket splits it when the slower bucket
+    -- changes (hourly runs dry first, then daily), and a fresh line lets new
+    -- arrivals cut ahead of sends that are already parked.
+    local rawResvA = redis.call('hget', KEYS[1], 'resv')
+    local rawResvB = redis.call('hget', KEYS[2], 'resv')
+    local base = now
+    if rawResvA ~= false and tonumber(rawResvA) > base then
+        base = tonumber(rawResvA)
+    end
+    if rawResvB ~= false and tonumber(rawResvB) > base then
+        base = tonumber(rawResvB)
+    end
     local slotAt
-    if rawResv ~= false and tonumber(rawResv) > now then
-        slotAt = tonumber(rawResv) + (requested / slowRefill) * 1000
+    if base > now then
+        slotAt = base + (requested / slowRefill) * 1000
     else
         slotAt = now + retryAfterMs
     end
@@ -224,8 +233,10 @@ if deniedIndex > 0 then
     if slotAt - now > reserveOnDenyMaxMs then
         return {0, deniedIndex, reserveOnDenyMaxMs, 0}
     end
-    redis.call('hset', KEYS[slowIndex], 'resv', slotAt)
-    redis.call('expire', KEYS[slowIndex], slowTtl)
+    redis.call('hset', KEYS[1], 'resv', slotAt)
+    redis.call('expire', KEYS[1], tonumber(ARGV[4]))
+    redis.call('hset', KEYS[2], 'resv', slotAt)
+    redis.call('expire', KEYS[2], tonumber(ARGV[7]))
     return {0, deniedIndex, math.ceil(slotAt - now), 1}
 end
 

--- a/nodejs/src/cdp/services/rate-limiter/rate-limiter.valkey.integration.test.ts
+++ b/nodejs/src/cdp/services/rate-limiter/rate-limiter.valkey.integration.test.ts
@@ -41,6 +41,6 @@ describe('RateLimiterService on Valkey Cluster', () => {
         const limiter = new RateLimiterService(valkeyPool, { name: 'team-email-cluster-test' })
 
         const claim = await limiter.claimAllOrNothingPair([buckets[0], buckets[1]], 10)
-        expect(claim).toEqual({ granted: true, deniedIndex: null, retryAfterMs: null })
+        expect(claim).toEqual({ granted: true, deniedIndex: null, retryAfterMs: null, reserved: false })
     })
 })

--- a/nodejs/src/cdp/workflows-e2e.serial.test.ts
+++ b/nodejs/src/cdp/workflows-e2e.serial.test.ts
@@ -42,7 +42,7 @@ import { UUIDT } from '~/common/utils/utils'
 import { createCdpConsumerDeps } from '~/tests/helpers/cdp'
 import { waitForExpect } from '~/tests/helpers/expectations'
 import { TEST_KAFKA_TOPICS, ensureKafkaTopics } from '~/tests/helpers/kafka'
-import { getFirstTeam, resetBehavioralCohortsDatabase, resetTestDatabase } from '~/tests/helpers/sql'
+import { createTeam, getFirstTeam, resetBehavioralCohortsDatabase, resetTestDatabase } from '~/tests/helpers/sql'
 
 import { Hub, Team } from '../../src/types'
 import { createRedisV2PoolFromConfig } from '../common/redis/redis-v2'
@@ -3607,6 +3607,155 @@ describe('Workflows E2E (email queue)', () => {
         // (dequeue + park) is at most 4 transitions. Anything higher means a
         // denied send went around the loop again.
         for (const job of parkedA) {
+            expect(job.transition_count).toBeLessThanOrEqual(4)
+        }
+    })
+
+    it("a team over its tier cap does not hold up another team's emails", async () => {
+        // Two teams, each with one email workflow. Team A sits on a tier that allows
+        // 2 emails per hour and gets 6 sends queued; team B is on a high tier with 3
+        // sends. The whole pipeline is real and the tier caps are enforced: B's emails
+        // must all go out while A's over-cap sends park on future slots from A's own
+        // refill, without cycling.
+        //
+        // The default email worker was built with the caps off, so swap in one that
+        // enforces them. Tier 0 allows 2/hour, tier 1 is effectively unlimited.
+        await emailWorker.stop()
+        hub.EMAIL_TEAM_SENDING_CAP_MODE = 'enforce'
+        hub.EMAIL_TEAM_SENDING_CAP_HOURLY_BY_TIER = '2,10000'
+        hub.EMAIL_TEAM_SENDING_CAP_DAILY_BY_TIER = '48,240000'
+        const enforcedQueue = new CyclotronJobQueuePostgresV2(hub.CONSUMER_BATCH_SIZE, hub)
+        emailWorker = new CdpCyclotronWorkerEmail(hub, deps, enforcedQueue)
+        await emailWorker.start()
+
+        // The tier buckets are keyed by team id and the test Redis keeps data between
+        // runs, so team A's bucket must start full or a previous run drains this one.
+        const capValkey = createRedisV2PoolFromConfig({
+            connection: hub.CDP_REDIS_HOST
+                ? {
+                      url: hub.CDP_REDIS_HOST,
+                      options: { port: hub.CDP_REDIS_PORT, password: hub.CDP_REDIS_PASSWORD },
+                  }
+                : { url: hub.REDIS_URL },
+            poolMinSize: hub.REDIS_POOL_MIN_SIZE,
+            poolMaxSize: hub.REDIS_POOL_MAX_SIZE,
+        })
+        await deleteKeysWithPrefix(capValkey, '@posthog/team-email-rate-hour')
+        await deleteKeysWithPrefix(capValkey, '@posthog/team-email-rate-day')
+
+        // Team A has no config row and defaults to tier 0. Team B gets tier 1.
+        const teamBId = await createTeam(hub.postgres, team.organization_id)
+        await hub.postgres.query(
+            PostgresUse.COMMON_WRITE,
+            `INSERT INTO workflows_teamworkflowsconfig
+                (team_id, capture_workflows_engagement_events, email_tracking_consent_mode,
+                 email_sending_suspension_reason, ses_tenant_sending_status, email_sending_tier)
+             VALUES ($1, false, 'off', '', '', 1)`,
+            [teamBId],
+            'set-team-email-tier'
+        )
+        await insertIntegration(hub.postgres, teamBId, {
+            id: 2,
+            kind: 'email',
+            config: {
+                email: 'sender@posthog.com',
+                name: 'Test Sender',
+                domain: 'posthog.com',
+                verified: true,
+                provider: 'maildev',
+            },
+        })
+
+        const buildFlow = (teamId: number, integrationId: number, triggerEvent: string, recipient: string): HogFlow =>
+            new FixtureHogFlowBuilder()
+                .withTeamId(teamId)
+                .withStatus('active')
+                .withExitCondition('exit_only_at_end')
+                .withWorkflow({
+                    actions: {
+                        trigger: {
+                            type: 'trigger',
+                            config: { type: 'event', ...eventNameFilter(triggerEvent) },
+                        },
+                        email_1: {
+                            type: 'function_email',
+                            config: {
+                                template_id: 'template-workflows-e2e-email',
+                                inputs: {
+                                    email: {
+                                        value: {
+                                            to: { email: recipient, name: 'Recipient' },
+                                            from: { integrationId, email: 'sender@posthog.com' },
+                                            subject: `To ${recipient}`,
+                                            text: 'Test text',
+                                            html: '<p>Test html</p>',
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                        exit: { type: 'exit', config: {} },
+                    },
+                    edges: [
+                        { from: 'trigger', to: 'email_1', type: 'continue' },
+                        { from: 'email_1', to: 'exit', type: 'continue' },
+                    ],
+                })
+                .build()
+
+        const flowA = buildFlow(team.id, 1, 'tier_a', 'recipient-tier-a@example.com')
+        const flowB = buildFlow(teamBId, 2, 'tier_b', 'recipient-tier-b@example.com')
+        await insertHogFlow(hub.postgres, flowA)
+        await insertHogFlow(hub.postgres, flowB)
+
+        const teamBGlobals = (i: number): HogFunctionInvocationGlobals =>
+            createHogExecutionGlobals({
+                project: { id: teamBId } as any,
+                event: {
+                    uuid: new UUIDT().toString(),
+                    event: 'tier_b',
+                    distinct_id: `person_tier_b_${i}`,
+                    properties: {},
+                    timestamp: '2024-09-03T09:00:00Z',
+                } as any,
+            })
+        const events = [
+            ...Array.from({ length: 6 }, (_, i) =>
+                createGlobals({
+                    event: 'tier_a',
+                    uuid: new UUIDT().toString(),
+                    distinct_id: `person_tier_a_${i}`,
+                } as any)
+            ),
+            ...Array.from({ length: 3 }, (_, i) => teamBGlobals(i)),
+        ]
+        const { backgroundTask } = await eventsConsumer.processBatch(events)
+        await backgroundTask
+
+        // Team B's 3 runs finish end to end; team A gets its 2 in-budget sends out.
+        await waitForExpect(async () => {
+            const jobs = await queryCyclotronJobs()
+            const bJobs = jobs.filter((j: any) => j.function_id === flowB.id)
+            expect(bJobs.length).toBe(3)
+            expect(bJobs.every((j: any) => j.status === 'completed')).toBe(true)
+
+            const sent = mockProducerObserver
+                .getProducedKafkaMessagesForTopic(KAFKA_APP_METRICS_2)
+                .filter((m: any) => m.value.app_source === 'hog_flow')
+                .filter((m: any) => m.value.metric_name === 'email_sent')
+                .reduce((sum: number, m: any) => sum + m.value.count, 0)
+            expect(sent).toBe(5)
+        }, 15000)
+
+        // Team A's 4 over-cap sends are parked far in the future (its refill is one
+        // token per 30 minutes), each dequeued once on the email queue.
+        const jobs = await queryCyclotronJobs()
+        const parkedA = jobs.filter(
+            (j: any) => j.function_id === flowA.id && j.queue_name === 'email' && j.status === 'available'
+        )
+        expect(parkedA.length).toBe(4)
+        for (const job of parkedA) {
+            expect(new Date(job.scheduled).getTime()).toBeGreaterThan(Date.now() + 25 * 60 * 1000)
             expect(job.transition_count).toBeLessThanOrEqual(4)
         }
     })


### PR DESCRIPTION
## Problem

The base PR (#97618) gives the per-workflow limit reserved retry slots. The team tier caps still park every denied send at the same shared wake time.

**How it worked before, with an example:** a team is over its hourly cap with 2,000 emails queued. The cap refills a token every couple of seconds. All 2,000 emails compute the same "capacity exists in ~2s" wake time, sleep, and then all wake together. One gets the token, 1,999 go back to sleep, and two seconds later the whole herd wakes again. 

## Changes

**How it works now, same example:** each of the 2,000 denied emails gets its own slot from the cap's refill schedule - the first at +2 s, the second at +4 s, and so on. Every email wakes once, at its own time, and sends. No herd, no re-denials, and other teams' emails flow in between because a parked email is not in anyone's way.

The mechanics:

- The pair claim keeps the same "last slot handed out" note as the base PR, on the slowest short bucket (a drained daily cap refills slower than the hourly one, so it owns the line).
- The first denial waits only for the pair's missing tokens; slots only go out up to one hour ahead, and deeper backlogs get "come back in an hour and ask again".
- The delay picker is shared with the workflow limit; tier-cap parks show up in `cdp_email_reserved_park_ms` under `limiter="team-email"`.
- Mechanical: `claimAllOrNothingPair` gains an optional `reserveOnDenyMs` argument, default 0, so existing callers are untouched.

> [!WARNING]
> This PR gates re-enforcing the tier caps. Enforcement was reverted to shadow (PostHog/charts#15394) because denied backlogs starved other teams; do not re-enforce before this PR and #97591 are deployed.

## How did you test this code?

All run locally against the dev stack, plus CI:

- Limiter, against real Redis: successive reserved pair denials get distinct, later slots paced by the slower bucket; the first slot charges only the pair's shortfall; the cursor stops at the horizon; calls without the new argument keep the exact old behavior.
- Cross-team isolation, service level: a team with a drained hourly cap parks four denied sends 10 s apart while a second team's send goes straight out.
- Cross-team isolation, full e2e (`workflows-e2e.serial.test.ts`): real events consumer, hogflow worker, email worker with the caps enforced, queue, and limiter. A tier-0 team (2 emails/hour) queues 6 sends; a tier-1 team's 3 emails all deliver while the 4 over-cap sends park on future slots from the small team's own refill, each dequeued once. Nothing simulated.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None beyond the sending tier guide on the base branch.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code as the second half of the park-not-poll change, split per limiter for review; stacked on #97618 because both edit the same Lua script and delay pickers. Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions. The reviewhog "consider" on the cold-cursor first slot is fixed here (same deficit charge the base PR got).
