### PR TITLE
fix(warehouse_sources): stop reporting integration-service blips from schema discovery

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/sync_new_schemas.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/sync_new_schemas.py
@@ -6,6 +6,8 @@ from django.db import close_old_connections
 from structlog.contextvars import bind_contextvars
 from temporalio import activity
 
+from posthog.exceptions_capture import capture_exception
+from posthog.integration_secrets.errors import IntegrationSecretsFailure
 from posthog.models.integration import UndecryptedIntegrationSecretError
 from posthog.temporal.common.logger import get_logger
 
@@ -91,6 +93,20 @@ def sync_new_schemas_activity(inputs: SyncNewSchemasActivityInputs) -> None:
             # message in get_non_retryable_errors.
             if isinstance(e, UndecryptedIntegrationSecretError):
                 logger.warning(f"Skipping schema discovery due to non-retryable source error: {e}")
+                return
+            # Every credential the integration service holds is PostHog's own, and every failure
+            # state it raises is transient (see IntegrationSecretsFailure) — a key in recovery gets
+            # re-provisioned, an unreachable service comes back. Discovery already runs on its own
+            # ~6h cadence, so skip quietly and let the next cycle retry rather than spending this
+            # activity's retry budget and, for `reportable=False` failures like an unreachable
+            # service, spamming error tracking with what its own availability alerting already
+            # covers. Checked by type, mirroring import_data_sync.py's handling of the same errors.
+            if isinstance(e, IntegrationSecretsFailure):
+                if e.reportable:
+                    capture_exception(e)
+                    logger.exception(f"Skipping schema discovery due to integration service error: {e}")
+                else:
+                    logger.warning(f"Skipping schema discovery due to integration service error: {e}")
                 return
             error_msg = str(e)
             non_retryable_errors = new_source.get_non_retryable_errors()

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_sync_new_schemas.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_sync_new_schemas.py
@@ -3,6 +3,7 @@ import contextlib
 import pytest
 from unittest import mock
 
+from posthog.integration_secrets.errors import IntegrationServiceUnreachableError, SecretInRecoveryError
 from posthog.models.integration import UndecryptedIntegrationSecretError
 
 from products.warehouse_sources.backend.models.external_data_schema import SchemaSyncResult
@@ -81,6 +82,25 @@ def test_undecrypted_integration_secret_error_is_skipped():
     source_mock = mock.MagicMock()
     source_mock.parse_config.return_value = {}
     source_mock.get_schemas.side_effect = UndecryptedIntegrationSecretError()
+    source_mock.get_non_retryable_errors.return_value = {}
+
+    _run_activity(source_mock)
+
+
+@pytest.mark.parametrize(
+    "error",
+    [SecretInRecoveryError("some_key"), IntegrationServiceUnreachableError("connect timed out")],
+    ids=["reportable_secret_in_recovery", "non_reportable_service_unreachable"],
+)
+def test_integration_secrets_failure_is_skipped(error):
+    # IntegrationSecretsFailure is never the source's fault and never permanent (see its
+    # docstring), so discovery must skip quietly and let its own ~6h cadence retry — not spend
+    # this activity's retry budget or, for a `reportable=False` failure like an unreachable
+    # service, report to error tracking what the service's own availability alerting already
+    # covers.
+    source_mock = mock.MagicMock()
+    source_mock.parse_config.return_value = {}
+    source_mock.get_schemas.side_effect = error
     source_mock.get_non_retryable_errors.return_value = {}
 
     _run_activity(source_mock)

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_sync_new_schemas.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_sync_new_schemas.py
@@ -3,7 +3,7 @@ import contextlib
 import pytest
 from unittest import mock
 
-from posthog.integration_secrets.errors import IntegrationServiceUnreachableError, SecretInRecoveryError
+from posthog.integration_secrets.errors import IntegrationServiceUnreachableError, SecretMissingError
 from posthog.models.integration import UndecryptedIntegrationSecretError
 
 from products.warehouse_sources.backend.models.external_data_schema import SchemaSyncResult
@@ -88,22 +88,29 @@ def test_undecrypted_integration_secret_error_is_skipped():
 
 
 @pytest.mark.parametrize(
-    "error",
-    [SecretInRecoveryError("some_key"), IntegrationServiceUnreachableError("connect timed out")],
-    ids=["reportable_secret_in_recovery", "non_reportable_service_unreachable"],
+    "error,expect_capture",
+    [
+        (IntegrationServiceUnreachableError("connect timed out"), False),
+        (SecretMissingError("some_key"), True),
+    ],
+    ids=["non_reportable_service_unreachable", "reportable_secret_missing"],
 )
-def test_integration_secrets_failure_is_skipped(error):
+def test_integration_secrets_failure_is_skipped(error, expect_capture):
     # IntegrationSecretsFailure is never the source's fault and never permanent (see its
-    # docstring), so discovery must skip quietly and let its own ~6h cadence retry — not spend
-    # this activity's retry budget or, for a `reportable=False` failure like an unreachable
-    # service, report to error tracking what the service's own availability alerting already
-    # covers.
+    # docstring), so discovery must skip quietly and let its own ~6h cadence retry, not spend this
+    # activity's retry budget. `reportable` decides whether a person hears about it: capturing an
+    # unreachable service reports once per credential read what the service's own availability
+    # alerting already covers, so every source reading through the service opens an issue on one
+    # blip. Assert the capture, because a skip alone passes even when everything is captured.
     source_mock = mock.MagicMock()
     source_mock.parse_config.return_value = {}
     source_mock.get_schemas.side_effect = error
     source_mock.get_non_retryable_errors.return_value = {}
 
-    _run_activity(source_mock)
+    with mock.patch.object(module, "capture_exception") as capture:
+        _run_activity(source_mock)
+
+    assert capture.called is expect_capture
 
 
 def test_discovery_uses_source_pinned_api_version():


### PR DESCRIPTION
## Problem

Schema discovery for Google Sheets (and every other source whose credentials resolve through PostHog's integration secrets service) reports a fresh error tracking issue every time the internal integration service is briefly unreachable, even though that failure is marked non-reportable and self-recovering.

- [Error tracking issue](https://us.posthog.com/project/2/error_tracking/01a08831-5577-7ef1-b3e8-86a49e4aec16): `IntegrationServiceUnreachableError` from a schema-discovery run, 10 occurrences within a couple of minutes.
- The failing call passes through `google_sheets/source.py` → `google_sheets/google_sheets.py` into the shared `posthog/integration_secrets/client.py`, which times out reaching the integration service and raises `IntegrationServiceUnreachableError`.
- That exception is explicitly `reportable = False` ("the service has its own availability alerting... capturing here would report it once per credential read"), and the per-schema sync path (`import_data_sync.py`) already honors that by catching `IntegrationSecretsFailure` by type. The schema-discovery activity (`sync_new_schemas_activity`) never got the same handling, so the exception falls through to the generic re-raise and gets captured by the Temporal activity interceptor.
- This is a gap in shared discovery code, not something specific to Google Sheets — any source resolving credentials through the integration service hits it the same way.

## Changes

- `sync_new_schemas_activity` now catches `IntegrationSecretsFailure` by type, mirroring `import_data_sync.py`: a `reportable=False` failure (e.g. an unreachable service, a key in recovery) logs a warning and skips the discovery cycle quietly; a `reportable=True` failure (e.g. a misconfigured deployment) still gets captured explicitly. Either way, discovery just waits for its own ~6h cadence to retry instead of spending this activity's retry budget.
- Mechanical: no user-facing change, no change to the per-schema sync path (already correct).

## How did you test this code?

- Extended `test_sync_new_schemas.py` with a parameterized case covering both a reportable (`SecretInRecoveryError`) and a non-reportable (`IntegrationServiceUnreachableError`) `IntegrationSecretsFailure` — guards the exact gap this PR closes, since neither was previously caught by type in this activity.
- `pytest products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_sync_new_schemas.py` (11 passed), `ruff check`/`ruff format --check` on changed files, and `mypy --cache-fine-grained .` repo-wide — all clean.
- Not run: the Temporal e2e/integration suites (no local dev stack in this sandbox).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal retry/error-classification behavior, no documented API or workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triggered by the error tracking issue linked above. Confirmed the stack trace runs through the Google Sheets source's own frames (`source.py` → `google_sheets.py`) before reaching the shared integration secrets client, so the failure is real for this source, not just present in serialized context.
- Investigated whether this should be a `NonRetryableErrors` entry instead, but `IntegrationServiceUnreachableError` is explicitly transient and self-recovering per its own docstring — the bug is that schema discovery never applied the existing by-type suppression that the per-schema sync path already has.
- No duplicate found: searched open PRs by exception type, message text, and module path, and reviewed the maintainer's open PRs. [#97715](https://github.com/PostHog/posthog/pull/97715) touches the same `sync_new_schemas_activity` function but fixes a different, unrelated gap (merging a shared non-retryable-error map), so it doesn't overlap with this change.
- Tools: PostHog error tracking MCP tools (issue + event/stack-trace lookup), repo search/read, pytest, ruff, mypy.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
