### PR TITLE
fix(wizard): generate cloud run keys independently of click events

### DIFF
--- a/products/wizard/frontend/wizardLibraryLogic.test.tsx
+++ b/products/wizard/frontend/wizardLibraryLogic.test.tsx
@@ -1,3 +1,5 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { Provider } from 'kea'
 import { expectLogic } from 'kea-test-utils'
 import posthog from 'posthog-js'
 
@@ -11,6 +13,7 @@ import { initKeaTests } from '~/test/init'
 
 import { wizardRegistryList, wizardRunsCreate } from './generated/api'
 import type { WizardProgramApi, WizardRunApi } from './generated/api.schemas'
+import { WizardRunsEmptyState } from './runs/WizardRunsEmptyState'
 import { wizardLibraryLogic } from './wizardLibraryLogic'
 import { wizardRunDetailsLogic } from './wizardRunDetailsLogic'
 
@@ -93,6 +96,7 @@ describe('wizardLibraryLogic', () => {
     })
 
     afterEach(() => {
+        cleanup()
         logic.unmount()
         jest.restoreAllMocks()
     })
@@ -123,9 +127,30 @@ describe('wizardLibraryLogic', () => {
         }
     })
 
+    it('creates a serializable cloud request after opening the Library from the empty state', async () => {
+        render(
+            <Provider>
+                <WizardRunsEmptyState onOpenLibrary={logic.actions.openLibrary} />
+            </Provider>
+        )
+        fireEvent.click(screen.getByText('Open Wizard Library'), { view: window })
+        await expectLogic(logic).toFinishAllListeners()
+        logic.actions.selectProgram(program)
+        logic.actions.setRepository('example/project')
+        logic.actions.createRun()
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(mockWizardRunsCreate).toHaveBeenCalledTimes(1)
+        const body = mockWizardRunsCreate.mock.calls[0][1]
+        expect(typeof body.idempotency_key).toBe('string')
+        expect(() => JSON.stringify(body)).not.toThrow()
+    })
+
     it('reuses the idempotency key after a failed cloud request', async () => {
         mockWizardRunsCreate.mockRejectedValue(new ApiError('private response content', 429))
-        logic.actions.openLibrary('stable-key')
+        logic.actions.openLibrary()
+        const idempotencyKey = logic.values.createRunIdempotencyKey
+        expect(typeof idempotencyKey).toBe('string')
         logic.actions.selectProgram(program)
         logic.actions.setRepository('posthog/posthog')
 
@@ -135,8 +160,8 @@ describe('wizardLibraryLogic', () => {
         await expectLogic(logic).toFinishAllListeners()
 
         expect(mockWizardRunsCreate).toHaveBeenCalledTimes(2)
-        expect(mockWizardRunsCreate.mock.calls[0][1].idempotency_key).toBe('stable-key')
-        expect(mockWizardRunsCreate.mock.calls[1][1].idempotency_key).toBe('stable-key')
+        expect(mockWizardRunsCreate.mock.calls[0][1].idempotency_key).toBe(idempotencyKey)
+        expect(mockWizardRunsCreate.mock.calls[1][1].idempotency_key).toBe(idempotencyKey)
         const events = jest
             .mocked(posthog.capture)
             .mock.calls.filter(([event]) => event.startsWith('wizard run create'))
@@ -154,7 +179,7 @@ describe('wizardLibraryLogic', () => {
     })
 
     it('does not create a server run for local execution', async () => {
-        logic.actions.openLibrary('stable-key')
+        logic.actions.openLibrary()
         logic.actions.selectProgram(program)
         logic.actions.setLibraryEnvironment('local')
 
@@ -166,7 +191,7 @@ describe('wizardLibraryLogic', () => {
     })
 
     it('runs the program version shown in the Library', async () => {
-        logic.actions.openLibrary('stable-key')
+        logic.actions.openLibrary()
         logic.actions.selectProgram(program)
         logic.actions.setRepository('posthog/posthog')
 
@@ -179,7 +204,7 @@ describe('wizardLibraryLogic', () => {
     it('does not open the cloud-only Library when cloud runs are unavailable', async () => {
         preflightLogic.actions.loadPreflightSuccess({ wizard_cloud_run_available: false } as any)
 
-        logic.actions.openLibrary('stable-key')
+        logic.actions.openLibrary()
         await expectLogic(logic).toFinishAllListeners()
 
         expect(logic.values.isLibraryOpen).toBe(false)
@@ -191,7 +216,7 @@ describe('wizardLibraryLogic', () => {
         mockWizardRunsCreate.mockResolvedValueOnce(createdRun)
         const detailsLogic = wizardRunDetailsLogic()
         detailsLogic.mount()
-        logic.actions.openLibrary('stable-key')
+        logic.actions.openLibrary()
         logic.actions.selectProgram(program)
         logic.actions.setRepository('posthog/posthog')
 

--- a/products/wizard/frontend/wizardLibraryLogic.ts
+++ b/products/wizard/frontend/wizardLibraryLogic.ts
@@ -79,7 +79,7 @@ export interface wizardLibraryLogicActions {
     loadRegistryFailure: (error: string, errorObject?: unknown) => { error: string; errorObject?: unknown }
     loadRegistrySuccess: (registry: WizardProgramApi[]) => { registry: WizardProgramApi[] }
     markCommandCopied: () => { value: true }
-    openLibrary: (idempotencyKey?: string) => { idempotencyKey: string }
+    openLibrary: () => { idempotencyKey: string }
     refreshRuns: () => { value: true }
     runAgain: (run: WizardRunApi) => { run: WizardRunApi }
     selectProgram: (program: WizardProgramApi) => { program: WizardProgramApi }
@@ -128,7 +128,7 @@ export const wizardLibraryLogic = kea<wizardLibraryLogicType>([
         ],
     })),
     actions({
-        openLibrary: (idempotencyKey = uuid()) => ({ idempotencyKey }),
+        openLibrary: () => ({ idempotencyKey: uuid() }),
         closeLibrary: true,
         setLibrarySearch: (search: string) => ({ search }),
         selectProgram: (program: WizardProgramApi) => ({ program }),


### PR DESCRIPTION
## Problem

Cloud runs fail to start when users open the Wizard Library from the empty-state button.
The click event becomes the idempotency key, so JSON serialization fails before the request reaches the server.

## Changes

Generate the key inside `openLibrary`, ignoring callback arguments. Retries retain the same key.
The UI looks unchanged. The test file moves to TSX to exercise the real button.

## How did you test this code?

The regression clicks the empty-state button and checks that the request contains a string key and serializes successfully.
It failed before the fix and passed afterward. The Library suite and TypeScript check passed locally.
No live cloud run was started.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: restores the existing cloud-run behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used GitHub CLI and local tests. Skills: writing-kea-logics, writing-pr-descriptions, and merging-prs.
The open Wizard PR search found no duplicate fix. The regression uses invented repository data; no session logs or screenshots are included.
