### PR TITLE
fix(flags): stamp cache verification completions where a rollout cannot reset them

### DIFF
--- a/docs/internal/feature-flags/hypercache-system.md
+++ b/docs/internal/feature-flags/hypercache-system.md
@@ -527,6 +527,14 @@ It winds down at a batch boundary two minutes before the soft limit,
 recording the partial run under `reason="deadline"` in `posthog_hypercache_verification_incomplete_runs_total`;
 the next run restarts from the first team.
 
+Each task that returns without raising stamps the time in
+`posthog_hypercache_verification_last_success_timestamp_seconds{cache_type="..."}`
+and in the shared cache under `posthog:hypercache_verification:last_success:<cache_type>`.
+Every worker republishes the stamps at boot, so the value survives a rollout that replaces
+every pod. Sweep liveness alerts read the age of this stamp, because the per-pod
+`posthog_celery_task_success_total` counters restart at zero on each rollout and a healthy
+sweep then reads the same as a stopped one.
+
 Configuration:
 
 ```bash

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -106,6 +106,7 @@ def _initialize_worker_metrics() -> None:
     adding one here cannot be silently skipped by another's early return.
     """
     _initialize_liveness_alerted_task_series()
+    _initialize_hypercache_verification_last_success()
     _initialize_cohort_backlog_metric()
 
 
@@ -121,6 +122,18 @@ def _initialize_liveness_alerted_task_series() -> None:
                 counter.labels(task_name=task_name)
     except Exception:
         logger.warning("failed_to_initialize_task_metric_series", exc_info=True)
+
+
+def _initialize_hypercache_verification_last_success() -> None:
+    # The cache verification sweeps stamp their last completed run in the shared cache, and
+    # every worker republishes those stamps here. Their liveness alerts then read a value a
+    # rollout cannot reset, unlike the per-pod celery success counters seeded above.
+    try:
+        from posthog.tasks.hypercache_verification import publish_last_verification_success
+
+        publish_last_verification_success()
+    except Exception:
+        logger.warning("failed_to_initialize_hypercache_verification_metrics", exc_info=True)
 
 
 def _initialize_cohort_backlog_metric() -> None:

--- a/posthog/tasks/hypercache_verification.py
+++ b/posthog/tasks/hypercache_verification.py
@@ -18,7 +18,7 @@ from django.core.cache import cache as django_cache
 import structlog
 from celery import shared_task
 from celery.exceptions import SoftTimeLimitExceeded
-from prometheus_client import Counter
+from prometheus_client import Counter, Gauge
 
 from posthog.celery_task_names import (
     VERIFY_FLAG_DEFINITIONS_CACHE_TASK_NAME,
@@ -75,12 +75,32 @@ HYPERCACHE_VERIFICATION_INCOMPLETE_RUNS_COUNTER = Counter(
     labelnames=["cache_type", "reason"],
 )
 
+_ALL_CACHE_TYPES = (*get_args(CacheType), FLAG_DEFINITIONS_CACHE_TYPE)
+
 # Pre-create every label pair so zero-valued series exist from worker boot: increase()
 # never misses a series' first increment, and alert expressions can be validated
 # against live series before any incident occurs.
-for _cache_type in (*get_args(CacheType), FLAG_DEFINITIONS_CACHE_TYPE):
+for _cache_type in _ALL_CACHE_TYPES:
     for _reason in get_args(IncompleteRunReason):
         HYPERCACHE_VERIFICATION_INCOMPLETE_RUNS_COUNTER.labels(cache_type=_cache_type, reason=_reason)
+
+# Unix time of the last run that returned without raising, which is the same event
+# posthog_celery_task_success_total counts. Liveness alerts read this gauge instead of that
+# counter because the counter lives in the worker process: a rollout replaces every pod, the
+# fleet's series restart at zero, and a healthy sweep then reads the same as a stopped one
+# until its next run completes. The stamp is kept in the shared cache and republished at
+# worker boot, so a rollout leaves it untouched.
+HYPERCACHE_VERIFICATION_LAST_SUCCESS_GAUGE = Gauge(
+    "posthog_hypercache_verification_last_success_timestamp_seconds",
+    "Unix time of the last verification run that returned without raising",
+    labelnames=["cache_type"],
+    multiprocess_mode="max",
+)
+
+_LAST_SUCCESS_KEY_PREFIX = "posthog:hypercache_verification:last_success:"
+# Bounds an abandoned key only. A running sweep re-stamps its key every cycle, and a gap
+# long enough to expire the key is many times longer than any alert window.
+_LAST_SUCCESS_TTL_SECONDS = 30 * 24 * 60 * 60
 
 _FIX_ISSUE_TYPES = ("cache_miss", "cache_mismatch", "expiry_missing")
 # Only the flags cache has a second writer (the Rust Kafka builder); the other
@@ -88,7 +108,7 @@ _FIX_ISSUE_TYPES = ("cache_miss", "cache_mismatch", "expiry_missing")
 # publish zero-valued series that can never increment.
 _FIX_WRITERS_BY_CACHE_TYPE = {
     cache_type: ("python", "rust", "unknown") if cache_type == "flags" else ("python",)
-    for cache_type in (*get_args(CacheType), FLAG_DEFINITIONS_CACHE_TYPE)
+    for cache_type in _ALL_CACHE_TYPES
 }
 # Same pre-creation rationale as above. It matters most for writer="rust": a
 # rust-attributed fix is the rare parity signal the Kafka-builder ramp gates on,
@@ -101,6 +121,37 @@ for _cache_type, _writers in _FIX_WRITERS_BY_CACHE_TYPE.items():
 
 def _record_incomplete_run(cache_type: str, reason: IncompleteRunReason) -> None:
     HYPERCACHE_VERIFICATION_INCOMPLETE_RUNS_COUNTER.labels(cache_type=cache_type, reason=reason).inc()
+
+
+def _last_success_key(cache_type: str) -> str:
+    return f"{_LAST_SUCCESS_KEY_PREFIX}{cache_type}"
+
+
+def _record_successful_run(cache_type: str) -> None:
+    """Stamp the run that just returned, in the gauge and in the shared cache.
+
+    Never raises. A cache that cannot hold the stamp must not turn a completed sweep into a
+    failed task; the gauge on this pod still carries the run until the pod is replaced.
+    """
+    completed_at = time.time()
+    HYPERCACHE_VERIFICATION_LAST_SUCCESS_GAUGE.labels(cache_type=cache_type).set(completed_at)
+    try:
+        django_cache.set(_last_success_key(cache_type), completed_at, timeout=_LAST_SUCCESS_TTL_SECONDS)
+    except Exception:
+        logger.warning("Failed to store last cache verification success", cache_type=cache_type, exc_info=True)
+
+
+def publish_last_verification_success() -> None:
+    """Republish the stamps on a worker that has just booted.
+
+    Every worker publishes them, so the alert takes the newest stamp across the fleet and a
+    rollout that replaces every pod never reads as a stalled sweep. A cache type that has no
+    stamp yet publishes no series, which keeps the alert dormant until the first run lands.
+    """
+    for cache_type in _ALL_CACHE_TYPES:
+        completed_at = django_cache.get(_last_success_key(cache_type))
+        if completed_at is not None:
+            HYPERCACHE_VERIFICATION_LAST_SUCCESS_GAUGE.labels(cache_type=cache_type).set(completed_at)
 
 
 def _log_batch_fetch_exhausted(cache_type: str, start_time: float, error: TeamBatchFetchError) -> None:
@@ -273,11 +324,13 @@ def verify_and_fix_flags_cache_task(self: PushGatewayTask) -> None:
     30-minute schedule so a run always finishes before the next one is due.
 
     Metrics: posthog_hypercache_verify_fixes_total{cache_type="flags", issue_type="...", writer="..."},
-    posthog_hypercache_verification_incomplete_runs_total{cache_type="flags", reason="..."}
+    posthog_hypercache_verification_incomplete_runs_total{cache_type="flags", reason="..."},
+    posthog_hypercache_verification_last_success_timestamp_seconds{cache_type="flags"}
     """
     _run_cache_verification(
         "flags", settings.FLAGS_CACHE_VERIFICATION_CHUNK_SIZE, self.soft_time_limit, self.time_limit
     )
+    _record_successful_run("flags")
 
 
 @shared_task(
@@ -300,11 +353,13 @@ def verify_and_fix_team_metadata_cache_task(self: PushGatewayTask) -> None:
     Expected duration: ~15-20 minutes (observed 2026-08-19).
 
     Metrics: posthog_hypercache_verify_fixes_total{cache_type="team_metadata", issue_type="..."},
-    posthog_hypercache_verification_incomplete_runs_total{cache_type="team_metadata", reason="..."}
+    posthog_hypercache_verification_incomplete_runs_total{cache_type="team_metadata", reason="..."},
+    posthog_hypercache_verification_last_success_timestamp_seconds{cache_type="team_metadata"}
     """
     _run_cache_verification(
         "team_metadata", settings.TEAM_METADATA_CACHE_VERIFICATION_CHUNK_SIZE, self.soft_time_limit, self.time_limit
     )
+    _record_successful_run("team_metadata")
 
 
 @shared_task(
@@ -330,6 +385,8 @@ def verify_and_fix_flag_definitions_cache_task(self: PushGatewayTask) -> None:
     at the deadline if it runs long, and the every-minute self-heal drain covers gaps.
 
     Metrics: posthog_hypercache_verify_fixes_total{cache_type="flag_definitions", issue_type="..."},
-    posthog_hypercache_verification_incomplete_runs_total{cache_type="flag_definitions", reason="..."}
+    posthog_hypercache_verification_incomplete_runs_total{cache_type="flag_definitions", reason="..."},
+    posthog_hypercache_verification_last_success_timestamp_seconds{cache_type="flag_definitions"}
     """
     _run_flag_definitions_verification(self.soft_time_limit, self.time_limit)
+    _record_successful_run(FLAG_DEFINITIONS_CACHE_TYPE)

--- a/posthog/tasks/test/test_hypercache_verification.py
+++ b/posthog/tasks/test/test_hypercache_verification.py
@@ -7,8 +7,12 @@ Tests cover:
 - Tasks skip when FLAGS_REDIS_URL not configured
 """
 
+import time
+from collections.abc import Callable
+
 from unittest.mock import MagicMock, patch
 
+from django.core.cache import cache as django_cache
 from django.test import SimpleTestCase, TestCase, override_settings
 
 from celery.exceptions import SoftTimeLimitExceeded
@@ -18,12 +22,26 @@ from prometheus_client import REGISTRY
 from posthog.storage.hypercache_verifier import TeamBatchFetchError, VerificationResult
 from posthog.tasks.hypercache_verification import (
     DEADLINE_HEADROOM_SECONDS,
+    HYPERCACHE_VERIFICATION_LAST_SUCCESS_GAUGE,
+    publish_last_verification_success,
     verify_and_fix_flag_definitions_cache_task,
     verify_and_fix_flags_cache_task,
     verify_and_fix_team_metadata_cache_task,
 )
 from posthog.tasks.test.utils import PushGatewayTaskTestMixin
 from posthog.tasks.utils import CeleryQueue
+
+
+def _last_success_key(cache_type: str) -> str:
+    return f"posthog:hypercache_verification:last_success:{cache_type}"
+
+
+def _last_success_gauge(cache_type: str) -> float | None:
+    """Current value of the last-success gauge in the default registry."""
+    return REGISTRY.get_sample_value(
+        "posthog_hypercache_verification_last_success_timestamp_seconds",
+        {"cache_type": cache_type},
+    )
 
 
 def _incomplete_runs(cache_type: str, reason: str) -> float:
@@ -370,3 +388,61 @@ class TestVerifyAndFixFlagDefinitionsCacheTask(PushGatewayTaskTestMixin, TestCas
             mock_run_verification.assert_not_called()
         finally:
             django_cache.delete(lock_key)
+
+
+@override_settings(FLAGS_REDIS_URL="redis://test")
+class TestLastVerificationSuccessStamp(PushGatewayTaskTestMixin, SimpleTestCase):
+    """The stamp these tasks leave is what the sweep liveness alerts read. A stamp that stops
+    being written reads as a stalled sweep, and one written on a failed run hides a real stall,
+    so both directions are covered here."""
+
+    TASKS = [
+        ("flags", verify_and_fix_flags_cache_task),
+        ("team_metadata", verify_and_fix_team_metadata_cache_task),
+        ("flag_definitions", verify_and_fix_flag_definitions_cache_task),
+    ]
+
+    def tearDown(self) -> None:
+        for cache_type, _ in self.TASKS:
+            django_cache.delete(_last_success_key(cache_type))
+        super().tearDown()
+
+    @parameterized.expand(TASKS)
+    @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
+    def test_completed_run_stamps_the_gauge_and_the_shared_cache(
+        self, cache_type: str, task: Callable[[], None], mock_run_verification: MagicMock
+    ) -> None:
+        mock_run_verification.return_value = VerificationResult()
+        started_at = time.time()
+
+        task()
+
+        stamp = django_cache.get(_last_success_key(cache_type))
+        assert stamp is not None and stamp >= started_at
+        assert _last_success_gauge(cache_type) == stamp
+
+    @parameterized.expand(TASKS)
+    @patch("posthog.tasks.hypercache_verification.capture_exception")
+    @patch("posthog.tasks.hypercache_verification._run_verification_for_cache")
+    def test_failed_run_leaves_the_previous_stamp_alone(
+        self, cache_type: str, task: Callable[[], None], mock_run_verification: MagicMock, mock_capture: MagicMock
+    ) -> None:
+        mock_run_verification.side_effect = Exception("verification failed")
+        earlier_run = 1_700_000_000.0
+        django_cache.set(_last_success_key(cache_type), earlier_run, timeout=60)
+        HYPERCACHE_VERIFICATION_LAST_SUCCESS_GAUGE.labels(cache_type=cache_type).set(earlier_run)
+
+        with self.assertRaises(Exception):
+            task()
+
+        assert django_cache.get(_last_success_key(cache_type)) == earlier_run
+        assert _last_success_gauge(cache_type) == earlier_run
+
+    def test_worker_boot_republishes_the_stored_stamp(self) -> None:
+        earlier_run = 1_700_000_000.0
+        django_cache.set(_last_success_key("flag_definitions"), earlier_run, timeout=60)
+        HYPERCACHE_VERIFICATION_LAST_SUCCESS_GAUGE.labels(cache_type="flag_definitions").set(0)
+
+        publish_last_verification_success()
+
+        assert _last_success_gauge("flag_definitions") == earlier_run


### PR DESCRIPTION
## Problem

The feature-flags rotation gets alerted for a healthy flag definitions sweep after a routine worker deploy.

- `FlagsCacheVerificationNotRunning` reads `posthog_celery_task_success_total`, which lives in the worker process. A rollout of `posthog-worker-django` replaces every pod, so the fleet's series restart at zero.
- The expression then reads zero until the first run completes on the new pods.
- For the flag definitions sweep that takes up to 95 minutes: an hourly schedule, plus a run that uses most of its 35 minute soft budget (#87131). That is longer than the alert tolerates, so the deploy alone fires it.
- The alert also becomes less useful the other way. Its window has to absorb the deploy gap, so a real stall is caught later than it could be.

## Changes

- Each verification task stamps the time it returns in `posthog_hypercache_verification_last_success_timestamp_seconds{cache_type="..."}` and in the shared cache.
- Every worker republishes the stamps at boot, in `_initialize_worker_metrics`. A rollout leaves the value alone, so an alert on the age of the stamp reads the sweep and not the deploy.
- The stamp marks the same event the success counter counts: a run that returned without raising, including the lock-skip and wind-down paths. "Is the sweep finishing" stays with `FlagsCacheVerificationRunsIncomplete`.
- A cache that cannot hold the stamp logs a warning and does not fail the task. A completed sweep must not be reported as a failed one.
- No series is pre-created. A cache type with no stamp yet publishes nothing, which keeps a new alert dormant instead of firing on no data.
- The alert change rides in PostHog/charts#15406, which pins its new expression to `cache_type="flag_definitions"` first.
- Nothing in the app looks different. This is observability only.
- Mechanical: the metric list in each task docstring, one paragraph in `docs/internal/feature-flags/hypercache-system.md`, and an `_ALL_CACHE_TYPES` constant that replaces the same tuple written three times.

## How did you test this code?

`posthog/tasks/test/test_hypercache_verification.py` and `posthog/test/test_celery.py` pass locally.

Three new cases in `TestLastVerificationSuccessStamp`, each aimed at a way this metric fails silently:

- A completed run stamps both the gauge and the cache. Without this, a refactor that drops the call leaves the alert permanently dormant, and a dormant alert looks identical to a healthy one.
- A failed run leaves the previous stamp alone. This catches the opposite mistake, a stamp moved into a `finally`, where a sweep that raises every hour would keep reporting itself alive.
- A worker boot republishes the stored stamp. This is the whole point of the change, so it guards against the rollout artifact coming back.

`mypy` passes over the three changed files. The repo-wide run that CI performs did not finish inside the sandbox time limit, so CI is the first full type check.

Not checked: the metric in a live environment, because the sweep needs a deployed worker to stamp anything.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`docs/internal/feature-flags/hypercache-system.md` gains the stamp under "Verification tasks".

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code) from a Slack thread asking whether a firing sweep liveness alert was real or an artifact. The investigation read this repo and the alert spec in `PostHog/charts`, and landed on the deploy artifact above.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

The first design considered was pushing the stamp through the existing pushgateway registry, which `PushGatewayTask` already uses. That was rejected: `push_to_gateway` replaces the whole group per run, so a failed run would delete the last stamp, and the value would still be lost on a pushgateway restart. Holding the stamp in the shared cache and republishing it from every worker keeps it on the normal scrape path, where the `environment` label the alerts match on already exists.

No duplicate: `gh pr list --state open --search` for hypercache verification liveness and for the new metric name found nothing.

Public artifact: nothing here carries material from the session. The numbers quoted above come from this repo's own schedule and task limits.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C07QP8BCRPS/p1788975024913709?thread_ts=1788975024.913709&cid=C07QP8BCRPS)*

