### PR TITLE
fix(hogql): publish Kargo release tags

### DIFF
--- a/.github/workflows/cd-hogql-lang-service-image.yml
+++ b/.github/workflows/cd-hogql-lang-service-image.yml
@@ -36,22 +36,29 @@ jobs:
             - name: Check out
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
-                  sparse-checkout: |
-                      services/hogql-language-service/
-                      .github/actions/docker-meta/
+                  sparse-checkout: services/hogql-language-service/
                   sparse-checkout-cone-mode: false
 
-            - name: Docker meta and registry login
-              id: docker-meta
-              uses: ./.github/actions/docker-meta
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
               with:
-                  image-name: hogql-lang-service
-                  aws-role-to-assume: ${{ vars.AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE }}
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
-                  dockerhub-username: ${{ secrets.DOCKERHUB_USER }}
-                  dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
-                  push-to-ghcr: 'false'
-                  push-to-dockerhub: 'false'
+                  role-to-assume: ${{ vars.AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE }}
+                  aws-region: us-east-1
+
+            - name: Login to Amazon ECR
+              id: aws-ecr
+              uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
+
+            - name: Image metadata and ordered release tag
+              id: docker-meta
+              uses: PostHog/shared-actions/container-image-metadata@2427cf9968667894226f164eab356d96ca930b22 # v1, shared-actions#51
+              with:
+                  images: ${{ steps.aws-ecr.outputs.registry }}/hogql-lang-service
+                  extra-tags: |
+                      type=ref,event=branch
+                      type=raw,value=${{ github.sha }}
+                      type=raw,value=latest,enable={{is_default_branch}}
+                  generate-ordered-release-tag: 'true'
 
             - name: Set up Depot CLI
               uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1.7.1
@@ -70,6 +77,15 @@ jobs:
                   annotations: ${{ steps.docker-meta.outputs.annotations }}
                   platforms: linux/arm64,linux/amd64
                   build-args: COMMIT_HASH=${{ github.sha }}
+
+            - name: Publish ordered release tag
+              if: vars.CD_DEPLOY_ENABLED == 'true'
+              uses: PostHog/shared-actions/container-image-metadata@2427cf9968667894226f164eab356d96ca930b22 # v1, shared-actions#51
+              with:
+                  images: ${{ steps.aws-ecr.outputs.registry }}/hogql-lang-service
+                  publish-ordered-release-tag: 'true'
+                  ordered-release-tag: ${{ steps.docker-meta.outputs.ordered-release-tag }}
+                  ordered-release-digest: ${{ steps.push.outputs.digest }}
 
     deploy:
         name: Trigger HogQL language service deployment


### PR DESCRIPTION
## Problem

The HogQL language service stays unavailable because Kargo cannot discover an eligible image and render its Kubernetes manifests.

The publisher creates conventional tags, while the Kargo Warehouse requires an ordered release tag tied to the source revision.

## Changes

- Publishes an ordered release alias so Kargo can discover and promote each language-service image.
- Uses the shared image metadata action for the ordered tag and OCI provenance contract.
- Preserves the existing branch, SHA, and latest image tags.
- Keeps every ECR write behind `CD_DEPLOY_ENABLED`.
- Removes unused registry logins from this ECR-only workflow.

Before:

```mermaid
flowchart LR
    A[Image build] --> B[ECR conventional tags]
    B --> C[Kargo finds no Freight]
    C --> D[Rendered path missing]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    class A,B phBlue;
    class C,D phRed;
```

After:

```mermaid
flowchart LR
    A[Image build] --> B[ECR ordered release tag]
    B --> C[Kargo Freight]
    C --> D[Rendered manifests]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A,B phBlue;
    class C,D phYellow;
```

## How did you test this code?

- `hogli lint:workflows` passed.
- `git diff --check` passed.
- Not tested against ECR because publishing occurs only from the protected master workflow.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation change. This fixes the publisher contract used by the existing deployment declaration.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex authored this PR using the authoring-ci-workflows, gating-production-deploys, Depot runner, PlatformCTL, and writing-pr-descriptions skills.

The duplicate search found no existing publisher fix. The shared metadata action replaced custom ordered-tag logic.