### PR TITLE
chore(ci): probe cache variables on fork runners

### DIFF
--- a/.github/workflows/depot-fork-env-probe.yml
+++ b/.github/workflows/depot-fork-env-probe.yml
@@ -1,0 +1,43 @@
+name: Depot fork environment probe
+
+on:
+    pull_request:
+        paths:
+            - '.github/workflows/depot-fork-env-probe.yml'
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions: {}
+
+jobs:
+    probe:
+        if: github.repository == 'PostHog/posthog'
+        name: Cache variable presence (${{ matrix.runner }})
+        runs-on: ${{ matrix.runner }}
+        timeout-minutes: 3
+        strategy:
+            fail-fast: false
+            matrix:
+                runner: [ubuntu-latest, depot-ubuntu-24.04]
+        steps:
+            - name: Report variable presence without values
+              shell: bash
+              env:
+                  PROBE_RUNNER: ${{ matrix.runner }}
+                  PROBE_IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+              run: |
+                  set +x
+                  {
+                      printf 'Runner: %s\n\nFork PR: %s\n\n' "$PROBE_RUNNER" "$PROBE_IS_FORK"
+                      printf '| Variable | Nonempty |\n| --- | --- |\n'
+                      for name in DEPOT_CACHE_TOKEN SCCACHE_WEBDAV_ENDPOINT SCCACHE_WEBDAV_TOKEN \
+                          SCCACHE_WEBDAV_USERNAME SCCACHE_WEBDAV_PASSWORD TURBO_API TURBO_TOKEN; do
+                          present=false
+                          if [[ -n "${!name}" ]]; then
+                              present=true
+                          fi
+                          printf '| %s | %s |\n' "$name" "$present"
+                      done
+                  } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/docs/internal/depot-fork-env-probe.md
+++ b/docs/internal/depot-fork-env-probe.md
@@ -1,0 +1,20 @@
+# Depot fork environment probe
+
+This temporary workflow checks whether a fork pull request receives cache-related environment variables on a Depot-hosted GitHub Actions runner.
+It runs the same presence check on a GitHub-hosted runner as a control.
+It does not use Depot CI.
+
+Open a draft pull request against `PostHog/posthog` that changes `.github/workflows/depot-fork-env-probe.yml`.
+GitHub may require approval before it runs a fork workflow.
+Read the **Depot fork environment probe** job summaries for both runners.
+The summary reports the selected runner, whether the pull request comes from a fork, and whether each allowlisted variable is nonempty.
+An empty variable and an unset variable both report `false`.
+
+The workflow does not check out repository code, request GitHub token permissions, reference repository secrets, or call cache APIs.
+It never prints variable values, lengths, hashes, or token claims.
+The results establish variable presence for those jobs only.
+They do not establish token validity, cache permissions, log masking, or behavior under different Depot settings.
+
+A same-repository pull request with the same workflow can provide a separate comparison of fork and same-repository behavior.
+The GitHub-hosted control is not a substitute for that comparison.
+Close the probe pull request after collecting the results; this workflow does not need to merge.


### PR DESCRIPTION
## Problem

Reviewers of #97587 need direct evidence of which cache variables a fork job receives on Depot-hosted GitHub Actions runners.
[Depot documents automatic credentials](https://depot.dev/docs/cache/authentication), but variable presence in a fork job remains unchecked.

## Changes

- Reviewers get boolean presence reports from a Depot runner and a GitHub-hosted control, both triggered by this fork PR.
- The probe uses an allowlist and never prints values, lengths, hashes, or token claims.
- The jobs do not check out code, reference GitHub secrets, request token permissions, or call cache APIs.
- The results do not establish cache authorization or same-repository behavior. The GitHub-hosted control is not a same-repository comparison.
- Documentation explains how to read the reports. No product UI changes.

Before:
```mermaid
flowchart LR
    D[Vendor documentation] --> I[Inferred fork behavior]
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class D,I phGray;
```

After:
```mermaid
flowchart LR
    F[Fork PR] --> D[Depot runner]
    F --> G[GitHub-hosted runner]
    D --> R[Boolean presence reports]
    G --> R
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class F phYellow;
    class D,G phBlue;
    class R phGray;
```

> [!NOTE]
> Temporary experiment: close without merging after collecting the reports. GitHub may require approval before running the fork workflow.

## How did you test this code?

Local validation exercised the workflow shell with unset, empty, and invented nonempty values, checking stdout and the summary for correct booleans and no values.
Actionlint, workflow lint, formatting, and preflight also ran locally.
[The fork probe completed successfully](https://github.com/PostHog/posthog/actions/runs/34394035939).
Both jobs report `Fork PR: true` and `false` for all seven allowlisted variables, meaning each variable is unset or empty.
The Depot fork job therefore does not receive the claimed nonempty environment variables in this run.
Same-repository behavior, cache authorization, and the effect of Depot settings remain unchecked.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`docs/internal/depot-fork-env-probe.md` documents the experiment and its limits.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Agent: OpenAI assistant in pi, using git, GitHub CLI, and hogli. The diff contains only a generic diagnostic and documentation.
Related PR #97587 changes runner policy; this experiment measures variable presence without changing that policy.
Skills: `/authoring-ci-workflows`, `/depot-github-runners`, `/writing-code-comments`, `/writing-tests`, `/writing-user-facing-copy`, `/running-ci-preflight`, `/writing-pr-descriptions`, and `/wt`.
