### PR TITLE
fix(warehouse-sources): recognize cross-source non-retryable errors in schema discovery

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/sync_new_schemas.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/sync_new_schemas.py
@@ -16,6 +16,7 @@ from products.warehouse_sources.backend.models.external_data_schema import (
     sync_old_schemas_with_new_schemas,
 )
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+from products.warehouse_sources.backend.temporal.data_imports.external_data_job import Any_Source_Errors
 from products.warehouse_sources.backend.temporal.data_imports.sources import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import error_message_matches
 from products.warehouse_sources.backend.types import ExternalDataSourceType
@@ -94,7 +95,12 @@ def sync_new_schemas_activity(inputs: SyncNewSchemasActivityInputs) -> None:
                 logger.warning(f"Skipping schema discovery due to non-retryable source error: {e}")
                 return
             error_msg = str(e)
-            non_retryable_errors = new_source.get_non_retryable_errors()
+            # Cross-source non-retryable errors (an unresolvable/private database host, bad SSH
+            # tunnel auth, a widened column type) are raised from shared connection/pipeline code,
+            # not any one source, so they never make it into a source's own get_non_retryable_errors.
+            # Without merging this in, discovery retries the activity's whole budget and reports on
+            # every attempt for a failure that will never recover on its own.
+            non_retryable_errors = {**Any_Source_Errors, **new_source.get_non_retryable_errors()}
             if error_message_matches(error_msg, non_retryable_errors):
                 logger.warning(f"Skipping schema discovery due to non-retryable source error: {error_msg}")
                 return

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_sync_new_schemas.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_sync_new_schemas.py
@@ -93,6 +93,19 @@ def test_retryable_error_is_reraised_for_temporal_retry():
         _run_activity(source_mock)
 
 
+def test_all_source_non_retryable_error_is_skipped():
+    # "Database host not allowed" (and the rest of Any_Source_Errors) is raised from shared
+    # connection code, not any one source, so it's never in a source's own
+    # get_non_retryable_errors. Without merging it in here, discovery retries forever and spams
+    # error tracking on a host that will never resolve.
+    source_mock = mock.MagicMock()
+    source_mock.parse_config.return_value = {}
+    source_mock.get_schemas.side_effect = Exception("Database host not allowed: could not resolve host")
+    source_mock.get_non_retryable_errors.return_value = {}
+
+    _run_activity(source_mock)
+
+
 def test_undecrypted_integration_secret_error_is_skipped():
     # Checked by type, not message, so it must be skipped even when get_non_retryable_errors
     # has no matching entry — otherwise discovery retries forever on an unrecoverable decryption


### PR DESCRIPTION
## Problem

- Schema discovery for a SQL Server (MSSQL) source whose configured host cannot be resolved keeps retrying every discovery cycle instead of stopping after the first attempt, and error tracking gets a fresh exception each time.
- The per-schema sync path already recognizes this same failure as non-retryable and stops immediately, so the discovery path is inconsistent with it.

## Changes

- `sync_new_schemas_activity` now merges the shared `Any_Source_Errors` map into the non-retryable check, not just the source's own `get_non_retryable_errors()`. This mirrors the merge already done in the per-schema sync activity (`import_data_sync.py`).
- An unresolvable/private database host, invalid SSH tunnel auth, and the other shared entries in `Any_Source_Errors` now stop schema discovery immediately instead of retrying to exhaustion.
- Mechanical: no user-facing UI change, and no change to the per-schema sync path (already correct).

## How did you test this code?

- Extended `test_sync_new_schemas.py` with a case asserting a shared (`Any_Source_Errors`) message is treated as non-retryable during discovery even when the source's own `get_non_retryable_errors()` returns nothing for it.
- Ran `pytest products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_sync_new_schemas.py` (8 passed) and `mypy` on the changed file — both clean.
- Not run: the Temporal e2e/integration suites (no local dev stack in this sandbox).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal retry/error-classification behavior, no documented API or workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triggered by an error tracking issue on `MSSQL` source ([`Database host not allowed: Couldn't resolve the host ...`](https://us.posthog.com/project/2/error_tracking/01a08728-b41f-76e0-ac49-4b17398c86fc)), 9 occurrences within ~2 minutes.
- Investigation traced the raise to `_check_direct_host` in the shared connection mixin (`sources/common/mixins.py`), reached via the MSSQL source's `get_schemas` → `connect` path. That message is already listed in the shared `Any_Source_Errors` map used by the per-schema sync finalization path, but `sync_new_schemas_activity` (schema discovery) only checked the source's own `get_non_retryable_errors()`, so the same error wasn't recognized there — a gap affecting every source's schema discovery, not just MSSQL.
- No duplicate found: searched open PRs by title/branch/file (`sync_new_schemas.py`, `Any_Source_Errors`, `Database host not allowed`, `mssql`) and reviewed the closest matches (#91882, #97519, #97454, #95376) — none touch this merge gap in schema discovery.
- Tools: PostHog error tracking MCP tools (issue + event/stack-trace lookup), repo search/read, pytest, mypy, ruff.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*