### PR TITLE
chore(ci): lint secrets a reusable workflow reads against its callers

### DIFF
--- a/.agents/skills/authoring-ci-workflows/SKILL.md
+++ b/.agents/skills/authoring-ci-workflows/SKILL.md
@@ -28,7 +28,7 @@ The linters own the mechanical rules (below); this skill is the **judgment calls
 ## What the linters already enforce
 
 Run `bin/hogli lint:workflows` and `actionlint` before pushing — they gate CI, and they (not this list) are the source of truth for what's enforced.
-Today that's: `timeout-minutes` on every job, the canonical PR concurrency block, a repo-wide budget for unscoped PR event dispatches, `dorny/paths-filter` negation safety, justification for full-depth checkouts, cache-write gating, semgrep service coverage, MCP path-filter coverage of the trees the MCP build compiles, required-check gate hygiene, and generic GHA correctness (bad `secrets.*` / `needs:` refs, deprecated `::set-output`, unknown runner labels).
+Today that's: `timeout-minutes` on every job, the canonical PR concurrency block, a repo-wide budget for unscoped PR event dispatches, `dorny/paths-filter` negation safety, justification for full-depth checkouts, cache-write gating, semgrep service coverage, MCP path-filter coverage of the trees the MCP build compiles, required-check gate hygiene, secrets a reusable workflow reads being declared and passed by its callers, and generic GHA correctness (bad `secrets.*` / `needs:` refs, deprecated `::set-output`, unknown runner labels).
 Third-party action digests are bumped by Renovate.
 
 ## The dispatch budget (500 runs / 10s / repo)
@@ -296,6 +296,14 @@ A dedicated GitHub App installation is its own bucket — rate-limit headroom pl
   Convention: `GH_APP_<PURPOSE>_APP_ID` (an org **variable** — app IDs are not sensitive, and org secret slots are capped at 100) + `GH_APP_<PURPOSE>_PRIVATE_KEY` (an org secret).
 - Cross-repo tokens set explicit `owner:` + `repositories:` (least privilege).
 - Creating the app + secret is out of scope here — use `/managing-github-actions-secrets`.
+
+### Secrets in reusable workflows
+
+A `workflow_call` workflow receives no secrets on its own.
+A `secrets.X` it reads interpolates to an empty string unless it declares `X` under `on.workflow_call.secrets` and every caller passes it, or a caller uses `secrets: inherit`.
+Nothing fails when that happens: an App-token step under `continue-on-error` falls back to `github.token` and the check stays green, which is how `ci-turbo` silently lost its dedicated rate-limit bucket.
+`WF010` fails an undeclared read, and fails a caller that omits a secret declared `required: true`.
+Declare `required: false` only when the callee genuinely works without the value, the way a smoke-test build withholds a publish key on purpose; that is the callee's promise, and the linter takes it at its word.
 
 ## Forks and untrusted PRs (public repo)
 

--- a/tools/hogli-commands/hogli_commands/tests/test_workflow_lint.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_workflow_lint.py
@@ -31,6 +31,7 @@ from hogli_commands.workflow_lint.checks.mcp_filter_coverage import McpFilterCov
 from hogli_commands.workflow_lint.checks.pr_concurrency import PrConcurrencyCheck
 from hogli_commands.workflow_lint.checks.pr_event_fanout import PrEventFanoutCheck
 from hogli_commands.workflow_lint.checks.required_gates import RequiredGateCheck
+from hogli_commands.workflow_lint.checks.reusable_secret_passthrough import ReusableSecretPassthroughCheck
 from hogli_commands.workflow_lint.checks.semgrep_services_coverage import SemgrepServicesCoverageCheck
 from hogli_commands.workflow_lint.cli import cmd_lint_workflows
 from hogli_commands.workflow_lint.model import PR_TRIGGERS, Workflow, WorkflowParseError, read_workflows
@@ -1806,3 +1807,101 @@ class TestLiveTreeSmoke:
         workflows = list(read_workflows(workflows_dir))
         for check in CHECKS:
             assert isinstance(check.run(workflows), CheckResult)
+
+
+class TestReusableSecretPassthroughCheck:
+    @staticmethod
+    def _callee(required: bool) -> str:
+        return f"""
+        name: R
+        on:
+          workflow_call:
+            secrets:
+              NEEDED:
+                required: {str(required).lower()}
+        jobs:
+          build:
+            runs-on: ubuntu-latest
+            timeout-minutes: 5
+            steps:
+              - run: echo
+                env:
+                  T: ${{{{ secrets.NEEDED }}}}
+        """
+
+    def test_flags_a_read_the_callee_never_declares(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "_callee.yml",
+            """
+            name: R
+            on:
+              workflow_call:
+            jobs:
+              build:
+                runs-on: ubuntu-latest
+                timeout-minutes: 5
+                steps:
+                  - run: echo
+                    env:
+                      T: ${{ secrets.NEVER_ARRIVES }}
+            """,
+        )
+        issues = ReusableSecretPassthroughCheck().run(_read_all(tmp_path)).issues
+        assert len(issues) == 1, [i.render() for i in issues]
+        assert "does not declare it" in issues[0].message
+
+    def test_flags_a_caller_omitting_a_required_secret(self, tmp_path: Path) -> None:
+        _write(tmp_path, "_callee.yml", self._callee(required=True))
+        _write(
+            tmp_path,
+            "caller.yml",
+            """
+            name: C
+            on: [push]
+            jobs:
+              call:
+                uses: ./.github/workflows/_callee.yml
+            """,
+        )
+        issues = ReusableSecretPassthroughCheck().run(_read_all(tmp_path)).issues
+        assert len(issues) == 1, [i.render() for i in issues]
+        assert issues[0].job == "call"
+        assert "does not pass it" in issues[0].message
+
+    def test_allows_a_caller_omitting_an_optional_secret(self, tmp_path: Path) -> None:
+        # `required: false` is the callee sanctioning absence, which callers rely on
+        # to withhold a publish credential from a dry-run build.
+        _write(tmp_path, "_callee.yml", self._callee(required=False))
+        _write(
+            tmp_path,
+            "caller.yml",
+            """
+            name: C
+            on: [push]
+            jobs:
+              call:
+                uses: ./.github/workflows/_callee.yml
+            """,
+        )
+        assert ReusableSecretPassthroughCheck().run(_read_all(tmp_path)).issues == []
+
+    @pytest.mark.parametrize(
+        "secrets_block",
+        [
+            "        secrets: inherit",
+            "        secrets:\n            NEEDED: ${{ secrets.SOME_OTHER_NAME }}",
+        ],
+        ids=["inherit", "renamed-passthrough"],
+    )
+    def test_satisfied_by_inherit_or_a_renamed_passthrough(self, tmp_path: Path, secrets_block: str) -> None:
+        _write(tmp_path, "_callee.yml", self._callee(required=True))
+        _write(
+            tmp_path,
+            "caller.yml",
+            "name: C\non: [push]\njobs:\n    call:\n        uses: ./.github/workflows/_callee.yml\n"
+            + secrets_block
+            + "\n",
+        )
+        issues = ReusableSecretPassthroughCheck().run(_read_all(tmp_path)).issues
+        assert issues == [], [i.render() for i in issues]

--- a/tools/hogli-commands/hogli_commands/tests/test_workflow_lint.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_workflow_lint.py
@@ -1829,23 +1829,19 @@ class TestReusableSecretPassthroughCheck:
                   T: ${{{{ secrets.NEEDED }}}}
         """
 
-    def test_flags_a_read_the_callee_never_declares(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize(
+        "on_block",
+        ["on:\n  workflow_call:", "on: workflow_call", "on: [workflow_call, push]"],
+        ids=["empty-mapping", "scalar", "list"],
+    )
+    def test_flags_a_read_the_callee_never_declares(self, tmp_path: Path, on_block: str) -> None:
         _write(
             tmp_path,
             "_callee.yml",
-            """
-            name: R
-            on:
-              workflow_call:
-            jobs:
-              build:
-                runs-on: ubuntu-latest
-                timeout-minutes: 5
-                steps:
-                  - run: echo
-                    env:
-                      T: ${{ secrets.NEVER_ARRIVES }}
-            """,
+            "name: R\n"
+            + on_block
+            + "\njobs:\n  build:\n    runs-on: ubuntu-latest\n    timeout-minutes: 5\n"
+            + "    steps:\n      - run: echo\n        env:\n          T: ${{ secrets.NEVER_ARRIVES }}\n",
         )
         issues = ReusableSecretPassthroughCheck().run(_read_all(tmp_path)).issues
         assert len(issues) == 1, [i.render() for i in issues]

--- a/tools/hogli-commands/hogli_commands/tests/test_workflow_lint.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_workflow_lint.py
@@ -1811,7 +1811,8 @@ class TestLiveTreeSmoke:
 
 class TestReusableSecretPassthroughCheck:
     @staticmethod
-    def _callee(required: bool) -> str:
+    def _callee(required: bool, reads: bool = True) -> str:
+        env = "T: ${{ secrets.NEEDED }}" if reads else "T: static"
         return f"""
         name: R
         on:
@@ -1826,7 +1827,7 @@ class TestReusableSecretPassthroughCheck:
             steps:
               - run: echo
                 env:
-                  T: ${{{{ secrets.NEEDED }}}}
+                  {env}
         """
 
     @pytest.mark.parametrize(
@@ -1847,8 +1848,31 @@ class TestReusableSecretPassthroughCheck:
         assert len(issues) == 1, [i.render() for i in issues]
         assert "does not declare it" in issues[0].message
 
-    def test_flags_a_caller_omitting_a_required_secret(self, tmp_path: Path) -> None:
-        _write(tmp_path, "_callee.yml", self._callee(required=True))
+    def test_reads_come_only_from_expressions(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "_callee.yml",
+            """
+            name: R
+            # Needs secrets.COMMENTED_ONLY to be configured in the repo.
+            on:
+              workflow_call:
+            jobs:
+              build:
+                runs-on: ubuntu-latest
+                timeout-minutes: 5
+                steps:
+                  - run: echo secrets.SHELL_LITERAL_ONLY
+                    env:
+                      T: ${{ secrets['BRACKETED'] }}
+            """,
+        )
+        issues = ReusableSecretPassthroughCheck().run(_read_all(tmp_path)).issues
+        assert [i.message.split(" ")[1] for i in issues] == ["secrets.BRACKETED"], [i.render() for i in issues]
+
+    @pytest.mark.parametrize("reads", [True, False], ids=["read", "declared-only"])
+    def test_flags_a_caller_omitting_a_required_secret(self, tmp_path: Path, reads: bool) -> None:
+        _write(tmp_path, "_callee.yml", self._callee(required=True, reads=reads))
         _write(
             tmp_path,
             "caller.yml",

--- a/tools/hogli-commands/hogli_commands/workflow_lint/checks/__init__.py
+++ b/tools/hogli-commands/hogli_commands/workflow_lint/checks/__init__.py
@@ -20,6 +20,7 @@ from .mcp_filter_coverage import McpFilterCoverageCheck
 from .pr_concurrency import PrConcurrencyCheck
 from .pr_event_fanout import PrEventFanoutCheck
 from .required_gates import RequiredGateCheck
+from .reusable_secret_passthrough import ReusableSecretPassthroughCheck
 from .semgrep_services_coverage import SemgrepServicesCoverageCheck
 
 CHECKS: list[WorkflowCheck] = [
@@ -32,6 +33,7 @@ CHECKS: list[WorkflowCheck] = [
     RequiredGateCheck(),
     PrEventFanoutCheck(),
     McpFilterCoverageCheck(),
+    ReusableSecretPassthroughCheck(),
 ]
 
 

--- a/tools/hogli-commands/hogli_commands/workflow_lint/checks/reusable_secret_passthrough.py
+++ b/tools/hogli-commands/hogli_commands/workflow_lint/checks/reusable_secret_passthrough.py
@@ -44,7 +44,12 @@ _SECRET_REF = re.compile(r"secrets\.([A-Za-z0-9_]+)")
 
 
 def _call_block(wf: Workflow) -> dict | None:
+    """The ``workflow_call`` trigger body, ``{}`` when it declares nothing, ``None`` when absent."""
     on = wf.on
+    if isinstance(on, str):
+        return {} if on == "workflow_call" else None
+    if isinstance(on, list):
+        return {} if "workflow_call" in on else None
     if not isinstance(on, dict):
         return None
     call = on.get("workflow_call")

--- a/tools/hogli-commands/hogli_commands/workflow_lint/checks/reusable_secret_passthrough.py
+++ b/tools/hogli-commands/hogli_commands/workflow_lint/checks/reusable_secret_passthrough.py
@@ -1,0 +1,144 @@
+"""A reusable workflow's secret reads must be declared and passed by every caller.
+
+Secrets do not flow into a ``workflow_call`` workflow on their own. A name the
+callee reads must be declared under ``on.workflow_call.secrets`` and then
+passed by each caller, or inherited wholesale with ``secrets: inherit``.
+Miss either half and the reference interpolates to an empty string.
+
+Nothing fails loudly when that happens. ``ci-turbo.yml`` once read an App
+private key while declaring no secrets at all, so its token step failed under
+``continue-on-error`` and the install fell back to ``github.token``, which lost
+the dedicated rate-limit bucket the App exists to provide, with a green check
+either way.
+
+Two rules, because the halves fail independently:
+
+- an undeclared read can never receive a value, whoever calls it;
+- a read declared ``required: true`` still arrives empty from a caller that
+  omits it.
+
+The second rule follows the declaration rather than second-guessing it.
+``required: false`` is the callee saying it tolerates absence, and callers rely
+on that: a smoke-test build deliberately withholds the symbol upload key so it
+does not publish symbols. Mark a secret ``required: true`` when every caller
+must supply it.
+
+A caller that passes a differently named secret through to the callee's input
+satisfies the second rule. The mapping is what matters, not the name matching.
+"""
+
+from __future__ import annotations
+
+import re
+
+from ..check import CheckResult, Issue, WorkflowCheck
+from ..model import Workflow
+
+LOCAL_CALL_PREFIX = "./.github/workflows/"
+INHERIT = "inherit"
+
+# GITHUB_TOKEN is minted per run and reaches every job, so it is never declared.
+IMPLICIT_SECRETS = frozenset({"GITHUB_TOKEN"})
+
+_SECRET_REF = re.compile(r"secrets\.([A-Za-z0-9_]+)")
+
+
+def _call_block(wf: Workflow) -> dict | None:
+    on = wf.on
+    if not isinstance(on, dict):
+        return None
+    call = on.get("workflow_call")
+    if call is None and "workflow_call" in on:
+        # `workflow_call:` with an empty body parses to None but is still callable.
+        return {}
+    return call if isinstance(call, dict) else None
+
+
+def _declared(call: dict) -> set[str]:
+    secrets = call.get("secrets")
+    return set(secrets.keys()) if isinstance(secrets, dict) else set()
+
+
+def _required(call: dict) -> set[str]:
+    secrets = call.get("secrets")
+    if not isinstance(secrets, dict):
+        return set()
+    return {name for name, body in secrets.items() if isinstance(body, dict) and body.get("required") is True}
+
+
+def _reads(wf: Workflow) -> set[str]:
+    text = wf.path.read_text(encoding="utf-8")
+    return set(_SECRET_REF.findall(text)) - IMPLICIT_SECRETS
+
+
+def _callee_name(uses: str) -> str | None:
+    if not uses.startswith(LOCAL_CALL_PREFIX):
+        return None
+    return uses[len(LOCAL_CALL_PREFIX) :].partition("@")[0]
+
+
+class ReusableSecretPassthroughCheck(WorkflowCheck):
+    id = "WF010-reusable-secret-passthrough"
+    label = "reusable secret pass-through"
+    description = "reusable workflows declare the secrets they read, and callers pass the required ones"
+
+    @property
+    def fix_hint(self) -> str | None:
+        return (
+            "Declare the secret under `on.workflow_call.secrets` in the called workflow, "
+            "then pass it from every caller's `secrets:` block (or use `secrets: inherit`)."
+        )
+
+    def run(self, workflows: list[Workflow]) -> CheckResult:
+        result = CheckResult()
+
+        callable_workflows: dict[str, tuple[Workflow, set[str], set[str]]] = {}
+        for wf in workflows:
+            call = _call_block(wf)
+            if call is None:
+                continue
+            declared = _declared(call)
+            reads = _reads(wf)
+            callable_workflows[wf.path.name] = (wf, _required(call) & reads, reads - declared)
+
+        for name, (wf, _needed, undeclared_reads) in sorted(callable_workflows.items()):
+            for secret in sorted(undeclared_reads):
+                result.issues.append(
+                    Issue(
+                        workflow=name,
+                        message=(
+                            f"reads secrets.{secret} but does not declare it under "
+                            "on.workflow_call.secrets, so it is always empty"
+                        ),
+                        file=str(wf.path),
+                    )
+                )
+
+        for caller in workflows:
+            for job in caller.jobs:
+                if job.uses is None:
+                    continue
+                callee_name = _callee_name(job.uses)
+                if callee_name is None or callee_name not in callable_workflows:
+                    continue
+
+                _callee_wf, needed, _undeclared = callable_workflows[callee_name]
+                if not needed:
+                    continue
+
+                passed_block = job.raw.get("secrets")
+                if passed_block == INHERIT:
+                    continue
+                passed = set(passed_block.keys()) if isinstance(passed_block, dict) else set()
+
+                for secret in sorted(needed - passed):
+                    result.issues.append(
+                        Issue(
+                            workflow=caller.path.name,
+                            job=job.name,
+                            message=f"calls {callee_name}, which requires secrets.{secret}, but does not pass it",
+                            file=str(caller.path),
+                        )
+                    )
+
+        return result

--- a/tools/hogli-commands/hogli_commands/workflow_lint/checks/reusable_secret_passthrough.py
+++ b/tools/hogli-commands/hogli_commands/workflow_lint/checks/reusable_secret_passthrough.py
@@ -14,14 +14,19 @@ either way.
 Two rules, because the halves fail independently:
 
 - an undeclared read can never receive a value, whoever calls it;
-- a read declared ``required: true`` still arrives empty from a caller that
-  omits it.
+- a secret declared ``required: true`` must be passed by every caller, whether
+  or not the callee reads it directly, because GitHub refuses to start the call
+  without it.
 
 The second rule follows the declaration rather than second-guessing it.
 ``required: false`` is the callee saying it tolerates absence, and callers rely
 on that: a smoke-test build deliberately withholds the symbol upload key so it
 does not publish symbols. Mark a secret ``required: true`` when every caller
 must supply it.
+
+Reads are collected from ``${{ }}`` expressions in the parsed YAML only. A
+``secrets.X`` in a YAML comment or in shell text outside an expression is not a
+read, and a bracket reference such as ``secrets['X']`` is.
 
 A caller that passes a differently named secret through to the callee's input
 satisfies the second rule. The mapping is what matters, not the name matching.
@@ -30,6 +35,7 @@ satisfies the second rule. The mapping is what matters, not the name matching.
 from __future__ import annotations
 
 import re
+from collections.abc import Iterator
 
 from ..check import CheckResult, Issue, WorkflowCheck
 from ..model import Workflow
@@ -40,7 +46,8 @@ INHERIT = "inherit"
 # GITHUB_TOKEN is minted per run and reaches every job, so it is never declared.
 IMPLICIT_SECRETS = frozenset({"GITHUB_TOKEN"})
 
-_SECRET_REF = re.compile(r"secrets\.([A-Za-z0-9_]+)")
+_EXPRESSION = re.compile(r"\$\{\{(.*?)\}\}", re.DOTALL)
+_SECRET_REF = re.compile(r"""\bsecrets(?:\.([A-Za-z0-9_]+)|\[\s*['"]([A-Za-z0-9_]+)['"]\s*\])""")
 
 
 def _call_block(wf: Workflow) -> dict | None:
@@ -71,9 +78,25 @@ def _required(call: dict) -> set[str]:
     return {name for name, body in secrets.items() if isinstance(body, dict) and body.get("required") is True}
 
 
+def _strings(node: object) -> Iterator[str]:
+    if isinstance(node, str):
+        yield node
+    elif isinstance(node, dict):
+        for key, value in node.items():
+            yield from _strings(key)
+            yield from _strings(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _strings(item)
+
+
 def _reads(wf: Workflow) -> set[str]:
-    text = wf.path.read_text(encoding="utf-8")
-    return set(_SECRET_REF.findall(text)) - IMPLICIT_SECRETS
+    reads: set[str] = set()
+    for text in _strings(wf.raw):
+        for expression in _EXPRESSION.findall(text):
+            for dotted, bracketed in _SECRET_REF.findall(expression):
+                reads.add(dotted or bracketed)
+    return reads - IMPLICIT_SECRETS
 
 
 def _callee_name(uses: str) -> str | None:
@@ -104,7 +127,7 @@ class ReusableSecretPassthroughCheck(WorkflowCheck):
                 continue
             declared = _declared(call)
             reads = _reads(wf)
-            callable_workflows[wf.path.name] = (wf, _required(call) & reads, reads - declared)
+            callable_workflows[wf.path.name] = (wf, _required(call), reads - declared)
 
         for name, (wf, _needed, undeclared_reads) in sorted(callable_workflows.items()):
             for secret in sorted(undeclared_reads):


### PR DESCRIPTION
## Problem

A reusable workflow that reads a secret nobody passes runs with an empty string, and nothing fails. `ci-turbo` ran that way: its App token step failed under `continue-on-error`, the install fell back to `github.token`, and the check stayed green while the dedicated rate-limit bucket went unused. PR #96637 passed the key through by hand, and nothing stops the same shape from coming back.

- Secrets do not flow into a `workflow_call` workflow on their own. The callee must declare the name under `on.workflow_call.secrets`, and every caller must pass it or use `secrets: inherit`.
- Neither half is checked today. actionlint validates the `secrets.X` syntax, not whether a value can ever arrive.

## Changes

- `bin/hogli lint:workflows` gains `WF010-reusable-secret-passthrough`. It fails a reusable workflow that reads a secret it does not declare, and a caller that omits a secret the callee marks `required: true`.
- Reads are collected from `${{ }}` expressions in the parsed YAML, so a `secrets.X` in a comment or in shell text is not a read. Both `secrets.X` and `secrets['X']` count.
- Every `required: true` declaration binds callers, whether or not the callee reads it, because GitHub refuses to start the call without it.
- `required: false` is taken at its word, so a caller may withhold an optional secret on purpose. The smoke-test build withholds the symbol upload key this way.
- A caller that maps a differently named secret onto the input passes. The mapping matters, not the name.
- Run against the `ci-turbo.yml` and `pr-housekeeping.yml` from the commit before #96637, the rule reports the original bug:

  ```
  ✗ ci-turbo.yml: reads secrets.GH_APP_POSTHOG_SETUP_ACTIONS_PRIVATE_KEY but does not declare it under on.workflow_call.secrets, so it is always empty
  ```

- The authoring-ci-workflows skill lists the rule and gains a short "Secrets in reusable workflows" section.
- Mechanical: the registry entry in `checks/__init__.py`.

## How did you test this code?

- New `TestReusableSecretPassthroughCheck` cases: an undeclared read across the three `on:` forms (empty mapping, scalar, list), a caller omitting a required secret that the callee reads or only declares, a caller allowed to omit an optional one, and `inherit` plus a renamed pass-through as one parameterized test. No existing test covered secrets in reusable workflows.
- One case feeds a callee with a commented `secrets.X`, an `echo secrets.X` shell literal and a bracketed `${{ secrets['X'] }}` read, and asserts only the bracketed name is reported. It guards the false positive on comments and the miss on the bracket form together.
- The full `bin/hogli lint:workflows` passes on this branch, so the rule adds no failure on the current workflows.
- Not run: repo-wide mypy. Only the `workflow_lint` package was type-checked locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The rule is documented in `.agents/skills/authoring-ci-workflows/SKILL.md` in this PR. No page under `docs/` covers the workflow linter.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5.1). Skills invoked: `/authoring-ci-workflows`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, `/reviewing-with-coderabbit`.

The check is the pass-through half of a two-rule draft dropped from #96637, renumbered to WF010. The other half, a checked-in secrets inventory, is not revived here.

CodeRabbit CLI ran once (`cr review --agent --committed --base master`). One major finding: `on: workflow_call` as a scalar or list escaped the rule. Valid, fixed in the second commit with parameterized cases. The skill's documented `--prompt-only` flag no longer exists in the installed CLI; `--agent` is the equivalent.

Greptile and Copilot review threads on the first push raised three valid findings, fixed in the third commit: the raw-file scan counted comments as reads, the bracket form escaped detection, and a `required: true` secret the callee never read did not bind callers.

Duplicate search (`gh pr list --state open --search "reusable workflow secrets lint"`) found nothing related. Nothing in the diff or this description draws on material outside this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

