### PR TITLE
fix(replay-vision): bound the vision drop's lock wait on posthog_team

### DIFF
--- a/products/replay_vision/backend/migrations/0093_drop_visionaction_tables.py
+++ b/products/replay_vision/backend/migrations/0093_drop_visionaction_tables.py
@@ -1,0 +1,40 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    """Drop the orphaned replay_vision_visionaction and replay_vision_visionactionrun tables.
+
+    Migration 0086 removed VisionAction and VisionActionRun from Django's model state with
+    SeparateDatabaseAndState and left both physical tables in place. It passed no
+    database_operations, so the tables kept every foreign key they had, including
+    visionaction.team_id and visionactionrun.team_id which both reference posthog_team.
+
+    Django no longer knows the two tables exist, so a cascade delete never removes their rows.
+    Every FK on them is DEFERRABLE INITIALLY DEFERRED, so a Team delete runs its whole cascade
+    and then fails at COMMIT with a ForeignKeyViolation. That makes team and organization
+    deletion impossible, and the failing transaction holds SELECT FOR UPDATE on posthog_team
+    while it runs, which blocks any concurrent insert that needs FOR KEY SHARE on the same team
+    row.
+
+    This is the second phase from safe-django-migrations.md "Dropping Tables". Dropping each
+    table also drops its foreign keys, which is what unblocks the cascade.
+
+    visionactionrun is dropped first because it references visionaction.
+
+    Irreversible: the row data is gone. The reverse is a no-op rather than a bogus CREATE TABLE,
+    so unapplying this leaves both tables absent, which no code reads or writes.
+    """
+
+    dependencies = [
+        ("replay_vision", "0092_replayobservationview"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="""
+                DROP TABLE IF EXISTS "replay_vision_visionactionrun";
+                DROP TABLE IF EXISTS "replay_vision_visionaction";
+            """,
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+    ]

--- a/products/replay_vision/backend/migrations/0093_drop_visionaction_tables.py
+++ b/products/replay_vision/backend/migrations/0093_drop_visionaction_tables.py
@@ -21,6 +21,16 @@ class Migration(migrations.Migration):
 
     visionactionrun is dropped first because it references visionaction.
 
+    Each table holds a foreign key to posthog_team, and Postgres needs ACCESS EXCLUSIVE on a
+    referenced table to drop a foreign key that points at it. So both drops take ACCESS EXCLUSIVE
+    on posthog_team. The lock is metadata-only and is held for microseconds, but posthog_team is
+    read on almost every request, so every query that arrives while the lock request waits queues
+    behind it. Both statements share one transaction, so posthog_team is locked one time.
+
+    lock_timeout bounds that wait to 2 seconds. bin/migrate otherwise applies MIGRATE_LOCK_TIMEOUT,
+    which defaults to 20 seconds. If the lock does not arrive in 2 seconds the migration fails and
+    bin/migrate retries it, which costs a retry instead of a 20 second queue on posthog_team.
+
     Irreversible: the row data is gone. The reverse is a no-op rather than a bogus CREATE TABLE,
     so unapplying this leaves both tables absent, which no code reads or writes.
     """
@@ -32,6 +42,7 @@ class Migration(migrations.Migration):
     operations = [
         migrations.RunSQL(
             sql="""
+                SET LOCAL lock_timeout = '2s';
                 DROP TABLE IF EXISTS "replay_vision_visionactionrun";
                 DROP TABLE IF EXISTS "replay_vision_visionaction";
             """,

--- a/products/replay_vision/backend/migrations/max_migration.txt
+++ b/products/replay_vision/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0092_replayobservationview
+0093_drop_visionaction_tables


### PR DESCRIPTION
## Problem

The table drop in #97901 takes `ACCESS EXCLUSIVE` on `posthog_team`, and nothing currently bounds how long it waits for that lock.

- Both dropped tables hold a foreign key to `posthog_team`.
- Postgres needs `ACCESS EXCLUSIVE` on a referenced table to drop a foreign key that points at it.
- The lock is metadata-only and is held for microseconds, so the hold is not the hazard.
- The wait is. Every query that arrives while the lock request queues waits behind it, and `posthog_team` is read on almost every request.
- Without this change the wait runs to `MIGRATE_LOCK_TIMEOUT`, which `bin/migrate` defaults to 20 seconds.

> [!IMPORTANT]
> This has to merge into #97901 **before** that migration applies in production. Django records an applied migration and never re-runs it, so adding this afterwards protects nothing. The base branch is #97901 for that reason.

## Changes

- The drop now gives up after 2 seconds instead of queueing on `posthog_team` for up to 20.
- `SET LOCAL lock_timeout = '2s'` runs inside the migration's transaction, ahead of both `DROP TABLE` statements.
- The docstring records why the drop touches `posthog_team` at all, which is not obvious from a `DROP TABLE` on an unrelated table.
- On timeout the migration fails and `bin/migrate` retries it, so the cost is a retry rather than a lock queue on the hottest table in the schema.

Both statements already share one transaction, so `posthog_team` is locked one time rather than once per table. That part is unchanged.

## How did you test this code?

Measured on local Postgres 15.12 (production Aurora is 15.15, same major version).

<details><summary>Lock behavior, measured</summary>

A child table with a deferred foreign key to a parent, then `DROP TABLE` on the child:

| operation | lock taken on the parent |
| --- | --- |
| `DROP TABLE child` | `AccessExclusiveLock` |
| `ALTER TABLE child DROP CONSTRAINT fk` | `AccessExclusiveLock` |
| `DROP TABLE child` after the foreign key is gone | none |

Read from `pg_locks` filtered to `pg_backend_pid()` inside an open transaction. There is no path that removes the foreign key without the parent lock, so bounding the wait is the available mitigation rather than avoiding the lock.

With one session holding `ACCESS SHARE` on the parent and a second session running the migration's SQL:

```
ERROR:  canceling statement due to lock timeout
elapsed: 2s
```

Without `SET LOCAL`, that session waits for the full `lock_timeout`.

</details>

- No new tests. The change is one `SET LOCAL` in a migration, and the measurement above is what establishes the behavior.
- Not run: the Django test suites. This checkout's migration history is drifted, so they fail on unrelated apps. CI covers them.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Opus 5 in Claude Code, directed by the assignee.

Skills invoked: `/django-migrations`, `/writing-code-comments`, `/writing-pr-descriptions`.

Split out of #97901 at the assignee's request so a reviewer with more Postgres locking background can weigh it on its own. The hot-parent lock was found after #97901 was opened, by testing the drop's lock behavior rather than reading it from documentation. `analyze_migration_risk` does not flag it: the policy that guards hot-table `ALTER`s cannot infer a foreign-key graph from raw SQL, so a `RunSQL` drop of a table that references `posthog_team` passes unflagged. A separate PR proposes closing that gap.

`SET LOCAL` was chosen over `SET` so the setting reverts with the transaction rather than leaking into the connection that `bin/migrate` reuses for later migrations.

Public artifact: nothing here carries non-public material. The diff is one migration file.
