### PR TITLE
fix(desktop): bump quill to beta.29 for light mode borders

### DIFF
--- a/products/desktop/packages/ui/package.json
+++ b/products/desktop/packages/ui/package.json
@@ -59,7 +59,7 @@
     "@posthog/git": "workspace:*",
     "@posthog/host-router": "workspace:*",
     "@posthog/platform": "workspace:*",
-    "@posthog/quill-charts": "0.3.0-beta.28",
+    "@posthog/quill-charts": "0.3.0-beta.29",
     "@posthog/shared": "workspace:*",
     "@posthog/workspace-client": "workspace:*",
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/products/desktop/pnpm-lock.yaml
+++ b/products/desktop/pnpm-lock.yaml
@@ -31,8 +31,8 @@ catalogs:
       specifier: 0.11.0
       version: 0.11.0
     '@posthog/quill':
-      specifier: 0.3.0-beta.28
-      version: 0.3.0-beta.28
+      specifier: 0.3.0-beta.29
+      version: 0.3.0-beta.29
     '@radix-ui/themes':
       specifier: ^3.2.1
       version: 3.3.0
@@ -209,7 +209,7 @@ importers:
         version: link:../../packages/quick-ask
       '@posthog/quill':
         specifier: 'catalog:'
-        version: 0.3.0-beta.28(@base-ui/react@1.3.0(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.1)
+        version: 0.3.0-beta.29(@base-ui/react@1.3.0(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.1)
       '@posthog/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -1353,8 +1353,8 @@ importers:
         specifier: workspace:*
         version: link:../platform
       '@posthog/quill-charts':
-        specifier: 0.3.0-beta.28
-        version: 0.3.0-beta.28(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 0.3.0-beta.29
+        version: 0.3.0-beta.29(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@posthog/shared':
         specifier: workspace:*
         version: link:../shared
@@ -1517,7 +1517,7 @@ importers:
         version: 2.1.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@posthog/quill':
         specifier: 'catalog:'
-        version: 0.3.0-beta.28(@base-ui/react@1.3.0(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.2.2)
+        version: 0.3.0-beta.29(@base-ui/react@1.3.0(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.2.2)
       '@posthog/tsconfig':
         specifier: workspace:*
         version: link:../../tooling/typescript
@@ -6261,9 +6261,6 @@ packages:
     engines: {node: '>=14.14', npm: '>=6'}
     hasBin: true
 
-  '@posthog/core@1.51.0':
-    resolution: {integrity: sha512-LilmmtjcrjV1LgaVNQXrAUt4IXcWIYMrwEtx6VJUUFDeBBdmeI99jshKGtAWugYeB3Wkcp9xQIVCrxIYRpNiRA==}
-
   '@posthog/core@1.51.1':
     resolution: {integrity: sha512-k0aDkW2XR7G0CWVnL0MZdY8wS5PhYvFtpWLdC2vD/sIUB6BGHhxNLgfVd2mLpmuf1zCBz5Q+p8g/01VL88s0Hg==}
 
@@ -6277,14 +6274,14 @@ packages:
   '@posthog/plugin-utils@2.0.0':
     resolution: {integrity: sha512-PC94+3zeEQ2IkhiU+pskOIOEkAFKZvwVixvrwpRfy+cl4b6gkTuHN44vp5OeG5ndfQOLJQF5onx8/K7yZC3i1g==}
 
-  '@posthog/quill-charts@0.3.0-beta.28':
-    resolution: {integrity: sha512-6C0MDyfmbPuxusWflJ2NPD9DpDGJBKSjMUnp6wn7GxRsXnnxGMGhAxjU9Vl2EpvM1QxL7IsargJj74GQAWEjsQ==}
+  '@posthog/quill-charts@0.3.0-beta.29':
+    resolution: {integrity: sha512-zuIP2dgt8hPOFmINAsueBMMnTEOlB5CXqWwqJBAWFM9cYlxIhd3IUZqRfwUC1Ockr/Yw0EqKwZwBAa7rLzdxvw==}
     peerDependencies:
       react: 19.2.6
       react-dom: 19.2.6
 
-  '@posthog/quill@0.3.0-beta.28':
-    resolution: {integrity: sha512-FFKyvNecHq+EU1KC3s8wEH0yuRdT/9mmMosvrUXnHP9RVIvscoS/DGBifUa0I1aI+I9HI2lVFp8GUUj1T+Q9mQ==}
+  '@posthog/quill@0.3.0-beta.29':
+    resolution: {integrity: sha512-ZKMlqqyNSchwgoVVpk2TrhANTWJqOJTY8xbdQRwC5XuhqqY1QQOmstJInMZhh0S1AEqc/qnG+H7KxDog5vJUCw==}
     engines: {node: '>=20'}
     peerDependencies:
       '@base-ui/react': ^1.3.0
@@ -6302,9 +6299,6 @@ packages:
     resolution: {integrity: sha512-QdSjBt+wt+j2VwLADpsr1Ii2j8F5rWe+V/m9O9PuZXWT8nUne8ML5ciMxAmsGTIIfVwmLhdXPtDlJEc2LuJ9rg==}
     peerDependencies:
       rollup: 4.59.0
-
-  '@posthog/types@1.409.1':
-    resolution: {integrity: sha512-lA2sSGQUdVknSQl93uN9eUXDwkCMjAuthq24GONGHzMWwVygsKNHlWCnlJsVv2giDokj2p1NopO4zsE2S7gYjA==}
 
   '@posthog/types@1.409.2':
     resolution: {integrity: sha512-hZ4EXZ1+BstMaxUkmAEg3qvgMR/S00Xb+wEwY/Tx2Dr9dBgiBWrERxaq2UwICh/Fh/vVXpKZT/0SkRtO8JKQ2A==}
@@ -20981,10 +20975,6 @@ snapshots:
     dependencies:
       detect-libc: 2.1.2
 
-  '@posthog/core@1.51.0':
-    dependencies:
-      '@posthog/types': 1.409.2
-
   '@posthog/core@1.51.1':
     dependencies:
       '@posthog/types': 1.409.2
@@ -21006,7 +20996,7 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
-  '@posthog/quill-charts@0.3.0-beta.28(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@posthog/quill-charts@0.3.0-beta.29(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@floating-ui/react': 0.27.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       d3-array: 3.2.4
@@ -21018,7 +21008,7 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       simple-statistics: 7.8.9
 
-  '@posthog/quill@0.3.0-beta.28(@base-ui/react@1.3.0(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.2.2)':
+  '@posthog/quill@0.3.0-beta.29(@base-ui/react@1.3.0(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.2.2)':
     dependencies:
       '@base-ui/react': 1.3.0(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       class-variance-authority: 0.7.1
@@ -21030,7 +21020,7 @@ snapshots:
       tailwind-merge: 2.6.1
       tailwindcss: 4.2.2
 
-  '@posthog/quill@0.3.0-beta.28(@base-ui/react@1.3.0(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.1)':
+  '@posthog/quill@0.3.0-beta.29(@base-ui/react@1.3.0(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.1)':
     dependencies:
       '@base-ui/react': 1.3.0(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       class-variance-authority: 0.7.1
@@ -21053,8 +21043,6 @@ snapshots:
       '@posthog/plugin-utils': 2.0.0
       magic-string: 0.30.21
       rollup: 4.62.2
-
-  '@posthog/types@1.409.1': {}
 
   '@posthog/types@1.409.2': {}
 
@@ -22018,7 +22006,9 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 

--- a/products/desktop/pnpm-workspace.yaml
+++ b/products/desktop/pnpm-workspace.yaml
@@ -14,7 +14,7 @@ catalog:
     '@parcel/watcher': ^2.5.6
     '@phosphor-icons/react': ^2.1.10
     '@posthog/brand': 0.11.0
-    '@posthog/quill': 0.3.0-beta.28
+    '@posthog/quill': 0.3.0-beta.29
     '@radix-ui/themes': ^3.2.1
     '@tanstack/react-query': ^5.100.14
     '@tanstack/react-router': ^1.170.10


### PR DESCRIPTION
## Problem

Borders in the desktop app are too faint to see in light mode, so cards, inputs and panels lose their edges.

- Quill's light-mode `--border` token sits at oklch lightness `0.9`, which is close to the `0.966` page background.
- The desktop app pins `@posthog/quill` in `products/desktop/pnpm-workspace.yaml`, so it does not pick up token fixes until the catalog moves.

## Changes

- Borders in light mode read darker across every quill surface: the token drops to oklch lightness `0.88`. Dark mode is unchanged.
- Bumps the quill catalog entry and `@posthog/quill-charts` from `0.3.0-beta.28` to `0.3.0-beta.29`.
- The lockfile update is mechanical.

The bump also carries quill's new `secondary` and `destructive-outline` Button and Link variants. No call site uses them yet.

No screenshot: the change is a token value, and capturing it means running the Electron app.

## How did you test this code?

- `pnpm --filter @posthog/ui typecheck` passes, which covers the new quill type surface.
- Not checked: the app was not launched, so the border change was read from the published package CSS rather than seen.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code committed the already-staged version bump, pushed, and wrote this description. Skills invoked: `/writing-pr-descriptions`.

The branch was renamed from `desktop/bump-quill-fix-borders` to `desktop-bump-quill-fix-borders`. A remote branch named `desktop` already exists, so git refuses any `desktop/*` ref.

The quill diff between beta.28 and beta.29 was read from the published npm tarballs to confirm the border token is the visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7JZFPCF4y89ntm3Tv7htC