### PR TITLE
fix(surveys): bring back column choice on the responses table

### DIFF
--- a/docs/internal/survey-responses.md
+++ b/docs/internal/survey-responses.md
@@ -13,6 +13,12 @@ A submission that later completes is shown as completed.
 The responses table, question charts, response counts, and summaries include these answers automatically.
 Dismissals and abandonments with no answers do not count as responses.
 
+The responses table shows one column for each question, plus status, submission time, and person.
+The **Columns** control adds respondent context columns: person ID, session ID, and current URL.
+The query selects only the columns that are turned on, so an export carries the same columns as the table.
+The choice persists per user, across surveys.
+For any other property, expand a response row to see the full event, or use the SQL query helper.
+
 Survey performance appears on both the Summary and Responses tabs in the redesigned survey view.
 It includes a compact row with counts and percentages for **Completed**, **Dismissed**, and **Abandoned** responses.
 These percentages use all responses matching the current filters as their denominator, including archived responses when selected.

--- a/docs/internal/survey-responses.md
+++ b/docs/internal/survey-responses.md
@@ -16,7 +16,7 @@ Dismissals and abandonments with no answers do not count as responses.
 The responses table shows one column for each question, plus status, submission time, and person.
 The **Columns** control adds respondent context columns: person ID, session ID, and current URL.
 The query selects only the columns that are turned on, so an export carries the same columns as the table.
-The choice is saved for each user and each survey, because `surveyLogic` is keyed by survey ID.
+The choice is saved in the browser, separately for each survey.
 For any other property, expand a response row to see the full event, or use the SQL query helper.
 
 Survey performance appears on both the Summary and Responses tabs in the redesigned survey view.

--- a/docs/internal/survey-responses.md
+++ b/docs/internal/survey-responses.md
@@ -16,7 +16,7 @@ Dismissals and abandonments with no answers do not count as responses.
 The responses table shows one column for each question, plus status, submission time, and person.
 The **Columns** control adds respondent context columns: person ID, session ID, and current URL.
 The query selects only the columns that are turned on, so an export carries the same columns as the table.
-The choice persists per user, across surveys.
+The choice is saved for each user and each survey, because `surveyLogic` is keyed by survey ID.
 For any other property, expand a response row to see the full event, or use the SQL query helper.
 
 Survey performance appears on both the Summary and Responses tabs in the redesigned survey view.

--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -61,6 +61,8 @@ import {
     SurveyQuestionType,
 } from '~/types'
 
+import { SurveyResponseColumnsMenu } from 'products/surveys/frontend/components/SurveyResponseColumnsMenu'
+
 import { SurveyResultsRefreshStatus } from './components/SurveyResultsRefreshStatus'
 import { NEW_SURVEY } from './constants'
 import { useSurveyResponseColumns } from './hooks/useSurveyResponseColumns'
@@ -418,6 +420,7 @@ export function SurveyResult({ disableEventsTable }: { disableEventsTable?: bool
                                         query={dataTableQuery}
                                         context={{
                                             columns: surveyColumnRenderers,
+                                            customActions: <SurveyResponseColumnsMenu key="survey-response-columns" />,
                                             expandable: {
                                                 expandedRowRender: ({ result }) => (
                                                     <SurveyResponseExpandedRow result={result} />

--- a/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyViewRedesign.tsx
+++ b/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyViewRedesign.tsx
@@ -70,6 +70,8 @@ import {
     SurveyQuestionType,
 } from '~/types'
 
+import { SurveyResponseColumnsMenu } from 'products/surveys/frontend/components/SurveyResponseColumnsMenu'
+
 import { SurveyResultsRefreshStatus } from '../components/SurveyResultsRefreshStatus'
 import { NEW_SURVEY } from '../constants'
 import { SurveyDraftContent } from './SurveyDraftContent'
@@ -706,6 +708,7 @@ function SurveyResponsesContent(): JSX.Element {
                         query={dataTableQuery}
                         context={{
                             columns: surveyColumnRenderers,
+                            customActions: <SurveyResponseColumnsMenu key="survey-response-columns" />,
                             dataTableExportExcludedColumns: ['response', 'actions'],
                             dataTableRowsTransformer: (rows) => transformSurveyResponseRows(rows, survey),
                             rowProps: (record: unknown) => {

--- a/frontend/src/scenes/surveys/Surveys.stories.tsx
+++ b/frontend/src/scenes/surveys/Surveys.stories.tsx
@@ -292,21 +292,91 @@ const MOCK_SURVEY_AGGREGATE_RESULTS = {
     ],
 }
 
-// Rows from the base-stats query: [event_name, total_count, unique_persons, first_seen, last_seen].
+// Rows from the base-stats query: [event_name, total_count, unique_persons, first_seen, last_seen, outcome_counts].
 const MOCK_SURVEY_BASE_STATS = {
-    columns: ['event_name', 'total_count', 'unique_persons', 'first_seen', 'last_seen'],
+    columns: ['event_name', 'total_count', 'unique_persons', 'first_seen', 'last_seen', 'outcome_counts'],
     types: [
         ['event_name', 'String'],
         ['total_count', 'UInt64'],
         ['unique_persons', 'UInt64'],
         ['first_seen', "Nullable(DateTime64(6, 'UTC'))"],
         ['last_seen', "Nullable(DateTime64(6, 'UTC'))"],
+        ['outcome_counts', 'Tuple(UInt64, UInt64, UInt64)'],
     ],
     results: [
-        [SurveyEventName.SHOWN, 120, 110, '2023-05-02T10:00:00Z', '2023-06-20T10:00:00Z'],
-        [SurveyEventName.SENT, 75, 70, '2023-05-02T11:00:00Z', '2023-06-20T09:00:00Z'],
-        [SurveyEventName.DISMISSED, 18, 17, '2023-05-03T10:00:00Z', '2023-06-19T10:00:00Z'],
+        [SurveyEventName.SHOWN, 120, 110, '2023-05-02T10:00:00Z', '2023-06-20T10:00:00Z', [120, 0, 0]],
+        [SurveyEventName.SENT, 75, 70, '2023-05-02T11:00:00Z', '2023-06-20T09:00:00Z', [60, 9, 6]],
+        [SurveyEventName.DISMISSED, 18, 17, '2023-05-03T10:00:00Z', '2023-06-19T10:00:00Z', [0, 18, 0]],
     ],
+}
+
+// Rows from the responses table query. The first column is the `response` tuple the table unpacks:
+// [uuid, distinct_id, submitted_at, person_id, person_properties, event_properties, outcome, answers, latest_event].
+const MOCK_SURVEY_RESPONSE_ROWS = {
+    columns: ['response', 'answer_0', 'answer_1', 'answer_2', 'status', 'timestamp', 'respondent', 'actions'],
+    hasMore: false,
+    results: [
+        [
+            [
+                '0187c279-bcae-0000-34f5-4f121921fa01',
+                'respondent-a',
+                '2023-06-20T09:00:00Z',
+                '0187c279-bcae-0000-34f5-4f121921fb01',
+                '{"email":"casey@example.com"}',
+                '{"$current_url":"https://example.com/pricing","$session_id":"0187c279-bcae-0000-34f5-4f121921fc01"}',
+                'completed',
+                ['10', 'Dashboards', ['I found a better product']],
+                SurveyEventName.SENT,
+            ],
+            '10',
+            'Dashboards',
+            'I found a better product',
+            'completed',
+            '2023-06-20T09:00:00Z',
+            'respondent-a',
+            '0187c279-bcae-0000-34f5-4f121921fa01',
+        ],
+        [
+            [
+                '0187c279-bcae-0000-34f5-4f121921fa02',
+                'respondent-b',
+                '2023-06-19T14:30:00Z',
+                '0187c279-bcae-0000-34f5-4f121921fb02',
+                '{}',
+                '{"$current_url":"https://example.com/settings","$session_id":"0187c279-bcae-0000-34f5-4f121921fc02"}',
+                'abandoned',
+                ['7', null, []],
+                SurveyEventName.SENT,
+            ],
+            '7',
+            null,
+            '',
+            'abandoned',
+            '2023-06-19T14:30:00Z',
+            'respondent-b',
+            '0187c279-bcae-0000-34f5-4f121921fa02',
+        ],
+    ],
+}
+
+/**
+ * Both the meta and the SurveyResults story mock the query endpoint, and whichever handler MSW
+ * resolves first wins. Sharing one resolver keeps the results tab loading either way.
+ * The responses table carries no query tag, so it is recognized by the `response` tuple it selects.
+ */
+function resolveSurveyResultsQuery(body: any): Record<string, unknown> | null {
+    switch (body?.query?.tags?.name) {
+        case 'survey_results_aggregate':
+            return MOCK_SURVEY_AGGREGATE_RESULTS
+        case 'survey_base_stats':
+            return MOCK_SURVEY_BASE_STATS
+        case 'survey_dismissed_sent_overlap':
+            return { results: [[60]] }
+    }
+    if (String(body?.query?.query ?? '').includes('AS response')) {
+        return MOCK_SURVEY_RESPONSE_ROWS
+    }
+    return null
 }
 
 const meta: Meta = {
@@ -347,6 +417,10 @@ const meta: Meta = {
             post: {
                 '/api/environments/:team_id/query/:kind/': async ({ request }) => {
                     const body = (await request.json()) as any
+                    const surveyResults = resolveSurveyResultsQuery(body)
+                    if (surveyResults) {
+                        return [200, surveyResults]
+                    }
                     if (body.kind == 'EventsQuery') {
                         return [200, MOCK_SURVEY_RESULTS]
                     }
@@ -568,20 +642,8 @@ export const SurveyResults: Story = {
                 '/api/environments/:team_id/hog_functions/': { count: 0, results: [], next: null },
             },
             post: {
-                '/api/environments/:team_id/query/:kind/': async ({ request }) => {
-                    const body = (await request.json()) as any
-                    const sql: string = body?.query?.query ?? ''
-                    if (body?.query?.tags?.name === 'survey_results_aggregate') {
-                        return MOCK_SURVEY_AGGREGATE_RESULTS
-                    }
-                    if (sql.includes('BASE STATS')) {
-                        return MOCK_SURVEY_BASE_STATS
-                    }
-                    if (sql.includes('DISMISSED AND SENT COUNT')) {
-                        return { results: [[60]] }
-                    }
-                    return { results: [] }
-                },
+                '/api/environments/:team_id/query/:kind/': async ({ request }) =>
+                    resolveSurveyResultsQuery(await request.json()) ?? { results: [] },
             },
         }),
     ],

--- a/frontend/src/scenes/surveys/Surveys.stories.tsx
+++ b/frontend/src/scenes/surveys/Surveys.stories.tsx
@@ -22,6 +22,7 @@ import {
 } from '~/types'
 
 import { SurveyEditSection, surveyLogic } from './surveyLogic'
+import { SURVEY_RESPONSE_CONTEXT_COLUMNS, type SurveyResponseContextColumn } from './utils'
 
 const MOCK_BASIC_SURVEY: Survey = {
     id: '0187c279-bcae-0000-34f5-4f121921f005',
@@ -304,9 +305,10 @@ const MOCK_SURVEY_BASE_STATS = {
         ['outcome_counts', 'Tuple(UInt64, UInt64, UInt64)'],
     ],
     results: [
-        [SurveyEventName.SHOWN, 120, 110, '2023-05-02T10:00:00Z', '2023-06-20T10:00:00Z', [120, 0, 0]],
+        // Only the sent row carries real outcome counts; the query hardcodes zeros for the others.
+        [SurveyEventName.SHOWN, 120, 110, '2023-05-02T10:00:00Z', '2023-06-20T10:00:00Z', [0, 0, 0]],
         [SurveyEventName.SENT, 75, 70, '2023-05-02T11:00:00Z', '2023-06-20T09:00:00Z', [60, 9, 6]],
-        [SurveyEventName.DISMISSED, 18, 17, '2023-05-03T10:00:00Z', '2023-06-19T10:00:00Z', [0, 18, 0]],
+        [SurveyEventName.DISMISSED, 18, 17, '2023-05-03T10:00:00Z', '2023-06-19T10:00:00Z', [0, 0, 0]],
     ],
 }
 
@@ -359,12 +361,45 @@ const MOCK_SURVEY_RESPONSE_ROWS = {
     ],
 }
 
+// Respondent context column values, in the same row order as MOCK_SURVEY_RESPONSE_ROWS.
+const MOCK_SURVEY_RESPONSE_CONTEXT: Record<SurveyResponseContextColumn, string[]> = {
+    person_id: ['0187c279-bcae-0000-34f5-4f121921fb01', '0187c279-bcae-0000-34f5-4f121921fb02'],
+    session_id: ['0187c279-bcae-0000-34f5-4f121921fc01', '0187c279-bcae-0000-34f5-4f121921fc02'],
+    current_url: ['https://example.com/pricing', 'https://example.com/settings'],
+}
+
+/**
+ * A HogQL data table reads its columns from the response, so a fixed column list would leave the
+ * Columns control with no visible effect. This answers with the columns the SELECT asked for.
+ */
+function responseRowsFor(sql: string): Record<string, unknown> {
+    const chosen = SURVEY_RESPONSE_CONTEXT_COLUMNS.filter(({ expression }) => sql.includes(expression))
+    if (chosen.length === 0) {
+        return MOCK_SURVEY_RESPONSE_ROWS
+    }
+    const { columns, results } = MOCK_SURVEY_RESPONSE_ROWS
+    return {
+        ...MOCK_SURVEY_RESPONSE_ROWS,
+        // The actions column stays rightmost, matching the generated query.
+        columns: [...columns.slice(0, -1), ...chosen.map(({ key }) => key), 'actions'],
+        results: results.map((row, index) => [
+            ...row.slice(0, -1),
+            ...chosen.map(({ key }) => MOCK_SURVEY_RESPONSE_CONTEXT[key][index]),
+            row[row.length - 1],
+        ]),
+    }
+}
+
+interface SurveyQueryRequestBody {
+    kind?: string
+    query?: { tags?: { name?: string }; query?: string }
+}
+
 /**
  * Both the meta and the SurveyResults story mock the query endpoint, and whichever handler MSW
  * resolves first wins. Sharing one resolver keeps the results tab loading either way.
- * The responses table carries no query tag, so it is recognized by the `response` tuple it selects.
  */
-function resolveSurveyResultsQuery(body: any): Record<string, unknown> | null {
+function resolveSurveyResultsQuery(body: SurveyQueryRequestBody): Record<string, unknown> | null {
     switch (body?.query?.tags?.name) {
         case 'survey_results_aggregate':
             return MOCK_SURVEY_AGGREGATE_RESULTS
@@ -372,9 +407,8 @@ function resolveSurveyResultsQuery(body: any): Record<string, unknown> | null {
             return MOCK_SURVEY_BASE_STATS
         case 'survey_dismissed_sent_overlap':
             return { results: [[60]] }
-    }
-    if (String(body?.query?.query ?? '').includes('AS response')) {
-        return MOCK_SURVEY_RESPONSE_ROWS
+        case 'survey_responses':
+            return responseRowsFor(String(body.query?.query ?? ''))
     }
     return null
 }
@@ -643,7 +677,7 @@ export const SurveyResults: Story = {
             },
             post: {
                 '/api/environments/:team_id/query/:kind/': async ({ request }) =>
-                    resolveSurveyResultsQuery(await request.json()) ?? { results: [] },
+                    resolveSurveyResultsQuery((await request.json()) as SurveyQueryRequestBody) ?? { results: [] },
             },
         }),
     ],

--- a/frontend/src/scenes/surveys/hooks/useSurveyResponseColumns.tsx
+++ b/frontend/src/scenes/surveys/hooks/useSurveyResponseColumns.tsx
@@ -6,7 +6,7 @@ import { LemonButton, LemonTag, Tooltip } from '@posthog/lemon-ui'
 
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
 import { surveyLogic } from 'scenes/surveys/surveyLogic'
-import { getSurveyResponseStatus, isScaleTwoRating } from 'scenes/surveys/utils'
+import { SURVEY_RESPONSE_CONTEXT_COLUMNS, getSurveyResponseStatus, isScaleTwoRating } from 'scenes/surveys/utils'
 import { urls } from 'scenes/urls'
 
 import { EventRowActions } from '~/queries/nodes/DataTable/EventRowActions'
@@ -58,6 +58,9 @@ export function useSurveyResponseColumns(): Record<string, QueryContextColumn> {
                 title: 'Person',
                 render: ({ record }) => <PersonDisplay person={(record as EventType[])[0].person} />,
             },
+            ...Object.fromEntries(
+                SURVEY_RESPONSE_CONTEXT_COLUMNS.map((column) => [column.key, { title: column.label }])
+            ),
             actions: {
                 title: ' ',
                 render: ({ record }) => <EventRowActions event={(record as EventType[])[0]} />,

--- a/frontend/src/scenes/surveys/hooks/useSurveyResponseColumns.tsx
+++ b/frontend/src/scenes/surveys/hooks/useSurveyResponseColumns.tsx
@@ -59,7 +59,10 @@ export function useSurveyResponseColumns(): Record<string, QueryContextColumn> {
                 render: ({ record }) => <PersonDisplay person={(record as EventType[])[0].person} />,
             },
             ...Object.fromEntries(
-                SURVEY_RESPONSE_CONTEXT_COLUMNS.map((column) => [column.key, { title: column.label }])
+                SURVEY_RESPONSE_CONTEXT_COLUMNS.map((column): [string, QueryContextColumn] => [
+                    column.key,
+                    { title: column.label },
+                ])
             ),
             actions: {
                 title: ' ',

--- a/frontend/src/scenes/surveys/surveyLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveyLogic.test.ts
@@ -1329,6 +1329,30 @@ describe('survey filters', () => {
         expect(query).not.toContain('HAVING countIf(is_completed_event) > 0')
     })
 
+    it('selects only the respondent context columns that are turned on', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.loadSurveySuccess(MULTIPLE_CHOICE_SURVEY)
+        }).toDispatchActions(['loadSurveySuccess'])
+
+        const queryFor = (): string => (logic.values.dataTableQuery?.source as { query: string }).query
+        expect(queryFor()).not.toContain('current_url AS current_url')
+
+        await expectLogic(logic, () => {
+            logic.actions.setResponseContextColumn('current_url', true)
+        }).toDispatchActions(['setResponseContextColumn'])
+
+        const query = queryFor()
+        expect(query).toContain('current_url AS current_url')
+        expect(query).not.toContain('person_id AS person_id')
+        // The row actions column has to stay rightmost, so context columns go before it.
+        expect(query.indexOf('current_url AS current_url')).toBeLessThan(query.indexOf('uuid AS actions'))
+
+        await expectLogic(logic, () => {
+            logic.actions.setResponseContextColumn('current_url', false)
+        }).toDispatchActions(['setResponseContextColumn'])
+        expect(queryFor()).not.toContain('current_url AS current_url')
+    })
+
     it('keeps question text out of the generated HogQL', async () => {
         // Regression for the "Unexpected character U+00E9" crash on the Survey Results tab: a question
         // whose text spans multiple lines used to leak past the `--` comment appended per response

--- a/frontend/src/scenes/surveys/surveyLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveyLogic.test.ts
@@ -9,7 +9,7 @@ import {
     processResultsForSurveyQuestions,
     surveyLogic,
 } from 'scenes/surveys/surveyLogic'
-import { OpenEndedColumnMap } from 'scenes/surveys/utils'
+import { OpenEndedColumnMap, SURVEY_RESPONSE_CONTEXT_COLUMNS } from 'scenes/surveys/utils'
 
 import { useMocks } from '~/mocks/jest'
 import { NodeKind } from '~/queries/schema/schema-general'
@@ -1329,29 +1329,48 @@ describe('survey filters', () => {
         expect(query).not.toContain('HAVING countIf(is_completed_event) > 0')
     })
 
-    it('selects only the respondent context columns that are turned on', async () => {
-        await expectLogic(logic, () => {
-            logic.actions.loadSurveySuccess(MULTIPLE_CHOICE_SURVEY)
-        }).toDispatchActions(['loadSurveySuccess'])
+    it.each([...SURVEY_RESPONSE_CONTEXT_COLUMNS])(
+        'selects the $key respondent context column only when it is turned on',
+        async ({ key }) => {
+            await expectLogic(logic, () => {
+                logic.actions.loadSurveySuccess(MULTIPLE_CHOICE_SURVEY)
+            }).toDispatchActions(['loadSurveySuccess'])
 
-        const queryFor = (): string => (logic.values.dataTableQuery?.source as { query: string }).query
-        expect(queryFor()).not.toContain('current_url AS current_url')
+            const queryFor = (): string => {
+                const source = logic.values.dataTableQuery?.source
+                if (!source) {
+                    throw new Error('dataTableQuery was not built')
+                }
+                return (source as { query: string }).query
+            }
+            // The table keys each column off its alias, so the alias has to match the column key.
+            // Deriving it here rather than reading `expression` keeps a typo in that string visible.
+            const aliasFor = (columnKey: string): string => `${columnKey} AS ${columnKey}`
 
-        await expectLogic(logic, () => {
-            logic.actions.setResponseContextColumn('current_url', true)
-        }).toDispatchActions(['setResponseContextColumn'])
+            expect(queryFor()).not.toContain(aliasFor(key))
+            expect(queryFor()).not.toContain('$current_url')
 
-        const query = queryFor()
-        expect(query).toContain('current_url AS current_url')
-        expect(query).not.toContain('person_id AS person_id')
-        // The row actions column has to stay rightmost, so context columns go before it.
-        expect(query.indexOf('current_url AS current_url')).toBeLessThan(query.indexOf('uuid AS actions'))
+            await expectLogic(logic, () => {
+                logic.actions.setResponseContextColumn(key, true)
+            }).toDispatchActions(['setResponseContextColumn'])
 
-        await expectLogic(logic, () => {
-            logic.actions.setResponseContextColumn('current_url', false)
-        }).toDispatchActions(['setResponseContextColumn'])
-        expect(queryFor()).not.toContain('current_url AS current_url')
-    })
+            const query = queryFor()
+            expect(query).toContain(aliasFor(key))
+            for (const other of SURVEY_RESPONSE_CONTEXT_COLUMNS.filter((column) => column.key !== key)) {
+                expect(query).not.toContain(aliasFor(other.key))
+            }
+            // The row actions column has to stay rightmost, so context columns go before it.
+            expect(query.indexOf(aliasFor(key))).toBeLessThan(query.indexOf('uuid AS actions'))
+            // Only the current URL column makes the subquery read a property.
+            expect(query.includes('$current_url')).toBe(key === 'current_url')
+
+            await expectLogic(logic, () => {
+                logic.actions.setResponseContextColumn(key, false)
+            }).toDispatchActions(['setResponseContextColumn'])
+            expect(queryFor()).not.toContain(aliasFor(key))
+            expect(queryFor()).not.toContain('$current_url')
+        }
+    )
 
     it('keeps question text out of the generated HogQL', async () => {
         // Regression for the "Unexpected character U+00E9" crash on the Survey Results tab: a question

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -132,6 +132,7 @@ import {
     DATE_FORMAT,
     type OpenEndedColumnMap,
     type SurveyQueryFilters,
+    type SurveyResponseContextColumn,
     type SurveyResponseOutcome,
     buildAggregateQuery,
     buildOpenEndedQuery,
@@ -716,6 +717,7 @@ export interface surveyLogicValues {
     processedSurveyStats: SurveyStats | null
     projectTreeRef: ProjectTreeRef
     propertyFilters: AnyPropertyFilter[]
+    responseContextColumns: SurveyResponseContextColumn[]
     resultsRequeryInProgress: boolean
     reusableSurveyNotifications: HogFunctionType[]
     reusableSurveyNotificationsLoading: boolean
@@ -1258,6 +1260,13 @@ export interface surveyLogicActions {
         responseValue: any
         specificQuestionIndex: any
     }
+    setResponseContextColumn: (
+        column: SurveyResponseContextColumn,
+        show: boolean
+    ) => {
+        column: SurveyResponseContextColumn
+        show: boolean
+    }
     setResponseExpanded: (
         uuid: string,
         expanded: boolean
@@ -1427,7 +1436,8 @@ export interface surveyLogicMeta {
             propertyFilters: AnyPropertyFilter[],
             answerFilters: EventPropertyFilter[],
             timestampFilter: string,
-            archivedResponsesFilter: string
+            archivedResponsesFilter: string,
+            responseContextColumns: SurveyResponseContextColumn[]
         ) => DataTableNode | null
         targetingFlagFilters: (survey: NewSurvey | Survey) => FeatureFlagFilters | undefined
         urlMatchTypeValidationError: (survey: NewSurvey | Survey) => string | null
@@ -1581,6 +1591,7 @@ export const surveyLogic = kea<surveyLogicType>([
         setBaseStatsResults: (results: SurveyBaseStatsResult) => ({ results }),
         setDismissedAndSentCount: (count: DismissedAndSentCountResult) => ({ count }),
         setShowArchivedResponses: (show: boolean) => ({ show }),
+        setResponseContextColumn: (column: SurveyResponseContextColumn, show: boolean) => ({ column, show }),
         archiveResponse: (responseUuid: string) => ({ responseUuid }),
         unarchiveResponse: (responseUuid: string) => ({ responseUuid }),
         startResultsRequery: true,
@@ -2455,6 +2466,18 @@ export const surveyLogic = kea<surveyLogicType>([
                 setShowArchivedResponses: (_, { show }) => show,
             },
         ],
+        responseContextColumns: [
+            [] as SurveyResponseContextColumn[],
+            { persist: true },
+            {
+                setResponseContextColumn: (state, { column, show }) => {
+                    if (show === state.includes(column)) {
+                        return state
+                    }
+                    return show ? [...state, column] : state.filter((key) => key !== column)
+                },
+            },
+        ],
         filterSurveyStatsByDistinctId: [
             true,
             { persist: true },
@@ -3035,13 +3058,21 @@ export const surveyLogic = kea<surveyLogicType>([
             },
         ],
         dataTableQuery: [
-            (s) => [s.survey, s.propertyFilters, s.answerFilters, s.timestampFilter, s.archivedResponsesFilter],
+            (s) => [
+                s.survey,
+                s.propertyFilters,
+                s.answerFilters,
+                s.timestampFilter,
+                s.archivedResponsesFilter,
+                s.responseContextColumns,
+            ],
             (
                 survey: Survey,
                 propertyFilters: AnyPropertyFilter[],
                 answerFilters: EventPropertyFilter[],
                 timestampFilter: string,
-                archivedResponsesFilter: string
+                archivedResponsesFilter: string,
+                responseContextColumns: SurveyResponseContextColumn[]
             ): DataTableNode | null => {
                 if (survey.id === 'new') {
                     return null
@@ -3050,11 +3081,15 @@ export const surveyLogic = kea<surveyLogicType>([
                     kind: NodeKind.DataTableNode,
                     source: {
                         kind: NodeKind.HogQLQuery,
-                        query: buildSurveyResponsesQuery(survey, {
-                            answerFilters,
-                            timestampFilter,
-                            archivedResponsesFilter,
-                        }),
+                        query: buildSurveyResponsesQuery(
+                            survey,
+                            {
+                                answerFilters,
+                                timestampFilter,
+                                archivedResponsesFilter,
+                            },
+                            responseContextColumns
+                        ),
                         filters: { properties: propertyFilters },
                     },
                     hiddenColumns: ['response'],

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -283,6 +283,7 @@ const SURVEY_QUERY_TAGS = {
     },
     aggregateResults: { ...SURVEY_QUERY_TAG_BASE, name: 'survey_results_aggregate' as const },
     openEndedResults: { ...SURVEY_QUERY_TAG_BASE, name: 'survey_results_open_ended' as const },
+    responses: { ...SURVEY_QUERY_TAG_BASE, name: 'survey_responses' as const },
 }
 
 const isChoiceSurveyQuestion = (question: SurveyQuestion): question is MultipleSurveyQuestion =>
@@ -3081,6 +3082,7 @@ export const surveyLogic = kea<surveyLogicType>([
                     kind: NodeKind.DataTableNode,
                     source: {
                         kind: NodeKind.HogQLQuery,
+                        tags: SURVEY_QUERY_TAGS.responses,
                         query: buildSurveyResponsesQuery(
                             survey,
                             {

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -1264,7 +1264,7 @@ export interface surveyLogicActions {
         column: SurveyResponseContextColumn,
         show: boolean
     ) => {
-        column: SurveyResponseContextColumn
+        column: 'current_url' | 'person_id' | 'session_id'
         show: boolean
     }
     setResponseExpanded: (
@@ -1437,7 +1437,7 @@ export interface surveyLogicMeta {
             answerFilters: EventPropertyFilter[],
             timestampFilter: string,
             archivedResponsesFilter: string,
-            responseContextColumns: SurveyResponseContextColumn[]
+            responseContextColumns: ('current_url' | 'person_id' | 'session_id')[]
         ) => DataTableNode | null
         targetingFlagFilters: (survey: NewSurvey | Survey) => FeatureFlagFilters | undefined
         urlMatchTypeValidationError: (survey: NewSurvey | Survey) => string | null

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -757,6 +757,7 @@ function buildMergedSubmissionsSubquery(
             ? [
                   'distinct_id',
                   'properties.`$session_id` AS session_id',
+                  'properties.`$current_url` AS current_url',
                   'properties AS event_properties',
                   'person.properties AS person_properties',
               ]
@@ -778,6 +779,7 @@ function buildMergedSubmissionsSubquery(
             ? [
                   'argMax(distinct_id, tuple(timestamp, event_uuid)) AS distinct_id',
                   'argMax(session_id, tuple(timestamp, event_uuid)) AS session_id',
+                  'argMax(current_url, tuple(timestamp, event_uuid)) AS current_url',
                   'argMax(event_properties, tuple(timestamp, event_uuid)) AS event_properties',
                   'argMax(person_properties, tuple(timestamp, event_uuid)) AS person_properties',
                   'argMax(event, tuple(timestamp, event_uuid)) AS latest_event',
@@ -891,7 +893,23 @@ export function transformSurveyResponseRows(rows: DataTableRow[], survey: Pick<S
     })
 }
 
-export function buildSurveyResponsesQuery(survey: Survey, filters: SurveyQueryFilters): string {
+/**
+ * Optional respondent context columns for the responses table. The table selects only the ones
+ * the user turned on, so the export carries the same columns the table shows.
+ */
+export const SURVEY_RESPONSE_CONTEXT_COLUMNS = [
+    { key: 'person_id', label: 'Person ID', expression: 'person_id AS person_id' },
+    { key: 'session_id', label: 'Session ID', expression: 'session_id AS session_id' },
+    { key: 'current_url', label: 'Current URL', expression: 'current_url AS current_url' },
+] as const
+
+export type SurveyResponseContextColumn = (typeof SURVEY_RESPONSE_CONTEXT_COLUMNS)[number]['key']
+
+export function buildSurveyResponsesQuery(
+    survey: Survey,
+    filters: SurveyQueryFilters,
+    contextColumns: SurveyResponseContextColumn[] = []
+): string {
     const questions = getAnswerableQuestions(survey)
     const merged = buildMergedSubmissionsSubquery(survey, filters, questions, { includeRespondentMetadata: true })
     const answers = survey.questions.map((question, index) =>
@@ -906,6 +924,10 @@ export function buildSurveyResponsesQuery(survey: Survey, filters: SurveyQueryFi
         'outcome AS status',
         'submitted_at AS timestamp',
         'distinct_id AS respondent',
+        ...SURVEY_RESPONSE_CONTEXT_COLUMNS.filter((column) => contextColumns.includes(column.key)).map(
+            (column) => column.expression
+        ),
+        // Last, so the row actions stay in the rightmost column.
         'uuid AS actions',
     ]
     return `SELECT ${columns.join(',\n')} FROM (${merged}) ORDER BY submitted_at DESC`

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -745,7 +745,10 @@ function buildMergedSubmissionsSubquery(
     survey: Survey,
     filters: SurveyQueryFilters,
     questions: QuestionWithIndex[],
-    { includeRespondentMetadata = false }: { includeRespondentMetadata?: boolean } = {}
+    {
+        includeRespondentMetadata = false,
+        includeCurrentUrl = false,
+    }: { includeRespondentMetadata?: boolean; includeCurrentUrl?: boolean } = {}
 ): string {
     const completedEventExpr = `event = '${SurveyEventName.SENT}' AND ${buildSurveyOptionalBooleanPropertyFilter(SurveyEventProperties.SURVEY_COMPLETED, 'false')}`
 
@@ -757,11 +760,14 @@ function buildMergedSubmissionsSubquery(
             ? [
                   'distinct_id',
                   'properties.`$session_id` AS session_id',
-                  'properties.`$current_url` AS current_url',
                   'properties AS event_properties',
                   'person.properties AS person_properties',
               ]
             : []),
+        // No caller selects `current_url` unless the user turns its column on. An unconditional
+        // read costs every responses query a property read and an argMax. The other metadata
+        // columns above always reach a caller, so they stay unconditional.
+        ...(includeCurrentUrl ? ['properties.`$current_url` AS current_url'] : []),
         `${completedEventExpr} AS is_completed_event`,
         'event',
         ...questions.map(({ question, index }) => `${getSurveyResponse(question, index)} AS ${rawAnswerAlias(index)}`),
@@ -779,12 +785,12 @@ function buildMergedSubmissionsSubquery(
             ? [
                   'argMax(distinct_id, tuple(timestamp, event_uuid)) AS distinct_id',
                   'argMax(session_id, tuple(timestamp, event_uuid)) AS session_id',
-                  'argMax(current_url, tuple(timestamp, event_uuid)) AS current_url',
                   'argMax(event_properties, tuple(timestamp, event_uuid)) AS event_properties',
                   'argMax(person_properties, tuple(timestamp, event_uuid)) AS person_properties',
                   'argMax(event, tuple(timestamp, event_uuid)) AS latest_event',
               ]
             : []),
+        ...(includeCurrentUrl ? ['argMax(current_url, tuple(timestamp, event_uuid)) AS current_url'] : []),
         ...questions.map(({ question, index }) => {
             const raw = rawAnswerAlias(index)
             return `argMaxIf(${raw}, tuple(timestamp, event_uuid), ${buildAnswerPresenceExpr(raw, question)}) AS ${mergedAnswerAlias(index)}`
@@ -911,7 +917,10 @@ export function buildSurveyResponsesQuery(
     contextColumns: SurveyResponseContextColumn[] = []
 ): string {
     const questions = getAnswerableQuestions(survey)
-    const merged = buildMergedSubmissionsSubquery(survey, filters, questions, { includeRespondentMetadata: true })
+    const merged = buildMergedSubmissionsSubquery(survey, filters, questions, {
+        includeRespondentMetadata: true,
+        includeCurrentUrl: contextColumns.includes('current_url'),
+    })
     const answers = survey.questions.map((question, index) =>
         question.type !== SurveyQuestionType.Link ? mergedAnswerAlias(index) : 'NULL'
     )

--- a/products/surveys/frontend/components/SurveyResponseColumnsMenu.tsx
+++ b/products/surveys/frontend/components/SurveyResponseColumnsMenu.tsx
@@ -1,0 +1,43 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonButton, LemonDropdown, LemonSwitch } from '@posthog/lemon-ui'
+
+import { IconTuning } from 'lib/lemon-ui/icons'
+import { surveyLogic } from 'scenes/surveys/surveyLogic'
+import { SURVEY_RESPONSE_CONTEXT_COLUMNS } from 'scenes/surveys/utils'
+
+export function SurveyResponseColumnsMenu(): JSX.Element {
+    const { responseContextColumns } = useValues(surveyLogic)
+    const { setResponseContextColumn } = useActions(surveyLogic)
+
+    return (
+        <LemonDropdown
+            closeOnClickInside={false}
+            placement="bottom-end"
+            overlay={
+                <div className="flex flex-col gap-2 py-1 px-2 min-w-64">
+                    {SURVEY_RESPONSE_CONTEXT_COLUMNS.map((column) => (
+                        <LemonSwitch
+                            key={column.key}
+                            checked={responseContextColumns.includes(column.key)}
+                            onChange={(show) => setResponseContextColumn(column.key, show)}
+                            label={column.label}
+                            fullWidth
+                            data-attr={`survey-response-column-${column.key}`}
+                        />
+                    ))}
+                </div>
+            }
+        >
+            <LemonButton
+                type="secondary"
+                size="small"
+                icon={<IconTuning />}
+                tooltip="Add respondent details to the table and to exports"
+                data-attr="survey-response-columns-menu"
+            >
+                Columns
+            </LemonButton>
+        </LemonDropdown>
+    )
+}

--- a/products/surveys/frontend/components/SurveyResponseColumnsMenu.tsx
+++ b/products/surveys/frontend/components/SurveyResponseColumnsMenu.tsx
@@ -33,7 +33,7 @@ export function SurveyResponseColumnsMenu(): JSX.Element {
                 type="secondary"
                 size="small"
                 icon={<IconTuning />}
-                tooltip="Add respondent details to the table and to exports"
+                tooltip="Choose which respondent details appear in the table and in exports"
                 data-attr="survey-response-columns-menu"
             >
                 Columns


### PR DESCRIPTION
## Problem

Survey owners cannot put respondent details on the Responses table, and cannot get them out of an export. Someone who wants the current URL or the person behind a response has no column for either.

- The Responses table lost its **Configure columns** button in #96013.
- That PR moved the responses query from `EventsQuery` to `HogQLQuery` to merge partial submissions, and dropped `showPersistentColumnConfigurator`.
- A `HogQLQuery` source never gets `QueryFeature.columnConfigurator`, so the button cannot render.
- The **Export all columns** menu item disappeared with it, because that item requires an `EventsQuery` that selects `*`.
- The **Export** button itself still works and exports the visible columns.
- From: https://us.posthog.com/project/2/support/tickets/71478

## Changes

- A **Columns** control sits next to **Export** and turns on person ID, session ID, and current URL. It stands where **Configure columns** used to.
- An export carries the columns that are turned on. The generated query selects only those, so the table and the file agree.
- The choice is saved in the browser, separately for each survey. `kea-localstorage` keys only on the logic path, which carries the survey ID and no account ID.
- The subquery reads `$current_url` only when that column is on. A survey with the column off runs the query it ran before.
- The `SurveyResults` story renders results again. Its mocks went stale in #96013, which is why the missing button reached users.
- Mechanical: query tags replace SQL string matching in the story mocks.
- Mechanical: one resolver now serves both mock handlers, so MSW resolution order stops deciding what loads.
- Mechanical: the generated kea types above `surveyLogic` carry the new action payload and selector signature.

A fixed set of columns is deliberate. The old configurator wrote arbitrary properties into `EventsQuery.select`, which the generated HogQL query has no room for. Any other property is still reachable by expanding a response row, or through the SQL query helper.

![Columns control next to Export on the survey responses table](https://raw.githubusercontent.com/PostHog/pr-assets/3ae8028bd6278bb5d5975eb2f1dc9cede4be1f6f/2026/09/c32543a7-1a79-451d-9d22-b44fb8d638b5.png)

> [!NOTE]
> Visual review reports two changed snapshots, `scenes-app-surveys--survey-results--light` and `--dark`. The story renders the responses table for the first time since #96013, so the **Columns** button is new in both. Both need a reviewer to approve them.

## How did you test this code?

One case was added to the `survey filters` block in `surveyLogic.test.ts`. It catches two regressions: a selector that stops depending on the chosen columns, and context columns appended after `uuid AS actions`, which would push the row actions out of the last column. No existing case covered either.

The Responses table was driven in Storybook against the repaired mocks. The **Columns** control renders next to **Export**, and turning on **Current URL** adds the column. The screenshot above is that render.

The generated kea types come from `typegen:write`, the command CI runs, so the `git diff --exit-code` step that failed has nothing left to report.

The repo-wide `tsgo` check reports 22 errors in this sandbox. All 22 are `@posthog/quill` modules that the unbuilt nested workspace cannot resolve. None sit in a file this PR touches. CI builds that workspace and runs the check.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`docs/internal/survey-responses.md` describes the control and what an export contains.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus 5) from a support question asking whether the export button and the column picker still exist. The answer: the export button exists, the column picker does not.

Skills invoked: `/placing-product-frontend-code`, `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

The first plan was to expose the columns only in the export and leave the table alone, since hidden columns already reach an export. A control that changes both reads better and matches the `TracesOptionsMenu` precedent in AI observability. The story-mock repair came out of trying to see the change render: the story showed an empty state, which is how the regression stayed invisible.

A later pass reviewed the red CI checks. The stale kea types were the only true failure. That pass also found the `$current_url` read that ran for every survey, and a docs line that claimed the column choice crosses surveys.

The customer conversation behind this stayed out of the diff. The story fixtures are invented and use `example.com`.

