### PR TITLE
fix(flags): release conditions match values with commas or spaces

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -7005,9 +7005,9 @@ snapshots:
     scenes-app-engineering-analytics-lead-time-box-plot--default--light:
         hash: v1.k794b7964.040d7b8b88503881e75c0e7d6c0bc8588c6096f1315f75b5071c2721d13f567a.jAkjFsaMTKwsbxZsBriJ6JoPzwYGQSXgG9ERQd0H06E
     scenes-app-engineering-analytics-repo-overview--repo-overview--dark:
-        hash: v1.k794b7964.1a470083e7a94ff46652f4368277eae5d35c927d65b58685e43ce34881e1e728.SEm3E8XvqrTHtJNRhVGX-9aaaw6xdWyzTNb_mw6c380
+        hash: v1.k794b7964.99bcc4aa618c0c6ceb0f5589213426fb51865d6353f30beaed25b64578f5ffc0.2rGiM6xEOYk0-SGcmLZBMZanICe_eWP-kSnvVtupzLE
     scenes-app-engineering-analytics-repo-overview--repo-overview--light:
-        hash: v1.k794b7964.f709ff67c44f86f69d951fc6fbb18b17b6090f6c5793bf6bc16fc803e0a0498c.SmWuVYGMNsp3hU9ipmoQyalTt57uRsG0DrLJlw7LzPU
+        hash: v1.k794b7964.fb0d3e9e51c16c40878d5b96d93d31aad8842801049a97f647ad0635b4a224c4.URJT0C0VW5uV5O8fOGADIVmsi8jUGHyqnwXcP5ojIRs
     scenes-app-engineering-analytics-repo-overview--repo-overview-with-trunk-queue-data--dark:
         hash: v1.k794b7964.99bcc4aa618c0c6ceb0f5589213426fb51865d6353f30beaed25b64578f5ffc0.F-ci8KA9aLO2BdWqAoyqoJe0vw3cdwL870yzUWI1ilI
     scenes-app-engineering-analytics-repo-overview--repo-overview-with-trunk-queue-data--light:

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.test.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.test.tsx
@@ -229,6 +229,51 @@ describe('PropertyValue', () => {
         })
     })
 
+    it('keeps a typed comma when only a searched value contains one', async () => {
+        useMocks({
+            get: {
+                '/api/event/values': ({ request }) => ({
+                    results: new URL(request.url).searchParams.get('value')
+                        ? [{ name: 'Zenith, Inc.' }]
+                        : [{ name: 'Acme' }, { name: 'Initech' }],
+                    refreshing: false,
+                }),
+            },
+        })
+
+        const onSet = jest.fn()
+        render(
+            <Provider>
+                <PropertyValue
+                    propertyKey="name"
+                    type={PropertyFilterType.Event}
+                    operator={PropertyOperator.Exact}
+                    onSet={onSet}
+                    value={[]}
+                />
+            </Provider>
+        )
+
+        const user = userEvent.setup()
+        const input = screen.getByRole('textbox')
+        await user.click(input)
+        await user.type(input, 'Zenith')
+
+        // the comma value is outside the first page of results, so wait for the search to return it
+        await waitFor(
+            () => {
+                expect(screen.getByText('Zenith, Inc.')).toBeInTheDocument()
+            },
+            { timeout: 3000 }
+        )
+
+        await user.keyboard(', Inc.{Enter}')
+
+        await waitFor(() => {
+            expect(onSet).toHaveBeenLastCalledWith(['Zenith, Inc.'])
+        })
+    })
+
     it('still splits typed input at a comma when no suggested value contains one', async () => {
         const onSet = jest.fn()
         render(

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.test.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.test.tsx
@@ -229,6 +229,57 @@ describe('PropertyValue', () => {
         })
     })
 
+    it('still splits typed input at a comma when no suggested value contains one', async () => {
+        const onSet = jest.fn()
+        render(
+            <Provider>
+                <PropertyValue
+                    propertyKey="name"
+                    type={PropertyFilterType.Event}
+                    operator={PropertyOperator.Exact}
+                    onSet={onSet}
+                    value={[]}
+                    staticValues={[{ name: 'Chrome' }, { name: 'Firefox' }]}
+                />
+            </Provider>
+        )
+
+        const user = userEvent.setup()
+        const input = screen.getByRole('textbox')
+        await user.click(input)
+        await user.type(input, 'Acme,')
+
+        await waitFor(() => {
+            expect(onSet).toHaveBeenLastCalledWith(['Acme'])
+        })
+    })
+
+    it('keeps the space on an already committed value when a second value is added', async () => {
+        const onSet = jest.fn()
+        render(
+            <Provider>
+                <PropertyValue
+                    propertyKey="name"
+                    type={PropertyFilterType.Event}
+                    operator={PropertyOperator.Exact}
+                    onSet={onSet}
+                    value={['Hedgebox Inc ']}
+                    staticValues={null}
+                />
+            </Provider>
+        )
+
+        const user = userEvent.setup()
+        const input = screen.getByRole('textbox')
+        await user.click(input)
+        await user.paste('Acme')
+        await user.keyboard('{Enter}')
+
+        await waitFor(() => {
+            expect(onSet).toHaveBeenLastCalledWith(['Hedgebox Inc ', 'Acme'])
+        })
+    })
+
     it('allows text when a polymorphic property overrides a globally inferred numeric type', async () => {
         propertyDefinitionsModel.actions.updatePropertyDefinitions({
             'event/current_value': {

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.test.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.test.tsx
@@ -274,6 +274,73 @@ describe('PropertyValue', () => {
         })
     })
 
+    it('keeps a typed comma when the values were already cached before mount', async () => {
+        // A closed filter popover unmounts the editor while the loaded values stay in the model,
+        // so a later open starts from a cached response instead of a fresh request
+        propertyDefinitionsModel.actions.setOptions('name', [{ name: 'Hedgebox, Inc.' }], true)
+
+        const onSet = jest.fn()
+        render(
+            <Provider>
+                <PropertyValue
+                    propertyKey="name"
+                    type={PropertyFilterType.Event}
+                    operator={PropertyOperator.Exact}
+                    onSet={onSet}
+                    value={[]}
+                />
+            </Provider>
+        )
+
+        const user = userEvent.setup()
+        const input = screen.getByRole('textbox')
+        await user.click(input)
+        await user.type(input, 'Hedgebox, Inc.')
+        await user.keyboard('{Enter}')
+
+        await waitFor(() => {
+            expect(onSet).toHaveBeenLastCalledWith(['Hedgebox, Inc.'])
+        })
+    })
+
+    it('splits again after the property switches to one whose values hold no comma', async () => {
+        propertyDefinitionsModel.actions.setOptions('name', [{ name: 'Hedgebox, Inc.' }], true)
+        propertyDefinitionsModel.actions.setOptions('city', [{ name: 'Berlin' }], true)
+
+        const onSet = jest.fn()
+        const { rerender } = render(
+            <Provider>
+                <PropertyValue
+                    propertyKey="name"
+                    type={PropertyFilterType.Event}
+                    operator={PropertyOperator.Exact}
+                    onSet={onSet}
+                    value={[]}
+                />
+            </Provider>
+        )
+        rerender(
+            <Provider>
+                <PropertyValue
+                    propertyKey="city"
+                    type={PropertyFilterType.Event}
+                    operator={PropertyOperator.Exact}
+                    onSet={onSet}
+                    value={[]}
+                />
+            </Provider>
+        )
+
+        const user = userEvent.setup()
+        const input = screen.getByRole('textbox')
+        await user.click(input)
+        await user.type(input, 'Berlin,')
+
+        await waitFor(() => {
+            expect(onSet).toHaveBeenLastCalledWith(['Berlin'])
+        })
+    })
+
     it('still splits typed input at a comma when no suggested value contains one', async () => {
         const onSet = jest.fn()
         render(

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.test.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.test.tsx
@@ -157,6 +157,7 @@ describe('PropertyValue', () => {
             label: 'trims surrounding whitespace from a pasted value before committing it',
             propertyKey: '$ai_trace_id',
             operator: PropertyOperator.Exact,
+            staticValues: null,
             pastedValue: ' 9c8a6265-382a-4972-9640-b400dabdd83e ',
             expectedArg: ['9c8a6265-382a-4972-9640-b400dabdd83e'],
         },
@@ -164,10 +165,19 @@ describe('PropertyValue', () => {
             label: 'preserves surrounding whitespace for regex operators, where it can be meaningful',
             propertyKey: '$current_url',
             operator: PropertyOperator.Regex,
+            staticValues: null,
             pastedValue: 'foo ',
             expectedArg: 'foo ',
         },
-    ])('$label', async ({ propertyKey, operator, pastedValue, expectedArg }) => {
+        {
+            label: 'keeps a trailing space that a suggested value also has, so exact matching still works',
+            propertyKey: 'name',
+            operator: PropertyOperator.Exact,
+            staticValues: [{ name: 'Hedgebox Inc ' }],
+            pastedValue: 'Hedgebox Inc ',
+            expectedArg: ['Hedgebox Inc '],
+        },
+    ])('$label', async ({ propertyKey, operator, staticValues, pastedValue, expectedArg }) => {
         const onSet = jest.fn()
         render(
             <Provider>
@@ -177,6 +187,7 @@ describe('PropertyValue', () => {
                     operator={operator}
                     onSet={onSet}
                     value={[]}
+                    staticValues={staticValues}
                 />
             </Provider>
         )
@@ -189,6 +200,32 @@ describe('PropertyValue', () => {
 
         await waitFor(() => {
             expect(onSet).toHaveBeenCalledWith(expectedArg)
+        })
+    })
+
+    it('keeps a typed comma inside the value when the suggested values contain commas', async () => {
+        const onSet = jest.fn()
+        render(
+            <Provider>
+                <PropertyValue
+                    propertyKey="name"
+                    type={PropertyFilterType.Event}
+                    operator={PropertyOperator.Exact}
+                    onSet={onSet}
+                    value={[]}
+                    staticValues={[{ name: 'Hedgebox, Inc.' }]}
+                />
+            </Provider>
+        )
+
+        const user = userEvent.setup()
+        const input = screen.getByRole('textbox')
+        await user.click(input)
+        await user.type(input, 'Hedgebox, Inc.')
+        await user.keyboard('{Enter}')
+
+        await waitFor(() => {
+            expect(onSet).toHaveBeenLastCalledWith(['Hedgebox, Inc.'])
         })
     })
 

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.test.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.test.tsx
@@ -325,6 +325,32 @@ describe('PropertyValue', () => {
         })
     })
 
+    it('keeps a trailing space on a suggested value when the person clicks away', async () => {
+        const onSet = jest.fn()
+        render(
+            <Provider>
+                <PropertyValue
+                    propertyKey="name"
+                    type={PropertyFilterType.Event}
+                    operator={PropertyOperator.Exact}
+                    onSet={onSet}
+                    value={[]}
+                    staticValues={[{ name: 'Hedgebox Inc ' }]}
+                />
+            </Provider>
+        )
+
+        const user = userEvent.setup()
+        const input = screen.getByRole('textbox')
+        await user.click(input)
+        await user.paste('Hedgebox Inc ')
+        await user.click(document.body)
+
+        await waitFor(() => {
+            expect(onSet).toHaveBeenLastCalledWith(['Hedgebox Inc '])
+        })
+    })
+
     it('allows text when a polymorphic property overrides a globally inferred numeric type', async () => {
         propertyDefinitionsModel.actions.updatePropertyDefinitions({
             'event/current_value': {

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -273,16 +273,17 @@ export function PropertyValue({
         return [...suggestedOptions, ...otherOptions]
     }, [propertyOptions?.values, initialSuggestedValues, staticValues])
 
-    // The suggestions are the values the property really holds, so they answer two questions that
-    // the raw user input cannot: whether a chosen value is a real value, and whether a comma is
-    // part of a value instead of a separator between values.
     const availableValues = useMemo(
         () => new Set(displayOptions.map((option) => toString(option.name))),
         [displayOptions]
     )
+    // Read the accumulated suggestions rather than the live options, because a search response
+    // replaces the options and would turn comma-separated entry back on part-way through typing.
     const someValueContainsComma = useMemo(
-        () => Array.from(availableValues).some((availableValue) => availableValue.includes(',')),
-        [availableValues]
+        () =>
+            (staticValues ?? []).some((option) => toString(option.name).includes(',')) ||
+            initialSuggestedValues.orderedKeys.some((key) => key.includes(',')),
+        [staticValues, initialSuggestedValues]
     )
 
     const onSearchTextChange = (newInput: string): void => {
@@ -436,8 +437,9 @@ export function PropertyValue({
     }
 
     // Comma-separated entry cuts the input in two at each comma, which makes a value that contains a
-    // comma impossible to type. The suggestions show when that applies. User agent strings always
-    // contain commas, so they stay in the list for the moment before the suggestions arrive.
+    // comma impossible to type. The suggested values show when that applies. The user agent keys
+    // stay for the two cases the suggestions miss: before the first response arrives, and a user
+    // agent value such as `curl/8.1.2` that holds no comma.
     const isUserAgentProperty = ['$raw_user_agent', '$initial_raw_user_agent', '$user_agent'].includes(propertyKey)
     const disableCommaSplitting = isUserAgentProperty || someValueContainsComma
 
@@ -498,13 +500,18 @@ export function PropertyValue({
                 }
                 onChange={(nextVal) => {
                     // A leading or trailing space is invisible in the value snack, so a pasted ID that
-                    // keeps one breaks the filter with no sign of why. Trim it away, with two
+                    // keeps one breaks the filter with no sign of why. Trim it away, with three
                     // exceptions. A regex operator can use the space as part of the pattern (for
                     // example `^ foo`). A value that the suggestions hold with that same space is a
-                    // real property value, and the filter must keep the space to match it.
+                    // real property value. An already committed value keeps what it was saved with,
+                    // because this callback receives every selected value on each edit.
                     const committedVal = isOperatorRegex(operator)
                         ? nextVal
-                        : nextVal.map((v) => (typeof v === 'string' && !availableValues.has(v) ? v.trim() : v))
+                        : nextVal.map((v) =>
+                              typeof v === 'string' && !availableValues.has(v) && !formattedValues.includes(v)
+                                  ? v.trim()
+                                  : v
+                          )
                     const newValues = committedVal.filter((v) => !formattedValues.includes(String(v)))
                     if (newValues.length > 0) {
                         const fromSuggestion = newValues.every((v) => availableValues.has(toString(v)))

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -144,9 +144,11 @@ export function PropertyValue({
         orderedKeys: string[]
     }>({ set: new Set(), orderedKeys: [] })
     // the first response is capped, so a value with a comma can appear only once the user searches
-    // for it. Remember that we saw one for as long as the property stays selected, so comma entry
-    // does not switch off again when the next search returns values without one.
-    const [sawValueContainingComma, setSawValueContainingComma] = useState(false)
+    // for it. Remember the property we saw one for, so comma entry does not switch off again when
+    // the next search returns values without one. Holding the property key rather than a boolean
+    // keeps the memory correct without a reset, which a cached response would otherwise race on
+    // mount.
+    const [keyWithValueContainingComma, setKeyWithValueContainingComma] = useState<string | null>(null)
     const currentSearchInput = useRef<string>('')
 
     const hasStaticValues = !!staticValues
@@ -241,14 +243,13 @@ export function PropertyValue({
             propertyOptions?.status === 'loaded' &&
             propertyOptions?.values?.some((v) => toString(v.name).includes(','))
         ) {
-            setSawValueContainingComma(true)
+            setKeyWithValueContainingComma(propertyKey)
         }
-    }, [propertyOptions?.status, propertyOptions?.values, hasStaticValues])
+    }, [propertyOptions?.status, propertyOptions?.values, hasStaticValues, propertyKey])
 
     // reset initial suggested values when propertyKey changes
     useEffect(() => {
         setInitialSuggestedValues({ set: new Set(), orderedKeys: [] })
-        setSawValueContainingComma(false)
     }, [propertyKey])
 
     // show suggested values first, then any other available options that aren't in the suggested list
@@ -296,7 +297,8 @@ export function PropertyValue({
     // Read the remembered result rather than the live options, because a search response replaces
     // the options and would turn comma-separated entry back on part-way through typing.
     const someValueContainsComma =
-        (staticValues ?? []).some((option) => toString(option.name).includes(',')) || sawValueContainingComma
+        (staticValues ?? []).some((option) => toString(option.name).includes(',')) ||
+        keyWithValueContainingComma === propertyKey
 
     const onSearchTextChange = (newInput: string): void => {
         const trimmedInput = newInput.trim()

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -143,6 +143,10 @@ export function PropertyValue({
         set: Set<string>
         orderedKeys: string[]
     }>({ set: new Set(), orderedKeys: [] })
+    // the first response is capped, so a value with a comma can appear only once the user searches
+    // for it. Remember that we saw one for as long as the property stays selected, so comma entry
+    // does not switch off again when the next search returns values without one.
+    const [sawValueContainingComma, setSawValueContainingComma] = useState(false)
     const currentSearchInput = useRef<string>('')
 
     const hasStaticValues = !!staticValues
@@ -230,9 +234,21 @@ export function PropertyValue({
         }
     }, [propertyOptions?.status, propertyOptions?.values, propertyOptions?.searchInput])
 
+    // watch every response, including a search response, for a value that holds a comma
+    useEffect(() => {
+        if (
+            !hasStaticValues &&
+            propertyOptions?.status === 'loaded' &&
+            propertyOptions?.values?.some((v) => toString(v.name).includes(','))
+        ) {
+            setSawValueContainingComma(true)
+        }
+    }, [propertyOptions?.status, propertyOptions?.values, hasStaticValues])
+
     // reset initial suggested values when propertyKey changes
     useEffect(() => {
         setInitialSuggestedValues({ set: new Set(), orderedKeys: [] })
+        setSawValueContainingComma(false)
     }, [propertyKey])
 
     // show suggested values first, then any other available options that aren't in the suggested list
@@ -277,14 +293,10 @@ export function PropertyValue({
         () => new Set(displayOptions.map((option) => toString(option.name))),
         [displayOptions]
     )
-    // Read the accumulated suggestions rather than the live options, because a search response
-    // replaces the options and would turn comma-separated entry back on part-way through typing.
-    const someValueContainsComma = useMemo(
-        () =>
-            (staticValues ?? []).some((option) => toString(option.name).includes(',')) ||
-            initialSuggestedValues.orderedKeys.some((key) => key.includes(',')),
-        [staticValues, initialSuggestedValues]
-    )
+    // Read the remembered result rather than the live options, because a search response replaces
+    // the options and would turn comma-separated entry back on part-way through typing.
+    const someValueContainsComma =
+        (staticValues ?? []).some((option) => toString(option.name).includes(',')) || sawValueContainingComma
 
     const onSearchTextChange = (newInput: string): void => {
         const trimmedInput = newInput.trim()

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -273,6 +273,18 @@ export function PropertyValue({
         return [...suggestedOptions, ...otherOptions]
     }, [propertyOptions?.values, initialSuggestedValues, staticValues])
 
+    // The suggestions are the values the property really holds, so they answer two questions that
+    // the raw user input cannot: whether a chosen value is a real value, and whether a comma is
+    // part of a value instead of a separator between values.
+    const availableValues = useMemo(
+        () => new Set(displayOptions.map((option) => toString(option.name))),
+        [displayOptions]
+    )
+    const someValueContainsComma = useMemo(
+        () => Array.from(availableValues).some((availableValue) => availableValue.includes(',')),
+        [availableValues]
+    )
+
     const onSearchTextChange = (newInput: string): void => {
         const trimmedInput = newInput.trim()
         if (trimmedInput !== currentSearchInput.current && !(operator && isOperatorFlag(operator))) {
@@ -423,8 +435,11 @@ export function PropertyValue({
         return <>{formatPropertyValueForDisplay(propertyKey, name, propertyDefinitionType, groupTypeIndex)}</>
     }
 
-    // Disable comma splitting for user agent properties that contain commas in their values
+    // Comma-separated entry cuts the input in two at each comma, which makes a value that contains a
+    // comma impossible to type. The suggestions show when that applies. User agent strings always
+    // contain commas, so they stay in the list for the moment before the suggestions arrive.
     const isUserAgentProperty = ['$raw_user_agent', '$initial_raw_user_agent', '$user_agent'].includes(propertyKey)
+    const disableCommaSplitting = isUserAgentProperty || someValueContainsComma
 
     const suggestionsLabel = staticValues
         ? staticValues.length > 0
@@ -482,16 +497,16 @@ export function PropertyValue({
                         : undefined
                 }
                 onChange={(nextVal) => {
-                    // Trim whitespace so a stray leading/trailing space (common when pasting an ID)
-                    // doesn't silently break the filter — the snack display hides the space.
-                    // Skip regex operators, where leading/trailing whitespace can be a meaningful
-                    // part of the pattern (e.g. `^ foo`, `bar $`).
-                    const trimmedVal = isOperatorRegex(operator)
+                    // A leading or trailing space is invisible in the value snack, so a pasted ID that
+                    // keeps one breaks the filter with no sign of why. Trim it away, with two
+                    // exceptions. A regex operator can use the space as part of the pattern (for
+                    // example `^ foo`). A value that the suggestions hold with that same space is a
+                    // real property value, and the filter must keep the space to match it.
+                    const committedVal = isOperatorRegex(operator)
                         ? nextVal
-                        : nextVal.map((v) => (typeof v === 'string' ? v.trim() : v))
-                    const newValues = trimmedVal.filter((v) => !formattedValues.includes(String(v)))
+                        : nextVal.map((v) => (typeof v === 'string' && !availableValues.has(v) ? v.trim() : v))
+                    const newValues = committedVal.filter((v) => !formattedValues.includes(String(v)))
                     if (newValues.length > 0) {
-                        const availableValues = new Set(displayOptions.map((o) => toString(o.name)))
                         const fromSuggestion = newValues.every((v) => availableValues.has(toString(v)))
 
                         posthog.capture('property_value_selected', {
@@ -502,12 +517,12 @@ export function PropertyValue({
                             had_search_input: currentSearchInput.current !== '',
                         })
                     }
-                    isMultiSelect ? setValue(trimmedVal) : setValue(trimmedVal[0])
+                    isMultiSelect ? setValue(committedVal) : setValue(committedVal[0])
                 }}
                 onInputChange={onSearchTextChange}
                 placeholder={placeholder}
                 size={size}
-                disableCommaSplitting={isUserAgentProperty}
+                disableCommaSplitting={disableCommaSplitting}
                 status={validationError ? 'danger' : 'default'}
                 title={titleNode}
                 popoverClassName="max-w-200"

--- a/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.test.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.test.tsx
@@ -417,6 +417,26 @@ describe('LemonInputSelect', () => {
         expect(lastCall[0]).toContain('alice@example.com')
     })
 
+    it('multiple-select mode: clicking away from an untouched edit keeps a value missing from options', async () => {
+        const onChange = jest.fn()
+
+        render(
+            <LemonInputSelect<string>
+                mode="multiple"
+                options={[{ key: 'Acme', label: 'Acme' }]}
+                value={['Hedgebox Inc ']}
+                onChange={onChange}
+                allowCustomValues
+            />
+        )
+
+        // Click the snack text to edit the value, then click away without changing it
+        await userEvent.click(screen.getByText('Hedgebox Inc'))
+        await userEvent.click(document.body)
+
+        expect(onChange).toHaveBeenLastCalledWith(['Hedgebox Inc '])
+    })
+
     it.each([
         {
             name: 'adds nothing when the limit is reached',

--- a/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
@@ -543,7 +543,9 @@ export function LemonInputSelect<T = string>({
             return
         }
         if (hasCustomValue) {
-            _onActionItem(inputValue.trim(), null)
+            // Keep the input as typed when an option holds it verbatim, because a leading or
+            // trailing space is part of that value and trimming it breaks an exact-match filter.
+            _onActionItem(optionMaps.keySet.has(inputValue) ? inputValue : inputValue.trim(), null)
         } else {
             setInputValue('')
         }

--- a/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
@@ -543,9 +543,14 @@ export function LemonInputSelect<T = string>({
             return
         }
         if (hasCustomValue) {
-            // Keep the input as typed when an option holds it verbatim, because a leading or
-            // trailing space is part of that value and trimming it breaks an exact-match filter.
-            _onActionItem(optionMaps.keySet.has(inputValue) ? inputValue : inputValue.trim(), null)
+            // Keep the input as typed when an option holds it verbatim, or when it still equals the
+            // value being edited. A leading or trailing space is part of such a value, and trimming
+            // it breaks an exact-match filter. The edited value is not always among the options,
+            // because a search response replaces them.
+            const itemBeingEdited = itemBeingEditedIndex !== null ? value?.[itemBeingEditedIndex] : undefined
+            const isEditUnchanged = itemBeingEdited !== undefined && getStringKey(itemBeingEdited) === inputValue
+            const keepVerbatim = optionMaps.keySet.has(inputValue) || isEditUnchanged
+            _onActionItem(keepVerbatim ? inputValue : inputValue.trim(), null)
         } else {
             setInputValue('')
         }


### PR DESCRIPTION
## Problem

A feature flag whose release condition filters on a group property does not match the group when that property value has a leading or trailing space. The flag stays off for a group the filter names, and the value editor gives no sign of why.

Two behaviors in the value editor cause it:

- The editor trims every value before it commits. A value picked from the suggestion list loses the space the real property value carries, so an "equals" rule compares a trimmed value against an untrimmed one.
- The editor splits typed input at each comma. A value that contains a comma is impossible to type, so the only way to enter one is the suggestion list.

The trim exists to stop a pasted ID with a stray space from breaking a filter. That reason holds for a value a person types or pastes. It does not hold for a value the suggestions supply.

## Changes

- A value picked from the suggestion list keeps its leading and trailing spaces, so an exact-match rule matches the group.
- That space survives later edits of the same filter row. Adding or removing a second value no longer rewrites the first.
- Clicking away from the field keeps the space too, not only picking a suggestion or pressing Enter.
- Clicking away from an edit nobody changed keeps the space, even after a search drops that value from the list.
- A typed or pasted value that no suggestion matches is still trimmed, so the pasted-ID fix stays.
- A property whose values contain a comma accepts a typed comma. A name like `Hedgebox, Inc.` goes in as one value.
- That holds for a value only a search reveals. The first page of values is capped, so a comma value often sits outside it.
- Reopening the filter keeps comma entry on. Cached values no longer reset the answer on mount.
- Comma entry does not switch on and off while a person types. The editor remembers a comma for as long as the property stays selected.
- A hardcoded list of three user agent keys stays as a fallback. It covers the moment before any response arrives, and a user agent value with no comma.
- Nothing looks different. The dropdown and the value snack render as before.

The change reads the suggestion list rather than a per-property allowlist, because the suggestions are the only place that says what a real value looks like.

The comma memory stores the property key it saw a comma for, rather than a plain yes or no. A different key does not match, so nothing has to reset it, and a cached response cannot race that reset on mount.

The blur fix touches `LemonInputSelect`, which the whole app uses. It keeps the input as typed only when an option holds it verbatim, or when it still equals the value being edited. Every other blur behaves as before.

> [!NOTE]
> One narrow route still trims. `LemonInputSelect` trims each token of a comma-separated batch, so a value with a trailing space and no comma loses that space when it is entered as part of such a batch. Comma entry is off for any property that has comma values, which leaves this too rare to justify changing the shared split path.

## How did you test this code?

Nine cases, eight in `PropertyValue.test.tsx` and one in `LemonInputSelect.test.tsx`, grouped by the route each one guards.

- A suggested value with a trailing space commits untrimmed, whether it is pasted and entered, or left by clicking away.
- An untouched edit keeps its space on click-away, even when the options no longer hold that value.
- A value that is already committed keeps its space when a second value is added.
- A comma stays inside the value when the property has comma values, including one only a search reveals, and after a remount that reads cached values.
- Comma-separated entry still splits when no value contains a comma.

Each case fails against the commit before the fix it guards. The two splitting cases are the exception: they pass either way, and cover a direction that had no coverage.

Not checked: the change was never opened in a browser, because this sandbox did not run the app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Opus 5 in PostHog Desktop, from a bug report with a screen recording of the failure. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

The first commit exempted a suggested value from the trim. Review then found five gaps, each fixed in a later commit. The exemption ran again over values that were already committed, because the value editor hands its callback the whole selected-value array. Comma detection read only the first page of suggestions, so a comma value that a search revealed still split. The shared select trimmed on blur before the value editor could exempt anything. Blur trimmed an unchanged edit too, because editing a value takes it out of the select's own list. And the comma memory cleared itself on mount, so reopening a filter with cached values lost it.

A visible marker for leading and trailing spaces in the value dropdown was written and then removed. It closes a related gap, where a person who types a value cannot see that the real value carries a space, but it is a separate UI change that needs its own visual review and it is not needed for the match to work.

No duplicate: `gh pr list --state open --search` found no open PR for either behavior.

Public artifact: no material from the session reached the code, the tests, the commit messages, or this description. The test values are invented.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
