### PR TITLE
fix(csp): allow blob workers, and pin the reason they are safe

### DIFF
--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -85,6 +85,7 @@ jobs:
                       js:
                         - 'frontend/**'
                         - 'nodejs/**'
+                        - 'packages/**'
                         - 'services/agent-proxy/**'
                         - 'services/integration-service/**'
                         - 'services/mcp/**'
@@ -106,6 +107,7 @@ jobs:
                         - '!frontend/**'
                         - '!livestream/**'
                         - '!nodejs/**'
+                        - '!packages/**'
                         - '!posthog/**'
                         - '!products/**'
                         - '!rust/**'
@@ -293,6 +295,7 @@ jobs:
                       --config p/trailofbits
                       --include /frontend
                       --include /nodejs
+                      --include /packages
                       --include /services/agent-proxy
                       --include /services/integration-service
                       --include /services/mcp
@@ -378,6 +381,7 @@ jobs:
                       --exclude /frontend
                       --exclude /livestream
                       --exclude /nodejs
+                      --exclude /packages
                       --exclude /posthog
                       --exclude /products
                       --exclude /rust

--- a/.semgrep/rules/security/no-dynamic-worker-body.test.ts
+++ b/.semgrep/rules/security/no-dynamic-worker-body.test.ts
@@ -16,6 +16,26 @@ const d = new Worker('data:text/javascript;charset=utf-8,' + encodeURIComponent(
 // ruleid: no-dynamic-worker-body
 const e = new Worker(`data:text/javascript,${encodeURIComponent(body)}`)
 
+// Revoking an object URL needs it held in a variable, so this is the shape a developer
+// writes when the blob worker is written correctly.
+const objectUrl = URL.createObjectURL(new Blob([source]))
+// ruleid: no-dynamic-worker-body
+const k = new Worker(objectUrl)
+
+// ruleid: no-dynamic-worker-body
+const l = new Worker(URL.createObjectURL(blob))
+
+// ruleid: no-dynamic-worker-body
+const m = new Worker(globalThis.URL.createObjectURL(new Blob([source])))
+
+const dataUrl = 'data:text/javascript,' + encodeURIComponent(source)
+// ruleid: no-dynamic-worker-body
+const n = new Worker(dataUrl)
+
+const templatedDataUrl = `data:text/javascript,${encodeURIComponent(body)}`
+// ruleid: no-dynamic-worker-body
+const o = new Worker(templatedDataUrl)
+
 // A same-origin file. This is the shape every first-party worker in the app uses, and it
 // needs no blob: allowance.
 // ok: no-dynamic-worker-body
@@ -27,10 +47,20 @@ const g = new Worker('/static/decompressionWorker.js', { type: 'module' })
 // ok: no-dynamic-worker-body
 const h = new Worker(WORKER_URL, { type: 'module' })
 
-// A blob URL kept in a variable still reads as a file path here. The rule catches the
-// inline construction, which is the shape that lets input reach a worker body.
+// Nothing in scope puts a blob or a data URL in this variable, so there is no flow to
+// report. A worker URL that arrives from outside the file is not something this rule can
+// judge.
 // ok: no-dynamic-worker-body
 const i = new Worker(precomputedUrl)
+
+// A same-origin path assembled from a value. The scheme decides, not the concatenation,
+// so this stays clean.
+// ok: no-dynamic-worker-body
+const p = new Worker('/static/workers/' + workerName, { type: 'module' })
+
+// An interpolated worker name is not the worker body.
+// ok: no-dynamic-worker-body
+const q = new Worker(WORKER_URL, { name: `snapshot-${playerId}` })
 
 // Object URLs for downloads and previews are untouched: nothing runs them as code.
 // ok: no-dynamic-worker-body

--- a/.semgrep/rules/security/no-dynamic-worker-body.test.ts
+++ b/.semgrep/rules/security/no-dynamic-worker-body.test.ts
@@ -1,0 +1,37 @@
+// @ts-nocheck
+// Test fixture for the no-dynamic-worker-body rule.
+
+// ruleid: no-dynamic-worker-body
+const a = new Worker(URL.createObjectURL(new Blob([source], { type: 'application/javascript' })))
+
+// ruleid: no-dynamic-worker-body
+const b = new SharedWorker(URL.createObjectURL(new Blob([userSuppliedCode])))
+
+// ruleid: no-dynamic-worker-body
+const c = new Worker(window.URL.createObjectURL(new Blob([template, payload])), { name: 'thing' })
+
+// ruleid: no-dynamic-worker-body
+const d = new Worker('data:text/javascript;charset=utf-8,' + encodeURIComponent(source))
+
+// ruleid: no-dynamic-worker-body
+const e = new Worker(`data:text/javascript,${encodeURIComponent(body)}`)
+
+// A same-origin file. This is the shape every first-party worker in the app uses, and it
+// needs no blob: allowance.
+// ok: no-dynamic-worker-body
+const f = new Worker(new URL('./hogqlParser.worker.ts', import.meta.url), { type: 'module' })
+
+// ok: no-dynamic-worker-body
+const g = new Worker('/static/decompressionWorker.js', { type: 'module' })
+
+// ok: no-dynamic-worker-body
+const h = new Worker(WORKER_URL, { type: 'module' })
+
+// A blob URL kept in a variable still reads as a file path here. The rule catches the
+// inline construction, which is the shape that lets input reach a worker body.
+// ok: no-dynamic-worker-body
+const i = new Worker(precomputedUrl)
+
+// Object URLs for downloads and previews are untouched: nothing runs them as code.
+// ok: no-dynamic-worker-body
+const j = URL.createObjectURL(new Blob([csv], { type: 'text/csv' }))

--- a/.semgrep/rules/security/no-dynamic-worker-body.test.ts
+++ b/.semgrep/rules/security/no-dynamic-worker-body.test.ts
@@ -53,14 +53,25 @@ const h = new Worker(WORKER_URL, { type: 'module' })
 // ok: no-dynamic-worker-body
 const i = new Worker(precomputedUrl)
 
-// A same-origin path assembled from a value. The scheme decides, not the concatenation,
-// so this stays clean.
+// A same-origin path assembled from a value. The scheme decides, not the concatenation
+// or the interpolation, so all three of these stay clean.
 // ok: no-dynamic-worker-body
 const p = new Worker('/static/workers/' + workerName, { type: 'module' })
 
-// An interpolated worker name is not the worker body.
 // ok: no-dynamic-worker-body
-const q = new Worker(WORKER_URL, { name: `snapshot-${playerId}` })
+const q = new Worker(`/static/workers/${workerName}.js`, { type: 'module' })
+
+// ok: no-dynamic-worker-body
+const r = new Worker(`${STATIC_BASE}/decompressionWorker.js`, { type: 'module' })
+
+const interpolatedPath = `/static/workers/${workerName}.js`
+// ok: no-dynamic-worker-body
+const s = new Worker(interpolatedPath, { type: 'module' })
+
+// Only the URL argument counts. A blob URL somewhere else in the call is not the worker
+// body.
+// ok: no-dynamic-worker-body
+const t = new Worker('/static/decompressionWorker.js', { name: URL.createObjectURL(debugBlob) })
 
 // Object URLs for downloads and previews are untouched: nothing runs them as code.
 // ok: no-dynamic-worker-body

--- a/.semgrep/rules/security/no-dynamic-worker-body.yaml
+++ b/.semgrep/rules/security/no-dynamic-worker-body.yaml
@@ -1,5 +1,6 @@
 rules:
     - id: no-dynamic-worker-body
+      mode: taint
       message: |
           Worker body built from a value rather than a constant. The app policy allows
           `worker-src 'self' blob:`, and that allowance rests on every blob worker body
@@ -22,6 +23,11 @@ rules:
           A bundled library that ships its own blob worker is fine, because its body is a
           compile-time constant. This rule covers first-party code.
 
+          The rule follows an object URL or a `data:` URL through the assignments in one
+          function, so it catches the shapes we write. It does not follow a URL back out
+          of a helper function that returns one, and it cannot read the fixed part of a
+          template literal. Treat it as a check on first-party code, not as a proof.
+
           If a dynamic body is genuinely unavoidable, put `// nosemgrep: no-dynamic-worker-body`
           on the line before it with a reason, and state where the body comes from and why
           no input can reach it.
@@ -36,19 +42,32 @@ rules:
               - '**/*.test.ts'
               - '**/*.test.tsx'
               - '**/*.spec.ts'
-      patterns:
+      pattern-sources:
           - pattern-either:
-                # A Blob assembled inline, then handed straight to a worker.
-                - pattern: new $WORKER(URL.createObjectURL(new Blob(...)), ...)
-                - pattern: new $WORKER(window.URL.createObjectURL(new Blob(...)), ...)
-                # A `data:` or `blob:` worker URL concatenated or interpolated from a value.
-                - pattern: new $WORKER("..." + $X, ...)
+                # Every object URL is minted at run time, whatever the receiver is spelled
+                # as: `URL`, `window.URL`, `globalThis.URL`, or a destructured alias.
+                - pattern: createObjectURL(...)
+                - pattern: $RECEIVER.createObjectURL(...)
+                # A `data:` or `blob:` URL concatenated from a value. The scheme has to be
+                # in the leading literal, so `'/static/' + name` stays clean.
+                - patterns:
+                      - pattern: $SCHEME + $X
+                      - metavariable-regex:
+                            metavariable: $SCHEME
+                            regex: '^[''"`](data|blob):'
+                # Semgrep cannot constrain the fixed part of a template literal, so any
+                # interpolated worker URL is a source. Give a same-origin path a real
+                # string or a `new URL(...)` rather than an interpolation.
                 - pattern: |
-                      new $WORKER(`...${$X}...`, ...)
-          # Without this every `new Error(`...${x}...`)` in the tree matches.
-          - metavariable-regex:
-                metavariable: $WORKER
-                regex: ^(Worker|SharedWorker)$
+                      `...${$X}...`
+      # Only the URL argument is a sink. Without this, an interpolated worker name in the
+      # options object matches too.
+      pattern-sinks:
+          - patterns:
+                - pattern-either:
+                      - pattern: new Worker($URL, ...)
+                      - pattern: new SharedWorker($URL, ...)
+                - focus-metavariable: $URL
       metadata:
           category: security
           confidence: MEDIUM

--- a/.semgrep/rules/security/no-dynamic-worker-body.yaml
+++ b/.semgrep/rules/security/no-dynamic-worker-body.yaml
@@ -38,6 +38,10 @@ rules:
               - frontend/src
               - products
               - common
+              # The leading slash pins this to the repository root. The entries above
+              # stay unanchored because anchoring them would drop directories this rule
+              # scans today, such as `nodejs/src/common`.
+              - /packages
           exclude:
               - '**/*.test.ts'
               - '**/*.test.tsx'

--- a/.semgrep/rules/security/no-dynamic-worker-body.yaml
+++ b/.semgrep/rules/security/no-dynamic-worker-body.yaml
@@ -1,0 +1,56 @@
+rules:
+    - id: no-dynamic-worker-body
+      message: |
+          Worker body built from a value rather than a constant. The app policy allows
+          `worker-src 'self' blob:`, and that allowance rests on every blob worker body
+          being fixed at build time.
+
+          A blob URL is safe to permit because only script can mint one, so an attacker
+          needs script execution before they can use it. That argument fails if our own
+          code turns attacker-influenced data into a worker body: a value the attacker
+          controls then becomes code running with this origin's network credentials,
+          reachable from a data-injection alone.
+
+          Build the worker from a real file instead:
+
+              new Worker(new URL('./thing.worker.ts', import.meta.url), { type: 'module' })
+
+          `frontend/src/scenes/data-warehouse/editor/hogqlParserWorkerManager.ts` and
+          `frontend/src/scenes/session-recordings/player/snapshot-processing/DecompressionWorkerManager.ts`
+          both do this. A same-origin file needs no `blob:` allowance at all.
+
+          A bundled library that ships its own blob worker is fine, because its body is a
+          compile-time constant. This rule covers first-party code.
+
+          If a dynamic body is genuinely unavoidable, put `// nosemgrep: no-dynamic-worker-body`
+          on the line before it with a reason, and state where the body comes from and why
+          no input can reach it.
+      severity: ERROR
+      languages: [typescript, javascript]
+      paths:
+          include:
+              - frontend/src
+              - products
+              - common
+          exclude:
+              - '**/*.test.ts'
+              - '**/*.test.tsx'
+              - '**/*.spec.ts'
+      patterns:
+          - pattern-either:
+                # A Blob assembled inline, then handed straight to a worker.
+                - pattern: new $WORKER(URL.createObjectURL(new Blob(...)), ...)
+                - pattern: new $WORKER(window.URL.createObjectURL(new Blob(...)), ...)
+                # A `data:` or `blob:` worker URL concatenated or interpolated from a value.
+                - pattern: new $WORKER("..." + $X, ...)
+                - pattern: |
+                      new $WORKER(`...${$X}...`, ...)
+          # Without this every `new Error(`...${x}...`)` in the tree matches.
+          - metavariable-regex:
+                metavariable: $WORKER
+                regex: ^(Worker|SharedWorker)$
+      metadata:
+          category: security
+          confidence: MEDIUM
+          references:
+              - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/worker-src

--- a/.semgrep/rules/security/no-dynamic-worker-body.yaml
+++ b/.semgrep/rules/security/no-dynamic-worker-body.yaml
@@ -25,8 +25,8 @@ rules:
 
           The rule follows an object URL or a `data:` URL through the assignments in one
           function, so it catches the shapes we write. It does not follow a URL back out
-          of a helper function that returns one, and it cannot read the fixed part of a
-          template literal. Treat it as a check on first-party code, not as a proof.
+          of a helper function that returns one. Treat it as a check on first-party code,
+          not as a proof.
 
           If a dynamic body is genuinely unavoidable, put `// nosemgrep: no-dynamic-worker-body`
           on the line before it with a reason, and state where the body comes from and why
@@ -55,11 +55,14 @@ rules:
                       - metavariable-regex:
                             metavariable: $SCHEME
                             regex: '^[''"`](data|blob):'
-                # Semgrep cannot constrain the fixed part of a template literal, so any
-                # interpolated worker URL is a source. Give a same-origin path a real
-                # string or a `new URL(...)` rather than an interpolation.
-                - pattern: |
-                      `...${$X}...`
+                # A `data:` or `blob:` URL interpolated from a value. A template-literal
+                # pattern cannot reach the fixed part, so bind the whole literal and read
+                # the scheme off its text. The `${` keeps a constant body out.
+                - patterns:
+                      - pattern: $TEMPLATE
+                      - metavariable-regex:
+                            metavariable: $TEMPLATE
+                            regex: '^`(data|blob):[\s\S]*\$\{'
       # Only the URL argument is a sink. Without this, an interpolated worker name in the
       # options object matches too.
       pattern-sinks:

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -1267,7 +1267,10 @@ class CSPMiddleware:
                 # this cannot register a persistent worker either.
                 #
                 # The reasoning holds only while every blob worker body is a compile-time constant.
-                # `no-dynamic-worker-body` in .semgrep/rules/security enforces that.
+                # `no-dynamic-worker-body` in .semgrep/rules/security checks first-party code for
+                # that. It follows an object URL or a `data:` URL into a worker constructor through
+                # the assignments in one function, so it catches the shapes we write rather than
+                # every possible one.
                 #
                 # posthog-js builds its rrweb recorder worker from a blob, and PixiJS builds two
                 # ImageBitmap workers the same way. Do not add `data:`: the recorder falls back to a

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -1261,7 +1261,18 @@ class CSPMiddleware:
                 # parses with a WebAssembly build, so both break without it.
                 f"script-src 'self' 'nonce-{nonce}' 'wasm-unsafe-eval' {resource_url} https://*.i.posthog.com",
                 f"font-src 'self' {resource_url} https://app-static.eu.posthog.com https://app-static-prod.posthog.com https://fonts.gstatic.com https://cdn.jsdelivr.net",
-                "worker-src 'self'",
+                # `blob:` grants nothing to an attacker who cannot already run script, because only
+                # script can mint a blob URL, and a worker started from one inherits this policy
+                # rather than escaping it. The ServiceWorker spec rejects `blob:` on its own, so
+                # this cannot register a persistent worker either.
+                #
+                # The reasoning holds only while every blob worker body is a compile-time constant.
+                # `no-dynamic-worker-body` in .semgrep/rules/security enforces that.
+                #
+                # posthog-js builds its rrweb recorder worker from a blob, and PixiJS builds two
+                # ImageBitmap workers the same way. Do not add `data:`: the recorder falls back to a
+                # data URL only when blob fails, so allowing blob stops those attempts.
+                "worker-src 'self' blob:",
                 "child-src 'none'",
                 "object-src 'none'",
                 "media-src https://res.cloudinary.com",


### PR DESCRIPTION
## Problem

Every session that records a replay reports a CSP violation. `worker-src 'self'` has no `blob:`, and posthog-js builds its rrweb recorder worker from a blob URL. PixiJS builds two ImageBitmap workers the same way.

That one directive is **85% of every CSP violation the app reports** — 28,114 of 33,097 in the last 24 hours, on main-app pages alone. It is the largest single obstacle to enforcing `script-src`, because the noise buries everything else.

## Changes

- Nobody sees anything different: the policy is still report-only, so this only stops the reports. It clears 86% of them, counting the 409 `script-src-elem` reports that are Firefox describing the same worker creation a second way.
- `blob:` is safe here. Only script can mint a blob URL, so an attacker needs script execution first; a worker started from one inherits this policy rather than escaping it; and the ServiceWorker spec rejects `blob:` on its own, so this cannot register a persistent worker.
- That argument holds only while every blob worker body is a compile-time constant. `no-dynamic-worker-body` turns the precondition into a check, so the allowance cannot outlive its reason. Our own code creates no blob workers at all — the three first-party `Worker` call sites load real same-origin files.
- The check also covers `packages/quill` and `packages/llm-normalizer`. Both are pnpm workspace roots whose source ships into the main app bundle, and neither the rule nor any job that loads our security rules reached them.
- One mechanical part: `semgrep-general` stops scanning `packages`, because `semgrep-js` now does. Every tree stays on exactly one job.
- `data:` is deliberately not added. The recorder falls back to a data URL only when the blob worker fails, so allowing blob stops those attempts.

## How did you test this code?

I am an agent. No manual testing.

- `semgrep --test` passes on the rule fixture.
- The rule finds **nothing** in `frontend/src`, `products` and `common`, so it does not break CI on existing code. My first draft used a bare metavariable for the constructor and matched every `new Error(` template literal in the tree; caught by scanning the real codebase rather than trusting the fixture, and fixed with a `metavariable-regex`.
- The widened scan reports nothing under `packages`: our own rules over 485 files, and `p/javascript`, `p/owasp-top-ten`, `p/security-audit` and `p/trailofbits` over 595 files. Measured locally on semgrep 1.146.0, not the CI image, so `semgrep-js` on this branch is the confirmation.
- No test on the middleware line. Asserting the directive string back restates it and catches nothing a reviewer would not; the precondition worth guarding is the semgrep rule. No existing test pins `worker-src`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5), with the PostHog MCP server for the violation data. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/writing-code-comments`, `/authoring-ci-workflows`.

No duplicate, but a related PR exists: **#96110** (draft, untouched since 2026-09-07) adds a second, permissive enforced policy via `setdefault` — `worker-src 'self' blob: data: https:` with `'unsafe-inline' 'unsafe-eval'`. Different mechanism and different goal: this PR fixes the report-only policy that will later be enforced, rather than adding a parallel header. The two would conflict textually in `posthog/middleware.py`.

The identification came from reading the shipped bundles rather than the source: `internal-j.posthog.com/static/*/posthog-recorder.js` builds the blob, and the Firefox-only `script-src-elem` reports turned out to be the same worker creation reported under a second directive.

Public artifact: nothing here draws on anything outside this repository.

