### PR TITLE
fix(ci): fail on forbidden eager imports

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -668,7 +668,7 @@ jobs:
                       echo "Skipping toolbar bundle section — script not present on this checkout"
                   fi
 
-            - name: Check eager graph budgets (warn only)
+            - name: Check eager graph budgets and forbidden imports
               if: always() && github.event_name == 'pull_request'
               run: |
                   if [ ! -f frontend/bin/check-eager-graph.mjs ]; then
@@ -683,7 +683,7 @@ jobs:
                       echo "Skipping eager graph check — no report found (branch may predate the check)"
                       exit 0
                   fi
-                  node frontend/bin/check-eager-graph.mjs --assert-report "$REPORT"
+                  node frontend/bin/check-eager-graph.mjs --assert-report "$REPORT" --fail-forbidden-hits
 
             - name: Check toolbar for CSP eval violations
               run: pnpm --filter=@posthog/frontend check-toolbar-csp-eval

--- a/frontend/bin/check-eager-graph.mjs
+++ b/frontend/bin/check-eager-graph.mjs
@@ -18,6 +18,7 @@ const reportOnly = process.argv.includes('--report-only')
 // recorded violations as warnings (GitHub Actions annotations) without failing CI — the
 // bundle-size Signals scout tracks regressions from the PR comment, so the check informs.
 const assertReportIndex = process.argv.indexOf('--assert-report')
+const failForbiddenHits = process.argv.includes('--fail-forbidden-hits')
 
 // The eager graph is everything a root actually SHIPS on the critical path — the bytes a
 // browser downloads and parses before that surface is interactive. It is measured from the
@@ -124,10 +125,11 @@ function warnViolation(message) {
 function assertReport(reportFilePath) {
     if (!fs.existsSync(reportFilePath)) {
         warnViolation(`Report not found at ${reportFilePath} — did the build run the check?`)
-        return 1
+        return { violations: 1, forbiddenHits: 0 }
     }
     const reportToAssert = JSON.parse(fs.readFileSync(reportFilePath, 'utf-8'))
     let violations = 0
+    let forbiddenHits = 0
     for (const message of reportToAssert.warnings ?? []) {
         warnViolation(message)
     }
@@ -137,6 +139,7 @@ function assertReport(reportFilePath) {
         violations++
     }
     for (const r of reportToAssert.roots) {
+        const rootForbiddenHits = r.forbiddenHits ?? []
         if (r.overBudget) {
             warnViolation(
                 `Eager graph for '${r.root}' ships ${formatMiB(r.bytes)}, over the ${formatMiB(r.budgetBytes)} budget.\n` +
@@ -147,22 +150,23 @@ function assertReport(reportFilePath) {
             )
             violations++
         }
-        for (const hit of r.forbiddenHits) {
+        for (const hit of rootForbiddenHits) {
             warnViolation(
                 `'${hit.module}' ships eagerly from '${r.root}' — it must stay behind a dynamic import.\n` +
                     `Import chain:\n   ${hit.chain.join('\n   -> ')}`
             )
             violations++
+            forbiddenHits++
         }
-        if (topLevelErrors.length === 0 && !r.overBudget && r.forbiddenHits.length === 0) {
+        if (topLevelErrors.length === 0 && !r.overBudget && rootForbiddenHits.length === 0) {
             console.info(`🟢 ${r.label}: ${formatMiB(r.bytes)} within ${formatMiB(r.budgetBytes)}`)
         }
     }
-    return violations
+    return { violations, forbiddenHits }
 }
 
 if (assertReportIndex !== -1) {
-    const violations = assertReport(process.argv[assertReportIndex + 1])
+    const { violations, forbiddenHits } = assertReport(process.argv[assertReportIndex + 1])
     if (violations) {
         console.warn(
             `\n⚠️ Eager graph check — ${violations} issue(s) above. Not failing CI: the bundle-size ` +
@@ -172,6 +176,10 @@ if (assertReportIndex !== -1) {
         // Neutral wording: warnings (e.g. a stale forbidden pattern) may have printed above
         // without counting as violations, so don't declare an unqualified all-clear.
         console.info('\nNo eager graph budget violations.')
+    }
+    if (failForbiddenHits && forbiddenHits > 0) {
+        console.error(`\n❌ Eager graph check found ${forbiddenHits} forbidden eager import(s).`)
+        process.exit(1)
     }
     process.exit(0)
 }

--- a/frontend/bin/check-eager-graph.mjs
+++ b/frontend/bin/check-eager-graph.mjs
@@ -125,7 +125,7 @@ function warnViolation(message) {
 function assertReport(reportFilePath) {
     if (!fs.existsSync(reportFilePath)) {
         warnViolation(`Report not found at ${reportFilePath} — did the build run the check?`)
-        return { violations: 1, forbiddenHits: 0 }
+        return { violations: 1, forbiddenHits: 0, analysisErrors: 1 }
     }
     const reportToAssert = JSON.parse(fs.readFileSync(reportFilePath, 'utf-8'))
     let violations = 0
@@ -162,11 +162,11 @@ function assertReport(reportFilePath) {
             console.info(`🟢 ${r.label}: ${formatMiB(r.bytes)} within ${formatMiB(r.budgetBytes)}`)
         }
     }
-    return { violations, forbiddenHits }
+    return { violations, forbiddenHits, analysisErrors: topLevelErrors.length }
 }
 
 if (assertReportIndex !== -1) {
-    const { violations, forbiddenHits } = assertReport(process.argv[assertReportIndex + 1])
+    const { violations, forbiddenHits, analysisErrors } = assertReport(process.argv[assertReportIndex + 1])
     if (violations) {
         console.warn(
             `\n⚠️ Eager graph check — ${violations} issue(s) above. Not failing CI: the bundle-size ` +
@@ -177,8 +177,10 @@ if (assertReportIndex !== -1) {
         // without counting as violations, so don't declare an unqualified all-clear.
         console.info('\nNo eager graph budget violations.')
     }
-    if (failForbiddenHits && forbiddenHits > 0) {
-        console.error(`\n❌ Eager graph check found ${forbiddenHits} forbidden eager import(s).`)
+    if (failForbiddenHits && (forbiddenHits > 0 || analysisErrors > 0)) {
+        console.error(
+            `\n❌ Eager graph check found ${forbiddenHits} forbidden eager import(s) and ${analysisErrors} analysis error(s).`
+        )
         process.exit(1)
     }
     process.exit(0)

--- a/frontend/bin/check-eager-graph.test.ts
+++ b/frontend/bin/check-eager-graph.test.ts
@@ -34,12 +34,13 @@ function runChecker(report: EagerGraphReport): number | null {
 
 describe('check-eager-graph.mjs', () => {
     it.each([
-        ['a forbidden eager import', [{ module: 'node_modules/monaco-editor/', chain: ['src/index.tsx'] }], false, 1],
-        ['a budget warning', [], true, 0],
-    ])('fails only for %s', (_, forbiddenHits, overBudget, expectedStatus) => {
+        ['a forbidden eager import', [{ module: 'node_modules/monaco-editor/', chain: ['src/index.tsx'] }], [], false, 1],
+        ['an analysis error', [], ['No output chunk found for src/index.tsx'], false, 1],
+        ['a budget warning', [], [], true, 0],
+    ])('fails only for %s', (_, forbiddenHits, errors, overBudget, expectedStatus) => {
         expect(
             runChecker({
-                errors: [],
+                errors,
                 roots: [{ root: 'src/index.tsx', forbiddenHits, largest: [], overBudget }],
                 warnings: [],
             })

--- a/frontend/bin/check-eager-graph.test.ts
+++ b/frontend/bin/check-eager-graph.test.ts
@@ -1,0 +1,48 @@
+import { spawnSync } from 'child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join, resolve } from 'path'
+
+const REPO_ROOT = resolve(__dirname, '..', '..')
+const CHECKER = join(REPO_ROOT, 'frontend', 'bin', 'check-eager-graph.mjs')
+
+interface EagerGraphReport {
+    errors: string[]
+    roots: {
+        forbiddenHits: { chain: string[]; module: string }[]
+        largest: { bytes: number; file: string }[]
+        overBudget: boolean
+        root: string
+    }[]
+    warnings: string[]
+}
+
+function runChecker(report: EagerGraphReport): number | null {
+    const directory = mkdtempSync(join(tmpdir(), 'eager-graph-'))
+    const reportPath = join(directory, 'report.json')
+    writeFileSync(reportPath, JSON.stringify(report))
+
+    try {
+        return spawnSync('node', [CHECKER, '--assert-report', reportPath, '--fail-forbidden-hits'], {
+            cwd: REPO_ROOT,
+            encoding: 'utf8',
+        }).status
+    } finally {
+        rmSync(directory, { recursive: true, force: true })
+    }
+}
+
+describe('check-eager-graph.mjs', () => {
+    it.each([
+        ['a forbidden eager import', [{ module: 'node_modules/monaco-editor/', chain: ['src/index.tsx'] }], false, 1],
+        ['a budget warning', [], true, 0],
+    ])('fails only for %s', (_, forbiddenHits, overBudget, expectedStatus) => {
+        expect(
+            runChecker({
+                errors: [],
+                roots: [{ root: 'src/index.tsx', forbiddenHits, largest: [], overBudget }],
+                warnings: [],
+            })
+        ).toBe(expectedStatus)
+    })
+})


### PR DESCRIPTION
## Problem

- Reviewers can see a forbidden eager import while CI still allows the change to merge.
- **Why:** This allows known boot-path regressions to reach users.

## Changes

- CI now fails when the eager graph reports a forbidden import.
- CI continues to warn, but not fail, for a size budget breach.
- A regression test covers both outcomes.

Before:

```mermaid
flowchart LR
    Report[Report has a forbidden import] --> Warning[CI writes a warning]
    Warning --> Merge[Merge can continue]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class Report phYellow;
    class Warning phRed;
    class Merge phBlue;
```

After:

```mermaid
flowchart LR
    Report[Report has a forbidden import] --> Failure[CI fails]
    Failure --> Block[Merge is blocked]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#c7ccd1,color:#000;
    class Report phYellow;
    class Failure phRed;
    class Block phBlue;
```

## How did you test this code?

- The eager-graph test passed for a forbidden import and a budget-only warning.
- The repository workflow linter passed.
- Not run: actionlint. Its current release rejects existing workflow syntax unrelated to this change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None. This changes internal CI behavior only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

🤖 This PR was created by PostHog Desktop Codex.

- Skills: stacking-prs, authoring-ci-workflows, and writing-pr-descriptions.
- No matching open PR or issue was found.
- This layer depends on the Monaco split in its base PR.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*