### PR TITLE
fix(desktop): keep startup phase statuses out of the transcript

### DIFF
--- a/products/desktop/packages/core/src/sessions/sessionStartup.ts
+++ b/products/desktop/packages/core/src/sessions/sessionStartup.ts
@@ -14,6 +14,12 @@ export type SessionStartupPhase = z.infer<
   typeof startupEventSchema
 >["message"]["params"]["status"];
 
+export function isSessionStartupPhase(
+  status: string,
+): status is SessionStartupPhase {
+  return status === "sdk_initialization" || status === "setup_hooks";
+}
+
 export function readSessionStartupPhase(
   event: unknown,
 ): SessionStartupPhase | undefined {

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
@@ -300,6 +300,29 @@ describe("buildConversationItems", () => {
     expect(fullIds.slice(-tailIds.length)).toEqual(tailIds);
   });
 
+  it.each(["sdk_initialization", "setup_hooks"] as const)(
+    "keeps the %s startup phase out of the transcript",
+    (phase) => {
+      // The pending-session view already shows the startup phase; the
+      // transcript must not also render a raw "Status: <phase>" row.
+      const result = buildConversationItems(
+        [
+          userPromptMsg(1, 1, "hi"),
+          statusMsg(2, phase),
+          agentMessageMsg(3, "done"),
+        ],
+        null,
+      );
+
+      const statusItems = result.items.filter(
+        (i): i is Extract<ConversationItem, { type: "session_update" }> =>
+          i.type === "session_update" && i.update.sessionUpdate === "status",
+      );
+      expect(statusItems).toHaveLength(0);
+      expect(result.isCompacting).toBe(false);
+    },
+  );
+
   it("clears the compacting spinner on a successful completion status, without duplicating the row", () => {
     // A successful compaction sends a terminal `status: compacting, isComplete:
     // true`. It must flip the existing status row, not append a second one.

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
@@ -303,8 +303,6 @@ describe("buildConversationItems", () => {
   it.each(["sdk_initialization", "setup_hooks"] as const)(
     "keeps the %s startup phase out of the transcript",
     (phase) => {
-      // The pending-session view already shows the startup phase; the
-      // transcript must not also render a raw "Status: <phase>" row.
       const result = buildConversationItems(
         [
           userPromptMsg(1, 1, "hi"),

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
@@ -8,6 +8,7 @@ import {
 } from "@posthog/agent/acp-extensions";
 import { extractPromptDisplayContent } from "@posthog/core/sessions/promptContent";
 import { isSteerPromptParams } from "@posthog/core/sessions/sessionEvents";
+import { isSessionStartupPhase } from "@posthog/core/sessions/sessionStartup";
 import {
   type AcpMessage,
   type AgentConversationEvent,
@@ -909,6 +910,10 @@ function handleRuntimeStatus(
   },
   timestamp: number,
 ): void {
+  // Startup phases surface in the pending-session status line
+  // (SessionStartupStatus), not as transcript rows.
+  if (isSessionStartupPhase(status.status)) return;
+
   ensureImplicitTurn(b, timestamp);
 
   if (status.status === "refusal" || status.status === "refusal_fallback") {

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
@@ -910,8 +910,6 @@ function handleRuntimeStatus(
   },
   timestamp: number,
 ): void {
-  // Startup phases surface in the pending-session status line
-  // (SessionStartupStatus), not as transcript rows.
   if (isSessionStartupPhase(status.status)) return;
 
   ensureImplicitTurn(b, timestamp);


### PR DESCRIPTION
## Problem

When a local session starts, the conversation shows raw rows like "Status: setup_hooks" and "Status: sdk_initialization". The startup status line above the composer already shows the same information in plain words ("Starting local agent", "Running repository setup"), so the transcript rows read as leaked internal names. The PR that introduced the friendly startup line (#96874) covered the pending-session view but not the transcript builder, which also receives these status notifications.

## Changes

- The transcript no longer renders the two startup phase statuses (`sdk_initialization`, `setup_hooks`). The pending-session status line remains the single place that shows them.
- Mechanical: a shared `isSessionStartupPhase` type guard in `@posthog/core/sessions/sessionStartup`, used by the transcript builder.

## How did you test this code?

Added a `test.each` case to `buildConversationItems.test.ts` covering both phases: a session that emits the phase status alongside a prompt and a reply must produce no `status` transcript rows. This guards the regression where the generic status fallback renders the raw phase name. Extending the existing status-notification tests in that file was the natural home; no other test covered the startup phases reaching the transcript.

Ran: `buildConversationItems.test.ts` (51 tests) and `sessionStartup.test.ts` (6 tests) pass; typecheck clean for `@posthog/ui` and `@posthog/core`; Biome clean on the touched files.

## Automatic notifications

None. This removes a raw internal label a person could see during startup.

## Docs update

None. No documented behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

No duplicate found: searched open PRs for the phase names and status rows. PR #97625 reworks the startup cover views but does not touch the transcript path this fix changes.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*