### PR TITLE
feat(desktop): split help out of the account menu

### DIFF
--- a/products/desktop/packages/shared/src/analytics-events.ts
+++ b/products/desktop/packages/shared/src/analytics-events.ts
@@ -290,6 +290,18 @@ export type SidebarNavItem =
   | "loops"
   | "more";
 
+export type HelpMenuItem =
+  | "documentation"
+  | "keyboard_shortcuts"
+  | "changelog"
+  | "discord"
+  | "website"
+  | "privacy";
+
+export interface HelpMenuItemClickedProperties {
+  item: HelpMenuItem;
+}
+
 /** Which sidebar shell the click came from, so the two can be compared. */
 export type SidebarLayout = "code" | "channels";
 
@@ -1576,6 +1588,7 @@ export const ANALYTICS_EVENTS = {
   BRAINROT_PLAYER_ERROR: "Brainrot player error",
   POSTHOG_WEB_OPENED: "PostHog web opened",
   SIDEBAR_NAV_ITEM_CLICKED: "Sidebar nav item clicked",
+  HELP_MENU_ITEM_CLICKED: "Help menu item clicked",
   TASK_LIST_GROUPING_CHANGED: "Task list grouping changed",
   TASK_LIST_APPEARANCE_CHANGED: "Task list appearance changed",
 
@@ -1789,6 +1802,7 @@ export type EventPropertyMap = {
   [ANALYTICS_EVENTS.BRAINROT_PLAYER_ERROR]: BrainrotPlayerErrorProperties;
   [ANALYTICS_EVENTS.POSTHOG_WEB_OPENED]: never;
   [ANALYTICS_EVENTS.SIDEBAR_NAV_ITEM_CLICKED]: SidebarNavItemClickedProperties;
+  [ANALYTICS_EVENTS.HELP_MENU_ITEM_CLICKED]: HelpMenuItemClickedProperties;
   [ANALYTICS_EVENTS.TASK_LIST_GROUPING_CHANGED]: TaskListGroupingChangedProperties;
   [ANALYTICS_EVENTS.TASK_LIST_APPEARANCE_CHANGED]: TaskListAppearanceChangedProperties;
 

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
@@ -29,6 +29,7 @@ import {
 } from "@posthog/ui/features/canvas/stores/channelPaneStore";
 import { useCurrentChannelStore } from "@posthog/ui/features/canvas/stores/currentChannelStore";
 import { useOnboardingStore } from "@posthog/ui/features/onboarding/onboardingStore";
+import { HelpMenu } from "@posthog/ui/features/sidebar/components/HelpMenu";
 import { NavResizeTooltip } from "@posthog/ui/features/sidebar/components/NavResizeTooltip";
 import { ProjectSwitcher } from "@posthog/ui/features/sidebar/components/ProjectSwitcher";
 import { SidebarMenu } from "@posthog/ui/features/sidebar/components/SidebarMenu";
@@ -326,8 +327,11 @@ function ChannelsSidebarImpl() {
           {/* The code layout keeps it in the footer: that sidebar's top is the nav
             section and task header, and there's no nav row to sit above. */}
           {!channelsLayout && (
-            <div className="shrink-0 px-2 pb-2">
-              <ProjectSwitcher />
+            <div className="flex shrink-0 items-center gap-1 px-2 pb-2">
+              <div className="min-w-0 flex-1">
+                <ProjectSwitcher />
+              </div>
+              <HelpMenu placement="footer" />
             </div>
           )}
         </div>

--- a/products/desktop/packages/ui/src/features/canvas/components/NavRail.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/NavRail.test.tsx
@@ -163,15 +163,16 @@ describe("NavRail", () => {
     expect(screen.queryByLabelText("Home")).not.toBeInTheDocument();
   });
 
-  it("keeps Search directly above Settings at the bottom of the rail", () => {
+  it("keeps Search, Help and Settings at the bottom of the rail", () => {
     render(<NavRail />);
 
     const buttonLabels = screen
       .getAllByRole("button")
       .map((button) => button.getAttribute("aria-label"));
 
-    expect(buttonLabels.slice(-3)).toEqual([
+    expect(buttonLabels.slice(-4)).toEqual([
       "Search",
+      "Help",
       "Settings",
       "Project switcher",
     ]);

--- a/products/desktop/packages/ui/src/features/canvas/components/NavRail.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/NavRail.tsx
@@ -39,6 +39,7 @@ import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFla
 import { useInboxAvailable } from "@posthog/ui/features/feature-flags/useInboxAvailable";
 import { useInboxDecisionCount } from "@posthog/ui/features/inbox/hooks/useInboxDecisionCount";
 import { openSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
+import { HelpMenu } from "@posthog/ui/features/sidebar/components/HelpMenu";
 import { ProjectSwitcher } from "@posthog/ui/features/sidebar/components/ProjectSwitcher";
 import { NAV_RAIL_WIDTH } from "@posthog/ui/features/sidebar/constants";
 import { CountBadge } from "@posthog/ui/primitives/CountBadge";
@@ -319,6 +320,7 @@ function NavRailImpl() {
             isActive={false}
             onClick={toggleCommandMenu}
           />
+          <HelpMenu />
           <NavIcon
             icon={<GearSix size={16} />}
             label="Settings"

--- a/products/desktop/packages/ui/src/features/sidebar/components/HelpMenu.test.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/HelpMenu.test.tsx
@@ -1,0 +1,52 @@
+import { EXTERNAL_LINKS } from "@posthog/shared";
+import { HelpMenu } from "@posthog/ui/features/sidebar/components/HelpMenu";
+import { useWhatsNewStore } from "@posthog/ui/features/updates/whatsNewStore";
+import { openExternalUrl } from "@posthog/ui/shell/openExternal";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@posthog/ui/shell/analytics", () => ({ track: vi.fn() }));
+vi.mock("@posthog/ui/shell/openExternal", () => ({
+  openExternalUrl: vi.fn(),
+}));
+vi.mock("@posthog/ui/features/settings/hooks/useOpenSettings", () => ({
+  openSettings: vi.fn(),
+}));
+
+const openMenu = async (): Promise<ReturnType<typeof userEvent.setup>> => {
+  const user = userEvent.setup();
+  render(<HelpMenu />);
+  await user.click(screen.getByLabelText("Help"));
+  return user;
+};
+
+describe("HelpMenu", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useWhatsNewStore.getState().close();
+  });
+
+  // These rows moved out of the account menu. Each one is the only way to
+  // reach its destination from the shell, so a dropped handler strands it.
+  it.each([
+    { label: "Documentation", url: EXTERNAL_LINKS.docs },
+    { label: "Join our Discord", url: EXTERNAL_LINKS.discord },
+    { label: "Website", url: EXTERNAL_LINKS.website },
+    { label: "Privacy policy", url: EXTERNAL_LINKS.privacy },
+  ])("opens $label outside the app", async ({ label, url }) => {
+    const user = await openMenu();
+
+    await user.click(await screen.findByText(label));
+
+    expect(openExternalUrl).toHaveBeenCalledWith(url);
+  });
+
+  it("opens the changelog dialog", async () => {
+    const user = await openMenu();
+
+    await user.click(await screen.findByText("View changelog"));
+
+    expect(useWhatsNewStore.getState().isOpen).toBe(true);
+  });
+});

--- a/products/desktop/packages/ui/src/features/sidebar/components/HelpMenu.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/HelpMenu.tsx
@@ -1,0 +1,160 @@
+import {
+  ArrowSquareOut,
+  BookOpen,
+  DiscordLogo,
+  Gift,
+  Globe,
+  Keyboard,
+  Question,
+  ShieldCheck,
+} from "@phosphor-icons/react";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@posthog/quill";
+import { EXTERNAL_LINKS } from "@posthog/shared";
+import {
+  ANALYTICS_EVENTS,
+  type HelpMenuItem,
+} from "@posthog/shared/analytics-events";
+import {
+  formatHotkey,
+  SHORTCUTS,
+} from "@posthog/ui/features/command/keyboard-shortcuts";
+import { openSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
+import { useHoldSidebarPeek } from "@posthog/ui/features/sidebar/useHoldSidebarPeek";
+import { useWhatsNewStore } from "@posthog/ui/features/updates/whatsNewStore";
+import { track } from "@posthog/ui/shell/analytics";
+import { openExternalUrl } from "@posthog/ui/shell/openExternal";
+import { useState } from "react";
+
+interface HelpMenuProps {
+  /** Where the trigger sits, which decides the side the menu opens on. */
+  placement?: "rail" | "footer";
+}
+
+/** Docs, shortcuts, changelog, feedback, and our public links. */
+export function HelpMenu({ placement = "rail" }: HelpMenuProps = {}) {
+  const [open, setOpen] = useState(false);
+  const holdPeek = useHoldSidebarPeek();
+  const handleOpenChange = (next: boolean): void => {
+    setOpen(next);
+    holdPeek(next);
+  };
+
+  const inRail = placement === "rail";
+
+  // Every row closes the menu, so the click is one step: record it, act, close.
+  const run = (item: HelpMenuItem, action: () => void) => () => {
+    track(ANALYTICS_EVENTS.HELP_MENU_ITEM_CLICKED, { item });
+    action();
+    setOpen(false);
+  };
+
+  return (
+    <DropdownMenu open={open} onOpenChange={handleOpenChange}>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <DropdownMenuTrigger
+              render={
+                <Button
+                  variant="default"
+                  size="icon"
+                  aria-label="Help"
+                  className="shrink-0 text-muted-foreground aria-expanded:bg-fill-active"
+                >
+                  <Question size={16} />
+                </Button>
+              }
+            />
+          }
+        />
+        <TooltipContent side={inRail ? "right" : "top"}>Help</TooltipContent>
+      </Tooltip>
+
+      <DropdownMenuContent
+        className="w-56"
+        side={inRail ? "right" : "top"}
+        align="end"
+        sideOffset={4}
+      >
+        <DropdownMenuGroup>
+          <DropdownMenuItem
+            onClick={run("documentation", () =>
+              openExternalUrl(EXTERNAL_LINKS.docs),
+            )}
+          >
+            <BookOpen size={14} className="text-gray-11" />
+            Documentation
+            <ArrowSquareOut size={14} className="ml-auto text-gray-11" />
+          </DropdownMenuItem>
+
+          <DropdownMenuItem
+            onClick={run("keyboard_shortcuts", () => openSettings("shortcuts"))}
+          >
+            <Keyboard size={14} className="text-gray-11" />
+            Keyboard shortcuts
+            <DropdownMenuShortcut>
+              {formatHotkey(SHORTCUTS.SHORTCUTS_SHEET)}
+            </DropdownMenuShortcut>
+          </DropdownMenuItem>
+
+          <DropdownMenuItem
+            onClick={run("changelog", () => useWhatsNewStore.getState().open())}
+          >
+            <Gift size={14} className="text-gray-11" />
+            View changelog
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+
+        <DropdownMenuSeparator />
+
+        <DropdownMenuGroup>
+          <DropdownMenuItem
+            onClick={run("discord", () =>
+              openExternalUrl(EXTERNAL_LINKS.discord),
+            )}
+          >
+            <DiscordLogo size={14} className="text-gray-11" />
+            Join our Discord
+            <ArrowSquareOut size={14} className="ml-auto text-gray-11" />
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+
+        <DropdownMenuSeparator />
+
+        <DropdownMenuGroup>
+          <DropdownMenuItem
+            onClick={run("website", () =>
+              openExternalUrl(EXTERNAL_LINKS.website),
+            )}
+          >
+            <Globe size={14} className="text-gray-11" />
+            Website
+            <ArrowSquareOut size={14} className="ml-auto text-gray-11" />
+          </DropdownMenuItem>
+
+          <DropdownMenuItem
+            onClick={run("privacy", () =>
+              openExternalUrl(EXTERNAL_LINKS.privacy),
+            )}
+          >
+            <ShieldCheck size={14} className="text-gray-11" />
+            Privacy policy
+            <ArrowSquareOut size={14} className="ml-auto text-gray-11" />
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/products/desktop/packages/ui/src/features/sidebar/components/ProjectSwitcher.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/ProjectSwitcher.tsx
@@ -2,14 +2,9 @@ import {
   Archive,
   ArrowSquareOut,
   Buildings,
-  DiscordLogo,
   FolderSimple,
   Gear,
-  Gift,
-  Info,
-  Keyboard,
   Plus,
-  ShieldCheck,
   SignOut,
 } from "@phosphor-icons/react";
 import {
@@ -22,7 +17,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuShortcut,
   DropdownMenuSub,
-  DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
   Item,
@@ -30,7 +24,6 @@ import {
   ItemDescription,
   ItemTitle,
 } from "@posthog/quill";
-import { EXTERNAL_LINKS } from "@posthog/shared";
 import { useArchivedTaskIds } from "@posthog/ui/features/archive/useArchivedTaskIds";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
@@ -45,7 +38,6 @@ import { useProjects } from "@posthog/ui/features/projects/useProjects";
 import { openSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
 import type { SettingsCategory } from "@posthog/ui/features/settings/types";
 import { useHoldSidebarPeek } from "@posthog/ui/features/sidebar/useHoldSidebarPeek";
-import { useWhatsNewStore } from "@posthog/ui/features/updates/whatsNewStore";
 import {
   type MenuFlyoutItem,
   MenuSubFlyout,
@@ -68,7 +60,7 @@ interface ProjectSwitcherProps {
   onNavigateToSettings?: (category: SettingsCategory) => void;
 }
 
-/** The account / project / org menu. */
+/** The account / project / org menu. Help lives in {@link HelpMenu}. */
 export function ProjectSwitcher({
   appearance = "row",
   onNavigateToSettings,
@@ -191,23 +183,6 @@ export function ProjectSwitcher({
   };
 
   const handleSettings = () => goToSettings("general");
-
-  const handleKeyboardShortcuts = () => goToSettings("shortcuts");
-
-  const handleOpenExternal = (url: string) => {
-    openExternalUrl(url);
-    setPopoverOpen(false);
-  };
-
-  const handleDiscord = () => {
-    openExternalUrl(EXTERNAL_LINKS.discord);
-    setPopoverOpen(false);
-  };
-
-  const handleViewChangelog = () => {
-    useWhatsNewStore.getState().open();
-    setPopoverOpen(false);
-  };
 
   const handleLogout = () => {
     setPopoverOpen(false);
@@ -339,47 +314,6 @@ export function ProjectSwitcher({
             </DropdownMenuGroup>
 
             <DropdownMenuSeparator />
-
-            <DropdownMenuItem onClick={handleDiscord}>
-              <DiscordLogo size={14} className="text-gray-11" />
-              Join our Discord
-              <ArrowSquareOut size={14} className="ml-auto text-gray-11" />
-            </DropdownMenuItem>
-
-            <DropdownMenuItem onClick={handleViewChangelog}>
-              <Gift size={14} className="text-gray-11" />
-              View changelog
-            </DropdownMenuItem>
-
-            <DropdownMenuSub>
-              <DropdownMenuSubTrigger>
-                <Info size={14} className="text-gray-11" />
-                Learn more
-              </DropdownMenuSubTrigger>
-              <DropdownMenuSubContent side="right" sideOffset={4}>
-                <DropdownMenuItem
-                  onClick={() => handleOpenExternal(EXTERNAL_LINKS.website)}
-                >
-                  <ArrowSquareOut size={14} className="text-gray-11" />
-                  Website
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                  onClick={() => handleOpenExternal(EXTERNAL_LINKS.privacy)}
-                >
-                  <ShieldCheck size={14} className="text-gray-11" />
-                  Privacy Policy
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={handleKeyboardShortcuts}>
-                  <Keyboard size={14} className="text-gray-11" />
-                  Keyboard Shortcuts
-                  <DropdownMenuShortcut>
-                    {isMac ? "⌘/" : "Ctrl+/"}
-                  </DropdownMenuShortcut>
-                </DropdownMenuItem>
-              </DropdownMenuSubContent>
-            </DropdownMenuSub>
 
             {showArchived && (
               <DropdownMenuItem onClick={handleArchived}>


### PR DESCRIPTION
## Problem

Desktop users looking for docs, the changelog, or Discord have to open the account menu, which is where they switch project and organization. Help and account are different jobs, so the help rows are hard to find and the account menu is long.

## Changes

- A help button sits in the nav rail, under Search and above Settings. It opens docs, keyboard shortcuts, the changelog, Discord, our website, and the privacy policy.
- The account menu now holds account work only: the signed-in user, project, organization, Archived, Settings, and Log out.
- The code layout keeps its help button beside the account row in the sidebar footer, so that shell loses nothing.
- Two labels move to sentence case: "Keyboard Shortcuts" and "Privacy Policy".
- The keyboard shortcuts row reads its hotkey from `SHORTCUTS.SHORTCUTS_SHEET` instead of a hardcoded string. Mechanical.
- A `Help menu item clicked` event records which row a person picks, so we can see whether the split makes these rows easier to reach.

No screenshot: the desktop UI has no Storybook harness in this checkout, and the Electron app needs a signed-in host. The menu reuses the same quill dropdown rows the account menu already draws.

> [!NOTE]
> [#95397](https://github.com/PostHog/posthog/pull/95397) adds a "Send feedback…" row to the same account-menu block this PR empties, so the two conflict textually. Feedback belongs in the help menu. Whichever lands second should move that row across, which is a one-line change against `HelpMenu.tsx`.

## How did you test this code?

- `HelpMenu.test.tsx` covers the moved rows: four external links open through `openExternalUrl`, and "View changelog" opens the what's new dialog. Each row is the only way to reach its destination from the shell, so a dropped handler would strand it silently.
- The NavRail rail-order test now expects Help between Search and Settings.
- Ran `vitest` on `HelpMenu`, `NavRail`, and `ChannelsSidebar`, plus `tsc --noEmit` for `@posthog/ui` and `@posthog/shared`.
- Not run: the Electron app itself, and the rest of the desktop suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Opus 5) from a Slack thread that compared our account menu with another app's help button. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

An earlier version of this change also added a "Send feedback" row, with its own dialog store and a second source for the feedback modal at the router root. That plumbing was dropped once [#95397](https://github.com/PostHog/posthog/pull/95397) turned up, because it builds the same store and a feedback shortcut. Two competing implementations of one modal is worse than one late row.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1788971270220769?thread_ts=1788971270.220769&cid=C09G8Q32R6F)*
