### PR TITLE
fix(replay-vision): drop orphaned vision action tables

### DIFF
--- a/products/replay_vision/backend/migrations/0093_drop_visionaction_tables.py
+++ b/products/replay_vision/backend/migrations/0093_drop_visionaction_tables.py
@@ -1,0 +1,40 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    """Drop the orphaned replay_vision_visionaction and replay_vision_visionactionrun tables.
+
+    Migration 0086 removed VisionAction and VisionActionRun from Django's model state with
+    SeparateDatabaseAndState and left both physical tables in place. It passed no
+    database_operations, so the tables kept every foreign key they had, including
+    visionaction.team_id and visionactionrun.team_id which both reference posthog_team.
+
+    Django no longer knows the two tables exist, so a cascade delete never removes their rows.
+    Every FK on them is DEFERRABLE INITIALLY DEFERRED, so a Team delete runs its whole cascade
+    and then fails at COMMIT with a ForeignKeyViolation. That makes team and organization
+    deletion impossible, and the failing transaction holds SELECT FOR UPDATE on posthog_team
+    while it runs, which blocks any concurrent insert that needs FOR KEY SHARE on the same team
+    row.
+
+    This is the second phase from safe-django-migrations.md "Dropping Tables". Dropping each
+    table also drops its foreign keys, which is what unblocks the cascade.
+
+    visionactionrun is dropped first because it references visionaction.
+
+    Irreversible: the row data is gone. The reverse is a no-op rather than a bogus CREATE TABLE,
+    so unapplying this leaves both tables absent, which no code reads or writes.
+    """
+
+    dependencies = [
+        ("replay_vision", "0092_replayobservationview"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="""
+                DROP TABLE IF EXISTS "replay_vision_visionactionrun";
+                DROP TABLE IF EXISTS "replay_vision_visionaction";
+            """,
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+    ]

--- a/products/replay_vision/backend/migrations/max_migration.txt
+++ b/products/replay_vision/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0092_replayobservationview
+0093_drop_visionaction_tables


### PR DESCRIPTION
## Problem

Deleting a team or an organization fails outright if that team ever used the legacy vision actions feature. The delete runs its whole cascade and then dies at `COMMIT`.

- Migration `0086` (#92983) removed `VisionAction` and `VisionActionRun` from Django's model state with `SeparateDatabaseAndState` and passed no `database_operations`, so both tables stayed in Postgres with every foreign key they had.
- Two of those foreign keys reference `posthog_team`, and every one of them is `DEFERRABLE INITIALLY DEFERRED`.
- Django no longer knows the tables exist, so a cascade delete never removes their rows.
- Postgres defers the check to `COMMIT`, so `Team.objects.delete()` completes the cascade and then raises `ForeignKeyViolation`.
- `delete_team_records` holds `SELECT FOR UPDATE` on `posthog_team` for that whole transaction, so each failed attempt also blocks any concurrent insert that needs `FOR KEY SHARE` on the same team row.

The bug is latent rather than immediate: it only fires for a team that has legacy vision action rows, so team deletion kept working for every other team after `0086` shipped.

## Changes

- Team and organization deletion now completes for teams that used legacy vision actions.
- Migration `0093` drops `replay_vision_visionactionrun`, then `replay_vision_visionaction`.
- Dropping each table also drops its foreign keys, which is what lets the cascade commit.
- The drop order matters because `visionactionrun` references `visionaction`; that is the only inbound foreign key either table has.

This is phase 2 of the table drop in [safe-django-migrations.md](https://github.com/PostHog/posthog/blob/master/docs/published/handbook/engineering/safe-django-migrations.md#dropping-tables). Phase 1 shipped in #92983 on 2 September 2026, so the safety window has passed.

> [!WARNING]
> The drop is irreversible. `reverse_sql` is a no-op rather than a bogus `CREATE TABLE`, so unapplying this leaves both tables absent. No code reads or writes them: the model classes are gone, and the only remaining `vision_action` references in the repo are access-control scope strings in the frontend.

## How did you test this code?

- `manage.py analyze_migration_risk` reports `✅ Validated staged drop: Found prior SeparateDatabaseAndState that removed model from state`, which is the check CI runs.
- The migration graph loads with `0093` as the single `replay_vision` leaf, and the autodetector reports no state drift.
- No new tests. A migration that drops two dead tables has no behavior to assert, and the staged-drop analyzer already gates the ordering.
- Not run: the Django test suites. This checkout's local migration history is drifted, so they fail on unrelated apps before reaching this migration. CI covers them.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Opus 5 in Claude Code, directed by the assignee while diagnosing a team-deletion failure.

Skills invoked: `/django-migrations`, `/writing-code-comments`, `/writing-pr-descriptions`.

The root cause was found by reading the failing `COMMIT` and tracing it back to `0086`. Two remedies were considered: dropping only the orphaned foreign keys, which is reversible and preserves the rows, or dropping the tables. This PR drops the tables, because `0086` already intended that, the safety window has passed, and one drop clears all of the orphaned keys at once, including the ones to `posthog_user` and `posthog_hogflow` that would break user and hog flow deletion the same way. The reversible constraint-only variant remains available if a reviewer prefers to keep the rows.

A companion concern is out of scope here: `delete_team_records` takes `select_for_update()` on `posthog_team`, which AGENTS.md calls out as the hot-parent-row anti-pattern. That lock is what turns a failing delete into contention for unrelated writers. Changing it needs its own discussion, because the docstring says the lock is deliberate.

Public artifact: nothing in this PR or this description carries non-public material. The diff is one migration file plus `max_migration.txt`.
