### PR TITLE
fix(wizard): use a searchable repository dropdown

### DIFF
--- a/docs/internal/wizard-runs.md
+++ b/docs/internal/wizard-runs.md
@@ -72,8 +72,6 @@ A user cannot update another user's local run.
 Cloud creation verifies that the project has a GitHub integration with access to the requested repository.
 The check runs again when execution starts because access can change while a run is queued.
 
-The Wizard Library uses a searchable repository dropdown with pagination and refresh. Archived repositories are excluded; the picker does not filter on GitHub's `can_push` field.
-
 After the database transaction commits, the backend starts a Temporal workflow with only the project ID and run ID.
 The provisioning activity marks the run as `running` before it creates the Wizard Worker.
 The handoff activity marks the run as `completed` after it persists the Run Artifacts.

--- a/docs/internal/wizard-runs.md
+++ b/docs/internal/wizard-runs.md
@@ -72,6 +72,8 @@ A user cannot update another user's local run.
 Cloud creation verifies that the project has a GitHub integration with access to the requested repository.
 The check runs again when execution starts because access can change while a run is queued.
 
+The Wizard Library uses a searchable repository dropdown with pagination and refresh. Archived repositories are excluded; the picker does not filter on GitHub's `can_push` field.
+
 After the database transaction commits, the backend starts a Temporal workflow with only the project ID and run ID.
 The provisioning activity marks the run as `running` before it creates the Wizard Worker.
 The handoff activity marks the run as `completed` after it persists the Run Artifacts.

--- a/frontend/src/lib/integrations/GitHubRepositoryCombobox.test.tsx
+++ b/frontend/src/lib/integrations/GitHubRepositoryCombobox.test.tsx
@@ -63,7 +63,7 @@ describe('GitHubRepositoryCombobox', () => {
         renderFilteredPicker()
         await userEvent.click(screen.getByRole('combobox'))
         expect(await screen.findByText(message)).toBeVisible()
-        expect(!!screen.queryByRole('button', { name: 'Load more' })).toBe(more)
+        expect(!!screen.queryByText('Load more')).toBe(more)
     })
 
     it('can select an available repository after loading past an archived-only page', async () => {
@@ -71,8 +71,8 @@ describe('GitHubRepositoryCombobox', () => {
         const onChange = jest.fn()
         renderFilteredPicker(onChange)
         await userEvent.click(screen.getByRole('combobox'))
-        await userEvent.click(await screen.findByRole('button', { name: 'Load more' }))
-        await userEvent.click(await screen.findByRole('option', { name: 'example-org/active' }))
+        await userEvent.click(await screen.findByText('Load more'))
+        await userEvent.click(await screen.findByText('example-org/active'))
         expect(onChange).toHaveBeenCalledWith('example-org/active')
     })
 

--- a/frontend/src/lib/integrations/GitHubRepositoryCombobox.test.tsx
+++ b/frontend/src/lib/integrations/GitHubRepositoryCombobox.test.tsx
@@ -1,0 +1,96 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Provider } from 'kea'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import { GitHubRepositoryCombobox } from './GitHubRepositoryCombobox'
+
+describe('GitHubRepositoryCombobox', () => {
+    let hasMore: boolean
+    let requests: number
+
+    beforeEach(() => {
+        hasMore = false
+        requests = 0
+        useMocks({
+            get: {
+                '/api/environments/:team_id/integrations/:id/github_repos': () => {
+                    const firstPage = requests++ === 0
+                    return [
+                        200,
+                        {
+                            repositories: [
+                                {
+                                    id: firstPage ? 1 : 2,
+                                    name: firstPage ? 'archived' : 'active',
+                                    full_name: firstPage ? 'example-org/archived' : 'example-org/active',
+                                    archived: firstPage,
+                                },
+                            ],
+                            has_more: firstPage && hasMore,
+                        },
+                    ]
+                },
+            },
+        })
+        initKeaTests()
+    })
+
+    afterEach(cleanup)
+
+    function renderFilteredPicker(onChange = jest.fn()): void {
+        render(
+            <Provider>
+                <GitHubRepositoryCombobox
+                    integrationId={123}
+                    value=""
+                    onChange={onChange}
+                    repositoryFilter={(repo) => !repo.archived}
+                />
+            </Provider>
+        )
+    }
+
+    it.each([
+        { more: false, message: 'No repositories found.' },
+        { more: true, message: 'No available repositories in these results. Load more to keep looking.' },
+    ])('describes empty filtered results with hasMore=$more', async ({ more, message }) => {
+        hasMore = more
+        renderFilteredPicker()
+        await userEvent.click(screen.getByRole('combobox'))
+        expect(await screen.findByText(message)).toBeVisible()
+        expect(!!screen.queryByRole('button', { name: 'Load more' })).toBe(more)
+    })
+
+    it('can select an available repository after loading past an archived-only page', async () => {
+        hasMore = true
+        const onChange = jest.fn()
+        renderFilteredPicker(onChange)
+        await userEvent.click(screen.getByRole('combobox'))
+        await userEvent.click(await screen.findByRole('button', { name: 'Load more' }))
+        await userEvent.click(await screen.findByRole('option', { name: 'example-org/active' }))
+        expect(onChange).toHaveBeenCalledWith('example-org/active')
+    })
+
+    it('disables the trigger and exposes its explanation', async () => {
+        render(
+            <Provider>
+                <GitHubRepositoryCombobox
+                    integrationId={123}
+                    value="example-org/active"
+                    onChange={jest.fn()}
+                    disabledReason="A cloud run is starting."
+                />
+            </Provider>
+        )
+        expect(screen.getByRole('combobox')).toHaveAttribute('aria-disabled', 'true')
+        expect(screen.getByRole('combobox')).toHaveAccessibleDescription('A cloud run is starting.')
+        expect(screen.getByRole('status')).toHaveTextContent('A cloud run is starting.')
+        await userEvent.click(screen.getByRole('combobox'))
+        expect(screen.getByRole('combobox')).toHaveAttribute('aria-expanded', 'false')
+    })
+})

--- a/frontend/src/lib/integrations/GitHubRepositoryCombobox.tsx
+++ b/frontend/src/lib/integrations/GitHubRepositoryCombobox.tsx
@@ -12,6 +12,8 @@ import {
     ComboboxTrigger,
 } from '@posthog/quill'
 
+import type { GitHubRepoApi } from 'products/integrations/frontend/generated/api.schemas'
+
 import { ComboboxLoadMoreFooter, ComboboxSearchField } from './ComboboxSearchChrome'
 import { githubRepositorySearchLogic } from './githubRepositorySearchLogic'
 
@@ -24,6 +26,8 @@ export interface GitHubRepositoryComboboxProps {
     placeholder?: string
     /** When true, prepends a "— No repository —" item so users can explicitly clear the selection. */
     showNoneOption?: boolean
+    repositoryFilter?: (repository: GitHubRepoApi) => boolean
+    fullWidth?: boolean
 }
 
 /**
@@ -41,38 +45,22 @@ export function GitHubRepositoryCombobox({
     disabled = false,
     placeholder = 'Select repository...',
     showNoneOption = false,
+    repositoryFilter,
+    fullWidth = false,
 }: GitHubRepositoryComboboxProps): JSX.Element {
     const logic = githubRepositorySearchLogic({ id: integrationId })
-    const { repositoryNames, loading, hasMore, searchQuery, error } = useValues(logic)
+    const { repositories, loading, hasMore, searchQuery, error } = useValues(logic)
+    const repositoryNames = (repositoryFilter ? repositories.filter(repositoryFilter) : repositories).map(
+        (repo) => repo.full_name
+    )
     const { setSearchQuery, loadMore, refresh } = useActions(logic)
 
     const triggerRef = useRef<HTMLButtonElement>(null)
     const [open, setOpen] = useState(false)
 
     const trimmedSearchQuery = searchQuery.trim()
-    // While the popover is open we surface loading inline in the list; closed-and-loading shows a disabled
-    // button so the trigger never flickers an empty selection.
+    // Keep the selected target visible while searching, loading, or refreshing.
     const showInlineLoadingState = open && loading
-    // Distinguish "this account genuinely has no repos" from "the search/refresh just hasn't returned yet".
-    const hasActiveSearchContext = open || trimmedSearchQuery.length > 0
-
-    if (loading && !showInlineLoadingState && repositoryNames.length === 0) {
-        return (
-            <Button variant="outline" size="sm" disabled>
-                <IconGithub className="shrink-0" />
-                Loading repos...
-            </Button>
-        )
-    }
-
-    if (repositoryNames.length === 0 && !showInlineLoadingState && !hasActiveSearchContext && !error) {
-        return (
-            <Button variant="outline" size="sm" disabled>
-                <IconGithub className="shrink-0" />
-                No GitHub repos
-            </Button>
-        )
-    }
 
     const items = showNoneOption ? [NONE_SENTINEL, ...repositoryNames] : repositoryNames
 
@@ -99,7 +87,14 @@ export function GitHubRepositoryCombobox({
         >
             <ComboboxTrigger
                 render={
-                    <Button ref={triggerRef} variant="outline" size="sm" disabled={disabled} aria-label="Repository">
+                    <Button
+                        ref={triggerRef}
+                        variant="outline"
+                        size="sm"
+                        disabled={disabled}
+                        aria-label="Repository"
+                        className={fullWidth ? 'min-h-10 w-full justify-start' : undefined}
+                    >
                         <IconGithub className="shrink-0" />
                         <span className="min-w-0 truncate">{value || placeholder}</span>
                     </Button>
@@ -123,7 +118,7 @@ export function GitHubRepositoryCombobox({
                             </ComboboxItem>
                         ) : (
                             <ComboboxItem key={repo} value={repo}>
-                                {repo}
+                                <span className="min-w-0 break-all">{repo}</span>
                             </ComboboxItem>
                         )
                     }

--- a/frontend/src/lib/integrations/GitHubRepositoryCombobox.tsx
+++ b/frontend/src/lib/integrations/GitHubRepositoryCombobox.tsx
@@ -1,5 +1,5 @@
 import { useActions, useValues } from 'kea'
-import { useRef, useState } from 'react'
+import { useId, useRef, useState } from 'react'
 
 import { IconGithub } from '@posthog/icons'
 import {
@@ -23,6 +23,7 @@ export interface GitHubRepositoryComboboxProps {
     value: string
     onChange: (value: string | null) => void
     disabled?: boolean
+    disabledReason?: string
     placeholder?: string
     /** When true, prepends a "— No repository —" item so users can explicitly clear the selection. */
     showNoneOption?: boolean
@@ -43,6 +44,7 @@ export function GitHubRepositoryCombobox({
     value,
     onChange,
     disabled = false,
+    disabledReason,
     placeholder = 'Select repository...',
     showNoneOption = false,
     repositoryFilter,
@@ -56,6 +58,8 @@ export function GitHubRepositoryCombobox({
     const { setSearchQuery, loadMore, refresh } = useActions(logic)
 
     const triggerRef = useRef<HTMLButtonElement>(null)
+    const disabledReasonId = useId()
+    const isDisabled = disabled || !!disabledReason
     const [open, setOpen] = useState(false)
 
     const trimmedSearchQuery = searchQuery.trim()
@@ -83,7 +87,7 @@ export function GitHubRepositoryCombobox({
             }}
             inputValue={searchQuery}
             onInputValueChange={(next: string) => setSearchQuery(next)}
-            disabled={disabled}
+            disabled={isDisabled}
         >
             <ComboboxTrigger
                 render={
@@ -91,8 +95,9 @@ export function GitHubRepositoryCombobox({
                         ref={triggerRef}
                         variant="outline"
                         size="sm"
-                        disabled={disabled}
+                        disabled={isDisabled}
                         aria-label="Repository"
+                        aria-describedby={disabledReason ? disabledReasonId : undefined}
                         className={fullWidth ? 'min-h-10 w-full justify-start' : undefined}
                     >
                         <IconGithub className="shrink-0" />
@@ -104,11 +109,16 @@ export function GitHubRepositoryCombobox({
                 <ComboboxSearchField
                     itemsLabel="repositories"
                     loading={loading}
-                    disabled={disabled}
+                    disabled={isDisabled}
                     onRefresh={refresh}
                 />
                 <ComboboxEmpty>
-                    {showInlineLoadingState ? 'Loading repositories...' : (error ?? 'No repositories found.')}
+                    {showInlineLoadingState
+                        ? 'Loading repositories...'
+                        : (error ??
+                          (hasMore
+                              ? 'No available repositories in these results. Load more to keep looking.'
+                              : 'No repositories found.'))}
                 </ComboboxEmpty>
                 <ComboboxList>
                     {(repo: string) =>
@@ -134,6 +144,11 @@ export function GitHubRepositoryCombobox({
                     />
                 )}
             </ComboboxContent>
+            {disabledReason && (
+                <p id={disabledReasonId} className="mb-0 mt-1 text-xs text-muted" role="status">
+                    {disabledReason}
+                </p>
+            )}
         </Combobox>
     )
 }

--- a/products/wizard/frontend/library/WizardRepositoryPicker.test.ts
+++ b/products/wizard/frontend/library/WizardRepositoryPicker.test.ts
@@ -1,0 +1,27 @@
+import { isWizardRepositoryEligible } from './WizardRepositoryPicker'
+
+describe('isWizardRepositoryEligible', () => {
+    it('includes accessible installation repositories when GitHub reports can_push as false', () => {
+        expect(
+            isWizardRepositoryEligible({
+                id: 1,
+                name: 'posthog',
+                full_name: 'PostHog/posthog',
+                archived: false,
+                can_push: false,
+            })
+        ).toBe(true)
+    })
+
+    it('excludes archived repositories', () => {
+        expect(
+            isWizardRepositoryEligible({
+                id: 1,
+                name: 'posthog',
+                full_name: 'PostHog/posthog',
+                archived: true,
+                can_push: true,
+            })
+        ).toBe(false)
+    })
+})

--- a/products/wizard/frontend/library/WizardRepositoryPicker.test.ts
+++ b/products/wizard/frontend/library/WizardRepositoryPicker.test.ts
@@ -1,27 +1,18 @@
 import { isWizardRepositoryEligible } from './WizardRepositoryPicker'
 
 describe('isWizardRepositoryEligible', () => {
-    it('includes accessible installation repositories when GitHub reports can_push as false', () => {
+    it.each([
+        { archived: false, can_push: false, expected: true },
+        { archived: true, can_push: true, expected: false },
+    ])('returns $expected for archived=$archived and can_push=$can_push', ({ archived, can_push, expected }) => {
         expect(
             isWizardRepositoryEligible({
                 id: 1,
                 name: 'posthog',
                 full_name: 'PostHog/posthog',
-                archived: false,
-                can_push: false,
+                archived,
+                can_push,
             })
-        ).toBe(true)
-    })
-
-    it('excludes archived repositories', () => {
-        expect(
-            isWizardRepositoryEligible({
-                id: 1,
-                name: 'posthog',
-                full_name: 'PostHog/posthog',
-                archived: true,
-                can_push: true,
-            })
-        ).toBe(false)
+        ).toBe(expected)
     })
 })

--- a/products/wizard/frontend/library/WizardRepositoryPicker.tsx
+++ b/products/wizard/frontend/library/WizardRepositoryPicker.tsx
@@ -22,7 +22,7 @@ export function WizardRepositoryPicker({
             integrationId={integrationId}
             value={value}
             onChange={(repository) => onChange(repository ?? '')}
-            disabled={!!disabledReason}
+            disabledReason={disabledReason}
             repositoryFilter={isWizardRepositoryEligible}
             placeholder="Select a repository"
             fullWidth

--- a/products/wizard/frontend/library/WizardRepositoryPicker.tsx
+++ b/products/wizard/frontend/library/WizardRepositoryPicker.tsx
@@ -1,9 +1,10 @@
-import { useActions, useValues } from 'kea'
+import { GitHubRepositoryCombobox } from 'lib/integrations/GitHubRepositoryCombobox'
 
-import { IconCheck, IconRefresh, IconSearch } from '@posthog/icons'
-import { LemonBanner, LemonButton, LemonInput, LemonSkeleton, Spinner } from '@posthog/lemon-ui'
+import type { GitHubRepoApi } from 'products/integrations/frontend/generated/api.schemas'
 
-import { githubRepositorySearchLogic } from 'lib/integrations/githubRepositorySearchLogic'
+export function isWizardRepositoryEligible(repository: GitHubRepoApi): boolean {
+    return !repository.archived
+}
 
 export function WizardRepositoryPicker({
     integrationId,
@@ -16,66 +17,15 @@ export function WizardRepositoryPicker({
     onChange: (repository: string) => void
     disabledReason?: string
 }): JSX.Element {
-    const logic = githubRepositorySearchLogic({ id: integrationId })
-    const { repositories, loading, hasMore, searchQuery, error } = useValues(logic)
-    const { setSearchQuery, loadMore, refresh } = useActions(logic)
-
-    // Archived and read-only repositories cannot receive the run's pull request.
-    const eligible = repositories.filter((repository) => !repository.archived && repository.can_push !== false)
-
     return (
-        <div className="flex flex-col gap-1">
-            <LemonInput
-                value={searchQuery}
-                onChange={setSearchQuery}
-                prefix={<IconSearch />}
-                placeholder="Search repositories"
-                fullWidth
-                data-attr="wizard-cloud-repository-search"
-            />
-            {error ? (
-                <LemonBanner type="error" action={{ children: 'Try again', onClick: refresh }}>
-                    {error}
-                </LemonBanner>
-            ) : loading && repositories.length === 0 ? (
-                <LemonSkeleton repeat={3} className="h-10 w-full" />
-            ) : (
-                <div className="max-h-44 overflow-y-auto rounded border border-primary">
-                    {eligible.length === 0 ? (
-                        <p className="m-0 px-3 py-2 text-sm text-muted">
-                            {searchQuery ? 'No matching repositories.' : 'No repositories available.'}
-                        </p>
-                    ) : (
-                        eligible.map((repository) => (
-                            <LemonButton
-                                key={repository.id}
-                                onClick={() => onChange(repository.full_name)}
-                                active={repository.full_name === value}
-                                disabledReason={disabledReason}
-                                fullWidth
-                                icon={repository.full_name === value ? <IconCheck /> : undefined}
-                                className="justify-start"
-                                data-attr="wizard-cloud-repository-option"
-                            >
-                                {repository.full_name}
-                            </LemonButton>
-                        ))
-                    )}
-                </div>
-            )}
-            <div className="flex items-center gap-2">
-                {hasMore && !error && (
-                    <LemonButton size="small" onClick={loadMore} loading={loading} disabledReason={disabledReason}>
-                        Load more
-                    </LemonButton>
-                )}
-                {hasMore && !error && !loading && (
-                    <LemonButton size="small" icon={<IconRefresh />} onClick={refresh} disabledReason={disabledReason}>
-                        Refresh
-                    </LemonButton>
-                )}
-                {loading && repositories.length > 0 && <Spinner className="size-4" />}
-            </div>
-        </div>
+        <GitHubRepositoryCombobox
+            integrationId={integrationId}
+            value={value}
+            onChange={(repository) => onChange(repository ?? '')}
+            disabled={!!disabledReason}
+            repositoryFilter={isWizardRepositoryEligible}
+            placeholder="Select a repository"
+            fullWidth
+        />
     )
 }


### PR DESCRIPTION
## Problem

Wizard Library users have to browse a large inline repository list, and empty results can hide the refresh control.

This picker follow-up sits on top of merged #97063.

## Changes

- Choose a repository from a compact searchable dropdown with pagination.
- Keep the selected repository visible while results load, and keep refresh available for empty results.
- Exclude archived repositories while retaining accessible repositories with `can_push: false`.
- Explain why the picker is disabled and distinguish an empty page from exhausted results.

The picker reuses the shared GitHub combobox.

| Before | After |
| --- | --- |
| ![Before](https://raw.githubusercontent.com/PostHog/pr-assets/73f5d1637734826b220c6c495a8b9ea1650d89cb/2026/09/87e8410f-2984-4e8c-b2c8-4644b49d8f1a.png) | ![After](https://raw.githubusercontent.com/PostHog/pr-assets/dacb685e3feca64831264060cd46e3f328602c67/2026/09/05878f2a-d9c2-4585-97f4-a274920ae183.png) |

## How did you test this code?

- Ran regression tests for archived repositories, `can_push: false`, pagination past an archived-only page, and accessible disabled explanations.
- Ran TypeScript, scoped lint, and preflight checks.
- Verified repository selection inside LemonModal in local Storybook with Playwright. Screenshots use invented repositories.
- Live GitHub authorization and cloud execution were not tested.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used Git, GitHub CLI, Flox, and Playwright. The final scope is the repository picker; broader launch-flow work is excluded.

Skills: stacking-prs, writing-pr-descriptions, running-ci-preflight, writing-ui-components, writing-tests, writing-user-facing-copy, and frontend-design.

The duplicate PR search found no matching open picker PR. The diff contains public repository code and invented screenshot data.

