### PR TITLE
feat(warehouse-sources): promote App Store Connect to GA

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/source.py
@@ -78,7 +78,7 @@ The analytics tables need a key with the Admin role. Apple lets only an Admin ke
             name=SchemaExternalDataSourceType.APP_STORE_CONNECT,
             category=DataWarehouseSourceCategory.ANALYTICS,
             label="Apple (App Store Connect)",
-            releaseStatus=ReleaseStatus.BETA,
+            releaseStatus=ReleaseStatus.GA,
             keywords=["app store", "ios", "apple", "mobile analytics"],
             caption=caption,
             iconPath="/static/services/app_store_connect.png",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/tests/test_app_store_connect_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/tests/test_app_store_connect_source.py
@@ -60,12 +60,12 @@ def _input_fields(source: AppStoreConnectSource) -> dict[str, SourceFieldInputCo
 
 
 class TestAppStoreConnectSource:
-    def test_source_is_visible_and_labelled_beta(self) -> None:
+    def test_source_is_visible_and_generally_available(self) -> None:
         config = AppStoreConnectSource().get_source_config
 
         # `unreleasedSource` hides a source from users entirely; a finished source must not set it.
         assert not config.unreleasedSource
-        assert config.releaseStatus == ReleaseStatus.BETA
+        assert config.releaseStatus == ReleaseStatus.GA
         assert config.category == DataWarehouseSourceCategory.ANALYTICS
         assert config.docsUrl is not None
 


### PR DESCRIPTION
## Problem

Anyone picking Apple (App Store Connect) in the data warehouse source list still sees it marked as beta, which now understates how ready it is.

- The source has cleared both promotion gates: adoption is past the required team count, and its import error rate over the last 7 days sits well under the 2.5% ceiling.
- The beta label makes teams hesitate over a connector that is stable.

## Changes

- The source catalog and setup screens no longer label Apple (App Store Connect) as beta.
- `releaseStatus` on the source config moves from `ReleaseStatus.BETA` to `ReleaseStatus.GA`.
- Gating stays untouched. The source carries no `unreleasedSource` flag and no feature flag, so there was nothing to remove.
- No connector behavior, schema, endpoint, or sync logic changes.

The only user-visible difference is the missing beta label. No screenshot is attached, because the dev stack was not booted for a one-constant change.

## How did you test this code?

- Ran the source's own suite: `products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/tests/test_app_store_connect_source.py`.
- Renamed and updated the existing release-status assertion in that file, which is the test that would otherwise fail on this constant. No new test was added, because the change adds no new behavior to cover.
- Not run: the wider warehouse sources suites and any live App Store Connect sync. CI covers the former.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The posthog.com docs read release status from the `public_source_configs` API, so they pick this up with no doc edit.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Written by Claude Code (Opus 5) as a release-status promotion pass over data warehouse sources.
- Skills invoked: `/implementing-warehouse-sources` to confirm where release status lives and that `ReleaseStatus.GA` is the convention rather than omitting the field, and `/writing-pr-descriptions` for this body.
- Checked open PRs for a duplicate promotion from several angles (source name, "releaseStatus", "promote", plus the maintainer's own open PRs) and found none.
- The promotion metrics came from a project data query in the session. This description states them against the policy threshold instead of quoting the figures, since the repo is public.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
