### PR TITLE
fix(hogql): publish release aliases locally

### DIFF
--- a/.github/workflows/cd-hogql-lang-service-image.yml
+++ b/.github/workflows/cd-hogql-lang-service-image.yml
@@ -36,29 +36,22 @@ jobs:
             - name: Check out
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
-                  sparse-checkout: services/hogql-language-service/
+                  sparse-checkout: |
+                      services/hogql-language-service/
+                      .github/actions/docker-meta/
                   sparse-checkout-cone-mode: false
 
-            - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
-              with:
-                  role-to-assume: ${{ vars.AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE }}
-                  aws-region: us-east-1
-
-            - name: Login to Amazon ECR
-              id: aws-ecr
-              uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
-
-            - name: Image metadata and ordered release tag
+            - name: Docker meta and registry login
               id: docker-meta
-              uses: PostHog/shared-actions/container-image-metadata@2427cf9968667894226f164eab356d96ca930b22 # v1, shared-actions#51
+              uses: ./.github/actions/docker-meta
               with:
-                  images: ${{ steps.aws-ecr.outputs.registry }}/hogql-lang-service
-                  extra-tags: |
-                      type=ref,event=branch
-                      type=raw,value=${{ github.sha }}
-                      type=raw,value=latest,enable={{is_default_branch}}
-                  generate-ordered-release-tag: 'true'
+                  image-name: hogql-lang-service
+                  aws-role-to-assume: ${{ vars.AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  dockerhub-username: ${{ secrets.DOCKERHUB_USER }}
+                  dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
+                  push-to-ghcr: 'false'
+                  push-to-dockerhub: 'false'
 
             - name: Set up Depot CLI
               uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1.7.1
@@ -78,14 +71,145 @@ jobs:
                   platforms: linux/arm64,linux/amd64
                   build-args: COMMIT_HASH=${{ github.sha }}
 
-            - name: Publish ordered release tag
-              if: vars.CD_DEPLOY_ENABLED == 'true'
-              uses: PostHog/shared-actions/container-image-metadata@2427cf9968667894226f164eab356d96ca930b22 # v1, shared-actions#51
+    ordered_image_alias:
+        name: Publish ordered image alias
+        needs: build
+        if: ${{ needs.build.result == 'success' && github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true' && vars.ORDERED_IMAGE_ALIAS_PAUSED != 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+        runs-on: ubuntu-24.04
+        timeout-minutes: 5
+        continue-on-error: true
+        permissions:
+            id-token: write
+            contents: read
+
+        steps:
+            - name: Check out
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+            - name: Compute ordered release tag
+              id: ordered-release
+              timeout-minutes: 2
+              shell: bash
+              env:
+                  ORDERED_RELEASE_TAG_REGEX: ^r[0-9]{12}-[0-9a-f]{6}$
+              run: |
+                  set -uo pipefail
+
+                  if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+                      fetch_status=0
+                      timeout --kill-after=10s 90s git fetch \
+                          --no-tags \
+                          --prune \
+                          --no-recurse-submodules \
+                          --unshallow \
+                          --filter=tree:0 \
+                          origin \
+                          "+${GITHUB_REF}:refs/remotes/origin/${GITHUB_REF_NAME}" || fetch_status=$?
+                      if [ "$fetch_status" -ne 0 ]; then
+                          echo "::warning title=Ordered release tag skipped::Source history could not be fetched (status $fetch_status)."
+                          exit 0
+                      fi
+                  fi
+
+                  if [ "$(git rev-parse --is-shallow-repository 2>/dev/null)" != "false" ]; then
+                      echo "::warning title=Ordered release tag skipped::Complete source history is unavailable."
+                      exit 0
+                  fi
+
+                  if ! head_revision="$(git rev-parse HEAD)" || [ "$head_revision" != "$GITHUB_SHA" ]; then
+                      echo "::warning title=Ordered release tag skipped::The checked-out revision does not match GITHUB_SHA."
+                      exit 0
+                  fi
+
+                  if ! position="$(git rev-list --first-parent --count "$GITHUB_SHA")"; then
+                      echo "::warning title=Ordered release tag skipped::The source position could not be computed."
+                      exit 0
+                  fi
+
+                  if ! [[ "$position" =~ ^[1-9][0-9]{0,11}$ ]]; then
+                      echo "::warning title=Ordered release tag skipped::The source position is out of range."
+                      exit 0
+                  fi
+
+                  if ! printf -v tag 'r%012d-%.6s' "$position" "$GITHUB_SHA"; then
+                      echo "::warning title=Ordered release tag skipped::The source position could not be formatted."
+                      exit 0
+                  fi
+
+                  if ! [[ "$tag" =~ $ORDERED_RELEASE_TAG_REGEX ]]; then
+                      echo "::warning title=Ordered release tag skipped::${tag} does not match the required format."
+                      exit 0
+                  fi
+
+                  echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
+            - name: Warn when ordered image alias tag is unavailable
+              if: ${{ steps.ordered-release.outputs.tag == '' }}
+              shell: bash
+              run: echo "::warning title=Ordered image alias tag unavailable::Ordered image alias publication was skipped because no ordered release tag was generated."
+
+            - name: Set up Docker Buildx for ordered image alias
+              if: ${{ steps.ordered-release.outputs.tag != '' }}
+              uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+            - name: Configure AWS credentials for ordered image alias
+              if: ${{ steps.ordered-release.outputs.tag != '' }}
+              uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
               with:
-                  images: ${{ steps.aws-ecr.outputs.registry }}/hogql-lang-service
-                  publish-ordered-release-tag: 'true'
-                  ordered-release-tag: ${{ steps.docker-meta.outputs.ordered-release-tag }}
-                  ordered-release-digest: ${{ steps.push.outputs.digest }}
+                  role-to-assume: ${{ vars.AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE }}
+                  aws-region: us-east-1
+
+            - name: Log in to Amazon ECR for ordered image alias
+              if: ${{ steps.ordered-release.outputs.tag != '' }}
+              id: ecr-login
+              uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
+
+            - name: Publish and read back ordered image alias
+              if: ${{ steps.ordered-release.outputs.tag != '' }}
+              timeout-minutes: 2
+              shell: bash
+              env:
+                  ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+                  ECR_REPO: hogql-lang-service
+                  EXPECTED_DIGEST: ${{ needs.build.outputs.sha }}
+                  ORDERED_ALIAS: ${{ steps.ordered-release.outputs.tag }}
+              run: |
+                  set -uo pipefail
+
+                  if [ -z "$EXPECTED_DIGEST" ]; then
+                      echo "::warning title=Ordered image alias source digest unavailable::Ordered image alias publication was skipped because no image digest was resolved."
+                      exit 0
+                  fi
+
+                  SOURCE_IMAGE="${ECR_REGISTRY}/${ECR_REPO}@${EXPECTED_DIGEST}"
+                  TARGET_IMAGE="${ECR_REGISTRY}/${ECR_REPO}:${ORDERED_ALIAS}"
+
+                  publication_status=0
+                  timeout --kill-after=5s 40s docker buildx imagetools create \
+                      --prefer-index=false \
+                      --tag "$TARGET_IMAGE" \
+                      "$SOURCE_IMAGE" || publication_status=$?
+                  if [ "$publication_status" -ne 0 ]; then
+                      echo "::warning::Ordered alias publication exited with status $publication_status"
+                  fi
+
+                  resolved_digest="$(timeout --kill-after=5s 40s aws ecr batch-get-image \
+                      --repository-name "$ECR_REPO" \
+                      --image-ids imageTag="$ORDERED_ALIAS" \
+                      --accepted-media-types \
+                          "application/vnd.oci.image.index.v1+json" \
+                          "application/vnd.docker.distribution.manifest.list.v2+json" \
+                          "application/vnd.oci.image.manifest.v1+json" \
+                          "application/vnd.docker.distribution.manifest.v2+json" \
+                      --query 'images[0].imageId.imageDigest' \
+                      --output text)"
+
+                  if [ "$resolved_digest" != "$EXPECTED_DIGEST" ]; then
+                      echo "::error title=Ordered image alias integrity mismatch::The ordered image alias does not resolve to the expected image digest."
+                      exit 1
+                  fi
+
+                  echo "::notice title=Ordered image alias present::The ordered image alias resolves to the expected image digest."
 
     deploy:
         name: Trigger HogQL language service deployment


### PR DESCRIPTION
* Request at 2026-09-09 23:35:11.055836395 +0000 UTC m=+0.019838665
* Request to https://api.github.com/graphql
* Request took 308.72636ms
## Problem

The HogQL language service remains unavailable because its image workflow cannot resolve the private shared action added by #97936.

The workflow fails before checkout, so it publishes no Kargo-compatible image and the rendered application path remains absent.

## Changes

- Publishes the ordered image alias with the same monorepo-local pattern used by existing Rust and PostHog image workflows.
- Keeps the existing language-service image build and OCI annotations unchanged.
- Computes the release order from first-parent history and binds the alias to the build digest.
- Reads the alias back from ECR and rejects a digest mismatch.
- Keeps alias publication best-effort and behind the established deploy and pause variables.

Before:

```mermaid
flowchart LR
    A[Workflow starts] --> B[Resolve private action]
    B --> C[Workflow fails]
    C --> D[No Kargo Freight]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    class A,B phBlue;
    class C,D phRed;
```

After:

```mermaid
flowchart LR
    A[Image build] --> B[Local alias job]
    B --> C[Ordered ECR tag]
    C --> D[Kargo Freight]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A,B phBlue;
    class C,D phYellow;
```

## How did you test this code?

- `hogli lint:workflows` passed all repository workflow checks.
- `git diff --check` passed.
- Live ECR publication remains unchecked because only the canonical master workflow has production credentials.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation change. This restores the image contract documented by the generated Kargo Warehouse.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex authored this PR using the CI workflow, CI debugging, production deploy gating, code-comment, and PR-description skills.

The failed master run proved that the shared action was inaccessible. Existing Rust and PostHog publishers established the local alias-job design. No duplicate follow-up PR was open.

