### PR TITLE
chore(migrations): require dropping hot-parent FKs when retiring a model

### DIFF
--- a/.agents/skills/django-migrations/SKILL.md
+++ b/.agents/skills/django-migrations/SKILL.md
@@ -25,8 +25,11 @@ Adding migrations is fine. **Deleting a historical one — any `*/migrations/NNN
 To retire a model/table:
 
 1. Remove all usage and the model class. `makemigrations`, then wrap the generated `DeleteModel` in `migrations.SeparateDatabaseAndState(state_operations=[...])` (state only, no DB change). KEEP this file. Keep the app in `INSTALLED_APPS`.
+   **If the model has a `ForeignKey` to `posthog_team`, `posthog_user`, `posthog_organization` or `posthog_project`, drop that constraint in `database_operations` in this same migration.** This is required, not a cleanup. Django stops cascading into a table it can no longer see, so the child rows survive a parent delete. Those constraints are `DEFERRABLE INITIALLY DEFERRED`, so the parent delete runs its whole cascade and then fails at `COMMIT`, and team and organization deletion stay broken until someone drops the table.
 2. Deploy, wait at least one full deploy cycle.
-3. Optionally `DROP TABLE` later in a NEW `RunSQL` migration — never by deleting old files.
+3. `DROP TABLE` later in a NEW `RunSQL` migration — never by deleting old files. Treat this as owed work rather than an option whenever step 1 left a foreign key to a hot parent in place.
+   `DROP TABLE` takes `ACCESS EXCLUSIVE` on every table its foreign keys reference, so a drop that still points at a hot parent must `SET LOCAL lock_timeout` to bound the wait. See [hot table hazard](#hot-table-hazard).
+   `python manage.py audit_orphan_hot_table_fks` lists tables already in this state. Run it against a long-lived database: a squashed history has no `CreateModel` for a table that left Django's state before the squash, so a fresh database never creates it and the migration files hold no trace of it.
 
 Full guide: `safe-django-migrations.md` (`## Dropping Tables`, `### Removing a whole product or app`). Deleting a migration your branch added but never merged to master is allowed (regenerating).
 

--- a/docs/published/handbook/engineering/safe-django-migrations.md
+++ b/docs/published/handbook/engineering/safe-django-migrations.md
@@ -134,8 +134,28 @@ class Migration(migrations.Migration):
                 # Project). Django stops cascading into a table it cannot see, so the child rows
                 # outlive a parent delete. The constraint is DEFERRABLE INITIALLY DEFERRED, so the
                 # parent delete completes its cascade and then fails at COMMIT.
+                # Django names foreign keys with a hash suffix, so never hardcode the name with
+                # IF EXISTS: a wrong guess drops nothing and the migration still succeeds. Read the
+                # name from the catalog. The loop drops nothing on a re-run, so bin/migrate can
+                # retry the migration safely.
                 migrations.RunSQL(
-                    sql="ALTER TABLE posthog_oldfeature DROP CONSTRAINT IF EXISTS posthog_oldfeature_team_id_fkey",
+                    sql="""
+                    DO $$
+                    DECLARE fk record;
+                    BEGIN
+                        FOR fk IN
+                            SELECT con.conname
+                            FROM pg_constraint con
+                            JOIN pg_class src ON src.oid = con.conrelid
+                            JOIN pg_class tgt ON tgt.oid = con.confrelid
+                            WHERE con.contype = 'f'
+                              AND src.relname = 'posthog_oldfeature'
+                              AND tgt.relname = 'posthog_team'
+                        LOOP
+                            EXECUTE format('ALTER TABLE posthog_oldfeature DROP CONSTRAINT %I', fk.conname);
+                        END LOOP;
+                    END $$;
+                    """,
                     reverse_sql=migrations.RunSQL.noop,
                 ),
             ],
@@ -152,7 +172,7 @@ class Migration(migrations.Migration):
 - Django's `TransactionTestCase` uses `TRUNCATE` to clean up between tests
 - PostgreSQL won't truncate a table that has FKs pointing to it
 - Since the model is removed from Django's state, Django doesn't know to include it in the truncate list
-- Fix: Drop the FK constraints in `database_operations` (see commented example above) - you're dropping the table soon anyway
+- Fix: Drop the FK constraints in `database_operations` (see the example above) - required anyway, because leaving them breaks parent deletion
 
 **Step 2: Wait for safety window**
 

--- a/docs/published/handbook/engineering/safe-django-migrations.md
+++ b/docs/published/handbook/engineering/safe-django-migrations.md
@@ -130,17 +130,22 @@ class Migration(migrations.Migration):
                 migrations.DeleteModel(name='OldFeature'),
             ],
             database_operations=[
-                # If table has FKs to frequently-truncated tables (User, Team, Organization),
-                # drop those FK constraints to avoid blocking TransactionTestCase teardown.
-                # migrations.RunSQL(
-                #     sql="ALTER TABLE posthog_oldfeature DROP CONSTRAINT IF EXISTS posthog_oldfeature_team_id_fkey",
-                # ),
+                # Required when the table has an FK to a hot parent (Team, User, Organization,
+                # Project). Django stops cascading into a table it cannot see, so the child rows
+                # outlive a parent delete. The constraint is DEFERRABLE INITIALLY DEFERRED, so the
+                # parent delete completes its cascade and then fails at COMMIT.
+                migrations.RunSQL(
+                    sql="ALTER TABLE posthog_oldfeature DROP CONSTRAINT IF EXISTS posthog_oldfeature_team_id_fkey",
+                    reverse_sql=migrations.RunSQL.noop,
+                ),
             ],
         ),
     ]
 ```
 
 5. Deploy this PR and verify no errors in production
+
+**Deleting a parent becomes impossible if you skip that constraint drop.** Once the model leaves Django's state, a `Team.objects.delete()` cascade no longer reaches the table, so its rows keep referencing the team. Because the constraint is deferred, Postgres raises the violation at `COMMIT`, after the whole cascade has run, and the delete can never succeed. Team and organization deletion stay broken for every tenant with rows in that table until someone drops it. Run `python manage.py audit_orphan_hot_table_fks` against a long-lived database to list tables already in this state; a squashed history leaves no trace of them in the migration files.
 
 **Test infrastructure note:** If your table has foreign keys pointing TO frequently-truncated tables like `User`, `Team`, or `Organization`, you may see test failures like `cannot truncate a table referenced in a foreign key constraint`. This happens because:
 
@@ -159,6 +164,7 @@ class Migration(migrations.Migration):
 
 - Safe to leave unused tables temporarily, but long-term they can clutter schema introspection and slow migrations
 - Ensure no other models reference this table via foreign keys before dropping (Django won't cascade automatically)
+- `DROP TABLE` takes `ACCESS EXCLUSIVE` on every table its own foreign keys reference. If one of those is a hot parent, add `SET LOCAL lock_timeout` to bound the wait, because queries arriving while the lock request queues wait behind it
 - If you must drop it, use `RunSQL` with raw SQL (see example below)
 - In the PR description, reference the model removal PR (e.g., "Model removed in #12345, deployed X days ago") so reviewers can verify the safety window
 


### PR DESCRIPTION
## Problem

The guidance for retiring a model shows the step that prevents broken tenant deletion as a commented-out example, and frames it as a test-teardown convenience. Following the docs exactly produces a table that makes team and organization deletion impossible.

- safe-django-migrations.md phase 1 wraps `DeleteModel` in `SeparateDatabaseAndState`, which leaves the table in the database. That part is correct.
- Its `database_operations` block shows the foreign key constraint drop commented out, explained only as a way to keep `TransactionTestCase` teardown working.
- The real consequence is larger. Once the model leaves Django's state, a parent delete no longer cascades into the table, so the child rows keep referencing the parent.
- The constraints are `DEFERRABLE INITIALLY DEFERRED`, so the delete finishes its whole cascade and then fails at `COMMIT`. It can never succeed.
- Phase 3, the table drop, reads as "optional", so it reliably never happens.

## Changes

- Retiring a model now tells you to drop the hot-parent foreign key in the same migration, as a requirement rather than a commented-out suggestion.
- The example `database_operations` block is real code instead of a comment, and says why the drop matters.
- The docs now state the failure directly: skip the drop and tenant deletion breaks for every tenant with rows in that table, permanently.
- Phase 3 is described as owed work rather than an option once phase 1 leaves such a foreign key in place.
- Both documents record that `DROP TABLE` takes `ACCESS EXCLUSIVE` on every table its foreign keys reference, so a drop pointing at a hot parent needs `SET LOCAL lock_timeout`.
- Both point at `audit_orphan_hot_table_fks` (#97948) and note it must run against a long-lived database, because a squashed history leaves no trace of these tables in the migration files.

Documentation only. No code changes, and `.claude/skills/` is generated from `.agents/skills/`, so only the latter is edited.

## How did you test this code?

- No tests. The change is prose in one skill and one handbook page.
- `hogli format:markdown` ran through lint-staged on commit.
- The claims about lock behavior and `COMMIT`-time failure were measured on Postgres 15.12 while diagnosing the incident that prompted this, and are recorded in #97935 with the `pg_locks` output behind them.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

This PR is the docs update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Opus 5 in Claude Code, directed by the assignee.

Skills invoked: `/django-migrations`, `/writing-code-comments`, `/writing-pr-descriptions`.

Third of three PRs from one investigation: #97901 drops the two tables that broke deletion, #97935 bounds that drop's lock wait, and this one changes the guidance that produced them. The wording deliberately leads with the deletion failure rather than the test-teardown symptom, because the existing framing is what made the step look skippable.

An earlier plan added a CI repo-invariant test instead of documentation. That was dropped: the migration history squash removes the operations such a test would read, so it reports nothing. That finding is why both documents now say the audit has to run against a long-lived database.

Public artifact: nothing here carries non-public material.
