### PR TITLE
fix(auth): show a login message instead of a 500 on failed SSO signup

### DIFF
--- a/ee/api/test/test_authentication.py
+++ b/ee/api/test/test_authentication.py
@@ -11,7 +11,6 @@ from unittest.mock import patch
 
 from django.conf import settings
 from django.core import mail
-from django.core.exceptions import ValidationError
 from django.shortcuts import redirect
 from django.test import override_settings
 from django.utils import timezone
@@ -1035,21 +1034,18 @@ YotAcSbU3p5bzd11wpyebYHB"""
 
         user_count = User.objects.count()
 
-        with self.assertRaises(ValidationError) as e:
-            response = self.client.post(
-                "/complete/saml/",
-                {
-                    "SAMLResponse": saml_response,
-                    "RelayState": str(self.organization_domain.id),
-                },
-                format="multipart",
-                follow=True,
-            )
-
-        self.assertEqual(
-            str(e.exception),
-            "{'name': ['This field is required and was not provided by the IdP.']}",
+        response = self.client.post(
+            "/complete/saml/",
+            {
+                "SAMLResponse": saml_response,
+                "RelayState": str(self.organization_domain.id),
+            },
+            format="multipart",
+            follow=True,
         )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)  # because `follow=True`
+        self.assertRedirects(response, "/login?error_code=missing_idp_attribute")
 
         self.assertEqual(User.objects.count(), user_count)
 

--- a/frontend/src/scenes/authentication/shared/loginErrorMessages.tsx
+++ b/frontend/src/scenes/authentication/shared/loginErrorMessages.tsx
@@ -39,5 +39,7 @@ export const ERROR_MESSAGES: Record<string, string | JSX.Element> = {
         "You signed in with a different account. Please try again with the account you're logged in as.",
     invalid_invite:
         'This invite link is no longer valid. It may have expired or been revoked. Please ask your administrator for a new invite.',
+    missing_idp_attribute:
+        'Your SSO provider did not send your name or email address, so we could not create your account. Please ask your administrator to check your SSO configuration.',
     social_login_failure: 'Login failed. Please try again or contact your administrator.',
 }

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -822,11 +822,18 @@ def lookup_invite_for_saml(email: str, saml_relay_state: str) -> Optional[Organi
     config = IdentityProviderConfig.objects.filter(saml_relay_state=saml_relay_state).first()
     if config is None:
         return None
-    return (
+    invite = (
         OrganizationInvite.objects.filter(target_email=email, organization_id=config.organization_id)
         .order_by("-created_at")
         .first()
     )
+    # This lookup is a convenience for a person who logged in with a plain SSO button and presented
+    # no invite link. An expired invite must read as no invite here, because `validate()` raises on
+    # it and the signup then stops before it can fall through to JIT provisioning. Only the newest
+    # invite needs the test, because every older invite for the same email is expired too.
+    if invite is not None and invite.is_expired():
+        return None
+    return invite
 
 
 def process_social_invite_signup(
@@ -1037,10 +1044,11 @@ def social_create_user(
         missing_attr = "email" if not email else "name"
         posthoganalytics.tag("email", email)
         posthoganalytics.tag("name", full_name)
-        raise ValidationError(
-            {missing_attr: "This field is required and was not provided by the IdP."},
-            code="required",
-        )
+        # A raise here reaches Django's default 500 handler and shows the generic error page,
+        # because this is a plain Django view and the social auth middleware only translates
+        # `social_core` exceptions. A redirect gives the person a message they can act on.
+        logger.warning("social_create_user_missing_idp_attribute", missing_attribute=missing_attr)
+        return redirect("/login?error_code=missing_idp_attribute")
 
     # If we get here then it's a new user. We'll check for outstanding invites for them
     # on the organization domain or if JIT provisioning is enabled, we'll provision them.

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -3420,3 +3420,14 @@ class TestSAMLInviteLookup(APIBaseTest):
 
     def test_unknown_identifier_returns_nothing(self):
         assert lookup_invite_for_saml("joiner@example.com", "not-an-identifier") is None
+
+    def test_expired_invite_returns_nothing(self):
+        identifier = self._saml_identifier_for("saml-invite.example.com")
+        invite = OrganizationInvite.objects.create(
+            organization=self.organization, target_email="joiner@saml-invite.example.com"
+        )
+        OrganizationInvite.objects.filter(id=invite.id).update(
+            created_at=timezone.now() - timedelta(days=INVITE_DAYS_VALIDITY + 1)
+        )
+
+        assert lookup_invite_for_saml("joiner@saml-invite.example.com", identifier) is None

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -14,7 +14,10 @@ from urllib.parse import urlencode
 from django.conf import settings
 from django.contrib.auth import BACKEND_SESSION_KEY, logout
 from django.core.cache import cache
-from django.core.exceptions import MiddlewareNotUsed
+from django.core.exceptions import (
+    MiddlewareNotUsed,
+    ValidationError as DjangoValidationError,
+)
 from django.db import (
     connection,
     connections as db_connections,
@@ -33,6 +36,7 @@ from django_prometheus.middleware import Metrics
 from loginas.utils import is_impersonated_session, restore_original_login
 from opentelemetry import trace
 from prometheus_client import Counter, Histogram
+from rest_framework.exceptions import ValidationError as DRFValidationError
 from social_core.exceptions import AuthCanceled, AuthException, AuthFailed
 from statshog.defaults.django import statsd
 
@@ -42,11 +46,12 @@ from posthog.clickhouse.query_tagging import QueryCounter, get_query_tag_value, 
 from posthog.cloud_utils import is_cloud, is_dev_mode
 from posthog.constants import AUTH_BACKEND_KEYS
 from posthog.event_usage import get_event_source, get_mcp_properties, sanitize_header_value
+from posthog.exceptions_capture import capture_exception
 from posthog.geoip import get_geoip_properties
 from posthog.helpers.impersonation import get_original_user_from_session
 from posthog.helpers.sso import sso_failure_redirect_url
 from posthog.helpers.user_devices import set_known_device_cookie
-from posthog.models import Team, User
+from posthog.models import InviteExpiredException, Team, User
 from posthog.models.activity_logging.utils import (
     ACTIVITY_LOG_CLIENT_HEADER,
     ACTIVITY_LOG_CLIENT_MAX_LENGTH,
@@ -1346,6 +1351,17 @@ class SocialAuthExceptionMiddleware:
             url = sso_failure_redirect_url(request, "social_login_failure")
             separator = "&" if "?" in url else "?"
             return redirect(f"{url}{separator}{urlencode({'error_detail': error_detail})}")
+
+        # A pipeline function can raise a DRF or Django `ValidationError`, for example when the
+        # invite that the signup resolves is no longer usable. Neither type comes from
+        # `social_core`, and the callback is a plain Django view rather than a DRF view, so without
+        # this branch the exception reaches Django's default 500 handler and the person gets the
+        # generic error page with no next step. Report the exception here, because this branch
+        # stops it from reaching the 500 handler that would otherwise report it.
+        if isinstance(exception, DRFValidationError | DjangoValidationError):
+            capture_exception(exception)
+            error_code = "invalid_invite" if isinstance(exception, InviteExpiredException) else "social_login_failure"
+            return redirect(sso_failure_redirect_url(request, error_code))
 
         return None
 

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 from django.conf import settings
 from django.core.cache import cache
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.http import HttpResponse, HttpResponseRedirect
 from django.test import (
     Client as DjangoClient,
@@ -20,6 +21,7 @@ import structlog
 from loginas import settings as la_settings
 from parameterized import parameterized
 from rest_framework import status
+from rest_framework.exceptions import ValidationError as DRFValidationError
 from social_core.backends.base import BaseAuth
 from social_core.exceptions import AuthCanceled, AuthFailed, AuthMissingParameter
 
@@ -27,6 +29,7 @@ from posthog.api.test.test_organization import create_organization
 from posthog.api.test.test_team import create_team
 from posthog.middleware import per_request_logging_context_middleware
 from posthog.models.organization import Organization
+from posthog.models.organization_invite import InviteExpiredException
 from posthog.models.team import Team
 from posthog.models.user import User
 from posthog.settings import SITE_URL
@@ -2066,6 +2069,24 @@ class TestSocialAuthExceptionMiddleware(APIBaseTest):
                 "/complete/saml/",
                 AuthFailed(_social_auth_backend(), "sso_enforced"),
                 "/login?error_code=sso_enforced",
+            ),
+            (
+                "expired_invite_on_complete",
+                "/complete/saml/",
+                InviteExpiredException(),
+                "/login?error_code=invalid_invite",
+            ),
+            (
+                "unusable_invite_on_complete",
+                "/complete/saml/",
+                DRFValidationError("You already are a member of this organization.", code="user_already_member"),
+                "/login?error_code=social_login_failure",
+            ),
+            (
+                "django_validation_error_on_complete",
+                "/complete/saml/",
+                DjangoValidationError("This field is required and was not provided by the IdP."),
+                "/login?error_code=social_login_failure",
             ),
         ]
     )


### PR DESCRIPTION
## Problem

A person signing in with SSO can land on the generic "Oops! Things went south" error page, with no message and no next step. A retry gives the same page.

- The SSO callback is a plain Django view, and `SocialAuthExceptionMiddleware` translates only `social_core` exceptions. Anything else reaches Django's default 500 handler, which renders `posthog/templates/500.html`.
- An expired organization invite triggers this. `lookup_invite_for_saml` returns the newest invite for the email without filtering expired rows, and `invite.validate()` then raises `InviteExpiredException`.
- Clicking an invite link is not needed to hit it. A plain "Log in with SAML" button is enough, because that lookup is the fallback when the session holds no `invite_id`.
- An identity provider that omits the name or email attribute reaches the same page, through a Django `ValidationError` raised in `social_create_user`.

## Changes

- An expired invite no longer stops SSO signup. `lookup_invite_for_saml` treats it as no invite, so the flow continues to JIT provisioning or to the existing `jit_not_enabled` message.
- An identity provider that omits a name or email now sends the person to the login screen with new copy: "Your SSO provider did not send your name or email address, so we could not create your account. Please ask your administrator to check your SSO configuration."
- Any remaining DRF or Django `ValidationError` on an SSO callback becomes a login error instead of a 500. `InviteExpiredException` maps to the existing `invalid_invite` copy, and everything else to `social_login_failure`.
- The middleware reports each exception it absorbs, so error tracking keeps the signal that the 500 handler carried.
- The JIT provisioning path already recovered from an expired invite. This change gives the SAML fallback path the same behavior instead of adding a second recovery rule.

The new message renders in the existing login error banner, the component that renders `invalid_invite` today. Nothing about the layout changes, so there is no screenshot.

## How did you test this code?

Automated tests only. No manual browser run against an identity provider.

- `TestSAMLInviteLookup` gains an expired-invite case. It catches a regression where the SAML fallback resurrects an expired invite and dead-ends the login.
- `TestSocialAuthExceptionMiddleware` gains three cases: an expired invite, an unusable invite, and a Django `ValidationError`. They catch a regression where a non-`social_core` exception falls through to the 500 handler.
- `test_cannot_create_account_without_first_name_in_payload` asserted that the missing-name `ValidationError` propagates, so it encoded the 500 as expected behavior. It now asserts the redirect.
- Also run locally: `hogli build:openapi`, which produced no generated-type diff, and repo-wide mypy.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) in a PostHog Desktop cloud task. Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

The work started from a support investigation that traced the error screen to exceptions captured on the SSO callback. Every step of the chain was re-verified against this repository before any code changed. An earlier reading blamed a missing IdP attribute alone. The expired invite is the confirmed trigger, and both symptoms share one root cause, so both are fixed here.

The first design caught `InviteExpiredException` at the call site. Filtering the invite out of `lookup_invite_for_saml` replaced it, because the person presented no invite link and an unusable invite should not change the flow they get. The middleware branch stays as the net for the other `validate()` failures, which are reachable but were not observed.

No duplicate: `gh pr list --state open --search` over the invite, middleware, and lookup keywords found nothing. Nothing from the originating support session appears in the code, the tests, or this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
