### PR TITLE
fix(logs): align session error badge with related errors tab

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -9699,7 +9699,7 @@ snapshots:
     scenes-other-onboarding-legacy--ai-observability-sdk-install--dark:
         hash: v1.k794b7964.0c82a4b8b276a3f51b42dd3a20aed7672fbfb5f096e4bd9da51221b6eb52bbdc.iXUjftr_vTAULjZ_soSDjZ9o_RG2YPlJBCG4ZSuNTS0
     scenes-other-onboarding-legacy--ai-observability-sdk-install--light:
-        hash: v1.k794b7964.c6c5baa13b6d17723b6022b01f3a235df0e49a93c92993eca8d498c2c4dfe9e5.a09diijoUqSgzkc5MHr912Pij2owQlUx5mrdebH4fsU
+        hash: v1.k794b7964.678b8b0432e3d3e1dfc8853d4df36ca419c8cfb230a30c49cd80c3fa69a09efc.BDQs-dcVcwMzRljfmwl7bvbYMugh7SfERy2mZPRBkR0
     scenes-other-onboarding-legacy--ai-observability-sdk-install-with-cloud-run-flag--dark:
         hash: v1.k794b7964.0c82a4b8b276a3f51b42dd3a20aed7672fbfb5f096e4bd9da51221b6eb52bbdc.mNBXA38xho8_capLIbeLCS22SJlBdDCCYmsl30jy3bI
     scenes-other-onboarding-legacy--ai-observability-sdk-install-with-cloud-run-flag--light:

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/RelatedErrors/RelatedErrorsTab.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/RelatedErrors/RelatedErrorsTab.tsx
@@ -3,6 +3,7 @@ import { BindLogic, useActions, useValues } from 'kea'
 import { LemonBanner, LemonSkeleton } from '@posthog/lemon-ui'
 
 import { EmptyMessage } from 'lib/components/EmptyMessage/EmptyMessage'
+import { pluralize } from 'lib/utils/strings'
 
 import { MaxErrorTrackingIssuePreview } from '~/queries/schema/schema-assistant-error-tracking'
 
@@ -88,10 +89,11 @@ interface RelatedIssuesListProps {
 }
 
 function RelatedIssuesList({ issues }: RelatedIssuesListProps): JSX.Element {
+    const totalOccurrences = issues.reduce((sum, issue) => sum + issue.occurrences, 0)
     return (
         <div className="flex flex-col">
             <p className="text-muted text-sm mb-2">
-                {issues.length} error{issues.length !== 1 ? 's' : ''} found in this session
+                {pluralize(issues.length, 'issue')} with {pluralize(totalOccurrences, 'occurrence')} in this session
             </p>
             {issues.map((issue) => (
                 <ErrorTrackingIssueCard key={issue.id} issue={issue} showUserCount={false} />

--- a/products/logs/frontend/components/LogsViewer/logsSessionErrorsLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/logsSessionErrorsLogic.test.ts
@@ -101,6 +101,12 @@ describe('logsSessionErrorsLogic', () => {
         expect(queryBodies[0].query.query.match(/'session-a'/g)).toHaveLength(1)
     })
 
+    it('asks only about exceptions that error tracking linked to an issue', async () => {
+        await loadPage([makeLog('log-1', 'session-a')])
+
+        expect(queryBodies[0].query.query).toContain('isNotNull(properties.$exception_issue_id)')
+    })
+
     it('still builds a window when timestamps arrive as epoch numbers', async () => {
         await loadPage([
             { ...BASE_LOG, uuid: 'log-1', attributes: { sessionId: 'session-a' }, timestamp: '1788474031592' },

--- a/products/logs/frontend/components/LogsViewer/logsSessionErrorsLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/logsSessionErrorsLogic.ts
@@ -151,10 +151,10 @@ export type logsSessionErrorsLogicType = MakeLogicType<
 // errors" without the user opening the row's Related errors tab first. The count answers the
 // session, not the log line: an exception in the same session is co-occurring evidence, not a cause.
 //
-// The count comes from `$exception` events that error tracking linked to an issue. Events without
-// an issue id failed ingestion parsing and can never appear in the tab this badge opens, so the
-// badge skips them. The tab groups the counted events into issues, so the badge matches the tab's
-// occurrence total, not its issue count.
+// Only exceptions error tracking linked to an issue count: an event with no issue id failed
+// ingestion parsing, so the tab this badge opens can never list it. The two still disagree at the
+// edges, because the tab anchors its window to one row rather than the whole page, caps at 100
+// issues, and resolves issues through fingerprint state this query cannot see.
 export const logsSessionErrorsLogic = kea<logsSessionErrorsLogicType>([
     props({} as LogsSessionErrorsLogicProps),
     key((props) => props.id),

--- a/products/logs/frontend/components/LogsViewer/logsSessionErrorsLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/logsSessionErrorsLogic.ts
@@ -151,9 +151,10 @@ export type logsSessionErrorsLogicType = MakeLogicType<
 // errors" without the user opening the row's Related errors tab first. The count answers the
 // session, not the log line: an exception in the same session is co-occurring evidence, not a cause.
 //
-// The count comes from raw `$exception` events, while the tab it opens resolves them into Error
-// Tracking issues. So the badge counts events the tab may group, suppress, or filter out, and the
-// two can disagree on the number.
+// The count comes from `$exception` events that error tracking linked to an issue. Events without
+// an issue id failed ingestion parsing and can never appear in the tab this badge opens, so the
+// badge skips them. The tab groups the counted events into issues, so the badge matches the tab's
+// occurrence total, not its issue count.
 export const logsSessionErrorsLogic = kea<logsSessionErrorsLogicType>([
     props({} as LogsSessionErrorsLogicProps),
     key((props) => props.id),
@@ -197,6 +198,7 @@ export const logsSessionErrorsLogic = kea<logsSessionErrorsLogicType>([
                             SELECT properties.$session_id AS session_id, count() AS exceptions
                             FROM events
                             WHERE event = '$exception'
+                              AND isNotNull(properties.$exception_issue_id)
                               AND timestamp >= ${range.from}
                               AND timestamp <= ${range.to}
                               AND properties.$session_id IN ${sessionIds}

--- a/products/logs/frontend/components/VirtualizedLogsList/cells/SessionErrorsBadge.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/cells/SessionErrorsBadge.tsx
@@ -12,7 +12,7 @@ export interface SessionErrorsBadgeProps {
 // rather than implying the log caused the errors.
 export function SessionErrorsBadge({ errorCount, onClick }: SessionErrorsBadgeProps): JSX.Element {
     return (
-        <Tooltip title={`${pluralize(errorCount, 'error')} in this session. Click to see them.`}>
+        <Tooltip title={`${pluralize(errorCount, 'error occurrence')} in this session. Click to see them.`}>
             <LemonButton
                 size="xsmall"
                 icon={<IconWarning className="text-danger" />}


### PR DESCRIPTION
## Problem

A log row's session errors badge (from #95432) can say "9 errors in this session" while the Related errors tab it opens says "2 errors found in this session". Both numbers are correct: the badge counts $exception events, and the tab counts the error tracking issues those events group into. The copy hides that distinction, so the feature looks broken.

The badge also counts exceptions that error tracking never linked to an issue because ingestion could not parse them. Those events can never appear in the tab, so the badge promises rows the tab cannot show.

## Changes

- The badge tooltip now says "9 error occurrences in this session", and the tab header now says "2 issues with 9 occurrences in this session", so the two counts read as consistent.
- The badge query now skips exceptions without an $exception_issue_id, so it counts only occurrences the tab can list.
- The counts can still differ a little at the edges: the badge window spans the loaded page of logs, while the tab window is anchored to one row's timestamp.

No screenshots: the change alters text and a query only, and the layout is unchanged.

## How did you test this code?

- Extended products/logs/frontend/components/LogsViewer/logsSessionErrorsLogic.test.ts with one case that fails if the issue-id filter is removed from the badge query, which would re-include occurrences the tab can never show. No existing test covered the query's event predicate.
- Ran the full frontend Jest suite and the frontend typecheck in the sandbox; the touched files report no errors.
- Not run: Storybook visual review, since the sandbox has no built quill workspace.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code in a PostHog Desktop cloud task. Skills invoked: /writing-user-facing-copy, /writing-tests, /writing-pr-descriptions. The session first diagnosed the badge/tab mismatch (event count vs issue count, verified against the error tracking query builder and cymbal's write-through of unparseable events), then shipped the copy alignment and the issue-id filter the human chose. A duplicate-PR search found nothing covering this.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*