### PR TITLE
chore(product_analytics): split trends actors date window into helpers

### DIFF
--- a/products/product_analytics/backend/hogql_queries/trends/trends_actors_query_builder.py
+++ b/products/product_analytics/backend/hogql_queries/trends/trends_actors_query_builder.py
@@ -54,6 +54,23 @@ class DateWhereExprs:
         return [self.date_from_expr, self.date_to_expr]
 
 
+@frozen
+class ActorsDateWindow:
+    """Date window for actors queries, with comparison operator for the end boundary."""
+
+    from_datetime: datetime
+    to_datetime: datetime
+    to_op: ast.CompareOperationOp
+
+
+@frozen
+class ActorsExprs:
+    """Expression pair for active users calculations."""
+
+    from_expr: ast.Expr
+    to_expr: ast.Expr
+
+
 class TrendsActorsQueryBuilder:
     trends_query: TrendsQuery
     team: Team
@@ -423,18 +440,18 @@ class TrendsActorsQueryBuilder:
         query_from, query_to = date_range.date_from(), date_range.date_to()
 
         if self.is_total_value:
-            actors_from, actors_to, actors_to_op = self._total_value_actors_window(query_from, query_to)
+            window = self._total_value_actors_window(query_from, query_to)
         else:
-            actors_from, actors_to, actors_to_op = self._time_series_actors_window(date_range, query_from, query_to)
+            window = self._time_series_actors_window(date_range, query_from, query_to)
 
-        actors_from_expr: ast.Expr
-        actors_to_expr: ast.Expr
         # adjust date_from for weekly and monthly active calculations
         if self.is_active_users_math:
-            actors_from_expr, actors_to_expr = self._active_users_exprs(actors_from, actors_to, query_from, query_to)
+            exprs = self._active_users_exprs(window.from_datetime, window.to_datetime, query_from, query_to)
+            actors_from_expr = exprs.from_expr
+            actors_to_expr = exprs.to_expr
         else:
-            actors_from_expr = ast.Constant(value=actors_from)
-            actors_to_expr = ast.Constant(value=actors_to)
+            actors_from_expr = ast.Constant(value=window.from_datetime)
+            actors_to_expr = ast.Constant(value=window.to_datetime)
 
         return DateWhereExprs(
             date_from_expr=ast.CompareOperation(
@@ -444,25 +461,27 @@ class TrendsActorsQueryBuilder:
             ),
             date_to_expr=ast.CompareOperation(
                 left=ast.Field(chain=["timestamp"]),
-                op=actors_to_op,
+                op=window.to_op,
                 right=actors_to_expr,
             ),
         )
 
-    def _total_value_actors_window(
-        self, query_from: datetime, query_to: datetime
-    ) -> tuple[datetime, datetime, ast.CompareOperationOp]:
+    def _total_value_actors_window(self, query_from: datetime, query_to: datetime) -> ActorsDateWindow:
         if self.time_frame is not None:
             raise QueryError("A `day` is forbidden for trends actors queries with total value aggregation")
 
-        return query_from, query_to, ast.CompareOperationOp.LtEq
+        return ActorsDateWindow(
+            from_datetime=query_from,
+            to_datetime=query_to,
+            to_op=ast.CompareOperationOp.LtEq,
+        )
 
     def _time_series_actors_window(
         self,
         date_range: QueryDateRange | QueryCompareToDateRange | QueryPreviousPeriodDateRange,
         query_from: datetime,
         query_to: datetime,
-    ) -> tuple[datetime, datetime, ast.CompareOperationOp]:
+    ) -> ActorsDateWindow:
         if self.time_frame is None:
             raise QueryError("A `day` is required for trends actors queries without total value aggregation")
 
@@ -483,7 +502,11 @@ class TrendsActorsQueryBuilder:
                 actors_to_op = ast.CompareOperationOp.LtEq
                 actors_to = query_to
 
-        return actors_from, actors_to, actors_to_op
+        return ActorsDateWindow(
+            from_datetime=actors_from,
+            to_datetime=actors_to,
+            to_op=actors_to_op,
+        )
 
     def _previous_period_time_frame(
         self,
@@ -505,7 +528,7 @@ class TrendsActorsQueryBuilder:
 
     def _active_users_exprs(
         self, actors_from: datetime, actors_to: datetime, query_from: datetime, query_to: datetime
-    ) -> tuple[ast.Expr, ast.Expr]:
+    ) -> ActorsExprs:
         actors_from_expr: ast.Expr
         actors_to_expr: ast.Expr
 
@@ -535,7 +558,7 @@ class TrendsActorsQueryBuilder:
             actors_from_expr = ast.Call(name="greatest", args=[actors_from_expr, ast.Constant(value=query_from)])
             actors_to_expr = ast.Call(name="least", args=[ast.Constant(value=actors_to), ast.Constant(value=query_to)])
 
-        return actors_from_expr, actors_to_expr
+        return ActorsExprs(from_expr=actors_from_expr, to_expr=actors_to_expr)
 
     def _breakdown_where_expr(self) -> list[ast.Expr]:
         conditions: list[ast.Expr] = []

--- a/products/product_analytics/backend/hogql_queries/trends/trends_actors_query_builder.py
+++ b/products/product_analytics/backend/hogql_queries/trends/trends_actors_query_builder.py
@@ -417,87 +417,21 @@ class TrendsActorsQueryBuilder:
         return conditions
 
     def _date_where_expr(self) -> DateWhereExprs:
-        # types
-        date_range: QueryDateRange | QueryCompareToDateRange | QueryPreviousPeriodDateRange
-        if self.is_compare_previous:
-            date_range = self.trends_previous_date_range
-        else:
-            date_range = self.trends_date_range
-
+        date_range: QueryDateRange | QueryCompareToDateRange | QueryPreviousPeriodDateRange = (
+            self.trends_previous_date_range if self.is_compare_previous else self.trends_date_range
+        )
         query_from, query_to = date_range.date_from(), date_range.date_to()
-        actors_from: datetime
-        actors_from_expr: ast.Expr
-        actors_to: datetime
-        actors_to_expr: ast.Expr
-        actors_to_op: ast.CompareOperationOp = ast.CompareOperationOp.Lt
 
         if self.is_total_value:
-            if self.time_frame is not None:
-                raise QueryError("A `day` is forbidden for trends actors queries with total value aggregation")
-
-            actors_from = query_from
-            actors_to = query_to
-            actors_to_op = ast.CompareOperationOp.LtEq
+            actors_from, actors_to, actors_to_op = self._total_value_actors_window(query_from, query_to)
         else:
-            if self.time_frame is None:
-                raise QueryError("A `day` is required for trends actors queries without total value aggregation")
+            actors_from, actors_to, actors_to_op = self._time_series_actors_window(date_range, query_from, query_to)
 
-            # use previous day/week/... for time_frame
-            if self.is_compare_previous:
-                delta_mappings = None if self.is_compare_to else date_range.date_from_delta_mappings()  # type: ignore
-                if delta_mappings is None:
-                    # Either an explicit compare_to offset, or an "all time" range, which starts at the
-                    # earliest event and so has no relative delta to step back by. Both shift the frame
-                    # by the gap between the two periods' starts instead.
-                    self.time_frame = query_from + (self.time_frame - self.trends_date_range.date_from())
-                else:
-                    previous_time_frame = self.time_frame - relativedelta(**delta_mappings)
-                    if self.is_hourly:
-                        self.time_frame = previous_time_frame
-                    else:
-                        self.time_frame = previous_time_frame.replace(hour=0, minute=0, second=0, microsecond=0)
-
-            actors_from = self.time_frame
-            actors_to = actors_from + date_range.interval_relativedelta()
-
-            # exclude events before the query start and after the query end
-            if self.is_explicit and not self.is_active_users_math:
-                if query_from > actors_from:
-                    actors_from = query_from
-
-                if query_to < actors_to:
-                    actors_to_op = ast.CompareOperationOp.LtEq
-                    actors_to = query_to
-
+        actors_from_expr: ast.Expr
+        actors_to_expr: ast.Expr
         # adjust date_from for weekly and monthly active calculations
         if self.is_active_users_math:
-            if self.is_total_value:
-                # TRICKY: On total value (non-time-series) insights, WAU/MAU math is simply meaningless.
-                # There's no intuitive way to define the semantics of such a combination, so what we do is just turn it
-                # into a count of unique users between `date_to - INTERVAL (7|30) DAY` and `date_to`.
-                # This way we at least ensure the date range is the probably expected 7 or 30 days.
-                actors_from = actors_to
-
-            if self.is_weekly_active_math:
-                actors_from_expr = ast.ArithmeticOperation(
-                    op=ast.ArithmeticOperationOp.Sub,
-                    left=ast.Constant(value=actors_from),
-                    right=ast.Call(name="toIntervalDay", args=[ast.Constant(value=6)]),
-                )
-                actors_to_expr = ast.Constant(value=actors_to)
-            elif self.is_monthly_active_math:
-                actors_from_expr = ast.ArithmeticOperation(
-                    op=ast.ArithmeticOperationOp.Sub,
-                    left=ast.Constant(value=actors_from),
-                    right=ast.Call(name="toIntervalDay", args=[ast.Constant(value=29)]),
-                )
-                actors_to_expr = ast.Constant(value=actors_to)
-
-            if self.is_explicit:
-                actors_from_expr = ast.Call(name="greatest", args=[actors_from_expr, ast.Constant(value=query_from)])
-                actors_to_expr = ast.Call(
-                    name="least", args=[ast.Constant(value=actors_to), ast.Constant(value=query_to)]
-                )
+            actors_from_expr, actors_to_expr = self._active_users_exprs(actors_from, actors_to, query_from, query_to)
         else:
             actors_from_expr = ast.Constant(value=actors_from)
             actors_to_expr = ast.Constant(value=actors_to)
@@ -514,6 +448,94 @@ class TrendsActorsQueryBuilder:
                 right=actors_to_expr,
             ),
         )
+
+    def _total_value_actors_window(
+        self, query_from: datetime, query_to: datetime
+    ) -> tuple[datetime, datetime, ast.CompareOperationOp]:
+        if self.time_frame is not None:
+            raise QueryError("A `day` is forbidden for trends actors queries with total value aggregation")
+
+        return query_from, query_to, ast.CompareOperationOp.LtEq
+
+    def _time_series_actors_window(
+        self,
+        date_range: QueryDateRange | QueryCompareToDateRange | QueryPreviousPeriodDateRange,
+        query_from: datetime,
+        query_to: datetime,
+    ) -> tuple[datetime, datetime, ast.CompareOperationOp]:
+        if self.time_frame is None:
+            raise QueryError("A `day` is required for trends actors queries without total value aggregation")
+
+        # use previous day/week/... for time_frame
+        if self.is_compare_previous:
+            self.time_frame = self._previous_period_time_frame(date_range, self.time_frame, query_from)
+
+        actors_from = self.time_frame
+        actors_to = actors_from + date_range.interval_relativedelta()
+        actors_to_op = ast.CompareOperationOp.Lt
+
+        # exclude events before the query start and after the query end
+        if self.is_explicit and not self.is_active_users_math:
+            if query_from > actors_from:
+                actors_from = query_from
+
+            if query_to < actors_to:
+                actors_to_op = ast.CompareOperationOp.LtEq
+                actors_to = query_to
+
+        return actors_from, actors_to, actors_to_op
+
+    def _previous_period_time_frame(
+        self,
+        date_range: QueryDateRange | QueryCompareToDateRange | QueryPreviousPeriodDateRange,
+        time_frame: datetime,
+        query_from: datetime,
+    ) -> datetime:
+        delta_mappings = None if self.is_compare_to else date_range.date_from_delta_mappings()  # type: ignore
+        if delta_mappings is None:
+            # Either an explicit compare_to offset, or an "all time" range, which starts at the
+            # earliest event and so has no relative delta to step back by. Both shift the frame
+            # by the gap between the two periods' starts instead.
+            return query_from + (time_frame - self.trends_date_range.date_from())
+
+        previous_time_frame = time_frame - relativedelta(**delta_mappings)
+        if self.is_hourly:
+            return previous_time_frame
+        return previous_time_frame.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    def _active_users_exprs(
+        self, actors_from: datetime, actors_to: datetime, query_from: datetime, query_to: datetime
+    ) -> tuple[ast.Expr, ast.Expr]:
+        actors_from_expr: ast.Expr
+        actors_to_expr: ast.Expr
+
+        if self.is_total_value:
+            # TRICKY: On total value (non-time-series) insights, WAU/MAU math is simply meaningless.
+            # There's no intuitive way to define the semantics of such a combination, so what we do is just turn it
+            # into a count of unique users between `date_to - INTERVAL (7|30) DAY` and `date_to`.
+            # This way we at least ensure the date range is the probably expected 7 or 30 days.
+            actors_from = actors_to
+
+        if self.is_weekly_active_math:
+            actors_from_expr = ast.ArithmeticOperation(
+                op=ast.ArithmeticOperationOp.Sub,
+                left=ast.Constant(value=actors_from),
+                right=ast.Call(name="toIntervalDay", args=[ast.Constant(value=6)]),
+            )
+            actors_to_expr = ast.Constant(value=actors_to)
+        elif self.is_monthly_active_math:
+            actors_from_expr = ast.ArithmeticOperation(
+                op=ast.ArithmeticOperationOp.Sub,
+                left=ast.Constant(value=actors_from),
+                right=ast.Call(name="toIntervalDay", args=[ast.Constant(value=29)]),
+            )
+            actors_to_expr = ast.Constant(value=actors_to)
+
+        if self.is_explicit:
+            actors_from_expr = ast.Call(name="greatest", args=[actors_from_expr, ast.Constant(value=query_from)])
+            actors_to_expr = ast.Call(name="least", args=[ast.Constant(value=actors_to), ast.Constant(value=query_to)])
+
+        return actors_from_expr, actors_to_expr
 
     def _breakdown_where_expr(self) -> list[ast.Expr]:
         conditions: list[ast.Expr] = []


### PR DESCRIPTION
## Problem

Nobody sees this, but anyone changing which actors a trends graph point opens reads one method that decides five things at once. It picks the current or previous date range, sizes the window for total value, steps a time-series frame back a period, clamps the window to an explicit range, and rebuilds the bounds for weekly and monthly active math.

That method is where compare, explicit ranges, hourly intervals, and WAU/MAU math meet, so it is also where an off-by-one window silently changes the actor list under a graph point.

A repeated complexity sweep scored `_date_where_expr` at 16 against Ruff's C901 limit of 10. C901 sits in the global ignore list in `pyproject.toml`, so it never failed CI.

## Changes

- Nothing user-visible changes. Every window bound, comparison operator, and `QueryError` message stays as it was.
- `_date_where_expr` now picks the date range, asks for a window, and builds the two comparisons.
- `_total_value_actors_window` and `_time_series_actors_window` each return an `ActorsDateWindow`, so the end-boundary operator no longer starts as a default that later branches overwrite.
- `ActorsDateWindow` and `ActorsExprs` are `@frozen` dataclasses from `posthog.dataclasses`, which is the house convention for returning several values.
- `_previous_period_time_frame` holds the compare and compare-to frame shift, and takes the frame as an argument instead of reading `self.time_frame`.
- `_active_users_exprs` holds the weekly and monthly active bound math and returns an `ActorsExprs`.
- The diff is mechanical throughout. It moves code into four methods and two dataclasses, and adds no condition, removes none, and reorders none.

## How did you test this code?

`products/product_analytics/backend/hogql_queries/trends/test/test_trends_actors_query_builder.py` passes in this sandbox against a local Postgres and ClickHouse. It already covers every path this PR moved: hourly ranges, compare previous, compare to, total value, explicit `date_from` and `date_to`, weekly and monthly active math with each of those, and the two invalid `day` errors.

`test_trends_persons.py` passes too, which exercises the same window end to end.

Both suites were re-run after the dataclass change and still pass, with the same counts.

No tests added. A behavior-preserving move has no new regression to catch, and the existing cases pin each branch.

Not run: the rest of the product_analytics suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior, API, or setting changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app in a cloud task, acting on an inbox report that tracks Python functions above Ruff's C901 limit. A person asked for one PR per hotspot in that report's latest sweep. This is one of three independent PRs. The other two touch the BuildBetter warehouse source and the Max agent tool loop, and share no files with this one.

The report pointed at the pre-move path `posthog/hogql_queries/insights/trends/`. The file now lives under `products/product_analytics/backend/hogql_queries/trends/`.

No duplicate: `gh pr list --state open --search "trends_actors_query_builder in:title,body"` returned nothing.

Public artifact: the diff moves existing repository code only. No session material reached the code or this description.

The helpers first returned plain tuples. Semgrep's `tuple-return-prefer-dataclass` rule failed on that, and the fix landed as a second commit on this branch.

Skills invoked: `/writing-code-comments`, `/writing-pr-descriptions`, `/pr-shepherd`, `/writing-dataclasses`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0C0LU050GN/p1788980840802389?thread_ts=1788980840.802389&cid=C0C0LU050GN)*

