### PR TITLE
chore(tasks): provide task context to sandbox workflow tests

### DIFF
--- a/docs/published/handbook/engineering/ai/sandboxed-agents.md
+++ b/docs/published/handbook/engineering/ai/sandboxed-agents.md
@@ -517,6 +517,27 @@ For advanced setup options (Modal sandboxes, local agent packages, MCP), see the
 
 **Tip:** Set `SANDBOX_REPO_MOUNT_MAP` to bind-mount local repositories into the Docker container and skip cloning from GitHub. Format: `SANDBOX_REPO_MOUNT_MAP=org/repo:/local/path` (e.g., `SANDBOX_REPO_MOUNT_MAP=PostHog/posthog:~/Developer/posthog`). This can significantly reduce sandbox startup time for large repos.
 
+### Workflow integration tests
+
+`TestProcessTaskWorkflow` in `products/tasks/backend/temporal/process_task/tests/test_workflow.py`
+boots real Modal sandboxes. Set `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET`, then run:
+
+```sh
+hogli test products/tasks/backend/temporal/process_task/tests/test_workflow.py::TestProcessTaskWorkflow
+```
+
+The completion and failure cases use a fixture HTTP API inside the sandbox. It serves
+the test task and a prewarmed run waiting for a message, so the real agent can become
+ready without calling a live PostHog API or submitting an LLM prompt. The test waits
+for readiness before signaling completion, then checks persisted status, error, and
+sandbox shutdown. It does not test Django API authentication or LLM task execution.
+
+These tests consume the published sandbox image, not the agent source in the checkout.
+An agent release triggers a separate sandbox image build that installs the published
+package and updates the shared image. Running backend tests against that image alone
+does not validate an unpublished agent change. A release check must exercise the
+candidate image before promoting it to the shared tag.
+
 ## Questions?
 
 If you're unsure whether a sandboxed agent is the right fit for your use case,

--- a/products/tasks/backend/temporal/process_task/tests/test_workflow.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_workflow.py
@@ -7,6 +7,7 @@ import dataclasses
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 
@@ -17,14 +18,15 @@ from django.conf import settings
 
 from asgiref.sync import sync_to_async
 from parameterized import parameterized
+from temporalio import activity
 from temporalio.client import WorkflowFailureError
 from temporalio.common import RetryPolicy
 from temporalio.exceptions import ActivityError, ApplicationError, RetryState
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
-from products.tasks.backend.logic.services.sandbox import Sandbox, SandboxConfig, SandboxStatus, SandboxTemplate
-from products.tasks.backend.models import SandboxSnapshot
+from products.tasks.backend.logic.services.sandbox import Sandbox, SandboxBase, SandboxConfig, SandboxTemplate
+from products.tasks.backend.models import SandboxSnapshot, TaskRun
 from products.tasks.backend.temporal.babysit_pr.snapshot import BabysitJournal
 from products.tasks.backend.temporal.constants import (
     INACTIVITY_TIMEOUT_USER_SECONDS,
@@ -43,6 +45,7 @@ from products.tasks.backend.temporal.process_task.activities import (
     PrepareSandboxForRepositoryOutput,
     SendPermissionDenialGuidanceInput,
     SendPermissionResponseToSandboxInput,
+    StartAgentServerInput,
     StartAgentServerOutput,
     TaskProcessingContext,
     checkout_branch_in_sandbox,
@@ -175,15 +178,73 @@ class TestProcessTaskWorkflow:
     or timeout. Tests verify the workflow starts correctly and handles signals.
     """
 
+    @pytest.fixture
+    def sandbox_task_api(self, settings, test_task_run: TaskRun) -> Callable[[SandboxBase], None]:
+        settings.SANDBOX_API_URL = "http://127.0.0.1:8765"
+        test_task_run.state = {"prewarmed": True, "await_user_message": True}
+        test_task_run.save(update_fields=["state"])
+        task = test_task_run.task
+        payload = json.dumps(
+            {
+                "task": {
+                    "id": str(task.id),
+                    "team_id": task.team_id,
+                    "title": task.title,
+                    "description": task.description,
+                    "repository": task.repository,
+                    "origin_product": task.origin_product,
+                },
+                "run": {
+                    "id": str(test_task_run.id),
+                    "task": str(task.id),
+                    "state": test_task_run.state,
+                    "status": "in_progress",
+                },
+            }
+        ).encode()
+        server = Path(__file__).with_name("workflow_api.py").read_bytes()
+
+        def prepare_api(sandbox: SandboxBase) -> None:
+            # The remote agent cannot read this process's test database. Serve its
+            # task context inside the sandbox, without sending a prompt to an LLM.
+            for path, content in [("/tmp/workflow-api.json", payload), ("/tmp/workflow_api.py", server)]:
+                result = sandbox.write_file(path, content)
+                assert result.exit_code == 0, result.stderr
+            result = sandbox.execute("nohup python3 /tmp/workflow_api.py >/tmp/workflow-api.log 2>&1 </dev/null &")
+            assert result.exit_code == 0, result.stderr
+            result = sandbox.execute(
+                "curl --fail --silent --retry 10 --retry-connrefused --retry-delay 1 "
+                "--max-time 2 http://127.0.0.1:8765/health",
+                timeout_seconds=30,
+            )
+            assert result.exit_code == 0, result.stderr
+
+        return prepare_api
+
     async def _run_workflow_with_signal(
         self,
         run_id: str,
+        prepare_api: Callable[[SandboxBase], None],
         signal_status: str = "completed",
         signal_error: str | None = None,
         create_pr: bool = True,
     ) -> ProcessTaskOutput:
         workflow_id = str(uuid.uuid4())
         workflow_input = ProcessTaskInput(run_id=str(run_id), create_pr=create_pr)
+        ready = asyncio.Event()
+
+        @activity.defn(name="start_agent_server")
+        async def start_and_observe(input: StartAgentServerInput) -> StartAgentServerOutput:
+            sandbox = await sync_to_async(Sandbox.get_by_id)(input.sandbox_id)
+            await sync_to_async(prepare_api)(sandbox)
+            try:
+                result = await start_agent_server(input)
+            except Exception:
+                diagnostic = await sync_to_async(sandbox.execute)("cat /tmp/workflow-api.log /tmp/agent-server.log")
+                activity.logger.error("Fixture API diagnostics: %s %s", diagnostic.stdout, diagnostic.stderr)
+                raise
+            ready.set()
+            return result
 
         async with (
             await WorkflowEnvironment.start_time_skipping() as env,
@@ -199,7 +260,8 @@ class TestProcessTaskWorkflow:
                     inject_fresh_tokens_on_resume,
                     clone_repository_in_sandbox,
                     checkout_branch_in_sandbox,
-                    start_agent_server,
+                    start_and_observe,
+                    emit_progress_activity,
                     read_sandbox_logs,
                     cleanup_sandbox,
                     complete_run_stream,
@@ -219,11 +281,23 @@ class TestProcessTaskWorkflow:
                 execution_timeout=timedelta(minutes=60),
             )
 
-            await asyncio.sleep(2)
-
-            await handle.signal(ProcessTaskWorkflow.complete_task, args=[signal_status, signal_error])
-
-            result = await handle.result()
+            result_task = asyncio.create_task(handle.result())
+            ready_task = asyncio.create_task(ready.wait())
+            try:
+                done, _ = await asyncio.wait(
+                    [ready_task, result_task], timeout=180, return_when=asyncio.FIRST_COMPLETED
+                )
+                if result_task in done:
+                    raise AssertionError(f"Workflow finished before completion signal: {result_task.result()}")
+                assert ready_task in done, "Agent did not become ready"
+                await handle.signal(ProcessTaskWorkflow.complete_task, args=[signal_status, signal_error])
+                result = await result_task
+            finally:
+                ready_task.cancel()
+                await asyncio.gather(ready_task, return_exceptions=True)
+                if not result_task.done():
+                    await handle.cancel()
+                    await asyncio.gather(result_task, return_exceptions=True)
 
         return result
 
@@ -253,47 +327,25 @@ class TestProcessTaskWorkflow:
             if sandbox:
                 sandbox.destroy()
 
-    async def test_workflow_starts_agent_server_and_waits_for_signal(self, test_task_run, github_integration):
-        """Workflow starts agent-server and completes when signaled."""
-        snapshot = await sync_to_async(self._create_test_snapshot)(github_integration)
-
-        try:
-            result = await self._run_workflow_with_signal(test_task_run.id, signal_status="completed")
-
-            assert result.success is True
-            assert result.sandbox_id is not None
-
-        finally:
-            await sync_to_async(snapshot.delete)()
-
-    async def test_workflow_handles_failure_signal(self, test_task_run, github_integration):
-        """Workflow handles failure signal correctly."""
+    @pytest.mark.parametrize("signal_status,signal_error", [("completed", None), ("failed", "Test error")])
+    async def test_workflow_starts_agent_handles_signal_and_cleans_up(
+        self, test_task_run, github_integration, sandbox_task_api, assert_sandbox_shutdown, signal_status, signal_error
+    ):
         snapshot = await sync_to_async(self._create_test_snapshot)(github_integration)
 
         try:
             result = await self._run_workflow_with_signal(
-                test_task_run.id, signal_status="failed", signal_error="Test error"
+                test_task_run.id, sandbox_task_api, signal_status, signal_error
             )
 
             assert result.success is True
             assert result.sandbox_id is not None
 
-        finally:
-            await sync_to_async(snapshot.delete)()
+            await test_task_run.arefresh_from_db()
+            assert test_task_run.status == signal_status
+            assert test_task_run.error_message == signal_error
 
-    async def test_workflow_cleans_up_sandbox(self, test_task_run, github_integration):
-        snapshot = await sync_to_async(self._create_test_snapshot)(github_integration)
-
-        try:
-            result = await self._run_workflow_with_signal(test_task_run.id)
-
-            assert result.success is True
-            assert result.sandbox_id is not None
-
-            await asyncio.sleep(10)
-
-            sandbox = Sandbox.get_by_id(result.sandbox_id)
-            assert sandbox.get_status() == SandboxStatus.SHUTDOWN
+            await sync_to_async(assert_sandbox_shutdown)(result.sandbox_id, timeout_seconds=10)
 
         finally:
             await sync_to_async(snapshot.delete)()

--- a/products/tasks/backend/temporal/process_task/tests/workflow_api.py
+++ b/products/tasks/backend/temporal/process_task/tests/workflow_api.py
@@ -1,0 +1,63 @@
+import os
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+
+def main() -> None:
+    payload = json.loads(Path("/tmp/workflow-api.json").read_text())
+    task = payload["task"]
+    run = payload["run"]
+    task_path = f"/api/projects/{task['team_id']}/tasks/{task['id']}/"
+    run_path = f"{task_path}runs/{run['id']}/"
+
+    class Handler(BaseHTTPRequestHandler):
+        def respond(self, status: int, body: object) -> None:
+            data = json.dumps(body).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def authorized(self) -> bool:
+            if self.headers.get("Authorization") == f"Bearer {os.environ['POSTHOG_PERSONAL_API_KEY']}":
+                return True
+            self.respond(403, {"detail": "Invalid test credential"})
+            return False
+
+        def do_GET(self) -> None:
+            if self.path == "/health":
+                self.respond(200, {"ready": True})
+            elif self.authorized():
+                if self.path == task_path:
+                    self.respond(200, task)
+                elif self.path == run_path:
+                    self.respond(200, run)
+                elif self.path == "/api/users/@me/":
+                    self.respond(200, {"id": 1, "distinct_id": "workflow-test-user"})
+                else:
+                    self.respond(404, {"detail": "Unexpected test API request"})
+
+        def do_POST(self) -> None:
+            if self.authorized():
+                self.rfile.read(int(self.headers.get("Content-Length", "0")))
+                if self.path == f"{run_path}append_log/":
+                    self.respond(200, run)
+                else:
+                    self.respond(404, {"detail": "Unexpected test API request"})
+
+        def do_PATCH(self) -> None:
+            if self.authorized():
+                update = json.loads(self.rfile.read(int(self.headers.get("Content-Length", "0"))))
+                if self.path == run_path:
+                    run.update(update)
+                    self.respond(200, run)
+                else:
+                    self.respond(404, {"detail": "Unexpected test API request"})
+
+    HTTPServer(("127.0.0.1", 8765), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

Backend CI fails when the sandbox agent requires task data that exists only in the test database.

https://github.com/PostHog/posthog/pull/96752 requires that data before agent readiness. The published sandbox image brings this requirement into otherwise unchanged tests.

Failing job: https://github.com/PostHog/posthog/actions/runs/34370192567/job/102538787652

## Changes

- Workflow tests provide task data through a fixture API inside each real Modal sandbox.
- The real agent starts in a waiting state without submitting an LLM prompt.
- Completion and failure cases wait for agent readiness, then verify persisted status, error, and sandbox shutdown.
- Both cases retain the cleanup assertion, replacing a redundant third sandbox run and fixed sleeps.
- Production behavior and CI configuration remain unchanged; documentation explains the test boundary.

<details>
<summary>Test setup before and after</summary>

Before:

```mermaid
flowchart LR
    Agent{{Real sandbox agent}} --> API[Configured PostHog API]
    Data[Test data in local database]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Agent phBlue;
    class API phRed;
    class Data phGray;
```

After:

```mermaid
flowchart LR
    Data[Test task data] --> API[Fixture API inside sandbox]
    Agent{{Real sandbox agent}} --> API
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Agent phBlue;
    class API phRed;
    class Data phGray;
```

</details>

## How did you test this code?

Locally reproduced the original startup failure, then validated `TestProcessTaskWorkflow` against real Modal with the fixture API.

```sh
hogli test products/tasks/backend/temporal/process_task/tests/test_workflow.py::TestProcessTaskWorkflow
```

New assertions catch incorrect persisted completion/failure outcomes. The missing-task case remains unchanged. Django authentication and LLM execution are outside this suite's coverage.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated `docs/published/handbook/engineering/ai/sandboxed-agents.md`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

Codex assisted with GitHub CLI and local Modal validation. Skills: debugging-ci-failures, fixing-flaky-tests, writing-tests, writing-code-comments, establishing-code-ownership, running-ci-preflight, and writing-pr-descriptions.

Duplicate search found https://github.com/PostHog/posthog/pull/93889 covering shutdown polling; it does not supply the missing startup data. Fixtures use repository test data.
