### PR TITLE
fix(warehouse-sources): stop reporting integration-service blips during schema discovery

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/sync_new_schemas.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/sync_new_schemas.py
@@ -6,7 +6,10 @@ from django.db import close_old_connections
 from structlog.contextvars import bind_contextvars
 from temporalio import activity
 
+from posthog.exceptions_capture import capture_exception
+from posthog.integration_secrets.errors import IntegrationSecretsFailure
 from posthog.models.integration import UndecryptedIntegrationSecretError
+from posthog.temporal.common.errors import NonReportableError
 from posthog.temporal.common.logger import get_logger
 
 from products.data_warehouse.backend.facade.api import delete_discover_schemas_schedule
@@ -92,7 +95,25 @@ def sync_new_schemas_activity(inputs: SyncNewSchemasActivityInputs) -> None:
             if isinstance(e, UndecryptedIntegrationSecretError):
                 logger.warning(f"Skipping schema discovery due to non-retryable source error: {e}")
                 return
+
             error_msg = str(e)
+
+            # Every credential the integration service holds is PostHog's own (OAuth app secrets,
+            # API keys), never the customer's, and none of its failure states are permanent — a
+            # burned key gets re-provisioned, an unreachable service comes back. Unlike the skips
+            # above, this isn't ours to give up on: re-raise wrapped in NonReportableError so the
+            # workflow's own retry policy (discover_schemas_workflow.py) retries the activity, the
+            # same recovery import_data_sync.py's _handle_import_error already gives the per-schema
+            # sync path, without minting an error tracking issue per credential read for a platform
+            # blip the service's own availability alerting already covers.
+            if isinstance(e, IntegrationSecretsFailure):
+                if e.reportable:
+                    capture_exception(e)
+                    logger.exception(error_msg)
+                else:
+                    logger.warning(error_msg)
+                raise NonReportableError(error_msg) from e
+
             non_retryable_errors = new_source.get_non_retryable_errors()
             if error_message_matches(error_msg, non_retryable_errors):
                 logger.warning(f"Skipping schema discovery due to non-retryable source error: {error_msg}")

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_sync_new_schemas.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_sync_new_schemas.py
@@ -3,7 +3,9 @@ import contextlib
 import pytest
 from unittest import mock
 
+from posthog.integration_secrets.errors import IntegrationServiceUnreachableError
 from posthog.models.integration import UndecryptedIntegrationSecretError
+from posthog.temporal.common.errors import NonReportableError
 
 from products.warehouse_sources.backend.models.external_data_schema import SchemaSyncResult
 from products.warehouse_sources.backend.temporal.data_imports.workflow_activities import sync_new_schemas as module
@@ -84,6 +86,20 @@ def test_undecrypted_integration_secret_error_is_skipped():
     source_mock.get_non_retryable_errors.return_value = {}
 
     _run_activity(source_mock)
+
+
+def test_integration_service_unreachable_error_is_retried_without_reporting():
+    # An unreachable integration service is transient and never the customer's fault, so
+    # discovery must not disable the source (would need `handle_non_retryable_error`) nor mint
+    # an error tracking issue for it (reportable = False) — it must re-raise as
+    # NonReportableError so the workflow's retry policy picks it back up.
+    source_mock = mock.MagicMock()
+    source_mock.parse_config.return_value = {}
+    source_mock.get_schemas.side_effect = IntegrationServiceUnreachableError("connect timeout")
+    source_mock.get_non_retryable_errors.return_value = {}
+
+    with pytest.raises(NonReportableError):
+        _run_activity(source_mock)
 
 
 def test_discovery_uses_source_pinned_api_version():


### PR DESCRIPTION
## Problem

Google Ads schema discovery reported an issue in error tracking for a brief connect timeout to PostHog's own internal integration-credential service ([error tracking issue](https://us.posthog.com/project/2/error_tracking/01a08832-4145-7262-b0c4-a19750417166), 69 occurrences across many teams in a couple of minutes).

This credential (the Google Ads OAuth app secret) is one PostHog owns, not something the customer configured, and the outage is exactly the kind of thing that resolves on its own. The per-schema sync path (`import_data_sync.py`) already classifies this failure as transient and non-reportable. The schema-discovery activity (`sync_new_schemas_activity`, shared by every source) never got that same handling, so it fell through to a bare `raise` and the Temporal activity interceptor captured it as a real defect.

## Changes

- `sync_new_schemas_activity` now catches `IntegrationSecretsFailure` (the base type for every integration-service credential failure) before it can escape as a generic exception, and re-raises it wrapped in `NonReportableError`.
- The workflow's own retry policy (`discover_schemas_workflow.py`, 3 attempts) still retries the activity as before. The only change is that error tracking no longer gets a new issue for a credential outage its own availability alerting already covers.
- Mirrors the existing `IntegrationSecretsFailure` handling in `import_data_sync.py`'s `_handle_import_error`, so both discovery and sync paths agree.

## How did you test this code?

- Added `test_integration_service_unreachable_error_is_retried_without_reporting`, asserting the activity re-raises `NonReportableError` instead of the raw error. No existing test covered this failure type; the closest (`test_undecrypted_integration_secret_error_is_skipped`) exercises a different, non-retryable failure.
- Ran `pytest products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_sync_new_schemas.py` (8 passed) and `mypy` on the changed file — both clean.
- Not run: the Temporal integration suite, since this sandbox has no dev stack.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal error-classification behavior, no documented API or workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triggered by the error tracking issue linked above on the `GoogleAds` source, which surfaced a gap in the shared schema-discovery activity rather than in the Google Ads source code itself.
- Confirmed no open PR already covers this: [#97715](https://github.com/PostHog/posthog/pull/97715) touches the same activity but for an unrelated non-retryable-host classification.
- Skill invoked: `/writing-tests` before adding the regression test, `/writing-pr-descriptions` before writing this body.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
