### PR TITLE
chore(signals): correct scout docs on the name prefix

### DIFF
--- a/products/signals/skills/AGENTS.md
+++ b/products/signals/skills/AGENTS.md
@@ -10,7 +10,7 @@ Two distinct skill families live in this directory:
 
 ## Scout fleet convention (`signals-scout-*`)
 
-The harness discovers scouts by globbing `signals-scout-*` over the team's `LLMSkill` table. The canonical content on disk in this directory is mirrored to each agent-enabled team's `LLMSkill` rows by `scout_harness/lazy_seed.py` — see `../backend/scout_harness/AGENTS.md` for the sync mechanics, and the `sync_signals_scout_skills` management command for the manual fan-out path.
+A scout is a skill that holds a `SignalScoutConfig`. The harness globs `signals-scout-*` over the team's `LLMSkill` table to auto-register a config for a prefixed skill that has none, which is how the canonical fleet in this directory comes online. The canonical content on disk in this directory is mirrored to each agent-enabled team's `LLMSkill` rows by `scout_harness/lazy_seed.py` — see `../backend/scout_harness/AGENTS.md` for the sync mechanics, and the `sync_signals_scout_skills` management command for the manual fan-out path.
 
 ### Generalist + specialists
 

--- a/products/signals/skills/authoring-scouts/SKILL.md
+++ b/products/signals/skills/authoring-scouts/SKILL.md
@@ -28,9 +28,11 @@ A scout's output is the **report channel**: it lists `emit_report` / `edit_repor
 The canonical fleet runs this way, and **every new scout should too** — always include the `allowed_tools` opt-in when authoring one.
 (A historical signal-emitting channel — weak `emit-signal` findings a pipeline consolidated — still exists in the harness for scouts that never opted in, but it is deprecated: don't author new scouts on it, and opt an old one in rather than extending it.)
 
-A scout is just an `LLMSkill` whose name starts with `signals-scout-`.
-The harness discovers scouts by globbing `signals-scout-*` over the project's skills, loads the body **verbatim** as the agent's system prompt, and progressively reads any bundled reference files on demand.
-**The `signals-scout-` name prefix is load-bearing: a skill named anything else will never run as a scout.**
+A scout is an `LLMSkill` that holds a `SignalScoutConfig`.
+The harness loads the body **verbatim** as the agent's system prompt, and progressively reads any bundled reference files on demand.
+**The config row is what makes a skill a scout.** Any valid skill name works, so the `signals-scout-` prefix is optional.
+The prefix controls one thing: the coordinator globs `signals-scout-*` to auto-register a config for a skill that has none.
+A skill with any other name needs its config created alongside it, which is what `scout-create-prepare` / `-execute` does.
 
 ## The job before the writing
 

--- a/products/signals/skills/authoring-scouts/references/lifecycle-and-testing.md
+++ b/products/signals/skills/authoring-scouts/references/lifecycle-and-testing.md
@@ -4,11 +4,11 @@ How scouts get discovered, scheduled, and dispatched; the two distribution paths
 
 ## How a scout runs
 
-- **Discovery.** The harness globs `signals-scout-*` over the project's skills (`LLMSkill` rows).
-  Any matching skill is a scout.
-  No registration step.
+- **Discovery.** A scout is a skill that holds a `SignalScoutConfig`, and the coordinator dispatches from those config rows.
+  The `signals-scout-` name prefix is optional; it controls only auto-registration, below.
 - **Config.** Each scout has one `SignalScoutConfig` per `(project, skill_name)` carrying `run_interval_minutes` (default 1440), `enabled`, `emit`, `network_access` (`trusted` default, `full` for scouts that read arbitrary external sites), and a `last_run_at` stamp.
-  A config is **auto-registered** the first time the coordinator sees a `signals-scout-*` skill without one — authoring the skill is enough to get a scout.
+  A config is **auto-registered** the first time the coordinator sees a `signals-scout-*` skill without one, so authoring a prefixed skill is enough to get a scout.
+  A skill named anything else needs its config created with it.
   Prepare a fresh per-team scout and its config together with `posthog:scout-create-prepare`; the nested `config` object sets its schedule, emit posture, and destinations before it can run.
   Show the returned confirmation message, wait for the user to type `confirm`, then call `posthog:scout-create-execute` with the returned `confirmation_hash` and that literal confirmation.
   The lower-level `posthog:scout-config-create` remains available when a skill already exists without a config.

--- a/products/signals/skills/authoring-scouts/references/scout-anatomy.md
+++ b/products/signals/skills/authoring-scouts/references/scout-anatomy.md
@@ -14,9 +14,11 @@ Keep the body lean and push depth into references — every line of the body is 
 
 ## Naming
 
-The skill name **must** match `signals-scout-<scope>` — the harness discovers scouts by globbing `signals-scout-*`.
-`<scope>` is lowercase kebab-case naming the surface or question the scout watches: `signals-scout-error-tracking`, `signals-scout-checkout-funnel`, `signals-scout-mcp-feedback`.
-A skill named anything else is just a normal skill and never runs as a scout.
+Any valid skill name works: lowercase letters, numbers, and hyphens.
+The `SignalScoutConfig` row is what makes a skill a scout.
+Name it in lowercase kebab-case after the surface or question the scout watches: `error-tracking`, `checkout-funnel`, `mcp-feedback`.
+The canonical fleet keeps the `signals-scout-` prefix, and a per-team scout can use it too.
+The prefix only controls whether the coordinator auto-registers a config for a skill that has none, so a scout named anything else comes in through `scout-create-prepare` / `-execute`, which writes the skill and its config in one call.
 
 ## Frontmatter
 


### PR DESCRIPTION
## Problem

A person authoring a scout is told the `signals-scout-` name prefix is required, and it is not.
The authoring skill states it as load-bearing: "a skill named anything else will never run as a scout".
An author who wants a plain name therefore adds a prefix they do not need, or concludes the name they want is impossible.

The backend already treats the `SignalScoutConfig` row as the identity marker, so a scout created through `scout-create-prepare` / `-execute` runs under any valid skill name.
This lands the docs half of that change. The backend half was [#95979](https://github.com/PostHog/posthog/issues/95979).

## Changes

- The authoring skill now tells an author the config row makes a skill a scout, and that the prefix is optional.
- It names what the prefix still controls: the coordinator globs `signals-scout-*` to auto-register a config for a skill that has none.
- `scout-anatomy.md` drops the naming rule and points a scout with any other name at the atomic create endpoint.
- `lifecycle-and-testing.md` describes discovery from config rows rather than from a name glob.
- Docs only, across four markdown files. No code changes, and nothing in the product looks different.

## How did you test this code?

Verified against the live API rather than by reading the code.
A scout named `hedgehog-joke`, with no prefix, was created through `scout-create-prepare` / `-execute`.
The config registered, the skill row came back with `category: scout`, and a manually triggered run completed and authored its report normally.

No automated tests were run, because this PR changes four markdown files and no code.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

This PR is the docs update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Opus 5) from a Slack thread.
Skills invoked: `/authoring-scouts`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.

The stale lines surfaced from dogfooding the change, not from a docs sweep: creating a bare-named scout worked, and the skill that describes how to author one said it could not.

Scope stays on the skills docs. Three places still describe or key on the prefix and are left for a follow-up: `products/signals/backend/scout_harness/AGENTS.md`, `products/signals/ARCHITECTURE.md`, and two prefix-keyed strings at `products/skills/backend/api/community_skill_services.py:27` and `products/workflows/backend/api/workflow_scout_runs.py:67`.

No duplicate: `gh pr list --state open --search "scout prefix"` returned no open PR on scout naming or its docs.

Public artifact: the diff carries only repository-facing documentation. Nothing from the session reached it.
