### PR TITLE
fix(hogai): prevent frozen-time pydantic schema failures

### DIFF
--- a/ee/hogai/chat_agent/taxonomy/types.py
+++ b/ee/hogai/chat_agent/taxonomy/types.py
@@ -3,7 +3,7 @@ from typing import Generic, Optional, TypeVar
 
 from langchain_core.messages import BaseMessage as LangchainBaseMessage
 from langgraph.graph import END, START
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from ee.hogai.utils.types.base import BaseStateWithIntermediateSteps, BaseStateWithMessages
 
@@ -15,6 +15,8 @@ class TaxonomyAgentState(BaseStateWithIntermediateSteps, BaseStateWithMessages, 
     Partial state class for filter options functionality.
     Only includes fields relevant to filter options generation.
     """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     output: Optional[OutputType | str] = Field(default=None)
     """

--- a/ee/hogai/chat_agent/taxonomy/types.py
+++ b/ee/hogai/chat_agent/taxonomy/types.py
@@ -16,6 +16,7 @@ class TaxonomyAgentState(BaseStateWithIntermediateSteps, BaseStateWithMessages, 
     Only includes fields relevant to filter options generation.
     """
 
+    # URL imports can run inside frozen-time tests, where Pydantic sees Freezegun's datetime as arbitrary.
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     output: Optional[OutputType | str] = Field(default=None)


### PR DESCRIPTION
## Problem

Experiment tests can fail before request handling when frozen time overlaps a lazy PostHog AI import. The Pydantic schema builder then rejects the patched datetime type and blocks backend CI.

## Changes

- Taxonomy state imports now complete when tests freeze time.
- The generic state model allows the runtime types required by its LangChain fields.
- No product-facing behavior changes.

## How did you test this code?

- `uv run --frozen ruff check ee/hogai/chat_agent/taxonomy/types.py` passed.
- The focused taxonomy test file collects successfully.
- A Django setup and taxonomy state schema check passed.
- The database-backed test run was not completed because local Postgres was unavailable.
- The original failure is recorded in the [backend CI job](https://github.com/PostHog/posthog/actions/runs/34393900049/job/102609709642).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This change does not alter user-facing behavior or a documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The PostHog Slack app used the `debugging-ci-failures`, `writing-tests`, `maintaining-python-tests`, and `writing-pr-descriptions` skills. Existing taxonomy tests already cover this state, so no duplicate test was added. No matching open pull request or issue existed.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09ADEV3AJD/p1788984037232849)*
