### PR TITLE
fix(mcp): validate generated list app tool arguments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -118,6 +118,8 @@ rust/.github
 rust/docker
 rust/target
 **/__snapshots__
+# generate:ui-apps reads these committed tool input schemas while building the MCP image.
+!services/mcp/tests/unit/__snapshots__/tool-schemas
 !docker-compose.base.yml
 !docker-compose.dev.yml
 !docker

--- a/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
+++ b/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
@@ -316,6 +316,11 @@ Product teams own their definitions and control which operations are exposed as 
 
    Unknown keys are rejected at build time (Zod `.strict()`) to catch typos early.
 
+   For generated list apps, `generate:ui-apps` also checks `detail_tool` and the
+   `detail_args` keys against the tool's input schema snapshot, so a wrong argument
+   name fails generation instead of silently dropping the argument at runtime.
+   See "UI apps" in `services/mcp/CONTRIBUTING.md` for the rules.
+
    #### Custom input schemas
 
    By default, tool input schemas are auto-derived from OpenAPI via Orval.

--- a/services/mcp/CONTRIBUTING.md
+++ b/services/mcp/CONTRIBUTING.md
@@ -296,9 +296,18 @@ Convention defaults (derived from the app key and product directory):
 
 Override any field explicitly when the convention doesn't match
 (e.g. `click_prop: onEntityClick`, `detail_args: "{ entityId: item.id }"`).
-`detail_args` must match the target tool's actual parameter names —
-mismatching them (e.g. passing `flagId` to a tool that expects `id`) silently
-drops the argument instead of failing.
+`generate:ui-apps` checks `detail_tool` and the top-level keys of `detail_args`
+against the tool's input schema snapshot in `tests/unit/__snapshots__/tool-schemas/`.
+Generation fails for a tool without a snapshot, unknown argument names, and missing
+required arguments. For example, passing `flagId` to a tool that requires `id` reports
+both the unknown key and the missing argument, with the app and tool names.
+
+`detail_args` must be an object literal with explicit keys; spreads and computed keys
+are rejected because their names cannot be checked statically. The expression is
+parsed, not executed, so dynamic values and nested fields are still validated by the
+tool at call time. After adding a tool or changing its input schema, run
+`pnpm test tests/unit/tool-schema-snapshots.test.ts -u` to refresh the snapshot, then
+regenerate the UI apps.
 
 **Link tools to apps** with `ui_app`:
 

--- a/services/mcp/scripts/generate-ui-apps.ts
+++ b/services/mcp/scripts/generate-ui-apps.ts
@@ -20,6 +20,7 @@ import { fileURLToPath } from 'node:url'
 import { parse as parseYaml } from 'yaml'
 
 import { discoverDefinitions, isToolsConfig } from './lib/definitions.mjs'
+import { type ToolInputSchema, validateListAppToolCall } from './lib/validate-ui-app-tool-call'
 import { MCP_ROOT_DIR, ROOT_DIR } from './utils'
 import {
     type CategoryConfig,
@@ -401,6 +402,18 @@ ${appEntries},
 // Main
 // ------------------------------------------------------------------
 
+const TOOL_SCHEMA_SNAPSHOTS_DIR = path.join(MCP_ROOT_DIR, 'tests', 'unit', '__snapshots__', 'tool-schemas')
+
+// The snapshot test writes one JSON schema per registered tool, so the generator
+// can read tool inputs without loading the server bundle.
+function readToolInputSchema(toolName: string): ToolInputSchema | undefined {
+    const snapshotPath = path.join(TOOL_SCHEMA_SNAPSHOTS_DIR, `${toolName}.json`)
+    if (!fs.existsSync(snapshotPath)) {
+        return undefined
+    }
+    return JSON.parse(fs.readFileSync(snapshotPath, 'utf-8'))
+}
+
 function main(): void {
     const definitionSources = discoverDefinitions({ definitionsDir: DEFINITIONS_DIR, productsDir: PRODUCTS_DIR })
 
@@ -473,6 +486,7 @@ function main(): void {
                     process.exit(1)
                 }
                 const resolved = resolveListApp(appKey, appConfig, componentImport!)
+                validateListAppToolCall(appKey, resolved, readToolInputSchema(resolved.detail_tool))
                 const code = generateListApp(appKey, resolved)
                 const outPath = path.join(GENERATED_APPS_DIR, `${appKey}.tsx`)
                 fs.writeFileSync(outPath, code)

--- a/services/mcp/scripts/lib/validate-ui-app-tool-call.ts
+++ b/services/mcp/scripts/lib/validate-ui-app-tool-call.ts
@@ -1,0 +1,70 @@
+import ts from 'typescript'
+
+type ListAppCall = { detail_tool: string; detail_args: string }
+
+export type ToolInputSchema = { type?: string; properties?: Record<string, unknown>; required?: string[] }
+
+function argumentKeys(expression: string): string[] {
+    const source = `(${expression})`
+    const { diagnostics } = ts.transpileModule(source, { reportDiagnostics: true })
+    if (diagnostics?.some((diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error)) {
+        throw new Error('detail_args must be a valid object literal')
+    }
+    const file = ts.createSourceFile('detail-args.ts', source, ts.ScriptTarget.Latest, true)
+    const statement = file.statements[0]
+    if (
+        file.statements.length !== 1 ||
+        !statement ||
+        !ts.isExpressionStatement(statement) ||
+        !ts.isParenthesizedExpression(statement.expression) ||
+        !ts.isObjectLiteralExpression(statement.expression.expression)
+    ) {
+        throw new Error('detail_args must be an object literal with explicit argument keys')
+    }
+
+    return statement.expression.expression.properties.map((property) => {
+        if (
+            (!ts.isPropertyAssignment(property) && !ts.isShorthandPropertyAssignment(property)) ||
+            (!ts.isIdentifier(property.name) && !ts.isStringLiteral(property.name))
+        ) {
+            throw new Error(
+                'detail_args must use explicit argument keys; spreads and computed keys cannot be validated'
+            )
+        }
+        return property.name.text
+    })
+}
+
+export function validateListAppToolCall(
+    appKey: string,
+    config: ListAppCall,
+    schema: ToolInputSchema | undefined
+): void {
+    const context = `List app "${appKey}" calling "${config.detail_tool}"`
+    if (!schema) {
+        throw new Error(
+            `${context}: no input schema snapshot for this tool. Check the tool name, or run the tool schema snapshot test to record a new tool.`
+        )
+    }
+
+    let keys: string[]
+    try {
+        keys = argumentKeys(config.detail_args)
+    } catch (error) {
+        throw new Error(`${context}: ${error instanceof Error ? error.message : String(error)}`)
+    }
+
+    if (schema.type !== 'object' || !schema.properties) {
+        throw new Error(`${context}: the input schema must expose object properties to validate detail_args`)
+    }
+    const known = new Set(Object.keys(schema.properties))
+    const unknown = keys.filter((key) => !known.has(key))
+    const missing = (schema.required ?? []).filter((key) => !keys.includes(key))
+    if (unknown.length || missing.length) {
+        const problems = [
+            ...(unknown.length ? [`Unknown arguments: ${unknown.join(', ')}`] : []),
+            ...(missing.length ? [`Missing required arguments: ${missing.join(', ')}`] : []),
+        ]
+        throw new Error(`${context}: ${problems.join('. ')}. Check detail_args against the tool input schema.`)
+    }
+}

--- a/services/mcp/tests/unit/ui-app-tool-call-validation.test.ts
+++ b/services/mcp/tests/unit/ui-app-tool-call-validation.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import { validateListAppToolCall } from '../../scripts/lib/validate-ui-app-tool-call'
+
+describe('list app tool call validation', () => {
+    const schema = { type: 'object', properties: { id: {}, include_details: {} }, required: ['id'] }
+    const validate = (detail_args: string): void =>
+        validateListAppToolCall('survey-list', { detail_tool: 'survey-get', detail_args }, schema)
+
+    it('rejects the survey list argument mismatch against the committed tool schema snapshot', () => {
+        const snapshot = JSON.parse(
+            readFileSync(path.join(__dirname, '__snapshots__', 'tool-schemas', 'survey-get.json'), 'utf-8')
+        )
+        expect(() =>
+            validateListAppToolCall(
+                'survey-list',
+                { detail_tool: 'survey-get', detail_args: '{ surveyId: item.id }' },
+                snapshot
+            )
+        ).toThrow(/survey-list.*survey-get.*surveyId.*id/)
+    })
+
+    it.each(['{ id: item.id }', '{ "id": item.id, include_details: true }', '{ id }'])(
+        'accepts explicit argument keys: %s',
+        (args) => expect(() => validate(args)).not.toThrow()
+    )
+
+    it('rejects an unknown key even when all required arguments are supplied', () => {
+        expect(() => validate('{ id: item.id, typo: true }')).toThrow(/Unknown arguments: typo/)
+    })
+
+    it('rejects a missing required argument', () => {
+        expect(() => validate('{}')).toThrow(/Missing required arguments: id/)
+    })
+
+    it('rejects a tool without a schema snapshot', () => {
+        expect(() =>
+            validateListAppToolCall(
+                'survey-list',
+                { detail_tool: 'surveys-get', detail_args: '{ id: item.id }' },
+                undefined
+            )
+        ).toThrow(/survey-list.*surveys-get.*no input schema snapshot/)
+    })
+
+    it.each(['{ ...item }', '{ [field]: item.id }', 'item', '{ id: item.id', '{ id: item.id }; throw new Error()'])(
+        'rejects argument expressions whose keys cannot be checked: %s',
+        (args) => expect(() => validate(args)).toThrow(/detail_args/)
+    )
+
+    it('does not execute argument expressions during generation', () => {
+        expect(() => validate('{ id: (() => { throw new Error("executed") })() }')).not.toThrow()
+    })
+})


### PR DESCRIPTION
## Problem

- A person clicking a row in an MCP list app expects the detail view. When the list app sends the wrong argument name to its detail tool, the click silently falls back to chat instead.
- The tool drops an unknown argument without an error, so nothing in generation, typecheck, or tests notices the mismatch. It only fails when someone clicks.
- [The survey fix](https://github.com/PostHog/posthog/pull/97930) corrected one such mismatch by hand. Seven other generated list apps have the same exposure.

## Changes

- A wrong argument name in any generated list app now fails `generate:ui-apps` with a message that names the app, the tool, the unknown key, and the missing required key.
- The generator reads each detail tool's input schema from the snapshots in `services/mcp/tests/unit/__snapshots__/tool-schemas/`, which the snapshot test already keeps in sync with every registered tool.
- Bundling the server tool graph at generation time was rejected. It needs the gitignored `shared/` files, which CI creates after the build step, so every MCP job failed with that design.
- `detail_args` is parsed with the TypeScript parser and never executed. Spreads and computed keys are rejected because their names cannot be checked.
- `.dockerignore` re-includes the snapshot directory, because the MCP image build also runs the generator.
- Nothing changes in the generated apps or in what a user sees. The docs edits are mechanical.

Before:

```mermaid
flowchart LR
    A[App configuration] --> B[Generate list app]
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    class A phGray;
    class B phBlue;
```

After:

```mermaid
flowchart LR
    A[App configuration] --> C[Validate argument names]
    B[Tool schema snapshot] --> C
    C --> D[Generate list app]
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    class A,B phGray;
    class C,D phBlue;
```

## How did you test this code?

Done:

- New unit test file. It checks the real `survey-get` snapshot rejects the `surveyId` mismatch that shipped, plus unknown keys, missing keys, a tool without a snapshot, unsupported expressions, and an expression that must never execute. No existing test covered the generator's argument handling.
- A temporary `surveyId` argument in the surveys `tools.yaml` fails generation with the expected message. Restoring it regenerates all apps with no output changes.
- The MCP image built from this branch through a manual dispatch: https://github.com/PostHog/posthog/actions/runs/34496123446. The `.dockerignore` exception was also checked against Docker pattern semantics with `@balena/dockerignore`, because no Docker daemon was available locally.
- Not run locally: the MCP Docker build itself.

How to confirm the change is good:

1. The regression it exists for. Change the surveys `detail_args` to `{ surveyId: item.id }` and run `pnpm --filter=@posthog/mcp run generate:ui-apps`. It must fail and name `survey-list`, `survey-get`, `surveyId`, and `id`.
2. No false positives. The same command on the unchanged branch generates all 28 apps and leaves no diff. The [Build and validate UI Apps job](https://github.com/PostHog/posthog/actions/runs/34496082740/job/102935496610) runs exactly this.
3. The generator works where CI and Docker run it. The [Unit Tests job](https://github.com/PostHog/posthog/actions/runs/34503278644/job/102959122323) runs `pnpm build` before the `shared/` files exist, which is what broke the first design. The image build above covers the Docker context.
4. The limit to know. The check covers argument names only. A correct key with a wrong value type, or a nested field mismatch, still fails at call time. Typing the generated call against the tool schema would close that and is out of scope here.

The AI evals summary check fails on this PR and on the last three master runs of that workflow, so it is unrelated.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The MCP CONTRIBUTING guide carries the rules and the snapshot refresh command. The implementing MCP tools handbook page links to it.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex wrote the first version, which loaded tool schemas by bundling the server with esbuild. Claude Code reworked it in this session to read the committed schema snapshots after every MCP CI job failed on the missing `shared/` files, and rebased the branch onto master once the parent PR merged. Skills: implementing-mcp-tools, writing-tests, running-ci-preflight, writing-pr-descriptions.

`codex review` found one P1: the Docker build context excluded the snapshots. Fixed with the `.dockerignore` exception. The CodeRabbit CLI was not authenticated in this session, so the PR has no local CodeRabbit pass.

The duplicate PR search found no matching open change. The tests use repository schemas and synthetic expressions, with no private data.

https://claude.ai/code/session_01NUdW9LFhiv2pwyZRdsL8q1
