### PR TITLE
fix(data-imports): explain a sync whose rows are not objects

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
@@ -185,6 +185,15 @@ Any_Source_Errors: dict[str, str | None] = {
         "clients reject, such as an underscore. Fix the endpoint URL in your object storage settings, "
         "then re-enable the sync."
     ),
+    # Raised in shared pipeline code (`table_from_py_list` → `_process_batch`) when a batch carries
+    # rows that aren't objects, such as a REST resource whose selected response field holds arrays or
+    # scalars. Keyless rows carry no column names to build a table from, and the same shape comes back
+    # on every retry. Keep in step with `NON_MAPPING_ROW_ERROR` in arrow_utils.
+    "Rows from this table are not JSON objects": (
+        "This table's rows aren't objects with named fields, so PostHog has no columns to import. "
+        "If the source lets you choose which part of the response to read, point it at a list of "
+        "objects, then re-enable the sync."
+    ),
 }
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/arrow_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/arrow_utils.py
@@ -5,7 +5,7 @@ import math
 import uuid
 import decimal
 import datetime
-from collections.abc import Callable, Collection, Iterable, Iterator, Sequence
+from collections.abc import Callable, Collection, Iterable, Iterator, Mapping, Sequence
 from functools import _make_key, wraps
 from ipaddress import IPv4Address, IPv6Address
 from typing import TYPE_CHECKING, Any, Literal, Optional, cast
@@ -78,6 +78,26 @@ class MissingPrimaryKeysException(Exception):
 
     def __init__(self, message: str = MISSING_PRIMARY_KEYS_ERROR) -> None:
         super().__init__(message)
+
+
+# Matched as a substring by the shared non-retryable classification (`Any_Source_Errors`), so the
+# schema is paused with guidance instead of retrying rows whose shape cannot change. Keep the
+# wording in step with that entry.
+NON_MAPPING_ROW_ERROR = "Rows from this table are not JSON objects"
+
+
+class NonMappingRowError(Exception):
+    """A batch carries a row that isn't a key/value object, so there are no column names to build a
+    table from.
+
+    Usually a REST resource whose selected response field holds arrays or scalars instead of
+    objects, for example a reporting endpoint that returns bare row arrays and its column names
+    separately. The same shape comes back on every retry until the source config selects objects.
+    The message carries only the row's type, because row contents can hold customer data.
+    """
+
+    def __init__(self, row_type: str) -> None:
+        super().__init__(f"{NON_MAPPING_ROW_ERROR} (a row arrived as {row_type})")
 
 
 class QueryTimeoutException(Exception):
@@ -1337,12 +1357,21 @@ def _serialize_dict_columns(table_data: list[dict]) -> tuple[list[dict], set[str
 
 
 def _process_batch(
-    table_data: list[dict],
+    # Not `list[dict]`: a source can hand the pipeline rows that aren't objects, which the guard
+    # below rejects.
+    table_data: list[Any],
     schema: Optional[pa.Schema] = None,
     *,
     primary_keys: Optional[Sequence[str]] = None,
     binary_reporter: Optional[BinaryColumnReporter] = None,
 ) -> pa.Table:
+    # Every step below reads a row as a mapping, so without this check a keyless row fails deep in
+    # the conversion with a bare `'list' object has no attribute 'items'`, which names neither the
+    # cause nor a fix.
+    for row in table_data:
+        if not isinstance(row, Mapping):
+            raise NonMappingRowError(type(row).__name__)
+
     table_data, serialized_dict_columns = _serialize_dict_columns(table_data)
 
     # Support both given schemas and inferred schemas

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_utils.py
@@ -21,6 +21,7 @@ from products.warehouse_sources.backend.temporal.data_imports.external_data_job 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arrow_utils import (
     BillingLimitsWillBeReachedException,
     BinaryColumnReporter,
+    NonMappingRowError,
     SchemaColumnTypeChangedException,
     _get_max_decimal_type,
     _to_list_array,
@@ -254,6 +255,31 @@ def test_table_from_py_list_with_lists():
             ]
         )
     )
+
+
+@pytest.mark.parametrize(
+    "rows,row_type",
+    [
+        # A reporting endpoint whose selected field holds arrays, with column names returned
+        # separately, so every row reaches the pipeline without keys.
+        ([["first", 12], ["second", 34]], "list"),
+        # A selected field holding bare scalars.
+        (["first", "second"], "str"),
+        # Only a later row is keyless, so the check can't stop at the first row.
+        ([{"id": "first"}, ["second", 34]], "list"),
+    ],
+)
+def test_table_from_py_list_rejects_non_mapping_rows(rows, row_type):
+    with pytest.raises(NonMappingRowError) as exc_info:
+        table_from_py_list(rows)
+
+    message = str(exc_info.value)
+    assert row_type in message
+    # Row contents can hold customer data, so only the type is named
+    assert "first" not in message
+    # The message must stay matched by an Any_Source_Errors entry so the schema is paused with
+    # guidance instead of retrying rows whose shape can't change, on every source.
+    assert [key for key in Any_Source_Errors if key in message]
 
 
 def test_table_from_py_list_with_nan():


### PR DESCRIPTION
## Problem

A data warehouse sync stops with `AttributeError: 'list' object has no attribute 'items'` and shows that message on the table, so the customer cannot tell what to fix.

- A REST resource can select a response field that holds arrays or scalars instead of objects, for example a reporting endpoint that returns bare row arrays and its column names separately.
- Shared pipeline code reads every row as a mapping, so the batch fails inside `_serialize_dict_columns` on the first keyless row.
- The row shape is the same on every retry, so each attempt spends the retry budget and reports another exception. Live in error tracking: [issue 01a08834](https://us.posthog.com/project/2/error_tracking/01a08834-7b91-7530-b9a6-87ea75e2db1f).

## Changes

- A table whose rows have no keys now pauses with "This table's rows aren't objects with named fields, so PostHog has no columns to import", plus what to change, instead of the raw AttributeError.
- `_process_batch` rejects a non-mapping row before any Arrow work and raises `NonMappingRowError`. The message names the row's type only, because row contents can hold customer data.
- `Any_Source_Errors` matches that message, so every source pauses the schema with the guidance rather than retrying.
- The pipeline fails instead of importing keyless rows under an invented column name. A silent import looks like a working sync, and correcting the source config afterwards then needs a full table reset.
- Mechanical: `_process_batch` takes `list[Any]` rather than `list[dict]`, which is what its callers already pass.

## How did you test this code?

- Added `test_table_from_py_list_rejects_non_mapping_rows` in `pipelines/core/test/test_utils.py`, covering rows that arrive as arrays, rows that arrive as scalars, and a keyless row that is not the first row. It also asserts the message stays matched by an `Any_Source_Errors` key. No existing case covered a keyless row; they all vary the values inside a row.
- Ran the Arrow conversion, batcher, and pipeline load suites, repo-wide mypy, and `hogli ci:preflight --fix`.
- Not checked against a live source: this sandbox has no warehouse stack, so the paused-schema copy is verified through the registry assertion rather than in the app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged from an error tracking webhook with Claude Code, using the PostHog MCP error tracking tools to pull the issue, a representative event, and the sync context properties.
- Skills invoked: `/writing-pr-descriptions`, `/writing-tests`, `/writing-code-comments`.
- The frame reported on the issue sits in the Temporal capture interceptor; the in-app frame is `arrow_utils._serialize_dict_columns`. The crash predates that function, since the later `table_data[0].keys()` call fails the same way, so this is a long-standing gap rather than a regression.
- Considered wrapping keyless rows into a single `value` column instead. Rejected for the reason in Changes: an opaque column reads as a successful sync and costs a reset later.
- No duplicate: searched open PRs by exception type, message phrase, and module path, and listed the maintainer's open PRs. The nearest match, [#90883](https://github.com/PostHog/posthog/pull/90883), converts tuple values inside a row and does not touch row shape.
- Public artifact: the failing shape came from a live sync. The tests use invented values, and no source name, table name, or customer detail appears in the diff or this description.
