### PR TITLE
fix(groups): stop duplicate group rows and total revenue across sources

### DIFF
--- a/posthog/hogql/database/schema/groups_revenue_analytics.py
+++ b/posthog/hogql/database/schema/groups_revenue_analytics.py
@@ -106,10 +106,25 @@ def select_from_groups_revenue_analytics_table(context: HogQLContext) -> ast.Sel
 
     if not queries:
         return ast.SelectQuery.empty(columns=FIELDS)
-    elif len(queries) == 1:
-        return queries[0]
-    else:
-        return ast.SelectSetQuery.create_from_queries(queries, set_operator="UNION ALL")
+
+    inner_query: ast.SelectQuery | ast.SelectSetQuery = (
+        queries[0] if len(queries) == 1 else ast.SelectSetQuery.create_from_queries(queries, set_operator="UNION ALL")
+    )
+
+    # A group can earn revenue in more than one source, and each source is its own row above.
+    # Aggregating by `group_key` keeps this table at one row per group, so the `groups` join can't
+    # fan out the groups table and each group reports the revenue of all its sources together.
+    # Mirrors what `persons_revenue_analytics` does per person.
+    return ast.SelectQuery(
+        select=[
+            ast.Alias(alias="team_id", expr=ast.Constant(value=context.team_id)),
+            ast.Alias(alias="group_key", expr=ast.Field(chain=["group_key"])),
+            ast.Alias(alias="revenue", expr=ast.Call(name="sum", args=[ast.Field(chain=["revenue"])])),
+            ast.Alias(alias="mrr", expr=ast.Call(name="sum", args=[ast.Field(chain=["mrr"])])),
+        ],
+        select_from=ast.JoinExpr(table=inner_query),
+        group_by=[ast.Field(chain=["group_key"])],
+    )
 
 
 def _build_events_query(

--- a/posthog/hogql/database/schema/test/__snapshots__/test_groups_revenue_analytics.ambr
+++ b/posthog/hogql/database/schema/test/__snapshots__/test_groups_revenue_analytics.ambr
@@ -14,58 +14,17 @@
               groups.group_key) AS groups
   LEFT JOIN
     (SELECT 99999 AS team_id,
-            coalesce(revenue_agg.group_key, mrr_agg.group_key) AS group_key,
-            coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
-            coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+            group_key AS group_key,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT arrayJoin([revenue_analytics_revenue_item.group_0_key, revenue_analytics_revenue_item.group_1_key, revenue_analytics_revenue_item.group_2_key, revenue_analytics_revenue_item.group_3_key, revenue_analytics_revenue_item.group_4_key]) AS group_key,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
+       (SELECT 99999 AS team_id,
+               coalesce(revenue_agg.group_key, mrr_agg.group_key) AS group_key,
+               coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+               coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
         FROM
-          (SELECT toString(events.uuid) AS id,
-                  toString(events.uuid) AS invoice_item_id,
-                  'revenue_analytics.events.purchase' AS source_label,
-                  toTimeZone(events.timestamp, 'UTC') AS timestamp,
-                  timestamp AS created_at,
-                  isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '')) AS is_recurring,
-                  NULL AS product_id,
-                  toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
-                  events.`$group_0` AS group_0_key,
-                  events.`$group_1` AS group_1_key,
-                  events.`$group_2` AS group_2_key,
-                  events.`$group_3` AS group_3_key,
-                  events.`$group_4` AS group_4_key,
-                  NULL AS invoice_id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id,
-                  toString(events.`$session_id`) AS session_id,
-                  events.event AS event_name,
-                  NULL AS coupon,
-                  coupon AS coupon_id,
-                  'USD' AS original_currency,
-                  accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
-                  in(original_currency,
-                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                    'USD' AS currency,
-                    if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
-           FROM events
-           LEFT OUTER JOIN
-             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                     person_distinct_id_overrides.distinct_id AS distinct_id
-              FROM person_distinct_id_overrides
-              WHERE equals(person_distinct_id_overrides.team_id, 99999)
-              GROUP BY person_distinct_id_overrides.distinct_id
-              HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-           WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
-           ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-        WHERE notEmpty(group_key)
-        GROUP BY group_key) AS revenue_agg
-     FULL OUTER JOIN
-       (SELECT customer_to_group.group_key AS group_key,
-               sum(coalesce(mrr_by_customer.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
-        FROM
-          (SELECT DISTINCT revenue_analytics_revenue_item.customer_id AS customer_id,
-                           arrayJoin([revenue_analytics_revenue_item.group_0_key, revenue_analytics_revenue_item.group_1_key, revenue_analytics_revenue_item.group_2_key, revenue_analytics_revenue_item.group_3_key, revenue_analytics_revenue_item.group_4_key]) AS group_key
+          (SELECT arrayJoin([revenue_analytics_revenue_item.group_0_key, revenue_analytics_revenue_item.group_1_key, revenue_analytics_revenue_item.group_2_key, revenue_analytics_revenue_item.group_3_key, revenue_analytics_revenue_item.group_4_key]) AS group_key,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
            FROM
              (SELECT toString(events.uuid) AS id,
                      toString(events.uuid) AS invoice_item_id,
@@ -104,86 +63,95 @@
                  HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
               WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
               ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-           WHERE notEmpty(group_key)) AS customer_to_group
-        LEFT JOIN
-          (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
-                  sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
+           WHERE notEmpty(group_key)
+           GROUP BY group_key) AS revenue_agg
+        FULL OUTER JOIN
+          (SELECT customer_to_group.group_key AS group_key,
+                  sum(coalesce(mrr_by_customer.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
            FROM
-             (SELECT union.source_label AS source_label,
-                     union.customer_id AS customer_id,
-                     union.subscription_id AS subscription_id,
-                     argMax(union.amount, union.timestamp) AS mrr
+             (SELECT DISTINCT revenue_analytics_revenue_item.customer_id AS customer_id,
+                              arrayJoin([revenue_analytics_revenue_item.group_0_key, revenue_analytics_revenue_item.group_1_key, revenue_analytics_revenue_item.group_2_key, revenue_analytics_revenue_item.group_3_key, revenue_analytics_revenue_item.group_4_key]) AS group_key
               FROM
-                (SELECT revenue_item.source_label AS source_label,
-                        revenue_item.customer_id AS customer_id,
-                        revenue_item.subscription_id AS subscription_id,
-                        toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
-                        sum(revenue_item.amount) AS amount
+                (SELECT toString(events.uuid) AS id,
+                        toString(events.uuid) AS invoice_item_id,
+                        'revenue_analytics.events.purchase' AS source_label,
+                        toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                        timestamp AS created_at,
+                        isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '')) AS is_recurring,
+                        NULL AS product_id,
+                        toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
+                        events.`$group_0` AS group_0_key,
+                        events.`$group_1` AS group_1_key,
+                        events.`$group_2` AS group_2_key,
+                        events.`$group_3` AS group_3_key,
+                        events.`$group_4` AS group_4_key,
+                        NULL AS invoice_id,
+                        replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id,
+                        toString(events.`$session_id`) AS session_id,
+                        events.event AS event_name,
+                        NULL AS coupon,
+                        coupon AS coupon_id,
+                        'USD' AS original_currency,
+                        accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                        in(original_currency,
+                           ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                          if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                          divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                          'USD' AS currency,
+                          if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+                 FROM events
+                 LEFT OUTER JOIN
+                   (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                           person_distinct_id_overrides.distinct_id AS distinct_id
+                    FROM person_distinct_id_overrides
+                    WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                    GROUP BY person_distinct_id_overrides.distinct_id
+                    HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+                 WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+                 ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
+              WHERE notEmpty(group_key)) AS customer_to_group
+           LEFT JOIN
+             (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
+                     sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
+              FROM
+                (SELECT union.source_label AS source_label,
+                        union.customer_id AS customer_id,
+                        union.subscription_id AS subscription_id,
+                        argMax(union.amount, union.timestamp) AS mrr
                  FROM
-                   (SELECT toString(events.uuid) AS id,
-                           toString(events.uuid) AS invoice_item_id,
-                           'revenue_analytics.events.purchase' AS source_label,
-                           toTimeZone(events.timestamp, 'UTC') AS timestamp,
-                           timestamp AS created_at,
-                           isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '')) AS is_recurring,
-                           NULL AS product_id,
-                           toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
-                           events.`$group_0` AS group_0_key,
-                           events.`$group_1` AS group_1_key,
-                           events.`$group_2` AS group_2_key,
-                           events.`$group_3` AS group_3_key,
-                           events.`$group_4` AS group_4_key,
-                           NULL AS invoice_id,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id,
-                           toString(events.`$session_id`) AS session_id,
-                           events.event AS event_name,
-                           NULL AS coupon,
-                           coupon AS coupon_id,
-                           'USD' AS original_currency,
-                           accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
-                           in(original_currency,
-                              ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                             'USD' AS currency,
-                             if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
-                    FROM events
-                    LEFT OUTER JOIN
-                      (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                              person_distinct_id_overrides.distinct_id AS distinct_id
-                       FROM person_distinct_id_overrides
-                       WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                       GROUP BY person_distinct_id_overrides.distinct_id
-                       HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-                    WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
-                    ORDER BY timestamp DESC) AS revenue_item
-                 WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), 0))
-                 GROUP BY revenue_item.source_label,
-                          revenue_item.customer_id,
-                          revenue_item.subscription_id, timestamp
-                 ORDER BY timestamp DESC
-                 UNION ALL SELECT `revenue_analytics.events.purchase.subscription_events_revenue_view`.source_label AS source_label,
-                                  `revenue_analytics.events.purchase.subscription_events_revenue_view`.customer_id AS customer_id,
-                                  `revenue_analytics.events.purchase.subscription_events_revenue_view`.id AS subscription_id,
-                                  toTimeZone(`revenue_analytics.events.purchase.subscription_events_revenue_view`.ended_at, 'UTC') AS timestamp,
-                                  accurateCastOrNull(0, 'Decimal64(10)') AS amount
-                 FROM
-                   (SELECT subscription_id AS id,
-                           'revenue_analytics.events.purchase' AS source_label,
-                           NULL AS plan_id,
-                           product_id AS product_id,
-                           toString(person_id) AS customer_id,
-                           NULL AS status,
-                           min_timestamp AS started_at,
-                           if(greater(max_timestamp_plus_dropoff_days, today()), NULL, max_timestamp_plus_dropoff_days) AS ended_at,
-                           NULL AS metadata
+                   (SELECT revenue_item.source_label AS source_label,
+                           revenue_item.customer_id AS customer_id,
+                           revenue_item.subscription_id AS subscription_id,
+                           toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                           sum(revenue_item.amount) AS amount
                     FROM
-                      (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id,
-                              replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id,
+                      (SELECT toString(events.uuid) AS id,
+                              toString(events.uuid) AS invoice_item_id,
+                              'revenue_analytics.events.purchase' AS source_label,
+                              toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                              timestamp AS created_at,
+                              isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '')) AS is_recurring,
                               NULL AS product_id,
-                              min(toTimeZone(events.timestamp, 'UTC')) AS min_timestamp,
-                              max(toTimeZone(events.timestamp, 'UTC')) AS max_timestamp,
-                              addDays(max_timestamp, 45.0) AS max_timestamp_plus_dropoff_days
+                              toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
+                              events.`$group_0` AS group_0_key,
+                              events.`$group_1` AS group_1_key,
+                              events.`$group_2` AS group_2_key,
+                              events.`$group_3` AS group_3_key,
+                              events.`$group_4` AS group_4_key,
+                              NULL AS invoice_id,
+                              replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id,
+                              toString(events.`$session_id`) AS session_id,
+                              events.event AS event_name,
+                              NULL AS coupon,
+                              coupon AS coupon_id,
+                              'USD' AS original_currency,
+                              accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                              in(original_currency,
+                                 ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                                if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                                divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                                'USD' AS currency,
+                                if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
                        FROM events
                        LEFT OUTER JOIN
                          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -192,20 +160,58 @@
                           WHERE equals(person_distinct_id_overrides.team_id, 99999)
                           GROUP BY person_distinct_id_overrides.distinct_id
                           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-                       WHERE and(equals(events.team_id, 99999), and(1, isNotNull(subscription_id)))
-                       GROUP BY subscription_id,
-                                person_id)
-                    ORDER BY started_at DESC) AS `revenue_analytics.events.purchase.subscription_events_revenue_view`
-                 WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), 0))
-                 ORDER BY timestamp DESC) AS
-              union
-              GROUP BY source_label,
-                       customer_id,
-                       subscription_id
-              ORDER BY customer_id ASC,
-                       subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
-           GROUP BY customer_id) AS mrr_by_customer ON equals(customer_to_group.customer_id, mrr_by_customer.customer_id)
-        GROUP BY group_key) AS mrr_agg ON equals(revenue_agg.group_key, mrr_agg.group_key)) AS groups__revenue_analytics ON equals(groups.groups___key, groups__revenue_analytics.group_key)
+                       WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+                       ORDER BY timestamp DESC) AS revenue_item
+                    WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), 0))
+                    GROUP BY revenue_item.source_label,
+                             revenue_item.customer_id,
+                             revenue_item.subscription_id, timestamp
+                    ORDER BY timestamp DESC
+                    UNION ALL SELECT `revenue_analytics.events.purchase.subscription_events_revenue_view`.source_label AS source_label,
+                                     `revenue_analytics.events.purchase.subscription_events_revenue_view`.customer_id AS customer_id,
+                                     `revenue_analytics.events.purchase.subscription_events_revenue_view`.id AS subscription_id,
+                                     toTimeZone(`revenue_analytics.events.purchase.subscription_events_revenue_view`.ended_at, 'UTC') AS timestamp,
+                                     accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                    FROM
+                      (SELECT subscription_id AS id,
+                              'revenue_analytics.events.purchase' AS source_label,
+                              NULL AS plan_id,
+                              product_id AS product_id,
+                              toString(person_id) AS customer_id,
+                              NULL AS status,
+                              min_timestamp AS started_at,
+                              if(greater(max_timestamp_plus_dropoff_days, today()), NULL, max_timestamp_plus_dropoff_days) AS ended_at,
+                              NULL AS metadata
+                       FROM
+                         (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id,
+                                 replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id,
+                                 NULL AS product_id,
+                                 min(toTimeZone(events.timestamp, 'UTC')) AS min_timestamp,
+                                 max(toTimeZone(events.timestamp, 'UTC')) AS max_timestamp,
+                                 addDays(max_timestamp, 45.0) AS max_timestamp_plus_dropoff_days
+                          FROM events
+                          LEFT OUTER JOIN
+                            (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                                    person_distinct_id_overrides.distinct_id AS distinct_id
+                             FROM person_distinct_id_overrides
+                             WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                             GROUP BY person_distinct_id_overrides.distinct_id
+                             HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+                          WHERE and(equals(events.team_id, 99999), and(1, isNotNull(subscription_id)))
+                          GROUP BY subscription_id,
+                                   person_id)
+                       ORDER BY started_at DESC) AS `revenue_analytics.events.purchase.subscription_events_revenue_view`
+                    WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), 0))
+                    ORDER BY timestamp DESC) AS
+                 union
+                 GROUP BY source_label,
+                          customer_id,
+                          subscription_id
+                 ORDER BY customer_id ASC,
+                          subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+              GROUP BY customer_id) AS mrr_by_customer ON equals(customer_to_group.customer_id, mrr_by_customer.customer_id)
+           GROUP BY group_key) AS mrr_agg ON equals(revenue_agg.group_key, mrr_agg.group_key))
+     GROUP BY group_key) AS groups__revenue_analytics ON equals(groups.groups___key, groups__revenue_analytics.group_key)
   WHERE equals(groups.key, 'lolol0:xxx')
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
                      readonly=2,
@@ -237,216 +243,222 @@
               groups.group_key) AS groups
   LEFT JOIN
     (SELECT 99999 AS team_id,
-            revenue_analytics_customer__groups.key AS group_key,
-            sum(coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)'))) AS revenue,
-            sum(coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
+            group_key AS group_key,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT inner.id AS id,
-               inner.source_label AS source_label,
-               inner.timestamp AS timestamp,
-               inner.name AS name,
-               inner.email AS email,
-               inner.phone AS phone,
-               inner.address AS address,
-               if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(notEquals(inner.resolved_distinct_id, ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata,
-               inner.country AS country,
-               inner.cohort AS cohort,
-               inner.initial_coupon AS initial_coupon,
-               inner.initial_coupon_id AS initial_coupon_id
+       (SELECT 99999 AS team_id,
+               revenue_analytics_customer__groups.key AS group_key,
+               sum(coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)'))) AS revenue,
+               sum(coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
         FROM
-          (SELECT outer.id AS id,
-                  'stripe.posthog_test' AS source_label,
-                  parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
-                  outer.name AS name,
-                  outer.email AS email,
-                  outer.phone AS phone,
-                  outer.address AS address,
-                  outer.metadata AS metadata,
-                  JSONExtractString(address, 'country') AS country,
-                  cohort_inner.cohort AS cohort,
-                  cohort_inner.initial_coupon AS initial_coupon,
-                  cohort_inner.initial_coupon_id AS initial_coupon_id,
-                  ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id,
-                  ifNull(resolved.resolved_source, '') AS resolved_source
+          (SELECT inner.id AS id,
+                  inner.source_label AS source_label,
+                  inner.timestamp AS timestamp,
+                  inner.name AS name,
+                  inner.email AS email,
+                  inner.phone AS phone,
+                  inner.address AS address,
+                  if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(notEquals(inner.resolved_distinct_id, ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata,
+                  inner.country AS country,
+                  inner.cohort AS cohort,
+                  inner.initial_coupon AS initial_coupon,
+                  inner.initial_coupon_id AS initial_coupon_id
            FROM
-             (SELECT *
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
-           LEFT JOIN
-             (SELECT invoice.customer AS customer_id,
-                     formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
-                     argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
-                     argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
-              GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
-           LEFT JOIN
-             (SELECT child_meta.customer_id AS customer_id,
-                     argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id,
-                     argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
+             (SELECT outer.id AS id,
+                     'stripe.posthog_test' AS source_label,
+                     parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
+                     outer.name AS name,
+                     outer.email AS email,
+                     outer.phone AS phone,
+                     outer.address AS address,
+                     outer.metadata AS metadata,
+                     JSONExtractString(address, 'country') AS country,
+                     cohort_inner.cohort AS cohort,
+                     cohort_inner.initial_coupon AS initial_coupon,
+                     cohort_inner.initial_coupon_id AS initial_coupon_id,
+                     ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id,
+                     ifNull(resolved.resolved_source, '') AS resolved_source
               FROM
-                (SELECT posthog_test_stripe_invoice.customer AS customer_id,
-                        JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id,
-                        concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
-                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
-                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                 WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
-              GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner
-        ORDER BY timestamp DESC
-        LIMIT 1 BY id) AS revenue_analytics_customer
-     LEFT JOIN
-       (SELECT groups.key AS key,
-               key AS revenue_analytics_customer__groups___key
-        FROM
-          (SELECT groups.group_type_index AS index,
-                  groups.group_key AS key
-           FROM groups
-           WHERE equals(groups.team_id, 99999)
-           GROUP BY groups.group_type_index,
-                    groups.group_key) AS groups) AS revenue_analytics_customer__groups ON equals(revenue_analytics_customer.id, revenue_analytics_customer__groups.revenue_analytics_customer__groups___key)
-     LEFT JOIN
-       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM
-          (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                  invoice.invoice_item_id AS invoice_item_id,
-                  'stripe.posthog_test' AS source_label,
-                  addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                  invoice.created_at AS created_at,
-                  ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                  invoice.product_id AS product_id,
-                  invoice.customer_id AS customer_id,
-                  NULL AS group_0_key,
-                  NULL AS group_1_key,
-                  NULL AS group_2_key,
-                  NULL AS group_3_key,
-                  NULL AS group_4_key,
-                  invoice.id AS invoice_id,
-                  invoice.subscription_id AS subscription_id,
-                  NULL AS session_id,
-                  NULL AS event_name,
-                  JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                  JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                  upper(invoice.currency) AS original_currency,
-                  accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                  in(original_currency,
-                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                    'GBP' AS currency,
-                    divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
-           FROM
-             (SELECT posthog_test_stripe_invoice.id AS id,
-                     parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                     posthog_test_stripe_invoice.customer AS customer_id,
-                     posthog_test_stripe_invoice.subscription AS subscription_id,
-                     posthog_test_stripe_invoice.discount AS discount,
-                     arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                     JSONExtractString(data, 'id') AS invoice_item_id,
-                     JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                     coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                     greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                     JSONExtractString(data, 'currency') AS currency,
-                     JSONExtractString(data, 'price', 'product') AS product_id,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                     greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                     arrayJoin(range(0, period_months)) AS month_index,
-                     ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-              WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_analytics_revenue_item
-        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-     LEFT JOIN
-       (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
-               sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
-        FROM
-          (SELECT union.source_label AS source_label,
-                  union.customer_id AS customer_id,
-                  union.subscription_id AS subscription_id,
-                  argMax(union.amount, union.timestamp) AS mrr
-           FROM
-             (SELECT revenue_item.source_label AS source_label,
-                     revenue_item.customer_id AS customer_id,
-                     revenue_item.subscription_id AS subscription_id,
-                     toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
-                     sum(revenue_item.amount) AS amount
-              FROM
-                (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                        invoice.invoice_item_id AS invoice_item_id,
-                        'stripe.posthog_test' AS source_label,
-                        addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                        invoice.created_at AS created_at,
-                        ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                        invoice.product_id AS product_id,
-                        invoice.customer_id AS customer_id,
-                        NULL AS group_0_key,
-                        NULL AS group_1_key,
-                        NULL AS group_2_key,
-                        NULL AS group_3_key,
-                        NULL AS group_4_key,
-                        invoice.id AS invoice_id,
-                        invoice.subscription_id AS subscription_id,
-                        NULL AS session_id,
-                        NULL AS event_name,
-                        JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                        JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                        upper(invoice.currency) AS original_currency,
-                        accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                        in(original_currency,
-                           ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                          if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                          divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                          'GBP' AS currency,
-                          divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                (SELECT *
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
+              LEFT JOIN
+                (SELECT invoice.customer AS customer_id,
+                        formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
+                 GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
+              LEFT JOIN
+                (SELECT child_meta.customer_id AS customer_id,
+                        argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id,
+                        argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
                  FROM
-                   (SELECT posthog_test_stripe_invoice.id AS id,
-                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                           posthog_test_stripe_invoice.customer AS customer_id,
-                           posthog_test_stripe_invoice.subscription AS subscription_id,
-                           posthog_test_stripe_invoice.discount AS discount,
-                           arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                           JSONExtractString(data, 'id') AS invoice_item_id,
-                           JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                           coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                           greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                           JSONExtractString(data, 'currency') AS currency,
-                           JSONExtractString(data, 'price', 'product') AS product_id,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                           greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                           arrayJoin(range(0, period_months)) AS month_index,
-                           ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                   (SELECT posthog_test_stripe_invoice.customer AS customer_id,
+                           JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id,
+                           concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
+                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
                     FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                    WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_item
-              WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')), 0))
-              GROUP BY revenue_item.source_label,
-                       revenue_item.customer_id,
-                       revenue_item.subscription_id, timestamp
-              ORDER BY timestamp DESC
-              UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
-                               `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
-                               `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
-                               toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
-                               accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                    WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
+                 GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner
+           ORDER BY timestamp DESC
+           LIMIT 1 BY id) AS revenue_analytics_customer
+        LEFT JOIN
+          (SELECT groups.key AS key,
+                  key AS revenue_analytics_customer__groups___key
+           FROM
+             (SELECT groups.group_type_index AS index,
+                     groups.group_key AS key
+              FROM groups
+              WHERE equals(groups.team_id, 99999)
+              GROUP BY groups.group_type_index,
+                       groups.group_key) AS groups) AS revenue_analytics_customer__groups ON equals(revenue_analytics_customer.id, revenue_analytics_customer__groups.revenue_analytics_customer__groups___key)
+        LEFT JOIN
+          (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
+           FROM
+             (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                     invoice.invoice_item_id AS invoice_item_id,
+                     'stripe.posthog_test' AS source_label,
+                     addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                     invoice.created_at AS created_at,
+                     ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                     invoice.product_id AS product_id,
+                     invoice.customer_id AS customer_id,
+                     NULL AS group_0_key,
+                     NULL AS group_1_key,
+                     NULL AS group_2_key,
+                     NULL AS group_3_key,
+                     NULL AS group_4_key,
+                     invoice.id AS invoice_id,
+                     invoice.subscription_id AS subscription_id,
+                     NULL AS session_id,
+                     NULL AS event_name,
+                     JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                     JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                     upper(invoice.currency) AS original_currency,
+                     accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                     in(original_currency,
+                        ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                       if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                       divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                       'GBP' AS currency,
+                       divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
               FROM
-                (SELECT '' AS id,
-                        '' AS source_label,
-                        '' AS plan_id,
-                        '' AS product_id,
-                        '' AS customer_id,
-                        '' AS status,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
-                        '' AS metadata
-                 WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
-              WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')), 0))
-              ORDER BY timestamp DESC) AS
-           union
-           GROUP BY source_label,
-                    customer_id,
-                    subscription_id
-           ORDER BY customer_id ASC,
-                    subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
-        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)
-     WHERE notEmpty(group_key)
+                (SELECT posthog_test_stripe_invoice.id AS id,
+                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                        posthog_test_stripe_invoice.customer AS customer_id,
+                        posthog_test_stripe_invoice.subscription AS subscription_id,
+                        posthog_test_stripe_invoice.discount AS discount,
+                        arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                        JSONExtractString(data, 'id') AS invoice_item_id,
+                        JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                        coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                        greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                        JSONExtractString(data, 'currency') AS currency,
+                        JSONExtractString(data, 'price', 'product') AS product_id,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                        greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                        arrayJoin(range(0, period_months)) AS month_index,
+                        ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                 WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_analytics_revenue_item
+           GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+        LEFT JOIN
+          (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
+                  sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
+           FROM
+             (SELECT union.source_label AS source_label,
+                     union.customer_id AS customer_id,
+                     union.subscription_id AS subscription_id,
+                     argMax(union.amount, union.timestamp) AS mrr
+              FROM
+                (SELECT revenue_item.source_label AS source_label,
+                        revenue_item.customer_id AS customer_id,
+                        revenue_item.subscription_id AS subscription_id,
+                        toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                        sum(revenue_item.amount) AS amount
+                 FROM
+                   (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                           invoice.invoice_item_id AS invoice_item_id,
+                           'stripe.posthog_test' AS source_label,
+                           addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                           invoice.created_at AS created_at,
+                           ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                           invoice.product_id AS product_id,
+                           invoice.customer_id AS customer_id,
+                           NULL AS group_0_key,
+                           NULL AS group_1_key,
+                           NULL AS group_2_key,
+                           NULL AS group_3_key,
+                           NULL AS group_4_key,
+                           invoice.id AS invoice_id,
+                           invoice.subscription_id AS subscription_id,
+                           NULL AS session_id,
+                           NULL AS event_name,
+                           JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                           JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                           upper(invoice.currency) AS original_currency,
+                           accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                           in(original_currency,
+                              ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                             'GBP' AS currency,
+                             divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                    FROM
+                      (SELECT posthog_test_stripe_invoice.id AS id,
+                              parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                              posthog_test_stripe_invoice.customer AS customer_id,
+                              posthog_test_stripe_invoice.subscription AS subscription_id,
+                              posthog_test_stripe_invoice.discount AS discount,
+                              arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                              JSONExtractString(data, 'id') AS invoice_item_id,
+                              JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                              coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                              greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                              JSONExtractString(data, 'currency') AS currency,
+                              JSONExtractString(data, 'price', 'product') AS product_id,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                              greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                              arrayJoin(range(0, period_months)) AS month_index,
+                              ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                       FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                       WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_item
+                 WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')), 0))
+                 GROUP BY revenue_item.source_label,
+                          revenue_item.customer_id,
+                          revenue_item.subscription_id, timestamp
+                 ORDER BY timestamp DESC
+                 UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
+                                  `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
+                                  `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
+                                  toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
+                                  accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                 FROM
+                   (SELECT '' AS id,
+                           '' AS source_label,
+                           '' AS plan_id,
+                           '' AS product_id,
+                           '' AS customer_id,
+                           '' AS status,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
+                           '' AS metadata
+                    WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
+                 WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')), 0))
+                 ORDER BY timestamp DESC) AS
+              union
+              GROUP BY source_label,
+                       customer_id,
+                       subscription_id
+              ORDER BY customer_id ASC,
+                       subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
+           GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)
+        WHERE notEmpty(group_key)
+        GROUP BY group_key)
      GROUP BY group_key) AS groups__revenue_analytics ON equals(groups.groups___key, groups__revenue_analytics.group_key)
   ORDER BY groups.key ASC
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
@@ -479,58 +491,17 @@
               groups.group_key) AS groups
   LEFT JOIN
     (SELECT 99999 AS team_id,
-            coalesce(revenue_agg.group_key, mrr_agg.group_key) AS group_key,
-            coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
-            coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+            group_key AS group_key,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT arrayJoin([revenue_analytics_revenue_item.group_0_key, revenue_analytics_revenue_item.group_1_key, revenue_analytics_revenue_item.group_2_key, revenue_analytics_revenue_item.group_3_key, revenue_analytics_revenue_item.group_4_key]) AS group_key,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
+       (SELECT 99999 AS team_id,
+               coalesce(revenue_agg.group_key, mrr_agg.group_key) AS group_key,
+               coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+               coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
         FROM
-          (SELECT toString(events.uuid) AS id,
-                  toString(events.uuid) AS invoice_item_id,
-                  'revenue_analytics.events.purchase' AS source_label,
-                  toTimeZone(events.timestamp, 'UTC') AS timestamp,
-                  timestamp AS created_at,
-                  0 AS is_recurring,
-                  NULL AS product_id,
-                  toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
-                  events.`$group_0` AS group_0_key,
-                  events.`$group_1` AS group_1_key,
-                  events.`$group_2` AS group_2_key,
-                  events.`$group_3` AS group_3_key,
-                  events.`$group_4` AS group_4_key,
-                  NULL AS invoice_id,
-                  NULL AS subscription_id,
-                  toString(events.`$session_id`) AS session_id,
-                  events.event AS event_name,
-                  NULL AS coupon,
-                  coupon AS coupon_id,
-                  'USD' AS original_currency,
-                  accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
-                  in(original_currency,
-                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                    'USD' AS currency,
-                    if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
-           FROM events
-           LEFT OUTER JOIN
-             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                     person_distinct_id_overrides.distinct_id AS distinct_id
-              FROM person_distinct_id_overrides
-              WHERE equals(person_distinct_id_overrides.team_id, 99999)
-              GROUP BY person_distinct_id_overrides.distinct_id
-              HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-           WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
-           ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-        WHERE notEmpty(group_key)
-        GROUP BY group_key) AS revenue_agg
-     FULL OUTER JOIN
-       (SELECT customer_to_group.group_key AS group_key,
-               sum(coalesce(mrr_by_customer.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
-        FROM
-          (SELECT DISTINCT revenue_analytics_revenue_item.customer_id AS customer_id,
-                           arrayJoin([revenue_analytics_revenue_item.group_0_key, revenue_analytics_revenue_item.group_1_key, revenue_analytics_revenue_item.group_2_key, revenue_analytics_revenue_item.group_3_key, revenue_analytics_revenue_item.group_4_key]) AS group_key
+          (SELECT arrayJoin([revenue_analytics_revenue_item.group_0_key, revenue_analytics_revenue_item.group_1_key, revenue_analytics_revenue_item.group_2_key, revenue_analytics_revenue_item.group_3_key, revenue_analytics_revenue_item.group_4_key]) AS group_key,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
            FROM
              (SELECT toString(events.uuid) AS id,
                      toString(events.uuid) AS invoice_item_id,
@@ -569,90 +540,137 @@
                  HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
               WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
               ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-           WHERE notEmpty(group_key)) AS customer_to_group
-        LEFT JOIN
-          (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
-                  sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
+           WHERE notEmpty(group_key)
+           GROUP BY group_key) AS revenue_agg
+        FULL OUTER JOIN
+          (SELECT customer_to_group.group_key AS group_key,
+                  sum(coalesce(mrr_by_customer.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
            FROM
-             (SELECT union.source_label AS source_label,
-                     union.customer_id AS customer_id,
-                     union.subscription_id AS subscription_id,
-                     argMax(union.amount, union.timestamp) AS mrr
+             (SELECT DISTINCT revenue_analytics_revenue_item.customer_id AS customer_id,
+                              arrayJoin([revenue_analytics_revenue_item.group_0_key, revenue_analytics_revenue_item.group_1_key, revenue_analytics_revenue_item.group_2_key, revenue_analytics_revenue_item.group_3_key, revenue_analytics_revenue_item.group_4_key]) AS group_key
               FROM
-                (SELECT revenue_item.source_label AS source_label,
-                        revenue_item.customer_id AS customer_id,
-                        revenue_item.subscription_id AS subscription_id,
-                        toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
-                        sum(revenue_item.amount) AS amount
+                (SELECT toString(events.uuid) AS id,
+                        toString(events.uuid) AS invoice_item_id,
+                        'revenue_analytics.events.purchase' AS source_label,
+                        toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                        timestamp AS created_at,
+                        0 AS is_recurring,
+                        NULL AS product_id,
+                        toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
+                        events.`$group_0` AS group_0_key,
+                        events.`$group_1` AS group_1_key,
+                        events.`$group_2` AS group_2_key,
+                        events.`$group_3` AS group_3_key,
+                        events.`$group_4` AS group_4_key,
+                        NULL AS invoice_id,
+                        NULL AS subscription_id,
+                        toString(events.`$session_id`) AS session_id,
+                        events.event AS event_name,
+                        NULL AS coupon,
+                        coupon AS coupon_id,
+                        'USD' AS original_currency,
+                        accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                        in(original_currency,
+                           ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                          if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                          divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                          'USD' AS currency,
+                          if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+                 FROM events
+                 LEFT OUTER JOIN
+                   (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                           person_distinct_id_overrides.distinct_id AS distinct_id
+                    FROM person_distinct_id_overrides
+                    WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                    GROUP BY person_distinct_id_overrides.distinct_id
+                    HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+                 WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+                 ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
+              WHERE notEmpty(group_key)) AS customer_to_group
+           LEFT JOIN
+             (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
+                     sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
+              FROM
+                (SELECT union.source_label AS source_label,
+                        union.customer_id AS customer_id,
+                        union.subscription_id AS subscription_id,
+                        argMax(union.amount, union.timestamp) AS mrr
                  FROM
-                   (SELECT toString(events.uuid) AS id,
-                           toString(events.uuid) AS invoice_item_id,
-                           'revenue_analytics.events.purchase' AS source_label,
-                           toTimeZone(events.timestamp, 'UTC') AS timestamp,
-                           timestamp AS created_at,
-                           0 AS is_recurring,
-                           NULL AS product_id,
-                           toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
-                           events.`$group_0` AS group_0_key,
-                           events.`$group_1` AS group_1_key,
-                           events.`$group_2` AS group_2_key,
-                           events.`$group_3` AS group_3_key,
-                           events.`$group_4` AS group_4_key,
-                           NULL AS invoice_id,
-                           NULL AS subscription_id,
-                           toString(events.`$session_id`) AS session_id,
-                           events.event AS event_name,
-                           NULL AS coupon,
-                           coupon AS coupon_id,
-                           'USD' AS original_currency,
-                           accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
-                           in(original_currency,
-                              ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                             'USD' AS currency,
-                             if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
-                    FROM events
-                    LEFT OUTER JOIN
-                      (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                              person_distinct_id_overrides.distinct_id AS distinct_id
-                       FROM person_distinct_id_overrides
-                       WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                       GROUP BY person_distinct_id_overrides.distinct_id
-                       HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-                    WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
-                    ORDER BY timestamp DESC) AS revenue_item
-                 WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), 0))
-                 GROUP BY revenue_item.source_label,
-                          revenue_item.customer_id,
-                          revenue_item.subscription_id, timestamp
-                 ORDER BY timestamp DESC
-                 UNION ALL SELECT `revenue_analytics.events.purchase.subscription_events_revenue_view`.source_label AS source_label,
-                                  `revenue_analytics.events.purchase.subscription_events_revenue_view`.customer_id AS customer_id,
-                                  `revenue_analytics.events.purchase.subscription_events_revenue_view`.id AS subscription_id,
-                                  toTimeZone(`revenue_analytics.events.purchase.subscription_events_revenue_view`.ended_at, 'UTC') AS timestamp,
-                                  accurateCastOrNull(0, 'Decimal64(10)') AS amount
-                 FROM
-                   (SELECT '' AS id,
-                           '' AS source_label,
-                           '' AS plan_id,
-                           '' AS product_id,
-                           '' AS customer_id,
-                           '' AS status,
-                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
-                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
-                           '' AS metadata
-                    WHERE 0) AS `revenue_analytics.events.purchase.subscription_events_revenue_view`
-                 WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), 0))
-                 ORDER BY timestamp DESC) AS
-              union
-              GROUP BY source_label,
-                       customer_id,
-                       subscription_id
-              ORDER BY customer_id ASC,
-                       subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
-           GROUP BY customer_id) AS mrr_by_customer ON equals(customer_to_group.customer_id, mrr_by_customer.customer_id)
-        GROUP BY group_key) AS mrr_agg ON equals(revenue_agg.group_key, mrr_agg.group_key)) AS groups__revenue_analytics ON equals(groups.groups___key, groups__revenue_analytics.group_key)
+                   (SELECT revenue_item.source_label AS source_label,
+                           revenue_item.customer_id AS customer_id,
+                           revenue_item.subscription_id AS subscription_id,
+                           toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                           sum(revenue_item.amount) AS amount
+                    FROM
+                      (SELECT toString(events.uuid) AS id,
+                              toString(events.uuid) AS invoice_item_id,
+                              'revenue_analytics.events.purchase' AS source_label,
+                              toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                              timestamp AS created_at,
+                              0 AS is_recurring,
+                              NULL AS product_id,
+                              toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
+                              events.`$group_0` AS group_0_key,
+                              events.`$group_1` AS group_1_key,
+                              events.`$group_2` AS group_2_key,
+                              events.`$group_3` AS group_3_key,
+                              events.`$group_4` AS group_4_key,
+                              NULL AS invoice_id,
+                              NULL AS subscription_id,
+                              toString(events.`$session_id`) AS session_id,
+                              events.event AS event_name,
+                              NULL AS coupon,
+                              coupon AS coupon_id,
+                              'USD' AS original_currency,
+                              accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                              in(original_currency,
+                                 ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                                if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                                divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                                'USD' AS currency,
+                                if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+                       FROM events
+                       LEFT OUTER JOIN
+                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                                 person_distinct_id_overrides.distinct_id AS distinct_id
+                          FROM person_distinct_id_overrides
+                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                          GROUP BY person_distinct_id_overrides.distinct_id
+                          HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+                       WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+                       ORDER BY timestamp DESC) AS revenue_item
+                    WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), 0))
+                    GROUP BY revenue_item.source_label,
+                             revenue_item.customer_id,
+                             revenue_item.subscription_id, timestamp
+                    ORDER BY timestamp DESC
+                    UNION ALL SELECT `revenue_analytics.events.purchase.subscription_events_revenue_view`.source_label AS source_label,
+                                     `revenue_analytics.events.purchase.subscription_events_revenue_view`.customer_id AS customer_id,
+                                     `revenue_analytics.events.purchase.subscription_events_revenue_view`.id AS subscription_id,
+                                     toTimeZone(`revenue_analytics.events.purchase.subscription_events_revenue_view`.ended_at, 'UTC') AS timestamp,
+                                     accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                    FROM
+                      (SELECT '' AS id,
+                              '' AS source_label,
+                              '' AS plan_id,
+                              '' AS product_id,
+                              '' AS customer_id,
+                              '' AS status,
+                              toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
+                              toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
+                              '' AS metadata
+                       WHERE 0) AS `revenue_analytics.events.purchase.subscription_events_revenue_view`
+                    WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), 0))
+                    ORDER BY timestamp DESC) AS
+                 union
+                 GROUP BY source_label,
+                          customer_id,
+                          subscription_id
+                 ORDER BY customer_id ASC,
+                          subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+              GROUP BY customer_id) AS mrr_by_customer ON equals(customer_to_group.customer_id, mrr_by_customer.customer_id)
+           GROUP BY group_key) AS mrr_agg ON equals(revenue_agg.group_key, mrr_agg.group_key))
+     GROUP BY group_key) AS groups__revenue_analytics ON equals(groups.groups___key, groups__revenue_analytics.group_key)
   WHERE equals(groups.key, 'lolol0:xxx')
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -683,216 +701,222 @@
               groups.group_key) AS groups
   LEFT JOIN
     (SELECT 99999 AS team_id,
-            revenue_analytics_customer__groups.key AS group_key,
-            sum(coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)'))) AS revenue,
-            sum(coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
+            group_key AS group_key,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT inner.id AS id,
-               inner.source_label AS source_label,
-               inner.timestamp AS timestamp,
-               inner.name AS name,
-               inner.email AS email,
-               inner.phone AS phone,
-               inner.address AS address,
-               if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(notEquals(inner.resolved_distinct_id, ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata,
-               inner.country AS country,
-               inner.cohort AS cohort,
-               inner.initial_coupon AS initial_coupon,
-               inner.initial_coupon_id AS initial_coupon_id
+       (SELECT 99999 AS team_id,
+               revenue_analytics_customer__groups.key AS group_key,
+               sum(coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)'))) AS revenue,
+               sum(coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
         FROM
-          (SELECT outer.id AS id,
-                  'stripe.posthog_test' AS source_label,
-                  parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
-                  outer.name AS name,
-                  outer.email AS email,
-                  outer.phone AS phone,
-                  outer.address AS address,
-                  outer.metadata AS metadata,
-                  JSONExtractString(address, 'country') AS country,
-                  cohort_inner.cohort AS cohort,
-                  cohort_inner.initial_coupon AS initial_coupon,
-                  cohort_inner.initial_coupon_id AS initial_coupon_id,
-                  ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id,
-                  ifNull(resolved.resolved_source, '') AS resolved_source
+          (SELECT inner.id AS id,
+                  inner.source_label AS source_label,
+                  inner.timestamp AS timestamp,
+                  inner.name AS name,
+                  inner.email AS email,
+                  inner.phone AS phone,
+                  inner.address AS address,
+                  if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(notEquals(inner.resolved_distinct_id, ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata,
+                  inner.country AS country,
+                  inner.cohort AS cohort,
+                  inner.initial_coupon AS initial_coupon,
+                  inner.initial_coupon_id AS initial_coupon_id
            FROM
-             (SELECT *
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
-           LEFT JOIN
-             (SELECT invoice.customer AS customer_id,
-                     formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
-                     argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
-                     argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
-              GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
-           LEFT JOIN
-             (SELECT child_meta.customer_id AS customer_id,
-                     argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id,
-                     argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
+             (SELECT outer.id AS id,
+                     'stripe.posthog_test' AS source_label,
+                     parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
+                     outer.name AS name,
+                     outer.email AS email,
+                     outer.phone AS phone,
+                     outer.address AS address,
+                     outer.metadata AS metadata,
+                     JSONExtractString(address, 'country') AS country,
+                     cohort_inner.cohort AS cohort,
+                     cohort_inner.initial_coupon AS initial_coupon,
+                     cohort_inner.initial_coupon_id AS initial_coupon_id,
+                     ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id,
+                     ifNull(resolved.resolved_source, '') AS resolved_source
               FROM
-                (SELECT posthog_test_stripe_invoice.customer AS customer_id,
-                        JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id,
-                        concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
-                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
-                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                 WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
-              GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner
-        ORDER BY timestamp DESC
-        LIMIT 1 BY id) AS revenue_analytics_customer
-     LEFT JOIN
-       (SELECT groups.key AS key,
-               key AS revenue_analytics_customer__groups___key
-        FROM
-          (SELECT groups.group_type_index AS index,
-                  groups.group_key AS key
-           FROM groups
-           WHERE equals(groups.team_id, 99999)
-           GROUP BY groups.group_type_index,
-                    groups.group_key) AS groups) AS revenue_analytics_customer__groups ON equals(revenue_analytics_customer.email, revenue_analytics_customer__groups.revenue_analytics_customer__groups___key)
-     LEFT JOIN
-       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM
-          (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                  invoice.invoice_item_id AS invoice_item_id,
-                  'stripe.posthog_test' AS source_label,
-                  addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                  invoice.created_at AS created_at,
-                  ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                  invoice.product_id AS product_id,
-                  invoice.customer_id AS customer_id,
-                  NULL AS group_0_key,
-                  NULL AS group_1_key,
-                  NULL AS group_2_key,
-                  NULL AS group_3_key,
-                  NULL AS group_4_key,
-                  invoice.id AS invoice_id,
-                  invoice.subscription_id AS subscription_id,
-                  NULL AS session_id,
-                  NULL AS event_name,
-                  JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                  JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                  upper(invoice.currency) AS original_currency,
-                  accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                  in(original_currency,
-                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                    'GBP' AS currency,
-                    divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
-           FROM
-             (SELECT posthog_test_stripe_invoice.id AS id,
-                     parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                     posthog_test_stripe_invoice.customer AS customer_id,
-                     posthog_test_stripe_invoice.subscription AS subscription_id,
-                     posthog_test_stripe_invoice.discount AS discount,
-                     arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                     JSONExtractString(data, 'id') AS invoice_item_id,
-                     JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                     coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                     greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                     JSONExtractString(data, 'currency') AS currency,
-                     JSONExtractString(data, 'price', 'product') AS product_id,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                     greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                     arrayJoin(range(0, period_months)) AS month_index,
-                     ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-              WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_analytics_revenue_item
-        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-     LEFT JOIN
-       (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
-               sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
-        FROM
-          (SELECT union.source_label AS source_label,
-                  union.customer_id AS customer_id,
-                  union.subscription_id AS subscription_id,
-                  argMax(union.amount, union.timestamp) AS mrr
-           FROM
-             (SELECT revenue_item.source_label AS source_label,
-                     revenue_item.customer_id AS customer_id,
-                     revenue_item.subscription_id AS subscription_id,
-                     toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
-                     sum(revenue_item.amount) AS amount
-              FROM
-                (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                        invoice.invoice_item_id AS invoice_item_id,
-                        'stripe.posthog_test' AS source_label,
-                        addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                        invoice.created_at AS created_at,
-                        ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                        invoice.product_id AS product_id,
-                        invoice.customer_id AS customer_id,
-                        NULL AS group_0_key,
-                        NULL AS group_1_key,
-                        NULL AS group_2_key,
-                        NULL AS group_3_key,
-                        NULL AS group_4_key,
-                        invoice.id AS invoice_id,
-                        invoice.subscription_id AS subscription_id,
-                        NULL AS session_id,
-                        NULL AS event_name,
-                        JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                        JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                        upper(invoice.currency) AS original_currency,
-                        accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                        in(original_currency,
-                           ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                          if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                          divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                          'GBP' AS currency,
-                          divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                (SELECT *
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
+              LEFT JOIN
+                (SELECT invoice.customer AS customer_id,
+                        formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
+                 GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
+              LEFT JOIN
+                (SELECT child_meta.customer_id AS customer_id,
+                        argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id,
+                        argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
                  FROM
-                   (SELECT posthog_test_stripe_invoice.id AS id,
-                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                           posthog_test_stripe_invoice.customer AS customer_id,
-                           posthog_test_stripe_invoice.subscription AS subscription_id,
-                           posthog_test_stripe_invoice.discount AS discount,
-                           arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                           JSONExtractString(data, 'id') AS invoice_item_id,
-                           JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                           coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                           greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                           JSONExtractString(data, 'currency') AS currency,
-                           JSONExtractString(data, 'price', 'product') AS product_id,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                           greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                           arrayJoin(range(0, period_months)) AS month_index,
-                           ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                   (SELECT posthog_test_stripe_invoice.customer AS customer_id,
+                           JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id,
+                           concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
+                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
                     FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                    WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_item
-              WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')), 0))
-              GROUP BY revenue_item.source_label,
-                       revenue_item.customer_id,
-                       revenue_item.subscription_id, timestamp
-              ORDER BY timestamp DESC
-              UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
-                               `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
-                               `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
-                               toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
-                               accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                    WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
+                 GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner
+           ORDER BY timestamp DESC
+           LIMIT 1 BY id) AS revenue_analytics_customer
+        LEFT JOIN
+          (SELECT groups.key AS key,
+                  key AS revenue_analytics_customer__groups___key
+           FROM
+             (SELECT groups.group_type_index AS index,
+                     groups.group_key AS key
+              FROM groups
+              WHERE equals(groups.team_id, 99999)
+              GROUP BY groups.group_type_index,
+                       groups.group_key) AS groups) AS revenue_analytics_customer__groups ON equals(revenue_analytics_customer.email, revenue_analytics_customer__groups.revenue_analytics_customer__groups___key)
+        LEFT JOIN
+          (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
+           FROM
+             (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                     invoice.invoice_item_id AS invoice_item_id,
+                     'stripe.posthog_test' AS source_label,
+                     addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                     invoice.created_at AS created_at,
+                     ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                     invoice.product_id AS product_id,
+                     invoice.customer_id AS customer_id,
+                     NULL AS group_0_key,
+                     NULL AS group_1_key,
+                     NULL AS group_2_key,
+                     NULL AS group_3_key,
+                     NULL AS group_4_key,
+                     invoice.id AS invoice_id,
+                     invoice.subscription_id AS subscription_id,
+                     NULL AS session_id,
+                     NULL AS event_name,
+                     JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                     JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                     upper(invoice.currency) AS original_currency,
+                     accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                     in(original_currency,
+                        ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                       if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                       divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                       'GBP' AS currency,
+                       divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
               FROM
-                (SELECT '' AS id,
-                        '' AS source_label,
-                        '' AS plan_id,
-                        '' AS product_id,
-                        '' AS customer_id,
-                        '' AS status,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
-                        '' AS metadata
-                 WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
-              WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')), 0))
-              ORDER BY timestamp DESC) AS
-           union
-           GROUP BY source_label,
-                    customer_id,
-                    subscription_id
-           ORDER BY customer_id ASC,
-                    subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
-        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)
-     WHERE notEmpty(group_key)
+                (SELECT posthog_test_stripe_invoice.id AS id,
+                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                        posthog_test_stripe_invoice.customer AS customer_id,
+                        posthog_test_stripe_invoice.subscription AS subscription_id,
+                        posthog_test_stripe_invoice.discount AS discount,
+                        arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                        JSONExtractString(data, 'id') AS invoice_item_id,
+                        JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                        coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                        greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                        JSONExtractString(data, 'currency') AS currency,
+                        JSONExtractString(data, 'price', 'product') AS product_id,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                        greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                        arrayJoin(range(0, period_months)) AS month_index,
+                        ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                 WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_analytics_revenue_item
+           GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+        LEFT JOIN
+          (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
+                  sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
+           FROM
+             (SELECT union.source_label AS source_label,
+                     union.customer_id AS customer_id,
+                     union.subscription_id AS subscription_id,
+                     argMax(union.amount, union.timestamp) AS mrr
+              FROM
+                (SELECT revenue_item.source_label AS source_label,
+                        revenue_item.customer_id AS customer_id,
+                        revenue_item.subscription_id AS subscription_id,
+                        toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                        sum(revenue_item.amount) AS amount
+                 FROM
+                   (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                           invoice.invoice_item_id AS invoice_item_id,
+                           'stripe.posthog_test' AS source_label,
+                           addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                           invoice.created_at AS created_at,
+                           ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                           invoice.product_id AS product_id,
+                           invoice.customer_id AS customer_id,
+                           NULL AS group_0_key,
+                           NULL AS group_1_key,
+                           NULL AS group_2_key,
+                           NULL AS group_3_key,
+                           NULL AS group_4_key,
+                           invoice.id AS invoice_id,
+                           invoice.subscription_id AS subscription_id,
+                           NULL AS session_id,
+                           NULL AS event_name,
+                           JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                           JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                           upper(invoice.currency) AS original_currency,
+                           accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                           in(original_currency,
+                              ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                             'GBP' AS currency,
+                             divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                    FROM
+                      (SELECT posthog_test_stripe_invoice.id AS id,
+                              parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                              posthog_test_stripe_invoice.customer AS customer_id,
+                              posthog_test_stripe_invoice.subscription AS subscription_id,
+                              posthog_test_stripe_invoice.discount AS discount,
+                              arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                              JSONExtractString(data, 'id') AS invoice_item_id,
+                              JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                              coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                              greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                              JSONExtractString(data, 'currency') AS currency,
+                              JSONExtractString(data, 'price', 'product') AS product_id,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                              greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                              arrayJoin(range(0, period_months)) AS month_index,
+                              ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                       FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                       WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_item
+                 WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')), 0))
+                 GROUP BY revenue_item.source_label,
+                          revenue_item.customer_id,
+                          revenue_item.subscription_id, timestamp
+                 ORDER BY timestamp DESC
+                 UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
+                                  `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
+                                  `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
+                                  toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
+                                  accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                 FROM
+                   (SELECT '' AS id,
+                           '' AS source_label,
+                           '' AS plan_id,
+                           '' AS product_id,
+                           '' AS customer_id,
+                           '' AS status,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
+                           '' AS metadata
+                    WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
+                 WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')), 0))
+                 ORDER BY timestamp DESC) AS
+              union
+              GROUP BY source_label,
+                       customer_id,
+                       subscription_id
+              ORDER BY customer_id ASC,
+                       subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
+           GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)
+        WHERE notEmpty(group_key)
+        GROUP BY group_key)
      GROUP BY group_key) AS groups__revenue_analytics ON equals(groups.groups___key, groups__revenue_analytics.group_key)
   ORDER BY groups.key ASC
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
@@ -924,216 +948,222 @@
               groups.group_key) AS groups
   LEFT JOIN
     (SELECT 99999 AS team_id,
-            revenue_analytics_customer__groups.key AS group_key,
-            sum(coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)'))) AS revenue,
-            sum(coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
+            group_key AS group_key,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT inner.id AS id,
-               inner.source_label AS source_label,
-               inner.timestamp AS timestamp,
-               inner.name AS name,
-               inner.email AS email,
-               inner.phone AS phone,
-               inner.address AS address,
-               if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(notEquals(inner.resolved_distinct_id, ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata,
-               inner.country AS country,
-               inner.cohort AS cohort,
-               inner.initial_coupon AS initial_coupon,
-               inner.initial_coupon_id AS initial_coupon_id
+       (SELECT 99999 AS team_id,
+               revenue_analytics_customer__groups.key AS group_key,
+               sum(coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)'))) AS revenue,
+               sum(coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
         FROM
-          (SELECT outer.id AS id,
-                  'stripe.posthog_test' AS source_label,
-                  parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
-                  outer.name AS name,
-                  outer.email AS email,
-                  outer.phone AS phone,
-                  outer.address AS address,
-                  outer.metadata AS metadata,
-                  JSONExtractString(address, 'country') AS country,
-                  cohort_inner.cohort AS cohort,
-                  cohort_inner.initial_coupon AS initial_coupon,
-                  cohort_inner.initial_coupon_id AS initial_coupon_id,
-                  ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id,
-                  ifNull(resolved.resolved_source, '') AS resolved_source
+          (SELECT inner.id AS id,
+                  inner.source_label AS source_label,
+                  inner.timestamp AS timestamp,
+                  inner.name AS name,
+                  inner.email AS email,
+                  inner.phone AS phone,
+                  inner.address AS address,
+                  if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(notEquals(inner.resolved_distinct_id, ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata,
+                  inner.country AS country,
+                  inner.cohort AS cohort,
+                  inner.initial_coupon AS initial_coupon,
+                  inner.initial_coupon_id AS initial_coupon_id
            FROM
-             (SELECT *
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
-           LEFT JOIN
-             (SELECT invoice.customer AS customer_id,
-                     formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
-                     argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
-                     argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
-              GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
-           LEFT JOIN
-             (SELECT child_meta.customer_id AS customer_id,
-                     argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id,
-                     argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
+             (SELECT outer.id AS id,
+                     'stripe.posthog_test' AS source_label,
+                     parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
+                     outer.name AS name,
+                     outer.email AS email,
+                     outer.phone AS phone,
+                     outer.address AS address,
+                     outer.metadata AS metadata,
+                     JSONExtractString(address, 'country') AS country,
+                     cohort_inner.cohort AS cohort,
+                     cohort_inner.initial_coupon AS initial_coupon,
+                     cohort_inner.initial_coupon_id AS initial_coupon_id,
+                     ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id,
+                     ifNull(resolved.resolved_source, '') AS resolved_source
               FROM
-                (SELECT posthog_test_stripe_invoice.customer AS customer_id,
-                        JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id,
-                        concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
-                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
-                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                 WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
-              GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner
-        ORDER BY timestamp DESC
-        LIMIT 1 BY id) AS revenue_analytics_customer
-     LEFT JOIN
-       (SELECT groups.key AS key,
-               key AS revenue_analytics_customer__groups___key
-        FROM
-          (SELECT groups.group_type_index AS index,
-                  groups.group_key AS key
-           FROM groups
-           WHERE equals(groups.team_id, 99999)
-           GROUP BY groups.group_type_index,
-                    groups.group_key) AS groups) AS revenue_analytics_customer__groups ON equals(revenue_analytics_customer.id, revenue_analytics_customer__groups.revenue_analytics_customer__groups___key)
-     LEFT JOIN
-       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM
-          (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                  invoice.invoice_item_id AS invoice_item_id,
-                  'stripe.posthog_test' AS source_label,
-                  addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                  invoice.created_at AS created_at,
-                  ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                  invoice.product_id AS product_id,
-                  invoice.customer_id AS customer_id,
-                  NULL AS group_0_key,
-                  NULL AS group_1_key,
-                  NULL AS group_2_key,
-                  NULL AS group_3_key,
-                  NULL AS group_4_key,
-                  invoice.id AS invoice_id,
-                  invoice.subscription_id AS subscription_id,
-                  NULL AS session_id,
-                  NULL AS event_name,
-                  JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                  JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                  upper(invoice.currency) AS original_currency,
-                  accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                  in(original_currency,
-                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                    'GBP' AS currency,
-                    divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
-           FROM
-             (SELECT posthog_test_stripe_invoice.id AS id,
-                     parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                     posthog_test_stripe_invoice.customer AS customer_id,
-                     posthog_test_stripe_invoice.subscription AS subscription_id,
-                     posthog_test_stripe_invoice.discount AS discount,
-                     arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                     JSONExtractString(data, 'id') AS invoice_item_id,
-                     JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                     coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                     greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                     JSONExtractString(data, 'currency') AS currency,
-                     JSONExtractString(data, 'price', 'product') AS product_id,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                     greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                     arrayJoin(range(0, period_months)) AS month_index,
-                     ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-              WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_analytics_revenue_item
-        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-     LEFT JOIN
-       (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
-               sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
-        FROM
-          (SELECT union.source_label AS source_label,
-                  union.customer_id AS customer_id,
-                  union.subscription_id AS subscription_id,
-                  argMax(union.amount, union.timestamp) AS mrr
-           FROM
-             (SELECT revenue_item.source_label AS source_label,
-                     revenue_item.customer_id AS customer_id,
-                     revenue_item.subscription_id AS subscription_id,
-                     toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
-                     sum(revenue_item.amount) AS amount
-              FROM
-                (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                        invoice.invoice_item_id AS invoice_item_id,
-                        'stripe.posthog_test' AS source_label,
-                        addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                        invoice.created_at AS created_at,
-                        ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                        invoice.product_id AS product_id,
-                        invoice.customer_id AS customer_id,
-                        NULL AS group_0_key,
-                        NULL AS group_1_key,
-                        NULL AS group_2_key,
-                        NULL AS group_3_key,
-                        NULL AS group_4_key,
-                        invoice.id AS invoice_id,
-                        invoice.subscription_id AS subscription_id,
-                        NULL AS session_id,
-                        NULL AS event_name,
-                        JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                        JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                        upper(invoice.currency) AS original_currency,
-                        accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                        in(original_currency,
-                           ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                          if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                          divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                          'GBP' AS currency,
-                          divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                (SELECT *
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
+              LEFT JOIN
+                (SELECT invoice.customer AS customer_id,
+                        formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
+                 GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
+              LEFT JOIN
+                (SELECT child_meta.customer_id AS customer_id,
+                        argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id,
+                        argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
                  FROM
-                   (SELECT posthog_test_stripe_invoice.id AS id,
-                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                           posthog_test_stripe_invoice.customer AS customer_id,
-                           posthog_test_stripe_invoice.subscription AS subscription_id,
-                           posthog_test_stripe_invoice.discount AS discount,
-                           arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                           JSONExtractString(data, 'id') AS invoice_item_id,
-                           JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                           coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                           greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                           JSONExtractString(data, 'currency') AS currency,
-                           JSONExtractString(data, 'price', 'product') AS product_id,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                           greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                           arrayJoin(range(0, period_months)) AS month_index,
-                           ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                   (SELECT posthog_test_stripe_invoice.customer AS customer_id,
+                           JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id,
+                           concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
+                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
                     FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                    WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_item
-              WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')), 0))
-              GROUP BY revenue_item.source_label,
-                       revenue_item.customer_id,
-                       revenue_item.subscription_id, timestamp
-              ORDER BY timestamp DESC
-              UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
-                               `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
-                               `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
-                               toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
-                               accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                    WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
+                 GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner
+           ORDER BY timestamp DESC
+           LIMIT 1 BY id) AS revenue_analytics_customer
+        LEFT JOIN
+          (SELECT groups.key AS key,
+                  key AS revenue_analytics_customer__groups___key
+           FROM
+             (SELECT groups.group_type_index AS index,
+                     groups.group_key AS key
+              FROM groups
+              WHERE equals(groups.team_id, 99999)
+              GROUP BY groups.group_type_index,
+                       groups.group_key) AS groups) AS revenue_analytics_customer__groups ON equals(revenue_analytics_customer.id, revenue_analytics_customer__groups.revenue_analytics_customer__groups___key)
+        LEFT JOIN
+          (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
+           FROM
+             (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                     invoice.invoice_item_id AS invoice_item_id,
+                     'stripe.posthog_test' AS source_label,
+                     addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                     invoice.created_at AS created_at,
+                     ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                     invoice.product_id AS product_id,
+                     invoice.customer_id AS customer_id,
+                     NULL AS group_0_key,
+                     NULL AS group_1_key,
+                     NULL AS group_2_key,
+                     NULL AS group_3_key,
+                     NULL AS group_4_key,
+                     invoice.id AS invoice_id,
+                     invoice.subscription_id AS subscription_id,
+                     NULL AS session_id,
+                     NULL AS event_name,
+                     JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                     JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                     upper(invoice.currency) AS original_currency,
+                     accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                     in(original_currency,
+                        ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                       if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                       divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                       'GBP' AS currency,
+                       divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
               FROM
-                (SELECT '' AS id,
-                        '' AS source_label,
-                        '' AS plan_id,
-                        '' AS product_id,
-                        '' AS customer_id,
-                        '' AS status,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
-                        '' AS metadata
-                 WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
-              WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')), 0))
-              ORDER BY timestamp DESC) AS
-           union
-           GROUP BY source_label,
-                    customer_id,
-                    subscription_id
-           ORDER BY customer_id ASC,
-                    subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
-        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)
-     WHERE notEmpty(group_key)
+                (SELECT posthog_test_stripe_invoice.id AS id,
+                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                        posthog_test_stripe_invoice.customer AS customer_id,
+                        posthog_test_stripe_invoice.subscription AS subscription_id,
+                        posthog_test_stripe_invoice.discount AS discount,
+                        arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                        JSONExtractString(data, 'id') AS invoice_item_id,
+                        JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                        coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                        greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                        JSONExtractString(data, 'currency') AS currency,
+                        JSONExtractString(data, 'price', 'product') AS product_id,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                        greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                        arrayJoin(range(0, period_months)) AS month_index,
+                        ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                 WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_analytics_revenue_item
+           GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+        LEFT JOIN
+          (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
+                  sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
+           FROM
+             (SELECT union.source_label AS source_label,
+                     union.customer_id AS customer_id,
+                     union.subscription_id AS subscription_id,
+                     argMax(union.amount, union.timestamp) AS mrr
+              FROM
+                (SELECT revenue_item.source_label AS source_label,
+                        revenue_item.customer_id AS customer_id,
+                        revenue_item.subscription_id AS subscription_id,
+                        toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                        sum(revenue_item.amount) AS amount
+                 FROM
+                   (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                           invoice.invoice_item_id AS invoice_item_id,
+                           'stripe.posthog_test' AS source_label,
+                           addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                           invoice.created_at AS created_at,
+                           ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                           invoice.product_id AS product_id,
+                           invoice.customer_id AS customer_id,
+                           NULL AS group_0_key,
+                           NULL AS group_1_key,
+                           NULL AS group_2_key,
+                           NULL AS group_3_key,
+                           NULL AS group_4_key,
+                           invoice.id AS invoice_id,
+                           invoice.subscription_id AS subscription_id,
+                           NULL AS session_id,
+                           NULL AS event_name,
+                           JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                           JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                           upper(invoice.currency) AS original_currency,
+                           accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                           in(original_currency,
+                              ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                             'GBP' AS currency,
+                             divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                    FROM
+                      (SELECT posthog_test_stripe_invoice.id AS id,
+                              parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                              posthog_test_stripe_invoice.customer AS customer_id,
+                              posthog_test_stripe_invoice.subscription AS subscription_id,
+                              posthog_test_stripe_invoice.discount AS discount,
+                              arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                              JSONExtractString(data, 'id') AS invoice_item_id,
+                              JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                              coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                              greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                              JSONExtractString(data, 'currency') AS currency,
+                              JSONExtractString(data, 'price', 'product') AS product_id,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                              greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                              arrayJoin(range(0, period_months)) AS month_index,
+                              ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                       FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                       WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_item
+                 WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')), 0))
+                 GROUP BY revenue_item.source_label,
+                          revenue_item.customer_id,
+                          revenue_item.subscription_id, timestamp
+                 ORDER BY timestamp DESC
+                 UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
+                                  `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
+                                  `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
+                                  toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
+                                  accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                 FROM
+                   (SELECT '' AS id,
+                           '' AS source_label,
+                           '' AS plan_id,
+                           '' AS product_id,
+                           '' AS customer_id,
+                           '' AS status,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
+                           '' AS metadata
+                    WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
+                 WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')), 0))
+                 ORDER BY timestamp DESC) AS
+              union
+              GROUP BY source_label,
+                       customer_id,
+                       subscription_id
+              ORDER BY customer_id ASC,
+                       subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
+           GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)
+        WHERE notEmpty(group_key)
+        GROUP BY group_key)
      GROUP BY group_key) AS groups__revenue_analytics ON equals(groups.groups___key, groups__revenue_analytics.group_key)
   ORDER BY groups.key ASC
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
@@ -1165,216 +1195,222 @@
               groups.group_key) AS groups
   LEFT JOIN
     (SELECT 99999 AS team_id,
-            revenue_analytics_customer__groups.key AS group_key,
-            sum(coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)'))) AS revenue,
-            sum(coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
+            group_key AS group_key,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT inner.id AS id,
-               inner.source_label AS source_label,
-               inner.timestamp AS timestamp,
-               inner.name AS name,
-               inner.email AS email,
-               inner.phone AS phone,
-               inner.address AS address,
-               if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(notEquals(inner.resolved_distinct_id, ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata,
-               inner.country AS country,
-               inner.cohort AS cohort,
-               inner.initial_coupon AS initial_coupon,
-               inner.initial_coupon_id AS initial_coupon_id
+       (SELECT 99999 AS team_id,
+               revenue_analytics_customer__groups.key AS group_key,
+               sum(coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)'))) AS revenue,
+               sum(coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
         FROM
-          (SELECT outer.id AS id,
-                  'stripe.posthog_test' AS source_label,
-                  parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
-                  outer.name AS name,
-                  outer.email AS email,
-                  outer.phone AS phone,
-                  outer.address AS address,
-                  outer.metadata AS metadata,
-                  JSONExtractString(address, 'country') AS country,
-                  cohort_inner.cohort AS cohort,
-                  cohort_inner.initial_coupon AS initial_coupon,
-                  cohort_inner.initial_coupon_id AS initial_coupon_id,
-                  ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id,
-                  ifNull(resolved.resolved_source, '') AS resolved_source
+          (SELECT inner.id AS id,
+                  inner.source_label AS source_label,
+                  inner.timestamp AS timestamp,
+                  inner.name AS name,
+                  inner.email AS email,
+                  inner.phone AS phone,
+                  inner.address AS address,
+                  if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(notEquals(inner.resolved_distinct_id, ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata,
+                  inner.country AS country,
+                  inner.cohort AS cohort,
+                  inner.initial_coupon AS initial_coupon,
+                  inner.initial_coupon_id AS initial_coupon_id
            FROM
-             (SELECT *
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
-           LEFT JOIN
-             (SELECT invoice.customer AS customer_id,
-                     formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
-                     argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
-                     argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
-              GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
-           LEFT JOIN
-             (SELECT child_meta.customer_id AS customer_id,
-                     argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id,
-                     argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
+             (SELECT outer.id AS id,
+                     'stripe.posthog_test' AS source_label,
+                     parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
+                     outer.name AS name,
+                     outer.email AS email,
+                     outer.phone AS phone,
+                     outer.address AS address,
+                     outer.metadata AS metadata,
+                     JSONExtractString(address, 'country') AS country,
+                     cohort_inner.cohort AS cohort,
+                     cohort_inner.initial_coupon AS initial_coupon,
+                     cohort_inner.initial_coupon_id AS initial_coupon_id,
+                     ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id,
+                     ifNull(resolved.resolved_source, '') AS resolved_source
               FROM
-                (SELECT posthog_test_stripe_invoice.customer AS customer_id,
-                        JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id,
-                        concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
-                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
-                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                 WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
-              GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner
-        ORDER BY timestamp DESC
-        LIMIT 1 BY id) AS revenue_analytics_customer
-     LEFT JOIN
-       (SELECT groups.key AS key,
-               key AS revenue_analytics_customer__groups___key
-        FROM
-          (SELECT groups.group_type_index AS index,
-                  groups.group_key AS key
-           FROM groups
-           WHERE equals(groups.team_id, 99999)
-           GROUP BY groups.group_type_index,
-                    groups.group_key) AS groups) AS revenue_analytics_customer__groups ON equals(revenue_analytics_customer.id, revenue_analytics_customer__groups.revenue_analytics_customer__groups___key)
-     LEFT JOIN
-       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM
-          (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                  invoice.invoice_item_id AS invoice_item_id,
-                  'stripe.posthog_test' AS source_label,
-                  addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                  invoice.created_at AS created_at,
-                  ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                  invoice.product_id AS product_id,
-                  invoice.customer_id AS customer_id,
-                  NULL AS group_0_key,
-                  NULL AS group_1_key,
-                  NULL AS group_2_key,
-                  NULL AS group_3_key,
-                  NULL AS group_4_key,
-                  invoice.id AS invoice_id,
-                  invoice.subscription_id AS subscription_id,
-                  NULL AS session_id,
-                  NULL AS event_name,
-                  JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                  JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                  upper(invoice.currency) AS original_currency,
-                  accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                  in(original_currency,
-                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                    'GBP' AS currency,
-                    divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
-           FROM
-             (SELECT posthog_test_stripe_invoice.id AS id,
-                     parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                     posthog_test_stripe_invoice.customer AS customer_id,
-                     posthog_test_stripe_invoice.subscription AS subscription_id,
-                     posthog_test_stripe_invoice.discount AS discount,
-                     arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                     JSONExtractString(data, 'id') AS invoice_item_id,
-                     JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                     coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                     greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                     JSONExtractString(data, 'currency') AS currency,
-                     JSONExtractString(data, 'price', 'product') AS product_id,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                     greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                     arrayJoin(range(0, period_months)) AS month_index,
-                     ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-              WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_analytics_revenue_item
-        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-     LEFT JOIN
-       (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
-               sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
-        FROM
-          (SELECT union.source_label AS source_label,
-                  union.customer_id AS customer_id,
-                  union.subscription_id AS subscription_id,
-                  argMax(union.amount, union.timestamp) AS mrr
-           FROM
-             (SELECT revenue_item.source_label AS source_label,
-                     revenue_item.customer_id AS customer_id,
-                     revenue_item.subscription_id AS subscription_id,
-                     toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
-                     sum(revenue_item.amount) AS amount
-              FROM
-                (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                        invoice.invoice_item_id AS invoice_item_id,
-                        'stripe.posthog_test' AS source_label,
-                        addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                        invoice.created_at AS created_at,
-                        ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                        invoice.product_id AS product_id,
-                        invoice.customer_id AS customer_id,
-                        NULL AS group_0_key,
-                        NULL AS group_1_key,
-                        NULL AS group_2_key,
-                        NULL AS group_3_key,
-                        NULL AS group_4_key,
-                        invoice.id AS invoice_id,
-                        invoice.subscription_id AS subscription_id,
-                        NULL AS session_id,
-                        NULL AS event_name,
-                        JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                        JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                        upper(invoice.currency) AS original_currency,
-                        accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                        in(original_currency,
-                           ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                          if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                          divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                          'GBP' AS currency,
-                          divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                (SELECT *
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
+              LEFT JOIN
+                (SELECT invoice.customer AS customer_id,
+                        formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
+                 GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
+              LEFT JOIN
+                (SELECT child_meta.customer_id AS customer_id,
+                        argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id,
+                        argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
                  FROM
-                   (SELECT posthog_test_stripe_invoice.id AS id,
-                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                           posthog_test_stripe_invoice.customer AS customer_id,
-                           posthog_test_stripe_invoice.subscription AS subscription_id,
-                           posthog_test_stripe_invoice.discount AS discount,
-                           arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                           JSONExtractString(data, 'id') AS invoice_item_id,
-                           JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                           coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                           greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                           JSONExtractString(data, 'currency') AS currency,
-                           JSONExtractString(data, 'price', 'product') AS product_id,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                           greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                           arrayJoin(range(0, period_months)) AS month_index,
-                           ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                   (SELECT posthog_test_stripe_invoice.customer AS customer_id,
+                           JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id,
+                           concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
+                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
                     FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                    WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_item
-              WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')), 0))
-              GROUP BY revenue_item.source_label,
-                       revenue_item.customer_id,
-                       revenue_item.subscription_id, timestamp
-              ORDER BY timestamp DESC
-              UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
-                               `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
-                               `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
-                               toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
-                               accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                    WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
+                 GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner
+           ORDER BY timestamp DESC
+           LIMIT 1 BY id) AS revenue_analytics_customer
+        LEFT JOIN
+          (SELECT groups.key AS key,
+                  key AS revenue_analytics_customer__groups___key
+           FROM
+             (SELECT groups.group_type_index AS index,
+                     groups.group_key AS key
+              FROM groups
+              WHERE equals(groups.team_id, 99999)
+              GROUP BY groups.group_type_index,
+                       groups.group_key) AS groups) AS revenue_analytics_customer__groups ON equals(revenue_analytics_customer.id, revenue_analytics_customer__groups.revenue_analytics_customer__groups___key)
+        LEFT JOIN
+          (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
+           FROM
+             (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                     invoice.invoice_item_id AS invoice_item_id,
+                     'stripe.posthog_test' AS source_label,
+                     addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                     invoice.created_at AS created_at,
+                     ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                     invoice.product_id AS product_id,
+                     invoice.customer_id AS customer_id,
+                     NULL AS group_0_key,
+                     NULL AS group_1_key,
+                     NULL AS group_2_key,
+                     NULL AS group_3_key,
+                     NULL AS group_4_key,
+                     invoice.id AS invoice_id,
+                     invoice.subscription_id AS subscription_id,
+                     NULL AS session_id,
+                     NULL AS event_name,
+                     JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                     JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                     upper(invoice.currency) AS original_currency,
+                     accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                     in(original_currency,
+                        ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                       if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                       divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                       'GBP' AS currency,
+                       divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
               FROM
-                (SELECT '' AS id,
-                        '' AS source_label,
-                        '' AS plan_id,
-                        '' AS product_id,
-                        '' AS customer_id,
-                        '' AS status,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
-                        '' AS metadata
-                 WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
-              WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')), 0))
-              ORDER BY timestamp DESC) AS
-           union
-           GROUP BY source_label,
-                    customer_id,
-                    subscription_id
-           ORDER BY customer_id ASC,
-                    subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
-        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)
-     WHERE notEmpty(group_key)
+                (SELECT posthog_test_stripe_invoice.id AS id,
+                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                        posthog_test_stripe_invoice.customer AS customer_id,
+                        posthog_test_stripe_invoice.subscription AS subscription_id,
+                        posthog_test_stripe_invoice.discount AS discount,
+                        arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                        JSONExtractString(data, 'id') AS invoice_item_id,
+                        JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                        coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                        greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                        JSONExtractString(data, 'currency') AS currency,
+                        JSONExtractString(data, 'price', 'product') AS product_id,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                        greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                        arrayJoin(range(0, period_months)) AS month_index,
+                        ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                 WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_analytics_revenue_item
+           GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+        LEFT JOIN
+          (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
+                  sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
+           FROM
+             (SELECT union.source_label AS source_label,
+                     union.customer_id AS customer_id,
+                     union.subscription_id AS subscription_id,
+                     argMax(union.amount, union.timestamp) AS mrr
+              FROM
+                (SELECT revenue_item.source_label AS source_label,
+                        revenue_item.customer_id AS customer_id,
+                        revenue_item.subscription_id AS subscription_id,
+                        toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                        sum(revenue_item.amount) AS amount
+                 FROM
+                   (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                           invoice.invoice_item_id AS invoice_item_id,
+                           'stripe.posthog_test' AS source_label,
+                           addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                           invoice.created_at AS created_at,
+                           ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                           invoice.product_id AS product_id,
+                           invoice.customer_id AS customer_id,
+                           NULL AS group_0_key,
+                           NULL AS group_1_key,
+                           NULL AS group_2_key,
+                           NULL AS group_3_key,
+                           NULL AS group_4_key,
+                           invoice.id AS invoice_id,
+                           invoice.subscription_id AS subscription_id,
+                           NULL AS session_id,
+                           NULL AS event_name,
+                           JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                           JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                           upper(invoice.currency) AS original_currency,
+                           accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                           in(original_currency,
+                              ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                             'GBP' AS currency,
+                             divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                    FROM
+                      (SELECT posthog_test_stripe_invoice.id AS id,
+                              parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                              posthog_test_stripe_invoice.customer AS customer_id,
+                              posthog_test_stripe_invoice.subscription AS subscription_id,
+                              posthog_test_stripe_invoice.discount AS discount,
+                              arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                              JSONExtractString(data, 'id') AS invoice_item_id,
+                              JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                              coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                              greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                              JSONExtractString(data, 'currency') AS currency,
+                              JSONExtractString(data, 'price', 'product') AS product_id,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                              greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                              arrayJoin(range(0, period_months)) AS month_index,
+                              ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                       FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                       WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_item
+                 WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')), 0))
+                 GROUP BY revenue_item.source_label,
+                          revenue_item.customer_id,
+                          revenue_item.subscription_id, timestamp
+                 ORDER BY timestamp DESC
+                 UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
+                                  `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
+                                  `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
+                                  toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
+                                  accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                 FROM
+                   (SELECT '' AS id,
+                           '' AS source_label,
+                           '' AS plan_id,
+                           '' AS product_id,
+                           '' AS customer_id,
+                           '' AS status,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
+                           '' AS metadata
+                    WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
+                 WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')), 0))
+                 ORDER BY timestamp DESC) AS
+              union
+              GROUP BY source_label,
+                       customer_id,
+                       subscription_id
+              ORDER BY customer_id ASC,
+                       subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
+           GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)
+        WHERE notEmpty(group_key)
+        GROUP BY group_key)
      GROUP BY group_key) AS groups__revenue_analytics ON equals(groups.groups___key, groups__revenue_analytics.group_key)
   ORDER BY groups.key ASC
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
@@ -1406,216 +1442,222 @@
               groups.group_key) AS groups
   LEFT JOIN
     (SELECT 99999 AS team_id,
-            revenue_analytics_customer__groups.key AS group_key,
-            sum(coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)'))) AS revenue,
-            sum(coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
+            group_key AS group_key,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT inner.id AS id,
-               inner.source_label AS source_label,
-               inner.timestamp AS timestamp,
-               inner.name AS name,
-               inner.email AS email,
-               inner.phone AS phone,
-               inner.address AS address,
-               if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(notEquals(inner.resolved_distinct_id, ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata,
-               inner.country AS country,
-               inner.cohort AS cohort,
-               inner.initial_coupon AS initial_coupon,
-               inner.initial_coupon_id AS initial_coupon_id
+       (SELECT 99999 AS team_id,
+               revenue_analytics_customer__groups.key AS group_key,
+               sum(coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)'))) AS revenue,
+               sum(coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
         FROM
-          (SELECT outer.id AS id,
-                  'stripe.posthog_test' AS source_label,
-                  parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
-                  outer.name AS name,
-                  outer.email AS email,
-                  outer.phone AS phone,
-                  outer.address AS address,
-                  outer.metadata AS metadata,
-                  JSONExtractString(address, 'country') AS country,
-                  cohort_inner.cohort AS cohort,
-                  cohort_inner.initial_coupon AS initial_coupon,
-                  cohort_inner.initial_coupon_id AS initial_coupon_id,
-                  ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id,
-                  ifNull(resolved.resolved_source, '') AS resolved_source
+          (SELECT inner.id AS id,
+                  inner.source_label AS source_label,
+                  inner.timestamp AS timestamp,
+                  inner.name AS name,
+                  inner.email AS email,
+                  inner.phone AS phone,
+                  inner.address AS address,
+                  if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(notEquals(inner.resolved_distinct_id, ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata,
+                  inner.country AS country,
+                  inner.cohort AS cohort,
+                  inner.initial_coupon AS initial_coupon,
+                  inner.initial_coupon_id AS initial_coupon_id
            FROM
-             (SELECT *
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
-           LEFT JOIN
-             (SELECT invoice.customer AS customer_id,
-                     formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
-                     argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
-                     argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
-              GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
-           LEFT JOIN
-             (SELECT child_meta.customer_id AS customer_id,
-                     argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id,
-                     argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
+             (SELECT outer.id AS id,
+                     'stripe.posthog_test' AS source_label,
+                     parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
+                     outer.name AS name,
+                     outer.email AS email,
+                     outer.phone AS phone,
+                     outer.address AS address,
+                     outer.metadata AS metadata,
+                     JSONExtractString(address, 'country') AS country,
+                     cohort_inner.cohort AS cohort,
+                     cohort_inner.initial_coupon AS initial_coupon,
+                     cohort_inner.initial_coupon_id AS initial_coupon_id,
+                     ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id,
+                     ifNull(resolved.resolved_source, '') AS resolved_source
               FROM
-                (SELECT posthog_test_stripe_invoice.customer AS customer_id,
-                        JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id,
-                        concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
-                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
-                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                 WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
-              GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner
-        ORDER BY timestamp DESC
-        LIMIT 1 BY id) AS revenue_analytics_customer
-     LEFT JOIN
-       (SELECT groups.key AS key,
-               key AS revenue_analytics_customer__groups___key
-        FROM
-          (SELECT groups.group_type_index AS index,
-                  groups.group_key AS key
-           FROM groups
-           WHERE equals(groups.team_id, 99999)
-           GROUP BY groups.group_type_index,
-                    groups.group_key) AS groups) AS revenue_analytics_customer__groups ON equals(revenue_analytics_customer.id, revenue_analytics_customer__groups.revenue_analytics_customer__groups___key)
-     LEFT JOIN
-       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM
-          (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                  invoice.invoice_item_id AS invoice_item_id,
-                  'stripe.posthog_test' AS source_label,
-                  addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                  invoice.created_at AS created_at,
-                  ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                  invoice.product_id AS product_id,
-                  invoice.customer_id AS customer_id,
-                  NULL AS group_0_key,
-                  NULL AS group_1_key,
-                  NULL AS group_2_key,
-                  NULL AS group_3_key,
-                  NULL AS group_4_key,
-                  invoice.id AS invoice_id,
-                  invoice.subscription_id AS subscription_id,
-                  NULL AS session_id,
-                  NULL AS event_name,
-                  JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                  JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                  upper(invoice.currency) AS original_currency,
-                  accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                  in(original_currency,
-                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                    'GBP' AS currency,
-                    divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
-           FROM
-             (SELECT posthog_test_stripe_invoice.id AS id,
-                     parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                     posthog_test_stripe_invoice.customer AS customer_id,
-                     posthog_test_stripe_invoice.subscription AS subscription_id,
-                     posthog_test_stripe_invoice.discount AS discount,
-                     arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                     JSONExtractString(data, 'id') AS invoice_item_id,
-                     JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                     coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                     greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                     JSONExtractString(data, 'currency') AS currency,
-                     JSONExtractString(data, 'price', 'product') AS product_id,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                     greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                     arrayJoin(range(0, period_months)) AS month_index,
-                     ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-              WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_analytics_revenue_item
-        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-     LEFT JOIN
-       (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
-               sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
-        FROM
-          (SELECT union.source_label AS source_label,
-                  union.customer_id AS customer_id,
-                  union.subscription_id AS subscription_id,
-                  argMax(union.amount, union.timestamp) AS mrr
-           FROM
-             (SELECT revenue_item.source_label AS source_label,
-                     revenue_item.customer_id AS customer_id,
-                     revenue_item.subscription_id AS subscription_id,
-                     toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
-                     sum(revenue_item.amount) AS amount
-              FROM
-                (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                        invoice.invoice_item_id AS invoice_item_id,
-                        'stripe.posthog_test' AS source_label,
-                        addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                        invoice.created_at AS created_at,
-                        ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                        invoice.product_id AS product_id,
-                        invoice.customer_id AS customer_id,
-                        NULL AS group_0_key,
-                        NULL AS group_1_key,
-                        NULL AS group_2_key,
-                        NULL AS group_3_key,
-                        NULL AS group_4_key,
-                        invoice.id AS invoice_id,
-                        invoice.subscription_id AS subscription_id,
-                        NULL AS session_id,
-                        NULL AS event_name,
-                        JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                        JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                        upper(invoice.currency) AS original_currency,
-                        accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                        in(original_currency,
-                           ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                          if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                          divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                          'GBP' AS currency,
-                          divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                (SELECT *
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
+              LEFT JOIN
+                (SELECT invoice.customer AS customer_id,
+                        formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
+                 GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
+              LEFT JOIN
+                (SELECT child_meta.customer_id AS customer_id,
+                        argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id,
+                        argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
                  FROM
-                   (SELECT posthog_test_stripe_invoice.id AS id,
-                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                           posthog_test_stripe_invoice.customer AS customer_id,
-                           posthog_test_stripe_invoice.subscription AS subscription_id,
-                           posthog_test_stripe_invoice.discount AS discount,
-                           arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                           JSONExtractString(data, 'id') AS invoice_item_id,
-                           JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                           coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                           greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                           JSONExtractString(data, 'currency') AS currency,
-                           JSONExtractString(data, 'price', 'product') AS product_id,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                           greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                           arrayJoin(range(0, period_months)) AS month_index,
-                           ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                   (SELECT posthog_test_stripe_invoice.customer AS customer_id,
+                           JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id,
+                           concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
+                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
                     FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                    WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_item
-              WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')), 0))
-              GROUP BY revenue_item.source_label,
-                       revenue_item.customer_id,
-                       revenue_item.subscription_id, timestamp
-              ORDER BY timestamp DESC
-              UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
-                               `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
-                               `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
-                               toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
-                               accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                    WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
+                 GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner
+           ORDER BY timestamp DESC
+           LIMIT 1 BY id) AS revenue_analytics_customer
+        LEFT JOIN
+          (SELECT groups.key AS key,
+                  key AS revenue_analytics_customer__groups___key
+           FROM
+             (SELECT groups.group_type_index AS index,
+                     groups.group_key AS key
+              FROM groups
+              WHERE equals(groups.team_id, 99999)
+              GROUP BY groups.group_type_index,
+                       groups.group_key) AS groups) AS revenue_analytics_customer__groups ON equals(revenue_analytics_customer.id, revenue_analytics_customer__groups.revenue_analytics_customer__groups___key)
+        LEFT JOIN
+          (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
+           FROM
+             (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                     invoice.invoice_item_id AS invoice_item_id,
+                     'stripe.posthog_test' AS source_label,
+                     addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                     invoice.created_at AS created_at,
+                     ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                     invoice.product_id AS product_id,
+                     invoice.customer_id AS customer_id,
+                     NULL AS group_0_key,
+                     NULL AS group_1_key,
+                     NULL AS group_2_key,
+                     NULL AS group_3_key,
+                     NULL AS group_4_key,
+                     invoice.id AS invoice_id,
+                     invoice.subscription_id AS subscription_id,
+                     NULL AS session_id,
+                     NULL AS event_name,
+                     JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                     JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                     upper(invoice.currency) AS original_currency,
+                     accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                     in(original_currency,
+                        ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                       if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                       divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                       'GBP' AS currency,
+                       divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
               FROM
-                (SELECT '' AS id,
-                        '' AS source_label,
-                        '' AS plan_id,
-                        '' AS product_id,
-                        '' AS customer_id,
-                        '' AS status,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
-                        '' AS metadata
-                 WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
-              WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')), 0))
-              ORDER BY timestamp DESC) AS
-           union
-           GROUP BY source_label,
-                    customer_id,
-                    subscription_id
-           ORDER BY customer_id ASC,
-                    subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
-        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)
-     WHERE notEmpty(group_key)
+                (SELECT posthog_test_stripe_invoice.id AS id,
+                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                        posthog_test_stripe_invoice.customer AS customer_id,
+                        posthog_test_stripe_invoice.subscription AS subscription_id,
+                        posthog_test_stripe_invoice.discount AS discount,
+                        arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                        JSONExtractString(data, 'id') AS invoice_item_id,
+                        JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                        coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                        greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                        JSONExtractString(data, 'currency') AS currency,
+                        JSONExtractString(data, 'price', 'product') AS product_id,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                        greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                        arrayJoin(range(0, period_months)) AS month_index,
+                        ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                 WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_analytics_revenue_item
+           GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+        LEFT JOIN
+          (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
+                  sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
+           FROM
+             (SELECT union.source_label AS source_label,
+                     union.customer_id AS customer_id,
+                     union.subscription_id AS subscription_id,
+                     argMax(union.amount, union.timestamp) AS mrr
+              FROM
+                (SELECT revenue_item.source_label AS source_label,
+                        revenue_item.customer_id AS customer_id,
+                        revenue_item.subscription_id AS subscription_id,
+                        toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                        sum(revenue_item.amount) AS amount
+                 FROM
+                   (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                           invoice.invoice_item_id AS invoice_item_id,
+                           'stripe.posthog_test' AS source_label,
+                           addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                           invoice.created_at AS created_at,
+                           ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                           invoice.product_id AS product_id,
+                           invoice.customer_id AS customer_id,
+                           NULL AS group_0_key,
+                           NULL AS group_1_key,
+                           NULL AS group_2_key,
+                           NULL AS group_3_key,
+                           NULL AS group_4_key,
+                           invoice.id AS invoice_id,
+                           invoice.subscription_id AS subscription_id,
+                           NULL AS session_id,
+                           NULL AS event_name,
+                           JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                           JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                           upper(invoice.currency) AS original_currency,
+                           accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                           in(original_currency,
+                              ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                             'GBP' AS currency,
+                             divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                    FROM
+                      (SELECT posthog_test_stripe_invoice.id AS id,
+                              parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                              posthog_test_stripe_invoice.customer AS customer_id,
+                              posthog_test_stripe_invoice.subscription AS subscription_id,
+                              posthog_test_stripe_invoice.discount AS discount,
+                              arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                              JSONExtractString(data, 'id') AS invoice_item_id,
+                              JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                              coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                              greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                              JSONExtractString(data, 'currency') AS currency,
+                              JSONExtractString(data, 'price', 'product') AS product_id,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                              greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                              arrayJoin(range(0, period_months)) AS month_index,
+                              ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                       FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                       WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_item
+                 WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')), 0))
+                 GROUP BY revenue_item.source_label,
+                          revenue_item.customer_id,
+                          revenue_item.subscription_id, timestamp
+                 ORDER BY timestamp DESC
+                 UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
+                                  `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
+                                  `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
+                                  toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
+                                  accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                 FROM
+                   (SELECT '' AS id,
+                           '' AS source_label,
+                           '' AS plan_id,
+                           '' AS product_id,
+                           '' AS customer_id,
+                           '' AS status,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
+                           '' AS metadata
+                    WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
+                 WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')), 0))
+                 ORDER BY timestamp DESC) AS
+              union
+              GROUP BY source_label,
+                       customer_id,
+                       subscription_id
+              ORDER BY customer_id ASC,
+                       subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
+           GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)
+        WHERE notEmpty(group_key)
+        GROUP BY group_key)
      GROUP BY group_key) AS groups__revenue_analytics ON equals(groups.groups___key, groups__revenue_analytics.group_key)
   ORDER BY groups.key ASC
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
@@ -1648,216 +1690,222 @@
               groups.group_key) AS groups
   LEFT JOIN
     (SELECT 99999 AS team_id,
-            revenue_analytics_customer__groups.key AS group_key,
-            sum(coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)'))) AS revenue,
-            sum(coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
+            group_key AS group_key,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT inner.id AS id,
-               inner.source_label AS source_label,
-               inner.timestamp AS timestamp,
-               inner.name AS name,
-               inner.email AS email,
-               inner.phone AS phone,
-               inner.address AS address,
-               if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(notEquals(inner.resolved_distinct_id, ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata,
-               inner.country AS country,
-               inner.cohort AS cohort,
-               inner.initial_coupon AS initial_coupon,
-               inner.initial_coupon_id AS initial_coupon_id
+       (SELECT 99999 AS team_id,
+               revenue_analytics_customer__groups.key AS group_key,
+               sum(coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)'))) AS revenue,
+               sum(coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
         FROM
-          (SELECT outer.id AS id,
-                  'stripe.posthog_test' AS source_label,
-                  parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
-                  outer.name AS name,
-                  outer.email AS email,
-                  outer.phone AS phone,
-                  outer.address AS address,
-                  outer.metadata AS metadata,
-                  JSONExtractString(address, 'country') AS country,
-                  cohort_inner.cohort AS cohort,
-                  cohort_inner.initial_coupon AS initial_coupon,
-                  cohort_inner.initial_coupon_id AS initial_coupon_id,
-                  ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id,
-                  ifNull(resolved.resolved_source, '') AS resolved_source
+          (SELECT inner.id AS id,
+                  inner.source_label AS source_label,
+                  inner.timestamp AS timestamp,
+                  inner.name AS name,
+                  inner.email AS email,
+                  inner.phone AS phone,
+                  inner.address AS address,
+                  if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(notEquals(inner.resolved_distinct_id, ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata,
+                  inner.country AS country,
+                  inner.cohort AS cohort,
+                  inner.initial_coupon AS initial_coupon,
+                  inner.initial_coupon_id AS initial_coupon_id
            FROM
-             (SELECT *
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
-           LEFT JOIN
-             (SELECT invoice.customer AS customer_id,
-                     formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
-                     argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
-                     argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
-              GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
-           LEFT JOIN
-             (SELECT child_meta.customer_id AS customer_id,
-                     argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id,
-                     argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
+             (SELECT outer.id AS id,
+                     'stripe.posthog_test' AS source_label,
+                     parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
+                     outer.name AS name,
+                     outer.email AS email,
+                     outer.phone AS phone,
+                     outer.address AS address,
+                     outer.metadata AS metadata,
+                     JSONExtractString(address, 'country') AS country,
+                     cohort_inner.cohort AS cohort,
+                     cohort_inner.initial_coupon AS initial_coupon,
+                     cohort_inner.initial_coupon_id AS initial_coupon_id,
+                     ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id,
+                     ifNull(resolved.resolved_source, '') AS resolved_source
               FROM
-                (SELECT posthog_test_stripe_invoice.customer AS customer_id,
-                        JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id,
-                        concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
-                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
-                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                 WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
-              GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner
-        ORDER BY timestamp DESC
-        LIMIT 1 BY id) AS revenue_analytics_customer
-     LEFT JOIN
-       (SELECT groups.key AS key,
-               key AS revenue_analytics_customer__groups___key
-        FROM
-          (SELECT groups.group_type_index AS index,
-                  groups.group_key AS key
-           FROM groups
-           WHERE equals(groups.team_id, 99999)
-           GROUP BY groups.group_type_index,
-                    groups.group_key) AS groups) AS revenue_analytics_customer__groups ON equals(JSONExtractString(revenue_analytics_customer.metadata, 'id'), revenue_analytics_customer__groups.revenue_analytics_customer__groups___key)
-     LEFT JOIN
-       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM
-          (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                  invoice.invoice_item_id AS invoice_item_id,
-                  'stripe.posthog_test' AS source_label,
-                  addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                  invoice.created_at AS created_at,
-                  ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                  invoice.product_id AS product_id,
-                  invoice.customer_id AS customer_id,
-                  NULL AS group_0_key,
-                  NULL AS group_1_key,
-                  NULL AS group_2_key,
-                  NULL AS group_3_key,
-                  NULL AS group_4_key,
-                  invoice.id AS invoice_id,
-                  invoice.subscription_id AS subscription_id,
-                  NULL AS session_id,
-                  NULL AS event_name,
-                  JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                  JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                  upper(invoice.currency) AS original_currency,
-                  accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                  in(original_currency,
-                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                    'GBP' AS currency,
-                    divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
-           FROM
-             (SELECT posthog_test_stripe_invoice.id AS id,
-                     parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                     posthog_test_stripe_invoice.customer AS customer_id,
-                     posthog_test_stripe_invoice.subscription AS subscription_id,
-                     posthog_test_stripe_invoice.discount AS discount,
-                     arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                     JSONExtractString(data, 'id') AS invoice_item_id,
-                     JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                     coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                     greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                     JSONExtractString(data, 'currency') AS currency,
-                     JSONExtractString(data, 'price', 'product') AS product_id,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                     greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                     arrayJoin(range(0, period_months)) AS month_index,
-                     ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-              WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_analytics_revenue_item
-        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-     LEFT JOIN
-       (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
-               sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
-        FROM
-          (SELECT union.source_label AS source_label,
-                  union.customer_id AS customer_id,
-                  union.subscription_id AS subscription_id,
-                  argMax(union.amount, union.timestamp) AS mrr
-           FROM
-             (SELECT revenue_item.source_label AS source_label,
-                     revenue_item.customer_id AS customer_id,
-                     revenue_item.subscription_id AS subscription_id,
-                     toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
-                     sum(revenue_item.amount) AS amount
-              FROM
-                (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                        invoice.invoice_item_id AS invoice_item_id,
-                        'stripe.posthog_test' AS source_label,
-                        addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                        invoice.created_at AS created_at,
-                        ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                        invoice.product_id AS product_id,
-                        invoice.customer_id AS customer_id,
-                        NULL AS group_0_key,
-                        NULL AS group_1_key,
-                        NULL AS group_2_key,
-                        NULL AS group_3_key,
-                        NULL AS group_4_key,
-                        invoice.id AS invoice_id,
-                        invoice.subscription_id AS subscription_id,
-                        NULL AS session_id,
-                        NULL AS event_name,
-                        JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                        JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                        upper(invoice.currency) AS original_currency,
-                        accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                        in(original_currency,
-                           ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                          if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                          divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                          'GBP' AS currency,
-                          divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                (SELECT *
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
+              LEFT JOIN
+                (SELECT invoice.customer AS customer_id,
+                        formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
+                 GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
+              LEFT JOIN
+                (SELECT child_meta.customer_id AS customer_id,
+                        argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id,
+                        argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
                  FROM
-                   (SELECT posthog_test_stripe_invoice.id AS id,
-                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                           posthog_test_stripe_invoice.customer AS customer_id,
-                           posthog_test_stripe_invoice.subscription AS subscription_id,
-                           posthog_test_stripe_invoice.discount AS discount,
-                           arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                           JSONExtractString(data, 'id') AS invoice_item_id,
-                           JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                           coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                           greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                           JSONExtractString(data, 'currency') AS currency,
-                           JSONExtractString(data, 'price', 'product') AS product_id,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                           greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                           arrayJoin(range(0, period_months)) AS month_index,
-                           ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                   (SELECT posthog_test_stripe_invoice.customer AS customer_id,
+                           JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id,
+                           concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
+                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
                     FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                    WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_item
-              WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')), 0))
-              GROUP BY revenue_item.source_label,
-                       revenue_item.customer_id,
-                       revenue_item.subscription_id, timestamp
-              ORDER BY timestamp DESC
-              UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
-                               `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
-                               `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
-                               toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
-                               accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                    WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
+                 GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner
+           ORDER BY timestamp DESC
+           LIMIT 1 BY id) AS revenue_analytics_customer
+        LEFT JOIN
+          (SELECT groups.key AS key,
+                  key AS revenue_analytics_customer__groups___key
+           FROM
+             (SELECT groups.group_type_index AS index,
+                     groups.group_key AS key
+              FROM groups
+              WHERE equals(groups.team_id, 99999)
+              GROUP BY groups.group_type_index,
+                       groups.group_key) AS groups) AS revenue_analytics_customer__groups ON equals(JSONExtractString(revenue_analytics_customer.metadata, 'id'), revenue_analytics_customer__groups.revenue_analytics_customer__groups___key)
+        LEFT JOIN
+          (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
+           FROM
+             (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                     invoice.invoice_item_id AS invoice_item_id,
+                     'stripe.posthog_test' AS source_label,
+                     addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                     invoice.created_at AS created_at,
+                     ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                     invoice.product_id AS product_id,
+                     invoice.customer_id AS customer_id,
+                     NULL AS group_0_key,
+                     NULL AS group_1_key,
+                     NULL AS group_2_key,
+                     NULL AS group_3_key,
+                     NULL AS group_4_key,
+                     invoice.id AS invoice_id,
+                     invoice.subscription_id AS subscription_id,
+                     NULL AS session_id,
+                     NULL AS event_name,
+                     JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                     JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                     upper(invoice.currency) AS original_currency,
+                     accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                     in(original_currency,
+                        ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                       if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                       divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                       'GBP' AS currency,
+                       divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
               FROM
-                (SELECT '' AS id,
-                        '' AS source_label,
-                        '' AS plan_id,
-                        '' AS product_id,
-                        '' AS customer_id,
-                        '' AS status,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
-                        '' AS metadata
-                 WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
-              WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')), 0))
-              ORDER BY timestamp DESC) AS
-           union
-           GROUP BY source_label,
-                    customer_id,
-                    subscription_id
-           ORDER BY customer_id ASC,
-                    subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
-        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)
-     WHERE notEmpty(group_key)
+                (SELECT posthog_test_stripe_invoice.id AS id,
+                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                        posthog_test_stripe_invoice.customer AS customer_id,
+                        posthog_test_stripe_invoice.subscription AS subscription_id,
+                        posthog_test_stripe_invoice.discount AS discount,
+                        arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                        JSONExtractString(data, 'id') AS invoice_item_id,
+                        JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                        coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                        greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                        JSONExtractString(data, 'currency') AS currency,
+                        JSONExtractString(data, 'price', 'product') AS product_id,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                        greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                        arrayJoin(range(0, period_months)) AS month_index,
+                        ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                 WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_analytics_revenue_item
+           GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+        LEFT JOIN
+          (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
+                  sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
+           FROM
+             (SELECT union.source_label AS source_label,
+                     union.customer_id AS customer_id,
+                     union.subscription_id AS subscription_id,
+                     argMax(union.amount, union.timestamp) AS mrr
+              FROM
+                (SELECT revenue_item.source_label AS source_label,
+                        revenue_item.customer_id AS customer_id,
+                        revenue_item.subscription_id AS subscription_id,
+                        toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                        sum(revenue_item.amount) AS amount
+                 FROM
+                   (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                           invoice.invoice_item_id AS invoice_item_id,
+                           'stripe.posthog_test' AS source_label,
+                           addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                           invoice.created_at AS created_at,
+                           ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                           invoice.product_id AS product_id,
+                           invoice.customer_id AS customer_id,
+                           NULL AS group_0_key,
+                           NULL AS group_1_key,
+                           NULL AS group_2_key,
+                           NULL AS group_3_key,
+                           NULL AS group_4_key,
+                           invoice.id AS invoice_id,
+                           invoice.subscription_id AS subscription_id,
+                           NULL AS session_id,
+                           NULL AS event_name,
+                           JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                           JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                           upper(invoice.currency) AS original_currency,
+                           accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                           in(original_currency,
+                              ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                             'GBP' AS currency,
+                             divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                    FROM
+                      (SELECT posthog_test_stripe_invoice.id AS id,
+                              parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                              posthog_test_stripe_invoice.customer AS customer_id,
+                              posthog_test_stripe_invoice.subscription AS subscription_id,
+                              posthog_test_stripe_invoice.discount AS discount,
+                              arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                              JSONExtractString(data, 'id') AS invoice_item_id,
+                              JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                              coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                              greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                              JSONExtractString(data, 'currency') AS currency,
+                              JSONExtractString(data, 'price', 'product') AS product_id,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                              greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                              arrayJoin(range(0, period_months)) AS month_index,
+                              ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                       FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                       WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_item
+                 WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')), 0))
+                 GROUP BY revenue_item.source_label,
+                          revenue_item.customer_id,
+                          revenue_item.subscription_id, timestamp
+                 ORDER BY timestamp DESC
+                 UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
+                                  `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
+                                  `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
+                                  toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
+                                  accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                 FROM
+                   (SELECT '' AS id,
+                           '' AS source_label,
+                           '' AS plan_id,
+                           '' AS product_id,
+                           '' AS customer_id,
+                           '' AS status,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
+                           '' AS metadata
+                    WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
+                 WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')), 0))
+                 ORDER BY timestamp DESC) AS
+              union
+              GROUP BY source_label,
+                       customer_id,
+                       subscription_id
+              ORDER BY customer_id ASC,
+                       subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
+           GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)
+        WHERE notEmpty(group_key)
+        GROUP BY group_key)
      GROUP BY group_key) AS groups__revenue_analytics ON equals(groups.groups___key, groups__revenue_analytics.group_key)
   ORDER BY groups.key ASC
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
@@ -1882,58 +1930,17 @@
          groups_revenue_analytics.mrr AS mrr
   FROM
     (SELECT 99999 AS team_id,
-            coalesce(revenue_agg.group_key, mrr_agg.group_key) AS group_key,
-            coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
-            coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+            group_key AS group_key,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT arrayJoin([revenue_analytics_revenue_item.group_0_key, revenue_analytics_revenue_item.group_1_key, revenue_analytics_revenue_item.group_2_key, revenue_analytics_revenue_item.group_3_key, revenue_analytics_revenue_item.group_4_key]) AS group_key,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
+       (SELECT 99999 AS team_id,
+               coalesce(revenue_agg.group_key, mrr_agg.group_key) AS group_key,
+               coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+               coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
         FROM
-          (SELECT toString(events.uuid) AS id,
-                  toString(events.uuid) AS invoice_item_id,
-                  'revenue_analytics.events.purchase' AS source_label,
-                  toTimeZone(events.timestamp, 'UTC') AS timestamp,
-                  timestamp AS created_at,
-                  isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '')) AS is_recurring,
-                  NULL AS product_id,
-                  toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
-                  events.`$group_0` AS group_0_key,
-                  events.`$group_1` AS group_1_key,
-                  events.`$group_2` AS group_2_key,
-                  events.`$group_3` AS group_3_key,
-                  events.`$group_4` AS group_4_key,
-                  NULL AS invoice_id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id,
-                  toString(events.`$session_id`) AS session_id,
-                  events.event AS event_name,
-                  NULL AS coupon,
-                  coupon AS coupon_id,
-                  'USD' AS original_currency,
-                  accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
-                  in(original_currency,
-                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                    'USD' AS currency,
-                    if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
-           FROM events
-           LEFT OUTER JOIN
-             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                     person_distinct_id_overrides.distinct_id AS distinct_id
-              FROM person_distinct_id_overrides
-              WHERE equals(person_distinct_id_overrides.team_id, 99999)
-              GROUP BY person_distinct_id_overrides.distinct_id
-              HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-           WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
-           ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-        WHERE notEmpty(group_key)
-        GROUP BY group_key) AS revenue_agg
-     FULL OUTER JOIN
-       (SELECT customer_to_group.group_key AS group_key,
-               sum(coalesce(mrr_by_customer.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
-        FROM
-          (SELECT DISTINCT revenue_analytics_revenue_item.customer_id AS customer_id,
-                           arrayJoin([revenue_analytics_revenue_item.group_0_key, revenue_analytics_revenue_item.group_1_key, revenue_analytics_revenue_item.group_2_key, revenue_analytics_revenue_item.group_3_key, revenue_analytics_revenue_item.group_4_key]) AS group_key
+          (SELECT arrayJoin([revenue_analytics_revenue_item.group_0_key, revenue_analytics_revenue_item.group_1_key, revenue_analytics_revenue_item.group_2_key, revenue_analytics_revenue_item.group_3_key, revenue_analytics_revenue_item.group_4_key]) AS group_key,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
            FROM
              (SELECT toString(events.uuid) AS id,
                      toString(events.uuid) AS invoice_item_id,
@@ -1972,86 +1979,95 @@
                  HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
               WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
               ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
-           WHERE notEmpty(group_key)) AS customer_to_group
-        LEFT JOIN
-          (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
-                  sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
+           WHERE notEmpty(group_key)
+           GROUP BY group_key) AS revenue_agg
+        FULL OUTER JOIN
+          (SELECT customer_to_group.group_key AS group_key,
+                  sum(coalesce(mrr_by_customer.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
            FROM
-             (SELECT union.source_label AS source_label,
-                     union.customer_id AS customer_id,
-                     union.subscription_id AS subscription_id,
-                     argMax(union.amount, union.timestamp) AS mrr
+             (SELECT DISTINCT revenue_analytics_revenue_item.customer_id AS customer_id,
+                              arrayJoin([revenue_analytics_revenue_item.group_0_key, revenue_analytics_revenue_item.group_1_key, revenue_analytics_revenue_item.group_2_key, revenue_analytics_revenue_item.group_3_key, revenue_analytics_revenue_item.group_4_key]) AS group_key
               FROM
-                (SELECT revenue_item.source_label AS source_label,
-                        revenue_item.customer_id AS customer_id,
-                        revenue_item.subscription_id AS subscription_id,
-                        toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
-                        sum(revenue_item.amount) AS amount
+                (SELECT toString(events.uuid) AS id,
+                        toString(events.uuid) AS invoice_item_id,
+                        'revenue_analytics.events.purchase' AS source_label,
+                        toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                        timestamp AS created_at,
+                        isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '')) AS is_recurring,
+                        NULL AS product_id,
+                        toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
+                        events.`$group_0` AS group_0_key,
+                        events.`$group_1` AS group_1_key,
+                        events.`$group_2` AS group_2_key,
+                        events.`$group_3` AS group_3_key,
+                        events.`$group_4` AS group_4_key,
+                        NULL AS invoice_id,
+                        replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id,
+                        toString(events.`$session_id`) AS session_id,
+                        events.event AS event_name,
+                        NULL AS coupon,
+                        coupon AS coupon_id,
+                        'USD' AS original_currency,
+                        accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                        in(original_currency,
+                           ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                          if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                          divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                          'USD' AS currency,
+                          if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+                 FROM events
+                 LEFT OUTER JOIN
+                   (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                           person_distinct_id_overrides.distinct_id AS distinct_id
+                    FROM person_distinct_id_overrides
+                    WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                    GROUP BY person_distinct_id_overrides.distinct_id
+                    HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+                 WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+                 ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
+              WHERE notEmpty(group_key)) AS customer_to_group
+           LEFT JOIN
+             (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
+                     sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
+              FROM
+                (SELECT union.source_label AS source_label,
+                        union.customer_id AS customer_id,
+                        union.subscription_id AS subscription_id,
+                        argMax(union.amount, union.timestamp) AS mrr
                  FROM
-                   (SELECT toString(events.uuid) AS id,
-                           toString(events.uuid) AS invoice_item_id,
-                           'revenue_analytics.events.purchase' AS source_label,
-                           toTimeZone(events.timestamp, 'UTC') AS timestamp,
-                           timestamp AS created_at,
-                           isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '')) AS is_recurring,
-                           NULL AS product_id,
-                           toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
-                           events.`$group_0` AS group_0_key,
-                           events.`$group_1` AS group_1_key,
-                           events.`$group_2` AS group_2_key,
-                           events.`$group_3` AS group_3_key,
-                           events.`$group_4` AS group_4_key,
-                           NULL AS invoice_id,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id,
-                           toString(events.`$session_id`) AS session_id,
-                           events.event AS event_name,
-                           NULL AS coupon,
-                           coupon AS coupon_id,
-                           'USD' AS original_currency,
-                           accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
-                           in(original_currency,
-                              ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                             'USD' AS currency,
-                             if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
-                    FROM events
-                    LEFT OUTER JOIN
-                      (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                              person_distinct_id_overrides.distinct_id AS distinct_id
-                       FROM person_distinct_id_overrides
-                       WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                       GROUP BY person_distinct_id_overrides.distinct_id
-                       HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-                    WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
-                    ORDER BY timestamp DESC) AS revenue_item
-                 WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), 0))
-                 GROUP BY revenue_item.source_label,
-                          revenue_item.customer_id,
-                          revenue_item.subscription_id, timestamp
-                 ORDER BY timestamp DESC
-                 UNION ALL SELECT `revenue_analytics.events.purchase.subscription_events_revenue_view`.source_label AS source_label,
-                                  `revenue_analytics.events.purchase.subscription_events_revenue_view`.customer_id AS customer_id,
-                                  `revenue_analytics.events.purchase.subscription_events_revenue_view`.id AS subscription_id,
-                                  toTimeZone(`revenue_analytics.events.purchase.subscription_events_revenue_view`.ended_at, 'UTC') AS timestamp,
-                                  accurateCastOrNull(0, 'Decimal64(10)') AS amount
-                 FROM
-                   (SELECT subscription_id AS id,
-                           'revenue_analytics.events.purchase' AS source_label,
-                           NULL AS plan_id,
-                           product_id AS product_id,
-                           toString(person_id) AS customer_id,
-                           NULL AS status,
-                           min_timestamp AS started_at,
-                           if(greater(max_timestamp_plus_dropoff_days, today()), NULL, max_timestamp_plus_dropoff_days) AS ended_at,
-                           NULL AS metadata
+                   (SELECT revenue_item.source_label AS source_label,
+                           revenue_item.customer_id AS customer_id,
+                           revenue_item.subscription_id AS subscription_id,
+                           toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                           sum(revenue_item.amount) AS amount
                     FROM
-                      (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id,
-                              replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id,
+                      (SELECT toString(events.uuid) AS id,
+                              toString(events.uuid) AS invoice_item_id,
+                              'revenue_analytics.events.purchase' AS source_label,
+                              toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                              timestamp AS created_at,
+                              isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '')) AS is_recurring,
                               NULL AS product_id,
-                              min(toTimeZone(events.timestamp, 'UTC')) AS min_timestamp,
-                              max(toTimeZone(events.timestamp, 'UTC')) AS max_timestamp,
-                              addDays(max_timestamp, 45.0) AS max_timestamp_plus_dropoff_days
+                              toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
+                              events.`$group_0` AS group_0_key,
+                              events.`$group_1` AS group_1_key,
+                              events.`$group_2` AS group_2_key,
+                              events.`$group_3` AS group_3_key,
+                              events.`$group_4` AS group_4_key,
+                              NULL AS invoice_id,
+                              replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id,
+                              toString(events.`$session_id`) AS session_id,
+                              events.event AS event_name,
+                              NULL AS coupon,
+                              coupon AS coupon_id,
+                              'USD' AS original_currency,
+                              accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                              in(original_currency,
+                                 ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                                if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                                divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                                'USD' AS currency,
+                                if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
                        FROM events
                        LEFT OUTER JOIN
                          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -2060,20 +2076,58 @@
                           WHERE equals(person_distinct_id_overrides.team_id, 99999)
                           GROUP BY person_distinct_id_overrides.distinct_id
                           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-                       WHERE and(equals(events.team_id, 99999), and(1, isNotNull(subscription_id)))
-                       GROUP BY subscription_id,
-                                person_id)
-                    ORDER BY started_at DESC) AS `revenue_analytics.events.purchase.subscription_events_revenue_view`
-                 WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), 0))
-                 ORDER BY timestamp DESC) AS
-              union
-              GROUP BY source_label,
-                       customer_id,
-                       subscription_id
-              ORDER BY customer_id ASC,
-                       subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
-           GROUP BY customer_id) AS mrr_by_customer ON equals(customer_to_group.customer_id, mrr_by_customer.customer_id)
-        GROUP BY group_key) AS mrr_agg ON equals(revenue_agg.group_key, mrr_agg.group_key)) AS groups_revenue_analytics
+                       WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+                       ORDER BY timestamp DESC) AS revenue_item
+                    WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), 0))
+                    GROUP BY revenue_item.source_label,
+                             revenue_item.customer_id,
+                             revenue_item.subscription_id, timestamp
+                    ORDER BY timestamp DESC
+                    UNION ALL SELECT `revenue_analytics.events.purchase.subscription_events_revenue_view`.source_label AS source_label,
+                                     `revenue_analytics.events.purchase.subscription_events_revenue_view`.customer_id AS customer_id,
+                                     `revenue_analytics.events.purchase.subscription_events_revenue_view`.id AS subscription_id,
+                                     toTimeZone(`revenue_analytics.events.purchase.subscription_events_revenue_view`.ended_at, 'UTC') AS timestamp,
+                                     accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                    FROM
+                      (SELECT subscription_id AS id,
+                              'revenue_analytics.events.purchase' AS source_label,
+                              NULL AS plan_id,
+                              product_id AS product_id,
+                              toString(person_id) AS customer_id,
+                              NULL AS status,
+                              min_timestamp AS started_at,
+                              if(greater(max_timestamp_plus_dropoff_days, today()), NULL, max_timestamp_plus_dropoff_days) AS ended_at,
+                              NULL AS metadata
+                       FROM
+                         (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id,
+                                 replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id,
+                                 NULL AS product_id,
+                                 min(toTimeZone(events.timestamp, 'UTC')) AS min_timestamp,
+                                 max(toTimeZone(events.timestamp, 'UTC')) AS max_timestamp,
+                                 addDays(max_timestamp, 45.0) AS max_timestamp_plus_dropoff_days
+                          FROM events
+                          LEFT OUTER JOIN
+                            (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                                    person_distinct_id_overrides.distinct_id AS distinct_id
+                             FROM person_distinct_id_overrides
+                             WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                             GROUP BY person_distinct_id_overrides.distinct_id
+                             HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+                          WHERE and(equals(events.team_id, 99999), and(1, isNotNull(subscription_id)))
+                          GROUP BY subscription_id,
+                                   person_id)
+                       ORDER BY started_at DESC) AS `revenue_analytics.events.purchase.subscription_events_revenue_view`
+                    WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), 0))
+                    ORDER BY timestamp DESC) AS
+                 union
+                 GROUP BY source_label,
+                          customer_id,
+                          subscription_id
+                 ORDER BY customer_id ASC,
+                          subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+              GROUP BY customer_id) AS mrr_by_customer ON equals(customer_to_group.customer_id, mrr_by_customer.customer_id)
+           GROUP BY group_key) AS mrr_agg ON equals(revenue_agg.group_key, mrr_agg.group_key))
+     GROUP BY group_key) AS groups_revenue_analytics
   ORDER BY groups_revenue_analytics.group_key ASC
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
                      readonly=2,
@@ -2097,216 +2151,222 @@
          groups_revenue_analytics.mrr AS mrr
   FROM
     (SELECT 99999 AS team_id,
-            revenue_analytics_customer__groups.key AS group_key,
-            sum(coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)'))) AS revenue,
-            sum(coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
+            group_key AS group_key,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT inner.id AS id,
-               inner.source_label AS source_label,
-               inner.timestamp AS timestamp,
-               inner.name AS name,
-               inner.email AS email,
-               inner.phone AS phone,
-               inner.address AS address,
-               if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(notEquals(inner.resolved_distinct_id, ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata,
-               inner.country AS country,
-               inner.cohort AS cohort,
-               inner.initial_coupon AS initial_coupon,
-               inner.initial_coupon_id AS initial_coupon_id
+       (SELECT 99999 AS team_id,
+               revenue_analytics_customer__groups.key AS group_key,
+               sum(coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)'))) AS revenue,
+               sum(coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
         FROM
-          (SELECT outer.id AS id,
-                  'stripe.posthog_test' AS source_label,
-                  parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
-                  outer.name AS name,
-                  outer.email AS email,
-                  outer.phone AS phone,
-                  outer.address AS address,
-                  outer.metadata AS metadata,
-                  JSONExtractString(address, 'country') AS country,
-                  cohort_inner.cohort AS cohort,
-                  cohort_inner.initial_coupon AS initial_coupon,
-                  cohort_inner.initial_coupon_id AS initial_coupon_id,
-                  ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id,
-                  ifNull(resolved.resolved_source, '') AS resolved_source
+          (SELECT inner.id AS id,
+                  inner.source_label AS source_label,
+                  inner.timestamp AS timestamp,
+                  inner.name AS name,
+                  inner.email AS email,
+                  inner.phone AS phone,
+                  inner.address AS address,
+                  if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(notEquals(inner.resolved_distinct_id, ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata,
+                  inner.country AS country,
+                  inner.cohort AS cohort,
+                  inner.initial_coupon AS initial_coupon,
+                  inner.initial_coupon_id AS initial_coupon_id
            FROM
-             (SELECT *
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
-           LEFT JOIN
-             (SELECT invoice.customer AS customer_id,
-                     formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
-                     argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
-                     argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
-              GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
-           LEFT JOIN
-             (SELECT child_meta.customer_id AS customer_id,
-                     argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id,
-                     argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
+             (SELECT outer.id AS id,
+                     'stripe.posthog_test' AS source_label,
+                     parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
+                     outer.name AS name,
+                     outer.email AS email,
+                     outer.phone AS phone,
+                     outer.address AS address,
+                     outer.metadata AS metadata,
+                     JSONExtractString(address, 'country') AS country,
+                     cohort_inner.cohort AS cohort,
+                     cohort_inner.initial_coupon AS initial_coupon,
+                     cohort_inner.initial_coupon_id AS initial_coupon_id,
+                     ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id,
+                     ifNull(resolved.resolved_source, '') AS resolved_source
               FROM
-                (SELECT posthog_test_stripe_invoice.customer AS customer_id,
-                        JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id,
-                        concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
-                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
-                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                 WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
-              GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner
-        ORDER BY timestamp DESC
-        LIMIT 1 BY id) AS revenue_analytics_customer
-     LEFT JOIN
-       (SELECT groups.key AS key,
-               key AS revenue_analytics_customer__groups___key
-        FROM
-          (SELECT groups.group_type_index AS index,
-                  groups.group_key AS key
-           FROM groups
-           WHERE equals(groups.team_id, 99999)
-           GROUP BY groups.group_type_index,
-                    groups.group_key) AS groups) AS revenue_analytics_customer__groups ON equals(revenue_analytics_customer.id, revenue_analytics_customer__groups.revenue_analytics_customer__groups___key)
-     LEFT JOIN
-       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM
-          (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                  invoice.invoice_item_id AS invoice_item_id,
-                  'stripe.posthog_test' AS source_label,
-                  addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                  invoice.created_at AS created_at,
-                  ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                  invoice.product_id AS product_id,
-                  invoice.customer_id AS customer_id,
-                  NULL AS group_0_key,
-                  NULL AS group_1_key,
-                  NULL AS group_2_key,
-                  NULL AS group_3_key,
-                  NULL AS group_4_key,
-                  invoice.id AS invoice_id,
-                  invoice.subscription_id AS subscription_id,
-                  NULL AS session_id,
-                  NULL AS event_name,
-                  JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                  JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                  upper(invoice.currency) AS original_currency,
-                  accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                  in(original_currency,
-                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                    'GBP' AS currency,
-                    divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
-           FROM
-             (SELECT posthog_test_stripe_invoice.id AS id,
-                     parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                     posthog_test_stripe_invoice.customer AS customer_id,
-                     posthog_test_stripe_invoice.subscription AS subscription_id,
-                     posthog_test_stripe_invoice.discount AS discount,
-                     arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                     JSONExtractString(data, 'id') AS invoice_item_id,
-                     JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                     coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                     greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                     JSONExtractString(data, 'currency') AS currency,
-                     JSONExtractString(data, 'price', 'product') AS product_id,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                     greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                     arrayJoin(range(0, period_months)) AS month_index,
-                     ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-              WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_analytics_revenue_item
-        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-     LEFT JOIN
-       (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
-               sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
-        FROM
-          (SELECT union.source_label AS source_label,
-                  union.customer_id AS customer_id,
-                  union.subscription_id AS subscription_id,
-                  argMax(union.amount, union.timestamp) AS mrr
-           FROM
-             (SELECT revenue_item.source_label AS source_label,
-                     revenue_item.customer_id AS customer_id,
-                     revenue_item.subscription_id AS subscription_id,
-                     toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
-                     sum(revenue_item.amount) AS amount
-              FROM
-                (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                        invoice.invoice_item_id AS invoice_item_id,
-                        'stripe.posthog_test' AS source_label,
-                        addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                        invoice.created_at AS created_at,
-                        ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                        invoice.product_id AS product_id,
-                        invoice.customer_id AS customer_id,
-                        NULL AS group_0_key,
-                        NULL AS group_1_key,
-                        NULL AS group_2_key,
-                        NULL AS group_3_key,
-                        NULL AS group_4_key,
-                        invoice.id AS invoice_id,
-                        invoice.subscription_id AS subscription_id,
-                        NULL AS session_id,
-                        NULL AS event_name,
-                        JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                        JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                        upper(invoice.currency) AS original_currency,
-                        accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                        in(original_currency,
-                           ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                          if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                          divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                          'GBP' AS currency,
-                          divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                (SELECT *
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
+              LEFT JOIN
+                (SELECT invoice.customer AS customer_id,
+                        formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
+                        argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
+                 GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
+              LEFT JOIN
+                (SELECT child_meta.customer_id AS customer_id,
+                        argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id,
+                        argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
                  FROM
-                   (SELECT posthog_test_stripe_invoice.id AS id,
-                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                           posthog_test_stripe_invoice.customer AS customer_id,
-                           posthog_test_stripe_invoice.subscription AS subscription_id,
-                           posthog_test_stripe_invoice.discount AS discount,
-                           arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                           JSONExtractString(data, 'id') AS invoice_item_id,
-                           JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                           coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                           greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                           JSONExtractString(data, 'currency') AS currency,
-                           JSONExtractString(data, 'price', 'product') AS product_id,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                           greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                           arrayJoin(range(0, period_months)) AS month_index,
-                           ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                   (SELECT posthog_test_stripe_invoice.customer AS customer_id,
+                           JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id,
+                           concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref,
+                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
                     FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                    WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_item
-              WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')), 0))
-              GROUP BY revenue_item.source_label,
-                       revenue_item.customer_id,
-                       revenue_item.subscription_id, timestamp
-              ORDER BY timestamp DESC
-              UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
-                               `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
-                               `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
-                               toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
-                               accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                    WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
+                 GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner
+           ORDER BY timestamp DESC
+           LIMIT 1 BY id) AS revenue_analytics_customer
+        LEFT JOIN
+          (SELECT groups.key AS key,
+                  key AS revenue_analytics_customer__groups___key
+           FROM
+             (SELECT groups.group_type_index AS index,
+                     groups.group_key AS key
+              FROM groups
+              WHERE equals(groups.team_id, 99999)
+              GROUP BY groups.group_type_index,
+                       groups.group_key) AS groups) AS revenue_analytics_customer__groups ON equals(revenue_analytics_customer.id, revenue_analytics_customer__groups.revenue_analytics_customer__groups___key)
+        LEFT JOIN
+          (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
+           FROM
+             (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                     invoice.invoice_item_id AS invoice_item_id,
+                     'stripe.posthog_test' AS source_label,
+                     addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                     invoice.created_at AS created_at,
+                     ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                     invoice.product_id AS product_id,
+                     invoice.customer_id AS customer_id,
+                     NULL AS group_0_key,
+                     NULL AS group_1_key,
+                     NULL AS group_2_key,
+                     NULL AS group_3_key,
+                     NULL AS group_4_key,
+                     invoice.id AS invoice_id,
+                     invoice.subscription_id AS subscription_id,
+                     NULL AS session_id,
+                     NULL AS event_name,
+                     JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                     JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                     upper(invoice.currency) AS original_currency,
+                     accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                     in(original_currency,
+                        ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                       if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                       divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                       'GBP' AS currency,
+                       divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
               FROM
-                (SELECT '' AS id,
-                        '' AS source_label,
-                        '' AS plan_id,
-                        '' AS product_id,
-                        '' AS customer_id,
-                        '' AS status,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
-                        '' AS metadata
-                 WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
-              WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')), 0))
-              ORDER BY timestamp DESC) AS
-           union
-           GROUP BY source_label,
-                    customer_id,
-                    subscription_id
-           ORDER BY customer_id ASC,
-                    subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
-        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)
-     WHERE notEmpty(group_key)
+                (SELECT posthog_test_stripe_invoice.id AS id,
+                        parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                        posthog_test_stripe_invoice.customer AS customer_id,
+                        posthog_test_stripe_invoice.subscription AS subscription_id,
+                        posthog_test_stripe_invoice.discount AS discount,
+                        arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                        JSONExtractString(data, 'id') AS invoice_item_id,
+                        JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                        coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                        greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                        JSONExtractString(data, 'currency') AS currency,
+                        JSONExtractString(data, 'price', 'product') AS product_id,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                        fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                        greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                        arrayJoin(range(0, period_months)) AS month_index,
+                        ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                 WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_analytics_revenue_item
+           GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+        LEFT JOIN
+          (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
+                  sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
+           FROM
+             (SELECT union.source_label AS source_label,
+                     union.customer_id AS customer_id,
+                     union.subscription_id AS subscription_id,
+                     argMax(union.amount, union.timestamp) AS mrr
+              FROM
+                (SELECT revenue_item.source_label AS source_label,
+                        revenue_item.customer_id AS customer_id,
+                        revenue_item.subscription_id AS subscription_id,
+                        toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                        sum(revenue_item.amount) AS amount
+                 FROM
+                   (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                           invoice.invoice_item_id AS invoice_item_id,
+                           'stripe.posthog_test' AS source_label,
+                           addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                           invoice.created_at AS created_at,
+                           ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                           invoice.product_id AS product_id,
+                           invoice.customer_id AS customer_id,
+                           NULL AS group_0_key,
+                           NULL AS group_1_key,
+                           NULL AS group_2_key,
+                           NULL AS group_3_key,
+                           NULL AS group_4_key,
+                           invoice.id AS invoice_id,
+                           invoice.subscription_id AS subscription_id,
+                           NULL AS session_id,
+                           NULL AS event_name,
+                           JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                           JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                           upper(invoice.currency) AS original_currency,
+                           accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                           in(original_currency,
+                              ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                             'GBP' AS currency,
+                             divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                    FROM
+                      (SELECT posthog_test_stripe_invoice.id AS id,
+                              parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                              posthog_test_stripe_invoice.customer AS customer_id,
+                              posthog_test_stripe_invoice.subscription AS subscription_id,
+                              posthog_test_stripe_invoice.discount AS discount,
+                              arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                              JSONExtractString(data, 'id') AS invoice_item_id,
+                              JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                              coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                              greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                              JSONExtractString(data, 'currency') AS currency,
+                              JSONExtractString(data, 'price', 'product') AS product_id,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                              fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                              greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                              arrayJoin(range(0, period_months)) AS month_index,
+                              ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                       FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                       WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_item
+                 WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')), 0))
+                 GROUP BY revenue_item.source_label,
+                          revenue_item.customer_id,
+                          revenue_item.subscription_id, timestamp
+                 ORDER BY timestamp DESC
+                 UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
+                                  `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
+                                  `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
+                                  toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
+                                  accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                 FROM
+                   (SELECT '' AS id,
+                           '' AS source_label,
+                           '' AS plan_id,
+                           '' AS product_id,
+                           '' AS customer_id,
+                           '' AS status,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
+                           toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
+                           '' AS metadata
+                    WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
+                 WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')), 0))
+                 ORDER BY timestamp DESC) AS
+              union
+              GROUP BY source_label,
+                       customer_id,
+                       subscription_id
+              ORDER BY customer_id ASC,
+                       subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
+           GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)
+        WHERE notEmpty(group_key)
+        GROUP BY group_key)
      GROUP BY group_key) AS groups_revenue_analytics
   ORDER BY groups_revenue_analytics.mrr DESC
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
@@ -2324,6 +2384,160 @@
                      use_hive_partitioning=0
   '''
 # ---
+# name: TestGroupsRevenueAnalytics.test_revenue_aggregated_per_group_across_event_and_warehouse_sources
+  '''
+  SELECT groups.key AS key, groups__revenue_analytics.revenue AS `$virt_revenue`, groups__revenue_analytics.mrr AS `$virt_mrr`
+  FROM (
+  SELECT argMax(groups.group_key, toTimeZone(groups._timestamp, 'UTC')) AS groups___key, groups.group_type_index AS index, groups.group_key AS key
+  FROM groups
+  WHERE equals(groups.team_id, 99999)
+  GROUP BY groups.group_type_index, groups.group_key) AS groups
+  LEFT JOIN (
+  SELECT 99999 AS team_id, group_key AS group_key, sum(revenue) AS revenue, sum(mrr) AS mrr
+  FROM (
+  SELECT 99999 AS team_id, coalesce(revenue_agg.group_key, mrr_agg.group_key) AS group_key, coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue, coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+  FROM (
+  SELECT arrayJoin([revenue_analytics_revenue_item.group_0_key, revenue_analytics_revenue_item.group_1_key, revenue_analytics_revenue_item.group_2_key, revenue_analytics_revenue_item.group_3_key, revenue_analytics_revenue_item.group_4_key]) AS group_key, sum(revenue_analytics_revenue_item.amount) AS revenue
+  FROM (
+  SELECT toString(events.uuid) AS id, toString(events.uuid) AS invoice_item_id, 'revenue_analytics.events.purchase' AS source_label, toTimeZone(events.timestamp, 'UTC') AS timestamp, timestamp AS created_at, isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '')) AS is_recurring, NULL AS product_id, toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id, events.`$group_0` AS group_0_key, events.`$group_1` AS group_1_key, events.`$group_2` AS group_2_key, events.`$group_3` AS group_3_key, events.`$group_4` AS group_4_key, NULL AS invoice_id, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id, toString(events.`$session_id`) AS session_id, events.event AS event_name, NULL AS coupon, coupon AS coupon_id, 'USD' AS original_currency, accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount, in(original_currency, ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider, if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider, divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount, 'GBP' AS currency, if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'GBP'), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+  FROM events
+  LEFT OUTER JOIN (
+  SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id, person_distinct_id_overrides.distinct_id AS distinct_id
+  FROM person_distinct_id_overrides
+  WHERE equals(person_distinct_id_overrides.team_id, 99999)
+  GROUP BY person_distinct_id_overrides.distinct_id
+  HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+  WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+  ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
+  WHERE notEmpty(group_key)
+  GROUP BY group_key) AS revenue_agg
+  FULL OUTER JOIN (
+  SELECT customer_to_group.group_key AS group_key, sum(coalesce(mrr_by_customer.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
+  FROM (
+  SELECT DISTINCT revenue_analytics_revenue_item.customer_id AS customer_id, arrayJoin([revenue_analytics_revenue_item.group_0_key, revenue_analytics_revenue_item.group_1_key, revenue_analytics_revenue_item.group_2_key, revenue_analytics_revenue_item.group_3_key, revenue_analytics_revenue_item.group_4_key]) AS group_key
+  FROM (
+  SELECT toString(events.uuid) AS id, toString(events.uuid) AS invoice_item_id, 'revenue_analytics.events.purchase' AS source_label, toTimeZone(events.timestamp, 'UTC') AS timestamp, timestamp AS created_at, isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '')) AS is_recurring, NULL AS product_id, toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id, events.`$group_0` AS group_0_key, events.`$group_1` AS group_1_key, events.`$group_2` AS group_2_key, events.`$group_3` AS group_3_key, events.`$group_4` AS group_4_key, NULL AS invoice_id, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id, toString(events.`$session_id`) AS session_id, events.event AS event_name, NULL AS coupon, coupon AS coupon_id, 'USD' AS original_currency, accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount, in(original_currency, ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider, if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider, divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount, 'GBP' AS currency, if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'GBP'), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+  FROM events
+  LEFT OUTER JOIN (
+  SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id, person_distinct_id_overrides.distinct_id AS distinct_id
+  FROM person_distinct_id_overrides
+  WHERE equals(person_distinct_id_overrides.team_id, 99999)
+  GROUP BY person_distinct_id_overrides.distinct_id
+  HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+  WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+  ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
+  WHERE notEmpty(group_key)) AS customer_to_group
+    LEFT JOIN (
+    SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id, sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
+    FROM (
+    SELECT union.source_label AS source_label, union.customer_id AS customer_id, union.subscription_id AS subscription_id, argMax(union.amount, union.timestamp) AS mrr
+    FROM (
+    SELECT revenue_item.source_label AS source_label, revenue_item.customer_id AS customer_id, revenue_item.subscription_id AS subscription_id, toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp, sum(revenue_item.amount) AS amount
+    FROM (
+    SELECT toString(events.uuid) AS id, toString(events.uuid) AS invoice_item_id, 'revenue_analytics.events.purchase' AS source_label, toTimeZone(events.timestamp, 'UTC') AS timestamp, timestamp AS created_at, isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '')) AS is_recurring, NULL AS product_id, toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id, events.`$group_0` AS group_0_key, events.`$group_1` AS group_1_key, events.`$group_2` AS group_2_key, events.`$group_3` AS group_3_key, events.`$group_4` AS group_4_key, NULL AS invoice_id, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id, toString(events.`$session_id`) AS session_id, events.event AS event_name, NULL AS coupon, coupon AS coupon_id, 'USD' AS original_currency, accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount, in(original_currency, ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider, if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider, divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount, 'GBP' AS currency, if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'GBP'), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+    FROM events
+    LEFT OUTER JOIN (
+    SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id, person_distinct_id_overrides.distinct_id AS distinct_id
+    FROM person_distinct_id_overrides WHERE equals(person_distinct_id_overrides.team_id, 99999)
+  GROUP BY person_distinct_id_overrides.distinct_id
+  HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+  WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+  ORDER BY timestamp DESC) AS revenue_item
+  WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), 0))
+  GROUP BY revenue_item.source_label, revenue_item.customer_id, revenue_item.subscription_id, timestamp
+  ORDER BY timestamp DESC
+  UNION ALL
+  SELECT `revenue_analytics.events.purchase.subscription_events_revenue_view`.source_label AS source_label, `revenue_analytics.events.purchase.subscription_events_revenue_view`.customer_id AS customer_id, `revenue_analytics.events.purchase.subscription_events_revenue_view`.id AS subscription_id, toTimeZone(`revenue_analytics.events.purchase.subscription_events_revenue_view`.ended_at, 'UTC') AS timestamp, accurateCastOrNull(0, 'Decimal64(10)') AS amount
+  FROM (
+  SELECT subscription_id AS id, 'revenue_analytics.events.purchase' AS source_label, NULL AS plan_id, product_id AS product_id, toString(person_id) AS customer_id, NULL AS status, min_timestamp AS started_at, if(greater(max_timestamp_plus_dropoff_days, today()), NULL, max_timestamp_plus_dropoff_days) AS ended_at, NULL AS metadata
+  FROM (
+  SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id, NULL AS product_id, min(toTimeZone(events.timestamp, 'UTC')) AS min_timestamp, max(toTimeZone(events.timestamp, 'UTC')) AS max_timestamp, addDays(max_timestamp, 45.0) AS max_timestamp_plus_dropoff_days
+  FROM events
+  LEFT OUTER JOIN (
+  SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id, person_distinct_id_overrides.distinct_id AS distinct_id
+  FROM person_distinct_id_overrides
+  WHERE equals(person_distinct_id_overrides.team_id, 99999)
+  GROUP BY person_distinct_id_overrides.distinct_id
+  HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+  WHERE and(equals(events.team_id, 99999), and(1, isNotNull(subscription_id)))
+  GROUP BY subscription_id, person_id)
+  ORDER BY started_at DESC) AS `revenue_analytics.events.purchase.subscription_events_revenue_view`
+  WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), 0))
+  ORDER BY timestamp DESC) AS
+  union
+  GROUP BY source_label, customer_id, subscription_id
+  ORDER BY customer_id ASC, subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+  GROUP BY customer_id) AS mrr_by_customer ON equals(customer_to_group.customer_id, mrr_by_customer.customer_id)
+  GROUP BY group_key) AS mrr_agg ON equals(revenue_agg.group_key, mrr_agg.group_key)
+  UNION ALL
+  SELECT 99999 AS team_id, revenue_analytics_customer__groups.key AS group_key, sum(coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)'))) AS revenue, sum(coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
+  FROM (
+  SELECT inner.id AS id, inner.source_label AS source_label, inner.timestamp AS timestamp, inner.name AS name, inner.email AS email, inner.phone AS phone, inner.address AS address, if(notEquals(JSONExtractString(inner.metadata, 'posthog_person_distinct_id'), ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id_source', 'customer'))), if(notEquals(inner.resolved_distinct_id, ''), toJSONString(mapUpdate(mapFromArrays(JSONExtractKeys(ifNull(inner.metadata, '{}')), arrayMap(k -> JSONExtractString(ifNull(inner.metadata, '{}'), k), JSONExtractKeys(ifNull(inner.metadata, '{}')))), map('posthog_person_distinct_id', inner.resolved_distinct_id, 'posthog_person_distinct_id_source', inner.resolved_source))), inner.metadata)) AS metadata, inner.country AS country, inner.cohort AS cohort, inner.initial_coupon AS initial_coupon, inner.initial_coupon_id AS initial_coupon_id
+  FROM (
+  SELECT outer.id AS id, 'stripe.posthog_test' AS source_label, parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp, outer.name AS name, outer.email AS email, outer.phone AS phone, outer.address AS address, outer.metadata AS metadata, JSONExtractString(address, 'country') AS country, cohort_inner.cohort AS cohort, cohort_inner.initial_coupon AS initial_coupon, cohort_inner.initial_coupon_id AS initial_coupon_id, ifNull(resolved.resolved_distinct_id, '') AS resolved_distinct_id, ifNull(resolved.resolved_source, '') AS resolved_source
+  FROM (
+  SELECT *
+  FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
+  LEFT JOIN (
+  SELECT invoice.customer AS customer_id, formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort, argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon, argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
+  FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
+  GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
+  LEFT JOIN (
+  SELECT child_meta.customer_id AS customer_id, argMax(child_meta.distinct_id, child_meta.created_at) AS resolved_distinct_id, argMax(child_meta.source_ref, child_meta.created_at) AS resolved_source
+  FROM (
+  SELECT posthog_test_stripe_invoice.customer AS customer_id, JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id') AS distinct_id, concat('invoice', '::', ifNull(toString(posthog_test_stripe_invoice.id), '')) AS source_ref, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at
+  FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+  WHERE notEquals(JSONExtractString(posthog_test_stripe_invoice.metadata, 'posthog_person_distinct_id'), '')) AS child_meta
+  GROUP BY child_meta.customer_id) AS resolved ON equals(resolved.customer_id, outer.id)) AS inner
+  ORDER BY timestamp DESC
+  LIMIT 1 BY id) AS revenue_analytics_customer
+  LEFT JOIN (
+  SELECT groups.key AS key, key AS revenue_analytics_customer__groups___key
+  FROM (
+  SELECT groups.group_type_index AS index, groups.group_key AS key
+  FROM groups
+  WHERE equals(groups.team_id, 99999)
+  GROUP BY groups.group_type_index, groups.group_key) AS groups) AS revenue_analytics_customer__groups ON equals(revenue_analytics_customer.id, revenue_analytics_customer__groups.revenue_analytics_customer__groups___key)
+  LEFT JOIN (
+  SELECT revenue_analytics_revenue_item.customer_id AS customer_id, sum(revenue_analytics_revenue_item.amount) AS revenue
+  FROM (
+  SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id, invoice.invoice_item_id AS invoice_item_id, 'stripe.posthog_test' AS source_label, addMonths(invoice.timestamp, invoice.month_index) AS timestamp, invoice.created_at AS created_at, ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring, invoice.product_id AS product_id, invoice.customer_id AS customer_id, NULL AS group_0_key, NULL AS group_1_key, NULL AS group_2_key, NULL AS group_3_key, NULL AS group_4_key, invoice.id AS invoice_id, invoice.subscription_id AS subscription_id, NULL AS session_id, NULL AS event_name, JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon, JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id, upper(invoice.currency) AS original_currency, accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount, in(original_currency, ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider, if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider, divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount, 'GBP' AS currency, divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+  FROM (
+  SELECT posthog_test_stripe_invoice.id AS id, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at, posthog_test_stripe_invoice.customer AS customer_id, posthog_test_stripe_invoice.subscription AS subscription_id, posthog_test_stripe_invoice.discount AS discount, arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data, JSONExtractString(data, 'id') AS invoice_item_id, JSONExtractUInt(data, 'amount') AS amount_before_discount, coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount, greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured, JSONExtractString(data, 'currency') AS currency, JSONExtractString(data, 'price', 'product') AS product_id, fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start, fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end, greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months, arrayJoin(range(0, period_months)) AS month_index, ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+  FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+  WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_analytics_revenue_item
+  GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+  LEFT JOIN (
+  SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id, sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
+  FROM (
+  SELECT union.source_label AS source_label, union.customer_id AS customer_id, union.subscription_id AS subscription_id, argMax(union.amount, union.timestamp) AS mrr
+  FROM (
+  SELECT revenue_item.source_label AS source_label, revenue_item.customer_id AS customer_id, revenue_item.subscription_id AS subscription_id, toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp, sum(revenue_item.amount) AS amount
+  FROM (
+  SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id, invoice.invoice_item_id AS invoice_item_id, 'stripe.posthog_test' AS source_label, addMonths(invoice.timestamp, invoice.month_index) AS timestamp, invoice.created_at AS created_at, ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring, invoice.product_id AS product_id, invoice.customer_id AS customer_id, NULL AS group_0_key, NULL AS group_1_key, NULL AS group_2_key, NULL AS group_3_key, NULL AS group_4_key, invoice.id AS invoice_id, invoice.subscription_id AS subscription_id, NULL AS session_id, NULL AS event_name, JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon, JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id, upper(invoice.currency) AS original_currency, accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount, in(original_currency, ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider, if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider, divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount, 'GBP' AS currency, divideDecimal(if(equals(original_currency, currency), toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(0, 10), multiplyDecimal(divideDecimal(toDecimal128(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal128(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+  FROM (
+  SELECT posthog_test_stripe_invoice.id AS id, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at, posthog_test_stripe_invoice.customer AS customer_id, posthog_test_stripe_invoice.subscription AS subscription_id, posthog_test_stripe_invoice.discount AS discount, arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data, JSONExtractString(data, 'id') AS invoice_item_id, JSONExtractUInt(data, 'amount') AS amount_before_discount, coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount, greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured, JSONExtractString(data, 'currency') AS currency, JSONExtractString(data, 'price', 'product') AS product_id, fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start, fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end, greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months, arrayJoin(range(0, period_months)) AS month_index, ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+  FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+  WHERE if(isNull(posthog_test_stripe_invoice.paid), equals(posthog_test_stripe_invoice.status, 'paid'), posthog_test_stripe_invoice.paid)) AS invoice) AS revenue_item WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), 0))
+  GROUP BY revenue_item.source_label, revenue_item.customer_id, revenue_item.subscription_id, timestamp
+  ORDER BY timestamp DESC
+  UNION ALL
+  SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label, `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id, `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id, toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp, accurateCastOrNull(0, 'Decimal64(10)') AS amount
+  FROM (
+  SELECT '' AS id, '' AS source_label, '' AS plan_id, '' AS product_id, '' AS customer_id, '' AS status, toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at, toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at, '' AS metadata
+  WHERE 0) AS `stripe.posthog_test.subscription_revenue_view` WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), 0), ifNull(lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), 0))
+  ORDER BY timestamp DESC) AS
+  union
+  GROUP BY source_label, customer_id, subscription_id
+  ORDER BY customer_id ASC, subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
+  GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)
+  WHERE notEmpty(group_key)
+  GROUP BY group_key)
+  GROUP BY group_key) AS groups__revenue_analytics ON equals(groups.groups___key, groups__revenue_analytics.group_key)
+  WHERE equals(groups.key, 'cus_1')
+  LIMIT 100 SETTINGS format_csv_allow_double_quotes=1, readonly=2, max_execution_time=60, allow_experimental_object_type=1, max_ast_elements=4000000, max_expanded_ast_elements=4000000, max_bytes_before_external_group_by=0, transform_null_in=1, optimize_min_equality_disjunction_chain_length=4294967295, optimize_rewrite_aggregate_function_with_if=0, optimize_min_inequality_conjunction_chain_length=4294967295, allow_experimental_join_condition=1, use_hive_partitioning=0
+  '''
+# ---
 # name: TestGroupsRevenueAnalyticsManagedViewsets.test_get_mrr_via_lazy_join_for_events
   '''
   SELECT groups.key AS key,
@@ -2339,29 +2553,35 @@
               groups.group_key) AS groups
   LEFT JOIN
     (SELECT 99999 AS team_id,
-            coalesce(revenue_agg.group_key, mrr_agg.group_key) AS group_key,
-            coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
-            coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+            group_key AS group_key,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT arrayJoin([revenue_analytics_revenue_item.group_0_key, revenue_analytics_revenue_item.group_1_key, revenue_analytics_revenue_item.group_2_key, revenue_analytics_revenue_item.group_3_key, revenue_analytics_revenue_item.group_4_key]) AS group_key,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_revenue_item_events_revenue_view/revenue_analytics.events.purchase.revenue_item_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
-        WHERE notEmpty(group_key)
-        GROUP BY group_key) AS revenue_agg
-     FULL OUTER JOIN
-       (SELECT customer_to_group.group_key AS group_key,
-               sum(coalesce(mrr_by_customer.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
+       (SELECT 99999 AS team_id,
+               coalesce(revenue_agg.group_key, mrr_agg.group_key) AS group_key,
+               coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+               coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
         FROM
-          (SELECT DISTINCT revenue_analytics_revenue_item.customer_id AS customer_id,
-                           arrayJoin([revenue_analytics_revenue_item.group_0_key, revenue_analytics_revenue_item.group_1_key, revenue_analytics_revenue_item.group_2_key, revenue_analytics_revenue_item.group_3_key, revenue_analytics_revenue_item.group_4_key]) AS group_key
+          (SELECT arrayJoin([revenue_analytics_revenue_item.group_0_key, revenue_analytics_revenue_item.group_1_key, revenue_analytics_revenue_item.group_2_key, revenue_analytics_revenue_item.group_3_key, revenue_analytics_revenue_item.group_4_key]) AS group_key,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
            FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_revenue_item_events_revenue_view/revenue_analytics.events.purchase.revenue_item_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
-           WHERE notEmpty(group_key)) AS customer_to_group
-        LEFT JOIN
-          (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
-                  sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
-           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_mrr_events_revenue_view/revenue_analytics.events.purchase.mrr_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
-           GROUP BY customer_id) AS mrr_by_customer ON equals(customer_to_group.customer_id, mrr_by_customer.customer_id)
-        GROUP BY group_key) AS mrr_agg ON equals(revenue_agg.group_key, mrr_agg.group_key)) AS groups__revenue_analytics ON equals(groups.groups___key, groups__revenue_analytics.group_key)
+           WHERE notEmpty(group_key)
+           GROUP BY group_key) AS revenue_agg
+        FULL OUTER JOIN
+          (SELECT customer_to_group.group_key AS group_key,
+                  sum(coalesce(mrr_by_customer.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
+           FROM
+             (SELECT DISTINCT revenue_analytics_revenue_item.customer_id AS customer_id,
+                              arrayJoin([revenue_analytics_revenue_item.group_0_key, revenue_analytics_revenue_item.group_1_key, revenue_analytics_revenue_item.group_2_key, revenue_analytics_revenue_item.group_3_key, revenue_analytics_revenue_item.group_4_key]) AS group_key
+              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_revenue_item_events_revenue_view/revenue_analytics.events.purchase.revenue_item_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
+              WHERE notEmpty(group_key)) AS customer_to_group
+           LEFT JOIN
+             (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
+                     sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
+              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_mrr_events_revenue_view/revenue_analytics.events.purchase.mrr_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+              GROUP BY customer_id) AS mrr_by_customer ON equals(customer_to_group.customer_id, mrr_by_customer.customer_id)
+           GROUP BY group_key) AS mrr_agg ON equals(revenue_agg.group_key, mrr_agg.group_key))
+     GROUP BY group_key) AS groups__revenue_analytics ON equals(groups.groups___key, groups__revenue_analytics.group_key)
   WHERE equals(groups.key, 'lolol0:xxx')
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
                      readonly=2,
@@ -2393,33 +2613,39 @@
               groups.group_key) AS groups
   LEFT JOIN
     (SELECT 99999 AS team_id,
-            revenue_analytics_customer__groups.key AS group_key,
-            sum(coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)'))) AS revenue,
-            sum(coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
+            group_key AS group_key,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT *
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_customer_revenue_view/stripe.posthog_test.customer_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
-     LEFT JOIN
-       (SELECT groups.key AS key,
-               key AS revenue_analytics_customer__groups___key
+       (SELECT 99999 AS team_id,
+               revenue_analytics_customer__groups.key AS group_key,
+               sum(coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)'))) AS revenue,
+               sum(coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
         FROM
-          (SELECT groups.group_type_index AS index,
-                  groups.group_key AS key
-           FROM groups
-           WHERE equals(groups.team_id, 99999)
-           GROUP BY groups.group_type_index,
-                    groups.group_key) AS groups) AS revenue_analytics_customer__groups ON equals(revenue_analytics_customer.id, revenue_analytics_customer__groups.revenue_analytics_customer__groups___key)
-     LEFT JOIN
-       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_revenue_item_revenue_view/stripe.posthog_test.revenue_item_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
-        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-     LEFT JOIN
-       (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
-               sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_mrr_revenue_view/stripe.posthog_test.mrr_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `stripe.posthog_test.mrr_revenue_view`
-        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)
-     WHERE notEmpty(group_key)
+          (SELECT *
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_customer_revenue_view/stripe.posthog_test.customer_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
+        LEFT JOIN
+          (SELECT groups.key AS key,
+                  key AS revenue_analytics_customer__groups___key
+           FROM
+             (SELECT groups.group_type_index AS index,
+                     groups.group_key AS key
+              FROM groups
+              WHERE equals(groups.team_id, 99999)
+              GROUP BY groups.group_type_index,
+                       groups.group_key) AS groups) AS revenue_analytics_customer__groups ON equals(revenue_analytics_customer.id, revenue_analytics_customer__groups.revenue_analytics_customer__groups___key)
+        LEFT JOIN
+          (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_revenue_item_revenue_view/stripe.posthog_test.revenue_item_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
+           GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+        LEFT JOIN
+          (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
+                  sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_mrr_revenue_view/stripe.posthog_test.mrr_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `stripe.posthog_test.mrr_revenue_view`
+           GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)
+        WHERE notEmpty(group_key)
+        GROUP BY group_key)
      GROUP BY group_key) AS groups__revenue_analytics ON equals(groups.groups___key, groups__revenue_analytics.group_key)
   ORDER BY groups.key ASC
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
@@ -2452,29 +2678,35 @@
               groups.group_key) AS groups
   LEFT JOIN
     (SELECT 99999 AS team_id,
-            coalesce(revenue_agg.group_key, mrr_agg.group_key) AS group_key,
-            coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
-            coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+            group_key AS group_key,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT arrayJoin([revenue_analytics_revenue_item.group_0_key, revenue_analytics_revenue_item.group_1_key, revenue_analytics_revenue_item.group_2_key, revenue_analytics_revenue_item.group_3_key, revenue_analytics_revenue_item.group_4_key]) AS group_key,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_revenue_item_events_revenue_view/revenue_analytics.events.purchase.revenue_item_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
-        WHERE notEmpty(group_key)
-        GROUP BY group_key) AS revenue_agg
-     FULL OUTER JOIN
-       (SELECT customer_to_group.group_key AS group_key,
-               sum(coalesce(mrr_by_customer.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
+       (SELECT 99999 AS team_id,
+               coalesce(revenue_agg.group_key, mrr_agg.group_key) AS group_key,
+               coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+               coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
         FROM
-          (SELECT DISTINCT revenue_analytics_revenue_item.customer_id AS customer_id,
-                           arrayJoin([revenue_analytics_revenue_item.group_0_key, revenue_analytics_revenue_item.group_1_key, revenue_analytics_revenue_item.group_2_key, revenue_analytics_revenue_item.group_3_key, revenue_analytics_revenue_item.group_4_key]) AS group_key
+          (SELECT arrayJoin([revenue_analytics_revenue_item.group_0_key, revenue_analytics_revenue_item.group_1_key, revenue_analytics_revenue_item.group_2_key, revenue_analytics_revenue_item.group_3_key, revenue_analytics_revenue_item.group_4_key]) AS group_key,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
            FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_revenue_item_events_revenue_view/revenue_analytics.events.purchase.revenue_item_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
-           WHERE notEmpty(group_key)) AS customer_to_group
-        LEFT JOIN
-          (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
-                  sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
-           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_mrr_events_revenue_view/revenue_analytics.events.purchase.mrr_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
-           GROUP BY customer_id) AS mrr_by_customer ON equals(customer_to_group.customer_id, mrr_by_customer.customer_id)
-        GROUP BY group_key) AS mrr_agg ON equals(revenue_agg.group_key, mrr_agg.group_key)) AS groups__revenue_analytics ON equals(groups.groups___key, groups__revenue_analytics.group_key)
+           WHERE notEmpty(group_key)
+           GROUP BY group_key) AS revenue_agg
+        FULL OUTER JOIN
+          (SELECT customer_to_group.group_key AS group_key,
+                  sum(coalesce(mrr_by_customer.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
+           FROM
+             (SELECT DISTINCT revenue_analytics_revenue_item.customer_id AS customer_id,
+                              arrayJoin([revenue_analytics_revenue_item.group_0_key, revenue_analytics_revenue_item.group_1_key, revenue_analytics_revenue_item.group_2_key, revenue_analytics_revenue_item.group_3_key, revenue_analytics_revenue_item.group_4_key]) AS group_key
+              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_revenue_item_events_revenue_view/revenue_analytics.events.purchase.revenue_item_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
+              WHERE notEmpty(group_key)) AS customer_to_group
+           LEFT JOIN
+             (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
+                     sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
+              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_mrr_events_revenue_view/revenue_analytics.events.purchase.mrr_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+              GROUP BY customer_id) AS mrr_by_customer ON equals(customer_to_group.customer_id, mrr_by_customer.customer_id)
+           GROUP BY group_key) AS mrr_agg ON equals(revenue_agg.group_key, mrr_agg.group_key))
+     GROUP BY group_key) AS groups__revenue_analytics ON equals(groups.groups___key, groups__revenue_analytics.group_key)
   WHERE equals(groups.key, 'lolol0:xxx')
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
                      readonly=2,
@@ -2506,33 +2738,39 @@
               groups.group_key) AS groups
   LEFT JOIN
     (SELECT 99999 AS team_id,
-            revenue_analytics_customer__groups.key AS group_key,
-            sum(coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)'))) AS revenue,
-            sum(coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
+            group_key AS group_key,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT *
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_customer_revenue_view/stripe.posthog_test.customer_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
-     LEFT JOIN
-       (SELECT groups.key AS key,
-               key AS revenue_analytics_customer__groups___key
+       (SELECT 99999 AS team_id,
+               revenue_analytics_customer__groups.key AS group_key,
+               sum(coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)'))) AS revenue,
+               sum(coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
         FROM
-          (SELECT groups.group_type_index AS index,
-                  groups.group_key AS key
-           FROM groups
-           WHERE equals(groups.team_id, 99999)
-           GROUP BY groups.group_type_index,
-                    groups.group_key) AS groups) AS revenue_analytics_customer__groups ON equals(revenue_analytics_customer.email, revenue_analytics_customer__groups.revenue_analytics_customer__groups___key)
-     LEFT JOIN
-       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_revenue_item_revenue_view/stripe.posthog_test.revenue_item_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
-        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-     LEFT JOIN
-       (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
-               sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_mrr_revenue_view/stripe.posthog_test.mrr_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `stripe.posthog_test.mrr_revenue_view`
-        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)
-     WHERE notEmpty(group_key)
+          (SELECT *
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_customer_revenue_view/stripe.posthog_test.customer_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
+        LEFT JOIN
+          (SELECT groups.key AS key,
+                  key AS revenue_analytics_customer__groups___key
+           FROM
+             (SELECT groups.group_type_index AS index,
+                     groups.group_key AS key
+              FROM groups
+              WHERE equals(groups.team_id, 99999)
+              GROUP BY groups.group_type_index,
+                       groups.group_key) AS groups) AS revenue_analytics_customer__groups ON equals(revenue_analytics_customer.email, revenue_analytics_customer__groups.revenue_analytics_customer__groups___key)
+        LEFT JOIN
+          (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_revenue_item_revenue_view/stripe.posthog_test.revenue_item_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
+           GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+        LEFT JOIN
+          (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
+                  sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_mrr_revenue_view/stripe.posthog_test.mrr_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `stripe.posthog_test.mrr_revenue_view`
+           GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)
+        WHERE notEmpty(group_key)
+        GROUP BY group_key)
      GROUP BY group_key) AS groups__revenue_analytics ON equals(groups.groups___key, groups__revenue_analytics.group_key)
   ORDER BY groups.key ASC
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
@@ -2564,33 +2802,39 @@
               groups.group_key) AS groups
   LEFT JOIN
     (SELECT 99999 AS team_id,
-            revenue_analytics_customer__groups.key AS group_key,
-            sum(coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)'))) AS revenue,
-            sum(coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
+            group_key AS group_key,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT *
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_customer_revenue_view/stripe.posthog_test.customer_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
-     LEFT JOIN
-       (SELECT groups.key AS key,
-               key AS revenue_analytics_customer__groups___key
+       (SELECT 99999 AS team_id,
+               revenue_analytics_customer__groups.key AS group_key,
+               sum(coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)'))) AS revenue,
+               sum(coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
         FROM
-          (SELECT groups.group_type_index AS index,
-                  groups.group_key AS key
-           FROM groups
-           WHERE equals(groups.team_id, 99999)
-           GROUP BY groups.group_type_index,
-                    groups.group_key) AS groups) AS revenue_analytics_customer__groups ON equals(revenue_analytics_customer.id, revenue_analytics_customer__groups.revenue_analytics_customer__groups___key)
-     LEFT JOIN
-       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_revenue_item_revenue_view/stripe.posthog_test.revenue_item_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
-        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-     LEFT JOIN
-       (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
-               sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_mrr_revenue_view/stripe.posthog_test.mrr_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `stripe.posthog_test.mrr_revenue_view`
-        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)
-     WHERE notEmpty(group_key)
+          (SELECT *
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_customer_revenue_view/stripe.posthog_test.customer_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
+        LEFT JOIN
+          (SELECT groups.key AS key,
+                  key AS revenue_analytics_customer__groups___key
+           FROM
+             (SELECT groups.group_type_index AS index,
+                     groups.group_key AS key
+              FROM groups
+              WHERE equals(groups.team_id, 99999)
+              GROUP BY groups.group_type_index,
+                       groups.group_key) AS groups) AS revenue_analytics_customer__groups ON equals(revenue_analytics_customer.id, revenue_analytics_customer__groups.revenue_analytics_customer__groups___key)
+        LEFT JOIN
+          (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_revenue_item_revenue_view/stripe.posthog_test.revenue_item_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
+           GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+        LEFT JOIN
+          (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
+                  sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_mrr_revenue_view/stripe.posthog_test.mrr_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `stripe.posthog_test.mrr_revenue_view`
+           GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)
+        WHERE notEmpty(group_key)
+        GROUP BY group_key)
      GROUP BY group_key) AS groups__revenue_analytics ON equals(groups.groups___key, groups__revenue_analytics.group_key)
   ORDER BY groups.key ASC
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
@@ -2622,33 +2866,39 @@
               groups.group_key) AS groups
   LEFT JOIN
     (SELECT 99999 AS team_id,
-            revenue_analytics_customer__groups.key AS group_key,
-            sum(coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)'))) AS revenue,
-            sum(coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
+            group_key AS group_key,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT *
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_customer_revenue_view/stripe.posthog_test.customer_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
-     LEFT JOIN
-       (SELECT groups.key AS key,
-               key AS revenue_analytics_customer__groups___key
+       (SELECT 99999 AS team_id,
+               revenue_analytics_customer__groups.key AS group_key,
+               sum(coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)'))) AS revenue,
+               sum(coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
         FROM
-          (SELECT groups.group_type_index AS index,
-                  groups.group_key AS key
-           FROM groups
-           WHERE equals(groups.team_id, 99999)
-           GROUP BY groups.group_type_index,
-                    groups.group_key) AS groups) AS revenue_analytics_customer__groups ON equals(revenue_analytics_customer.id, revenue_analytics_customer__groups.revenue_analytics_customer__groups___key)
-     LEFT JOIN
-       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_revenue_item_revenue_view/stripe.posthog_test.revenue_item_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
-        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-     LEFT JOIN
-       (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
-               sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_mrr_revenue_view/stripe.posthog_test.mrr_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `stripe.posthog_test.mrr_revenue_view`
-        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)
-     WHERE notEmpty(group_key)
+          (SELECT *
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_customer_revenue_view/stripe.posthog_test.customer_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
+        LEFT JOIN
+          (SELECT groups.key AS key,
+                  key AS revenue_analytics_customer__groups___key
+           FROM
+             (SELECT groups.group_type_index AS index,
+                     groups.group_key AS key
+              FROM groups
+              WHERE equals(groups.team_id, 99999)
+              GROUP BY groups.group_type_index,
+                       groups.group_key) AS groups) AS revenue_analytics_customer__groups ON equals(revenue_analytics_customer.id, revenue_analytics_customer__groups.revenue_analytics_customer__groups___key)
+        LEFT JOIN
+          (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_revenue_item_revenue_view/stripe.posthog_test.revenue_item_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
+           GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+        LEFT JOIN
+          (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
+                  sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_mrr_revenue_view/stripe.posthog_test.mrr_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `stripe.posthog_test.mrr_revenue_view`
+           GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)
+        WHERE notEmpty(group_key)
+        GROUP BY group_key)
      GROUP BY group_key) AS groups__revenue_analytics ON equals(groups.groups___key, groups__revenue_analytics.group_key)
   ORDER BY groups.key ASC
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
@@ -2681,33 +2931,39 @@
               groups.group_key) AS groups
   LEFT JOIN
     (SELECT 99999 AS team_id,
-            revenue_analytics_customer__groups.key AS group_key,
-            sum(coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)'))) AS revenue,
-            sum(coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
+            group_key AS group_key,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT *
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_customer_revenue_view/stripe.posthog_test.customer_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
-     LEFT JOIN
-       (SELECT groups.key AS key,
-               key AS revenue_analytics_customer__groups___key
+       (SELECT 99999 AS team_id,
+               revenue_analytics_customer__groups.key AS group_key,
+               sum(coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)'))) AS revenue,
+               sum(coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
         FROM
-          (SELECT groups.group_type_index AS index,
-                  groups.group_key AS key
-           FROM groups
-           WHERE equals(groups.team_id, 99999)
-           GROUP BY groups.group_type_index,
-                    groups.group_key) AS groups) AS revenue_analytics_customer__groups ON equals(JSONExtractString(revenue_analytics_customer.metadata, 'id'), revenue_analytics_customer__groups.revenue_analytics_customer__groups___key)
-     LEFT JOIN
-       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_revenue_item_revenue_view/stripe.posthog_test.revenue_item_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
-        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-     LEFT JOIN
-       (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
-               sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_mrr_revenue_view/stripe.posthog_test.mrr_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `stripe.posthog_test.mrr_revenue_view`
-        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)
-     WHERE notEmpty(group_key)
+          (SELECT *
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_customer_revenue_view/stripe.posthog_test.customer_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
+        LEFT JOIN
+          (SELECT groups.key AS key,
+                  key AS revenue_analytics_customer__groups___key
+           FROM
+             (SELECT groups.group_type_index AS index,
+                     groups.group_key AS key
+              FROM groups
+              WHERE equals(groups.team_id, 99999)
+              GROUP BY groups.group_type_index,
+                       groups.group_key) AS groups) AS revenue_analytics_customer__groups ON equals(JSONExtractString(revenue_analytics_customer.metadata, 'id'), revenue_analytics_customer__groups.revenue_analytics_customer__groups___key)
+        LEFT JOIN
+          (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_revenue_item_revenue_view/stripe.posthog_test.revenue_item_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
+           GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+        LEFT JOIN
+          (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
+                  sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_mrr_revenue_view/stripe.posthog_test.mrr_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `stripe.posthog_test.mrr_revenue_view`
+           GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)
+        WHERE notEmpty(group_key)
+        GROUP BY group_key)
      GROUP BY group_key) AS groups__revenue_analytics ON equals(groups.groups___key, groups__revenue_analytics.group_key)
   ORDER BY groups.key ASC
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
@@ -2732,29 +2988,35 @@
          groups_revenue_analytics.mrr AS mrr
   FROM
     (SELECT 99999 AS team_id,
-            coalesce(revenue_agg.group_key, mrr_agg.group_key) AS group_key,
-            coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
-            coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+            group_key AS group_key,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT arrayJoin([revenue_analytics_revenue_item.group_0_key, revenue_analytics_revenue_item.group_1_key, revenue_analytics_revenue_item.group_2_key, revenue_analytics_revenue_item.group_3_key, revenue_analytics_revenue_item.group_4_key]) AS group_key,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_revenue_item_events_revenue_view/revenue_analytics.events.purchase.revenue_item_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
-        WHERE notEmpty(group_key)
-        GROUP BY group_key) AS revenue_agg
-     FULL OUTER JOIN
-       (SELECT customer_to_group.group_key AS group_key,
-               sum(coalesce(mrr_by_customer.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
+       (SELECT 99999 AS team_id,
+               coalesce(revenue_agg.group_key, mrr_agg.group_key) AS group_key,
+               coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+               coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
         FROM
-          (SELECT DISTINCT revenue_analytics_revenue_item.customer_id AS customer_id,
-                           arrayJoin([revenue_analytics_revenue_item.group_0_key, revenue_analytics_revenue_item.group_1_key, revenue_analytics_revenue_item.group_2_key, revenue_analytics_revenue_item.group_3_key, revenue_analytics_revenue_item.group_4_key]) AS group_key
+          (SELECT arrayJoin([revenue_analytics_revenue_item.group_0_key, revenue_analytics_revenue_item.group_1_key, revenue_analytics_revenue_item.group_2_key, revenue_analytics_revenue_item.group_3_key, revenue_analytics_revenue_item.group_4_key]) AS group_key,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
            FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_revenue_item_events_revenue_view/revenue_analytics.events.purchase.revenue_item_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
-           WHERE notEmpty(group_key)) AS customer_to_group
-        LEFT JOIN
-          (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
-                  sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
-           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_mrr_events_revenue_view/revenue_analytics.events.purchase.mrr_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
-           GROUP BY customer_id) AS mrr_by_customer ON equals(customer_to_group.customer_id, mrr_by_customer.customer_id)
-        GROUP BY group_key) AS mrr_agg ON equals(revenue_agg.group_key, mrr_agg.group_key)) AS groups_revenue_analytics
+           WHERE notEmpty(group_key)
+           GROUP BY group_key) AS revenue_agg
+        FULL OUTER JOIN
+          (SELECT customer_to_group.group_key AS group_key,
+                  sum(coalesce(mrr_by_customer.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
+           FROM
+             (SELECT DISTINCT revenue_analytics_revenue_item.customer_id AS customer_id,
+                              arrayJoin([revenue_analytics_revenue_item.group_0_key, revenue_analytics_revenue_item.group_1_key, revenue_analytics_revenue_item.group_2_key, revenue_analytics_revenue_item.group_3_key, revenue_analytics_revenue_item.group_4_key]) AS group_key
+              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_revenue_item_events_revenue_view/revenue_analytics.events.purchase.revenue_item_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
+              WHERE notEmpty(group_key)) AS customer_to_group
+           LEFT JOIN
+             (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
+                     sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
+              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_mrr_events_revenue_view/revenue_analytics.events.purchase.mrr_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+              GROUP BY customer_id) AS mrr_by_customer ON equals(customer_to_group.customer_id, mrr_by_customer.customer_id)
+           GROUP BY group_key) AS mrr_agg ON equals(revenue_agg.group_key, mrr_agg.group_key))
+     GROUP BY group_key) AS groups_revenue_analytics
   ORDER BY groups_revenue_analytics.group_key ASC
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
                      readonly=2,
@@ -2778,33 +3040,39 @@
          groups_revenue_analytics.mrr AS mrr
   FROM
     (SELECT 99999 AS team_id,
-            revenue_analytics_customer__groups.key AS group_key,
-            sum(coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)'))) AS revenue,
-            sum(coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
+            group_key AS group_key,
+            sum(revenue) AS revenue,
+            sum(mrr) AS mrr
      FROM
-       (SELECT *
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_customer_revenue_view/stripe.posthog_test.customer_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
-     LEFT JOIN
-       (SELECT groups.key AS key,
-               key AS revenue_analytics_customer__groups___key
+       (SELECT 99999 AS team_id,
+               revenue_analytics_customer__groups.key AS group_key,
+               sum(coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)'))) AS revenue,
+               sum(coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)'))) AS mrr
         FROM
-          (SELECT groups.group_type_index AS index,
-                  groups.group_key AS key
-           FROM groups
-           WHERE equals(groups.team_id, 99999)
-           GROUP BY groups.group_type_index,
-                    groups.group_key) AS groups) AS revenue_analytics_customer__groups ON equals(revenue_analytics_customer.id, revenue_analytics_customer__groups.revenue_analytics_customer__groups___key)
-     LEFT JOIN
-       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
-               sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_revenue_item_revenue_view/stripe.posthog_test.revenue_item_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
-        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
-     LEFT JOIN
-       (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
-               sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
-        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_mrr_revenue_view/stripe.posthog_test.mrr_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `stripe.posthog_test.mrr_revenue_view`
-        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)
-     WHERE notEmpty(group_key)
+          (SELECT *
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_customer_revenue_view/stripe.posthog_test.customer_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
+        LEFT JOIN
+          (SELECT groups.key AS key,
+                  key AS revenue_analytics_customer__groups___key
+           FROM
+             (SELECT groups.group_type_index AS index,
+                     groups.group_key AS key
+              FROM groups
+              WHERE equals(groups.team_id, 99999)
+              GROUP BY groups.group_type_index,
+                       groups.group_key) AS groups) AS revenue_analytics_customer__groups ON equals(revenue_analytics_customer.id, revenue_analytics_customer__groups.revenue_analytics_customer__groups___key)
+        LEFT JOIN
+          (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                  sum(revenue_analytics_revenue_item.amount) AS revenue
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_revenue_item_revenue_view/stripe.posthog_test.revenue_item_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
+           GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+        LEFT JOIN
+          (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
+                  sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_mrr_revenue_view/stripe.posthog_test.mrr_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `stripe.posthog_test.mrr_revenue_view`
+           GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)
+        WHERE notEmpty(group_key)
+        GROUP BY group_key)
      GROUP BY group_key) AS groups_revenue_analytics
   ORDER BY groups_revenue_analytics.mrr DESC
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,

--- a/posthog/hogql/database/schema/test/test_groups_revenue_analytics.py
+++ b/posthog/hogql/database/schema/test/test_groups_revenue_analytics.py
@@ -401,6 +401,68 @@ class TestGroupsRevenueAnalytics(TestGroupsRevenueAnalyticsMixin):
                 [(self.group0_id, Decimal("350.42"), Decimal("257.23"))],
             )
 
+    def test_revenue_aggregated_per_group_across_event_and_warehouse_sources(self):
+        self.create_sources()
+        self.team.base_currency = CurrencyCode.GBP.value
+        self.team.save()
+
+        # The join maps a warehouse customer id onto a group key. No group type mappings here: a
+        # mapping created now empties the group key of every older event, which would silence the
+        # event source and hide the very overlap this test is about.
+        DataWarehouseJoin.objects.create(
+            team=self.team,
+            source_table_name=f"stripe.posthog_test.{SCHEMA.source_suffix}",
+            source_table_key="id",
+            joining_table_name="groups",
+            joining_table_key="key",
+            field_name="groups",
+        )
+
+        self.setup_events_with_subscriptions()
+        self.team.revenue_analytics_config.events = [
+            RevenueAnalyticsEventItem(
+                eventName=self.PURCHASE_EVENT_NAME,
+                revenueProperty=self.REVENUE_PROPERTY,
+                revenueCurrencyProperty=RevenueCurrencyPropertyConfig(static="USD"),
+                currencyAwareDecimal=True,
+                subscriptionProperty=self.SUBSCRIPTION_PROPERTY,
+                subscriptionDropoffMode=SubscriptionDropoffMode.AFTER_DROPOFF_PERIOD,
+            )
+        ]
+        self.team.revenue_analytics_config.save()
+        self.team.save()
+
+        # `cus_1` earns revenue in both sources, so each leg of the UNION ALL holds a row for it
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="cus_1")
+        _create_event(
+            event=self.PURCHASE_EVENT_NAME,
+            team=self.team,
+            distinct_id=self.DISTINCT_ID,
+            timestamp=self.EVENT_TIMESTAMP,
+            properties={
+                self.REVENUE_PROPERTY: 20000,
+                "$group_0": "cus_1",
+                self.SUBSCRIPTION_PROPERTY: "sub_cus_1",
+            },
+        )
+
+        with freeze_time(self.QUERY_TIMESTAMP):
+            response = execute_hogql_query(
+                parse_select(
+                    "SELECT key, $virt_revenue, $virt_mrr FROM groups WHERE key = {key}",
+                    placeholders={"key": ast.Constant(value="cus_1")},
+                ),
+                self.team,
+                user=self.user,
+                modifiers=self.MODIFIERS,
+            )
+
+            # Event source 159.4 + warehouse source 283.8496260553, and the same for MRR
+            self.assertEqual(
+                response.results,
+                [("cus_1", Decimal("443.2496260553"), Decimal("387.3754547238"))],
+            )
+
     def test_query_revenue_analytics_table_sources(self):
         self.setup_schema_sources()
         self.join.source_table_key = "id"

--- a/posthog/hogql_queries/actor_strategies.py
+++ b/posthog/hogql_queries/actor_strategies.py
@@ -52,6 +52,10 @@ class ActorStrategy:
     def filter_conditions(self) -> list[ast.Expr]:
         return []
 
+    def origin_join_conditions(self) -> list[ast.Expr]:
+        """Extra `ON` conditions for the join between the source query and the origin table."""
+        return []
+
     def order_by(self) -> Optional[list[ast.OrderExpr]]:
         return None
 
@@ -217,6 +221,17 @@ class GroupStrategy(ActorStrategy):
 
     def input_columns(self) -> list[str]:
         return ["group"]
+
+    def origin_join_conditions(self) -> list[ast.Expr]:
+        # `groups` holds every group type of the team, so a key alone matches the same key under
+        # another group type and returns one duplicate row per extra type.
+        return [
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.Eq,
+                left=ast.Field(chain=[self.origin, "index"]),
+                right=ast.Constant(value=self.group_type_index),
+            )
+        ]
 
     def filter_conditions(self) -> list[ast.Expr]:
         where_exprs: list[ast.Expr] = []

--- a/posthog/hogql_queries/actors_query_runner.py
+++ b/posthog/hogql_queries/actors_query_runner.py
@@ -549,6 +549,10 @@ class ActorsQueryRunner(AnalyticsQueryRunner[ActorsQueryResponse]):
                         ]
                     )
 
+                origin_join_conditions = self.strategy.origin_join_conditions()
+                if origin_join_conditions:
+                    join_on = ast.And(exprs=[join_on, *origin_join_conditions])
+
                 # remove id, which now comes from the origin
                 for source in (
                     [source_query] if isinstance(source_query, ast.SelectQuery) else source_query.select_queries()

--- a/posthog/hogql_queries/test/__snapshots__/test_insight_actors_query_runner.ambr
+++ b/posthog/hogql_queries/test/__snapshots__/test_insight_actors_query_runner.ambr
@@ -44,7 +44,7 @@
         FROM groups
         WHERE equals(groups.team_id, 99999)
         GROUP BY groups.group_type_index,
-                 groups.group_key) AS groups ON equals(groups.key, source.actor_id)
+                 groups.group_key) AS groups ON and(equals(groups.key, source.actor_id), equals(groups.index, 0))
      ORDER BY groups.properties___name ASC SETTINGS optimize_aggregation_in_order=1,
                                                     join_algorithm='auto')
   LIMIT 100 SETTINGS readonly=2,

--- a/posthog/hogql_queries/test/test_actors_query_runner.py
+++ b/posthog/hogql_queries/test/test_actors_query_runner.py
@@ -728,6 +728,51 @@ class TestActorsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         assert group["id"] == "org2"
         assert set(group.keys()) == {"id", "group_type_index"}
 
+    def test_group_actors_query_with_key_reused_by_another_group_type(self):
+        for group_type_index, group_type in ((0, "organization"), (1, "company")):
+            create_group_type_mapping_without_created_at(
+                team=self.team,
+                project_id=self.team.project_id,
+                group_type=group_type,
+                group_type_index=group_type_index,
+            )
+            create_group(
+                team_id=self.team.pk,
+                group_type_index=group_type_index,
+                group_key="org1",
+                properties={"name": "org1.inc"},
+            )
+
+        _create_person(team=self.team, distinct_ids=["user1"], properties={})
+        _create_event(
+            team=self.team,
+            event="pageview",
+            distinct_id="user1",
+            properties={"$group_0": "org1"},
+            timestamp="2023-01-01T12:00:00Z",
+        )
+
+        flush_persons_and_events()
+
+        runner = self._create_runner(
+            ActorsQuery(
+                # `properties` only exists on the groups table, so this joins the source query with it
+                select=["group", "event_count", "properties.name"],
+                source=InsightActorsQuery(
+                    source=TrendsQuery(
+                        dateRange=DateRange(date_from="2023-01-01", date_to="2023-01-01"),
+                        interval=IntervalType.DAY,
+                        series=[EventsNode(event="pageview", math="unique_group", math_group_type_index=0)],
+                    ),
+                    series=0,
+                    day="2023-01-01T12:00:00Z",
+                ),
+            )
+        )
+        response = runner.calculate()
+
+        assert [(row[0]["id"], row[1]) for row in response.results] == [("org1", 1)]
+
     @patch("posthog.hogql_queries.paginators.execute_hogql_query", wraps=execute_hogql_query)
     def test_funnel_source_with_poe_mode(self, spy_execute_hogql_query):
         self.team.modifiers = {

--- a/posthog/hogql_queries/test/test_actors_query_runner.py
+++ b/posthog/hogql_queries/test/test_actors_query_runner.py
@@ -43,6 +43,7 @@ from posthog.hogql.visitor import clear_locations
 
 from posthog.clickhouse.client import sync_execute
 from posthog.hogql_queries.actors_query_runner import ActorsQueryRunner
+from posthog.models.filters.utils import GroupTypeIndex
 from posthog.models.group.util import create_group
 from posthog.models.utils import UUIDT
 from posthog.test.test_utils import create_group_type_mapping_without_created_at
@@ -729,7 +730,8 @@ class TestActorsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         assert set(group.keys()) == {"id", "group_type_index"}
 
     def test_group_actors_query_with_key_reused_by_another_group_type(self):
-        for group_type_index, group_type in ((0, "organization"), (1, "company")):
+        group_types: list[tuple[GroupTypeIndex, str]] = [(0, "organization"), (1, "company")]
+        for group_type_index, group_type in group_types:
             create_group_type_mapping_without_created_at(
                 team=self.team,
                 project_id=self.team.project_id,

--- a/products/product_analytics/backend/hogql_queries/stickiness/test/__snapshots__/test_stickiness_insight_actors.ambr
+++ b/products/product_analytics/backend/hogql_queries/stickiness/test/__snapshots__/test_stickiness_insight_actors.ambr
@@ -26,7 +26,7 @@
         FROM groups
         WHERE equals(groups.team_id, 99999)
         GROUP BY groups.group_type_index,
-                 groups.group_key) AS groups ON equals(groups.key, source.group_key)
+                 groups.group_key) AS groups ON and(equals(groups.key, source.group_key), equals(groups.index, 0))
      ORDER BY groups.properties___name ASC SETTINGS optimize_aggregation_in_order=1,
                                                     join_algorithm='auto')
   LIMIT 100 SETTINGS readonly=2,


### PR DESCRIPTION
## Problem

A group shows up twice in a group list, so a customer analytics dashboard reads as if the project holds duplicate groups. Two separate defects produce that same row, and both need a column that reads group data, which the MRR and Lifetime value columns of the power users table do.

- The actors query joins the source query to `groups` on the group key alone. `groups` holds every group type of a project, so a key that exists under two group types matches once per type.
- `groups_revenue_analytics` returns the `UNION ALL` of one query per revenue source. A group that earns revenue in two sources holds two rows there, so the join to it fans out.

The second defect also reports the wrong money. Each duplicate row carries the MRR of one source instead of the total of all of them.

## Changes

- A group list returns one row per group again, and its counts stop being repeated.
- A group that earns revenue in several sources now reports the total of all of them in `$virt_mrr` and `$virt_revenue`.
- `GroupStrategy.origin_join_conditions()` adds `groups.index = <group type index>` to the join. The condition sits on the join rather than in `filter_conditions()`, because a `WHERE` also runs on the join-free path, where `groups.index` does not resolve, and that would push every group actors query through the groups join.
- `groups_revenue_analytics` wraps the union in an aggregation by group key. This mirrors what `persons_revenue_analytics` already does per person.
- Mechanical: 21 SQL snapshots now carry the extra join condition or the extra aggregation.

Nothing looks different for a project whose group keys belong to one group type and whose groups earn revenue in at most one source, so there is no screenshot to add.

## How did you test this code?

Each fix has a test that fails without it.

- `test_group_actors_query_with_key_reused_by_another_group_type`: one key registered under two group types returns one row. It selects `properties.name`, which is what forces the groups join. Without the fix the group comes back twice.
- `test_revenue_aggregated_per_group_across_event_and_warehouse_sources`: a group with revenue in both an event source and a warehouse source returns one row holding both sources' revenue and MRR. Without the fix it returns two rows, one per source. No existing groups test configured two sources at once, which is why the defect survived.
- Ran locally: the actors query runner, insight actors, stickiness, trends and funnel actors suites, both revenue analytics schema suites, the groups schema suite, and the MRR view suite.
- Not checked: the customer analytics scene in a browser.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by Claude Opus 5 in PostHog Desktop. Skills invoked: `/writing-tests`, `/announcing-behavior-changes`, `/writing-pr-descriptions`.
- The first commit fixed the group type join only. A review question, "are there other causes?", turned up the revenue source fan-out, which a two-source test then reproduced.
- A first attempt at that test created group type mappings after the events. A mapping empties the group key of every older event, which silenced the event source and hid the overlap. The test now leaves the mappings out and says why.
- `/announcing-behavior-changes` says no in-app notice: duplicate rows that stop appearing need no explanation. The MRR change moves a number up for affected projects, from one source to all sources, which the changelog can carry.
- Neither fix helps a project that wants its own numeric group property in the MRR column. That column reads revenue analytics only, and the feature request stands.
- The report behind this came from a user message. Nothing from it reaches the diff, and the test data is invented.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
