### PR TITLE
feat(charts): infer date axis intervals

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.test.ts
@@ -587,14 +587,14 @@ describe('sqlLineGraphAdapter', () => {
             data: ['a', 'b'],
         }
 
-        it('adds an x-axis tick formatter for date axes', () => {
+        it('passes the timezone for date axes', () => {
             const config = buildLineChartConfig({ xData: dateXData, chartSettings: {}, timezone: 'UTC' })
-            expect(config.xAxis?.tickFormatter).toBeInstanceOf(Function)
+            expect(config.xAxis?.timezone).toBe('UTC')
         })
 
-        it('omits the tick formatter for non-date axes', () => {
+        it('omits the timezone for non-date axes', () => {
             const config = buildLineChartConfig({ xData: stringXData, chartSettings: {}, timezone: 'UTC' })
-            expect(config.xAxis?.tickFormatter).toBeUndefined()
+            expect(config.xAxis?.timezone).toBeUndefined()
             expect(config.xAxis?.tickLabelRotation).toBeUndefined()
         })
 
@@ -1004,7 +1004,7 @@ describe('sqlLineGraphAdapter', () => {
             expect(config.showAxisLines).toEqual({ x: true, y: false })
         })
 
-        it('wires goal lines, legend, and a date x-axis formatter', () => {
+        it('wires goal lines, legend, and the date x-axis timezone', () => {
             const config = buildComboChartConfig({
                 xData: dateXData,
                 chartSettings: { showLegend: true },
@@ -1012,7 +1012,7 @@ describe('sqlLineGraphAdapter', () => {
                 visualizationType: ChartDisplayType.ActionsBar,
                 goalLines: [{ label: 'Target', value: 100 }],
             })
-            expect(config.xAxis?.tickFormatter).toBeInstanceOf(Function)
+            expect(config.xAxis?.timezone).toBe('UTC')
             expect(config.goalLines).toHaveLength(1)
             expect(config.legend).toEqual({ show: true, position: 'top', interactive: true })
             expect(config.tooltip).toMatchObject({ enabled: true, pinnable: true })

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.ts
@@ -14,7 +14,6 @@ import {
     type ValueLabelsConfig,
     type XAxisConfig,
     type YAxisConfig,
-    createXAxisTickCallback,
 } from '@posthog/quill-charts'
 
 import { dayjs } from 'lib/dayjs'
@@ -333,7 +332,7 @@ function buildXAxisConfig(
 
     return {
         label: chartSettings.xAxisLabel,
-        tickFormatter: isDateAxis ? createXAxisTickCallback({ allDays: xData.data, timezone }) : undefined,
+        timezone: isDateAxis ? timezone : undefined,
         tickLabelRotation: isDateAxis ? undefined : tickLabelRotation,
         hide: chartSettings.showXAxisTicks === false,
     }

--- a/frontend/src/scenes/data-warehouse/scene/MonitoringTab.tsx
+++ b/frontend/src/scenes/data-warehouse/scene/MonitoringTab.tsx
@@ -3,7 +3,7 @@ import { memo, useMemo } from 'react'
 import type { ReactNode } from 'react'
 
 import { IconRefresh } from '@posthog/icons'
-import { TimeSeriesLineChart, createXAxisTickCallback } from '@posthog/quill-charts'
+import { TimeSeriesLineChart } from '@posthog/quill-charts'
 import type { TimeSeriesLineChartConfig } from '@posthog/quill-charts'
 
 import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
@@ -98,15 +98,12 @@ function MonitoringChart({
     const data = useMemo(() => buildMonitoringChartData(responses, metrics), [responses, metrics])
     const config = useChartConfig<TimeSeriesLineChartConfig>(
         () => ({
-            xAxis: {
-                timezone: 'UTC',
-                tickFormatter: createXAxisTickCallback({ allDays: data.labels, timezone: 'UTC' }),
-            },
+            xAxis: { timezone: 'UTC' },
             yAxis,
             legend: { show: data.series.length > 1, interactive: true, position: 'bottom' },
             tooltip: { placement: 'cursor', sortedByValue: true, valueFormatter },
         }),
-        [data.labels, data.series.length, valueFormatter, yAxis]
+        [data.series.length, valueFormatter, yAxis]
     )
 
     return (

--- a/frontend/src/scenes/hog-functions/invocations/InvocationsSparkline.tsx
+++ b/frontend/src/scenes/hog-functions/invocations/InvocationsSparkline.tsx
@@ -4,7 +4,6 @@ import { useCallback, useMemo, useState } from 'react'
 import { IconChevronDown } from '@posthog/icons'
 import { LemonButton, SpinnerOverlay } from '@posthog/lemon-ui'
 import {
-    createXAxisTickCallback,
     type DateRangeZoomData,
     DefaultTooltip,
     type Series,
@@ -55,9 +54,9 @@ export function InvocationsSparkline({
     const theme = useChartTheme()
     const config = useChartConfig<TimeSeriesBarChartConfig>(
         () => ({
-            xAxis: { tickFormatter: createXAxisTickCallback({ allDays: dates, timezone: projectTimezone }) },
+            xAxis: { timezone: projectTimezone },
         }),
-        [dates, projectTimezone]
+        [projectTimezone]
     )
 
     const onDateRangeZoom = useCallback(

--- a/packages/quill/packages/charts/src/charts/TimeSeriesBarChart/TimeSeriesBarChart.tsx
+++ b/packages/quill/packages/charts/src/charts/TimeSeriesBarChart/TimeSeriesBarChart.tsx
@@ -137,7 +137,7 @@ export function TimeSeriesBarChart<Meta = unknown>({
         primaryYAxis,
         yAxes,
     } = useTimeSeries(series, labels, theme, { xAxis, yAxis, valueLabels, legend })
-    const timeSeriesTooltipConfig = useTimeSeriesTooltipConfig(tooltipConfig, xAxis)
+    const timeSeriesTooltipConfig = useTimeSeriesTooltipConfig(tooltipConfig, xAxis, labels)
 
     // `axisOrientation` flows through `barChartConfig` into chart context, so `ReferenceLine`
     // reads it automatically — no need to stamp each line here.

--- a/packages/quill/packages/charts/src/charts/TimeSeriesComboChart/TimeSeriesComboChart.tsx
+++ b/packages/quill/packages/charts/src/charts/TimeSeriesComboChart/TimeSeriesComboChart.tsx
@@ -114,7 +114,7 @@ export function TimeSeriesComboChart<Meta = unknown>({
         primaryYAxis,
         yAxes,
     } = useTimeSeries(series, labels, theme, { xAxis, yAxis, valueLabels, legend })
-    const timeSeriesTooltipConfig = useTimeSeriesTooltipConfig(tooltipConfig, xAxis)
+    const timeSeriesTooltipConfig = useTimeSeriesTooltipConfig(tooltipConfig, xAxis, labels)
 
     const { referenceLines, valueDomain } = useGoalLines(goalLines, chartSeries)
 

--- a/packages/quill/packages/charts/src/charts/TimeSeriesLineChart/TimeSeriesLineChart.stories.tsx
+++ b/packages/quill/packages/charts/src/charts/TimeSeriesLineChart/TimeSeriesLineChart.stories.tsx
@@ -142,7 +142,7 @@ interface DateAxisCellProps {
     title: string
     labels: string[]
     series: Series[]
-    interval: TimeInterval
+    interval?: TimeInterval
     timezone: string
 }
 
@@ -350,9 +350,9 @@ export const ComparisonOf: Story = {
 
 export const DateAxis: Story = {
     render: () => {
-        const cells: { interval: TimeInterval; labels: string[]; series: Series[]; title: string }[] = [
+        const cells: { interval?: TimeInterval; labels: string[]; series: Series[]; title: string }[] = [
             { interval: 'hour', labels: HOURLY_LABELS, series: HOURLY_SERIES, title: 'hour' },
-            { interval: 'day', labels: DAILY_LABELS, series: DAILY_SERIES, title: 'day' },
+            { labels: DAILY_LABELS, series: DAILY_SERIES, title: 'day (inferred)' },
             { interval: 'month', labels: MONTHLY_LABELS, series: MONTHLY_SERIES, title: 'month' },
         ]
         return (

--- a/packages/quill/packages/charts/src/charts/TimeSeriesLineChart/TimeSeriesLineChart.test.tsx
+++ b/packages/quill/packages/charts/src/charts/TimeSeriesLineChart/TimeSeriesLineChart.test.tsx
@@ -2,7 +2,14 @@ import { cleanup, fireEvent } from '@testing-library/react'
 
 import { useChartLayout } from '../../core/chart-context'
 import type { ChartTheme, Series } from '../../core/types'
-import { getHogChart, renderHogChart, setupJsdom, setupSyncRaf } from '../../testing'
+import {
+    createDefaultTooltipAccessor,
+    getHogChart,
+    renderHogChart,
+    setupJsdom,
+    setupSyncRaf,
+    waitForHogChartTooltip,
+} from '../../testing'
 import { TimeSeriesLineChart } from './TimeSeriesLineChart'
 
 const THEME: ChartTheme = {
@@ -66,6 +73,23 @@ describe('TimeSeriesLineChart', () => {
             expect(ticks.length).toBeGreaterThan(0)
             // The auto formatter renders day-mode labels as "MMM D" (or month name on the 1st).
             expect(ticks.some((t) => /Jun \d+/.test(t))).toBe(true)
+        })
+
+        it('infers the date formatter and tooltip header from timezone and chart labels', async () => {
+            const labels = ['2024-06-10', '2024-06-11', '2024-06-12']
+            const { chart } = renderHogChart(
+                <TimeSeriesLineChart
+                    series={[{ key: 'a', label: 'A', data: [1, 2, 3] }]}
+                    labels={labels}
+                    theme={THEME}
+                    config={{ xAxis: { timezone: 'UTC' } }}
+                />,
+                { nativeTooltip: true }
+            )
+            expect(chart.xTicks().some((tick) => /Jun \d+/.test(tick))).toBe(true)
+
+            chart.hoverAtIndex(0)
+            expect(createDefaultTooltipAccessor(await waitForHogChartTooltip()).label()).toBe('Mon, Jun 10, 2024')
         })
 
         it('explicit xAxis.tickFormatter wins over the auto date formatter', () => {

--- a/packages/quill/packages/charts/src/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
+++ b/packages/quill/packages/charts/src/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
@@ -120,7 +120,7 @@ export function TimeSeriesLineChart<Meta = unknown>({
         primaryYAxis,
         yAxes,
     } = useTimeSeries(series, labels, theme, { xAxis, yAxis, valueLabels, legend })
-    const timeSeriesTooltipConfig = useTimeSeriesTooltipConfig(tooltipConfig, xAxis)
+    const timeSeriesTooltipConfig = useTimeSeriesTooltipConfig(tooltipConfig, xAxis, labels)
 
     const finalSeries = useDerivedSeries(chartSeries, {
         confidenceIntervals,

--- a/packages/quill/packages/charts/src/docs/axes.md
+++ b/packages/quill/packages/charts/src/docs/axes.md
@@ -25,7 +25,7 @@ Theme-side restyle knobs, all optional: `theme.axisLineColor` strokes the baseli
 
 ## X-axis
 
-- Labels must be unique. The x-scale keys positions off the strings, so a duplicate collapses onto the first occurrence and draws the series backwards. On time-series charts pass ISO date strings, never formatted display labels that repeat across years, and format ticks via `xAxis.timezone` and `interval` or `tickFormatter`.
+- Labels must be unique. The x-scale keys positions off the strings, so a duplicate collapses onto the first occurrence and draws the series backwards. On time-series charts pass ISO date strings, never formatted display labels that repeat across years. Set `xAxis.timezone` to format ticks and tooltip headers. The library infers the interval from `allDays` or chart labels; set `interval` only to override it. `tickFormatter` overrides automatic formatting.
 - `xAxis.tickLabelRotation` (`-45` tilts left) fixes the rotation, clamped to `-90..90`. Omit it to keep horizontal labels and the collision behavior.
 - `maxCategoryLabelWidth` truncates category labels with an ellipsis and reveals the full value on hover. It also clamps the axis margin, so a long label cannot push the plot off screen. `MAX_CATEGORY_LABEL_WIDTH` is the exported default.
 

--- a/packages/quill/packages/charts/src/utils/dates.test.ts
+++ b/packages/quill/packages/charts/src/utils/dates.test.ts
@@ -322,6 +322,13 @@ describe('createXAxisTickCallback', () => {
         })
     })
 
+    it('infers daily labels across a daylight-saving transition', () => {
+        const labels = ['2026-03-08', '2026-03-09']
+        const callback = createXAxisTickCallback({ allDays: labels, timezone: 'America/New_York' })
+
+        expect(labels.map((label, index) => callback?.(label, index))).toEqual(['Mar 8', 'Mar 9'])
+    })
+
     describe('fallbacks', () => {
         it.each([
             { scenario: 'allDays is empty', allDays: [] as (string | number)[] },

--- a/packages/quill/packages/charts/src/utils/dates.ts
+++ b/packages/quill/packages/charts/src/utils/dates.ts
@@ -36,7 +36,7 @@ export function createXAxisTickCallback({
         return
     }
 
-    const resolvedInterval = interval ?? inferInterval(parsedDates)
+    const resolvedInterval = interval ?? inferInterval(parsedDates, isDateOnlyLabel(allDays[0]))
     const mode = pickMode(resolvedInterval, parsedDates, first, last)
 
     return (_value: string | number, index: number): string | null => {
@@ -187,7 +187,21 @@ function formatQuarterLabel(date: Dayjs): string {
     return `Q${Math.floor(date.month() / 3) + 1}`
 }
 
-function inferInterval(parsedDates: Dayjs[]): TimeInterval {
+export function inferTimeInterval(allDays: string[], timezone: string): TimeInterval | undefined {
+    if (allDays.length === 0) {
+        return undefined
+    }
+    const parsedDates = allDays.map((day) => parseDateForAxis(day, timezone))
+    const first = parsedDates[0]
+    const last = parsedDates[parsedDates.length - 1]
+    return first?.isValid() && last?.isValid() ? inferInterval(parsedDates, isDateOnlyLabel(allDays[0])) : undefined
+}
+
+function isDateOnlyLabel(label: string | number): boolean {
+    return typeof label === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(label)
+}
+
+function inferInterval(parsedDates: Dayjs[], dateOnlyLabels: boolean): TimeInterval {
     if (parsedDates.length < 2) {
         return 'day'
     }
@@ -195,7 +209,7 @@ function inferInterval(parsedDates: Dayjs[]): TimeInterval {
     if (diffHours < 1) {
         return 'minute'
     }
-    if (diffHours < 24) {
+    if (!dateOnlyLabels && diffHours < 24) {
         return 'hour'
     }
     const diffDays = Math.abs(parsedDates[1].diff(parsedDates[0], 'day'))

--- a/packages/quill/packages/charts/src/utils/use-axis-formatters.ts
+++ b/packages/quill/packages/charts/src/utils/use-axis-formatters.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 
 import { DEFAULT_Y_AXIS_ID, type TooltipConfig, type YAxis } from '../core/types'
-import { createTooltipDateFormatter, createXAxisTickCallback, type TimeInterval } from './dates'
+import { createTooltipDateFormatter, createXAxisTickCallback, inferTimeInterval, type TimeInterval } from './dates'
 import { buildYTickFormatter, type YFormatterConfig } from './y-formatters'
 
 export interface XAxisConfig {
@@ -13,9 +13,9 @@ export interface XAxisConfig {
     hide?: boolean
     /** Timezone used when interpreting date labels for the auto date formatter. */
     timezone?: string
-    /** Bucket size for the auto date formatter. */
+    /** Bucket size for the auto date formatter. Inferred from `allDays` or chart labels when omitted. */
     interval?: TimeInterval
-    /** Source dates for the auto date formatter. Falls back to `labels` when omitted. */
+    /** Source dates for the auto date formatter. Falls back to chart labels when omitted. */
     allDays?: string[]
 }
 
@@ -59,7 +59,7 @@ export function useXTickFormatter(
         if (xAxis?.tickFormatter) {
             return xAxis.tickFormatter
         }
-        if (xAxis?.timezone && xAxis?.interval) {
+        if (xAxis?.timezone) {
             return createXAxisTickCallback({
                 timezone: xAxis.timezone,
                 interval: xAxis.interval,
@@ -71,22 +71,32 @@ export function useXTickFormatter(
 }
 
 /** Tooltip config with the header label defaulted to a full formatted date when the x-axis is
- *  date-driven (`timezone` + `interval` set) — the axis ticks are already auto-formatted then, so
- *  a raw ISO header would be the odd one out. An explicit `labelFormatter` wins. */
+ *  date-driven. The axis and tooltip infer the same interval, so a raw ISO header does not remain
+ *  after the axis ticks are formatted. An explicit `labelFormatter` wins. */
 export function useTimeSeriesTooltipConfig(
     tooltip: TooltipConfig | undefined,
-    xAxis: XAxisConfig | undefined
+    xAxis: XAxisConfig | undefined,
+    labels: string[]
 ): TooltipConfig | undefined {
     const { timezone, interval } = xAxis ?? {}
+    const effectiveAllDays = xAxis?.allDays ?? labels
     return useMemo(() => {
-        if (tooltip?.labelFormatter || !timezone || !interval) {
+        if (tooltip?.labelFormatter || !timezone) {
+            return tooltip
+        }
+        const resolvedInterval = interval ?? inferTimeInterval(effectiveAllDays, timezone)
+        if (!resolvedInterval) {
             return tooltip
         }
         return {
             ...tooltip,
-            labelFormatter: createTooltipDateFormatter({ interval, timezone, allDays: xAxis?.allDays }),
+            labelFormatter: createTooltipDateFormatter({
+                interval: resolvedInterval,
+                timezone,
+                allDays: effectiveAllDays,
+            }),
         }
-    }, [tooltip, timezone, interval, xAxis?.allDays])
+    }, [tooltip, timezone, interval, effectiveAllDays])
 }
 
 /** Non-hook resolution of a {@link YAxisConfig} into a tick formatter. An explicit `tickFormatter`

--- a/products/error_tracking/frontend/components/IssueReleases/IssueReleasesStackedChart.tsx
+++ b/products/error_tracking/frontend/components/IssueReleases/IssueReleasesStackedChart.tsx
@@ -1,7 +1,7 @@
 import { useValues } from 'kea'
 import { useMemo } from 'react'
 
-import { DefaultTooltip, TimeSeriesBarChart, createXAxisTickCallback } from '@posthog/quill-charts'
+import { DefaultTooltip, TimeSeriesBarChart } from '@posthog/quill-charts'
 import type { PointClickData, Series, TimeSeriesBarChartConfig } from '@posthog/quill-charts'
 
 import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
@@ -34,14 +34,13 @@ export function IssueReleasesStackedChart({
             })),
         [releases, theme.colors]
     )
-    const tickFormatter = useMemo(() => createXAxisTickCallback({ timezone, allDays: labels }), [labels, timezone])
     const config = useChartConfig<TimeSeriesBarChartConfig>(
         () => ({
             barLayout: 'stacked',
             barCornerRadius: 2,
             bandPadding: 0.15,
             margins: { top: 4 },
-            xAxis: { tickFormatter },
+            xAxis: { timezone },
             yAxis: { hide: true },
             showAxisLines: { x: true, y: false },
             showTickMarks: false,
@@ -49,7 +48,7 @@ export function IssueReleasesStackedChart({
             showGrid: false,
             tooltip: { placement: 'cursor', pinnable: false, hitArea: 'band' },
         }),
-        [tickFormatter]
+        [timezone]
     )
 
     const onPointClick = ({ series: clicked }: PointClickData<IssueReleaseStrip>): void => {

--- a/products/error_tracking/frontend/components/VolumeSparkline/VolumeSparkline.tsx
+++ b/products/error_tracking/frontend/components/VolumeSparkline/VolumeSparkline.tsx
@@ -3,7 +3,6 @@ import { useEffect, useMemo, useRef } from 'react'
 
 import {
     type ChartMargins,
-    createXAxisTickCallback,
     type DateRangeZoomData,
     type PointClickData,
     type Series,
@@ -105,13 +104,6 @@ export function VolumeSparkline({
 
     const showAxis = xAxis !== 'none'
     const eventLabelReserve = events.length > 0 ? EVENT_LABEL_HEIGHT + EVENT_LABEL_BAR_GAP : undefined
-    // Quill's own tick callback: project-timezone labels at the granularity it infers from the
-    // bucket spacing, deduped per period. Only built when ticks actually render.
-    const tickFormatter = useMemo(
-        () => (xAxis === 'full' ? createXAxisTickCallback({ timezone, allDays: labels }) : undefined),
-        [labels, timezone, xAxis]
-    )
-
     const config = useChartConfig<TimeSeriesBarChartConfig>(
         () => ({
             minBarSize: LAYOUTS[layout].minBarSize,
@@ -119,7 +111,7 @@ export function VolumeSparkline({
             bandPadding: LAYOUTS[layout].bandPadding,
             margins: resolveMargins(layout, eventLabelReserve),
             valueDomain: { min: 0, max: maxValue },
-            xAxis: { hide: xAxis !== 'full', tickFormatter },
+            xAxis: { hide: xAxis !== 'full', timezone: xAxis === 'full' ? timezone : undefined },
             yAxis: { hide: true },
             showAxisLines: { x: showAxis, y: false },
             showTickMarks: false,
@@ -128,7 +120,7 @@ export function VolumeSparkline({
             // Hover is surfaced as issue metrics beside the chart, not as a tooltip over it.
             tooltip: { enabled: false },
         }),
-        [layout, xAxis, showAxis, eventLabelReserve, tickFormatter, maxValue]
+        [layout, xAxis, showAxis, eventLabelReserve, timezone, maxValue]
     )
 
     const onDateRangeZoom = useMemo(() => {

--- a/products/metrics/frontend/components/MetricsSeriesChart.test.tsx
+++ b/products/metrics/frontend/components/MetricsSeriesChart.test.tsx
@@ -110,8 +110,6 @@ describe('MetricsSeriesChart', () => {
         expect(tooltip.value('http.requests')).toBe('0')
     })
 
-    // Guards createXAxisTickCallback and the tz-aware labelFormatter wiring: a regression here
-    // renders raw ISO strings on every tick and tooltip header instead of formatted dates.
     it('formats the x-axis ticks and tooltip label as tz-aware dates', async () => {
         renderChart([seriesWith({}, [1, 2, 3])])
         const chart = getHogChart()

--- a/products/metrics/frontend/components/MetricsSeriesChart.tsx
+++ b/products/metrics/frontend/components/MetricsSeriesChart.tsx
@@ -7,7 +7,6 @@ import {
     type TimeSeriesBarChartConfig,
     TimeSeriesLineChart,
     type TimeSeriesLineChartConfig,
-    createXAxisTickCallback,
 } from '@posthog/quill-charts'
 
 import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
@@ -64,11 +63,11 @@ export function MetricsSeriesChart({
         () =>
             buildMetricsChartConfig({
                 display,
-                xAxis: { tickFormatter: createXAxisTickCallback({ allDays: labels, timezone }) },
+                xAxis: { timezone },
                 seriesCount: chartSeries.length,
                 labelFormatter: (label: string) => dayjs(label).tz(timezone).format('D MMM YYYY HH:mm:ss'),
             }),
-        [labels, timezone, chartSeries.length, display]
+        [timezone, chartSeries.length, display]
     )
 
     const markers = exemplars?.length ? <MetricsExemplarMarkers exemplars={exemplars} /> : null

--- a/products/tracing/frontend/TracingSparkline.tsx
+++ b/products/tracing/frontend/TracingSparkline.tsx
@@ -5,7 +5,6 @@ import { LemonButton, LemonSegmentedButton, SpinnerOverlay } from '@posthog/lemo
 import {
     BarChart,
     type BarChartConfig,
-    createXAxisTickCallback,
     type DateRangeZoomData,
     DefaultTooltip,
     type HeatmapBrushData,
@@ -105,11 +104,9 @@ export function TracingSparkline({
     // Duration mode is categorical (1ms, 2ms, ...); activity mode is a time axis keyed on ISO dates.
     const timeConfig = useChartConfig<TimeSeriesBarChartConfig>(
         () => ({
-            xAxis: {
-                tickFormatter: createXAxisTickCallback({ allDays: sparklineData.dates, timezone: displayTimezone }),
-            },
+            xAxis: { timezone: displayTimezone },
         }),
-        [sparklineData.dates, displayTimezone]
+        [displayTimezone]
     )
     const durationConfig = useChartConfig<BarChartConfig>(() => ({}), [])
 


### PR DESCRIPTION
## Problem

Chart authors must create date tick callbacks even though the time-series axis configuration already identifies the chart timezone.

## Changes

- Time-series charts infer the date interval from raw chart labels when `xAxis.timezone` is set.
- Tooltip headers use the same inferred interval as the axis ticks.
- Existing chart consumers now use the axis configuration instead of local date callback setup.
- Explicit intervals and custom tick or tooltip formatters keep their precedence.
- No visual change is intended for existing consumers.

## How did you test this code?

- Ran the focused chart and metrics Jest tests. The new cases guard automatic tooltip formatting and daily labels across daylight saving time.
- Built `@posthog/quill-charts`.
- Ran Oxlint and `hogli ci:preflight --fix`.
- The full frontend type check remains blocked by missing `@posthog/hogvm` declarations in unrelated frontend files.
- Did not run browser testing. The changed behavior has unit coverage and no intended visual change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- Updated the chart axis documentation and the date-axis Storybook example.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- PostHog Desktop and an Explore subagent reviewed the chart API and the final diff.
- Skills invoked: `working-with-charts`, `writing-tests`, `writing-code-comments`, `writing-user-facing-copy`, `running-ci-preflight`, and `writing-pr-descriptions`.
- The design extends the existing axis configuration instead of adding a new formatter API.
- An open pull request search found no duplicate work.
- This change contains no material from private task context.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
