### PR TITLE
fix(data-warehouse): show syncs PostHog halted in the health view

### DIFF
--- a/products/data_warehouse/backend/presentation/views/data_warehouse.py
+++ b/products/data_warehouse/backend/presentation/views/data_warehouse.py
@@ -691,13 +691,15 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
                 )
 
             # Get failed syncs from ExternalDataSchema
-            # Only show syncs that are actively enabled but failing
+            # A schema the user switched off is not a failure to report. A schema PostHog halted
+            # after a non-retryable error is one, because only the user can repair the source and
+            # turn syncing back on. `auto_disabled_at` tells the two apart.
             problem_syncs = (
                 ExternalDataSchema.objects.filter(
                     team_id=self.team_id,
                     deleted=False,
-                    should_sync=True,
                 )
+                .filter(Q(should_sync=True) | Q(auto_disabled_at__isnull=False))
                 .filter(
                     Q(status=ExternalDataSchemaStatus.FAILED) | Q(status=ExternalDataSchemaStatus.BILLING_LIMIT_REACHED)
                 )
@@ -706,8 +708,12 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
 
             for schema in problem_syncs:
                 sync_status = "failed"
+                failed_at = schema.last_synced_at
                 if schema.status == ExternalDataSchemaStatus.BILLING_LIMIT_REACHED:
                     sync_status = "billing_limit"
+                elif not schema.should_sync:
+                    sync_status = "disabled"
+                    failed_at = schema.auto_disabled_at
 
                 results.append(
                     {
@@ -717,7 +723,7 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
                         "source_type": schema.source.source_type if schema.source else None,
                         "status": sync_status,
                         "error": schema.latest_error,
-                        "failed_at": schema.last_synced_at.isoformat() if schema.last_synced_at else None,
+                        "failed_at": failed_at.isoformat() if failed_at else None,
                         "url": f"/data-warehouse/sources/{schema.source_id}" if schema.source_id else None,
                     }
                 )

--- a/products/data_warehouse/backend/presentation/views/data_warehouse.py
+++ b/products/data_warehouse/backend/presentation/views/data_warehouse.py
@@ -28,8 +28,10 @@ from posthog.cloud_utils import get_cached_instance_license
 from posthog.helpers.dashboard_templates import create_data_ops_dashboard
 from posthog.models.organization import OrganizationMembership
 from posthog.models.team.extensions import get_or_create_team_extension
+from posthog.permissions import is_service_auth
 from posthog.utils import convert_property_value, flatten
 
+from products.access_control.backend.facade.user_access_control import access_level_satisfied_for_resource
 from products.batch_exports.backend.facade.models import BatchExportRun
 from products.cdp.backend.facade.models import HogFunction, HogFunctionState, HogFunctionType
 from products.data_modeling.backend.facade.models import DataModelingJob, DataModelingJobEngine, DataWarehouseSavedQuery
@@ -694,7 +696,7 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
             # A schema the user switched off is not a failure to report. A schema PostHog halted
             # after a non-retryable error is one, because only the user can repair the source and
             # turn syncing back on. `auto_disabled_at` tells the two apart.
-            problem_syncs = (
+            problem_syncs = list(
                 ExternalDataSchema.objects.filter(
                     team_id=self.team_id,
                     deleted=False,
@@ -703,8 +705,23 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
                 .filter(
                     Q(status=ExternalDataSchemaStatus.FAILED) | Q(status=ExternalDataSchemaStatus.BILLING_LIMIT_REACHED)
                 )
-                .select_related("source")
+                .select_related("source", "table")
             )
+
+            if not is_service_auth(request):
+                # A schema has no access rules of its own. Resolve each row through its table or
+                # source, as the schema list does, so a member denied on a source does not read
+                # its table names and errors here.
+                user_access_control = self.user_access_control
+                user_access_control.preload_object_access_controls(
+                    [schema.table or schema.source for schema in problem_syncs]
+                )
+                problem_syncs = [
+                    schema
+                    for schema in problem_syncs
+                    if (level := user_access_control.get_user_access_level(schema.table or schema.source)) is not None
+                    and access_level_satisfied_for_resource("warehouse_table", level, "viewer")
+                ]
 
             for schema in problem_syncs:
                 sync_status = "failed"

--- a/products/data_warehouse/backend/tests/api/test_data_warehouse.py
+++ b/products/data_warehouse/backend/tests/api/test_data_warehouse.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
+import pytest
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
@@ -20,6 +21,7 @@ from products.warehouse_sources.backend.facade.models import (
     ExternalDataSchema,
     ExternalDataSource,
 )
+from products.warehouse_sources.backend.facade.testing import WarehouseAccessControlTestMixin
 
 
 class TestDataWarehouseAPI(APIBaseTest):
@@ -801,22 +803,25 @@ class TestDataHealthIssuesReadsTheNewestRun(APIBaseTest):
         assert "orders" not in self._reported()
 
 
+HALTED_AT = datetime(2026, 1, 15, 12, 0, tzinfo=UTC)
+
+
+def _failing_schema(team, **fields) -> ExternalDataSchema:
+    source = ExternalDataSource.objects.create(
+        source_id="test-id", connection_id="conn-id", destination_id="dest-id", team=team, source_type="Stripe"
+    )
+    return ExternalDataSchema.objects.create(
+        name="customers", team=team, source=source, latest_error="Invalid API key", **fields
+    )
+
+
+def _reported_syncs(client, team_id: int) -> dict[str, dict]:
+    response = client.get(f"/api/projects/{team_id}/data_warehouse/data_health_issues/")
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    return {r["id"]: r for r in response.json()["results"] if r["type"] == "external_data_sync"}
+
+
 class TestDataHealthIssuesSyncVisibility(APIBaseTest):
-    HALTED_AT = datetime(2026, 1, 15, 12, 0, tzinfo=UTC)
-
-    def _schema(self, **fields) -> ExternalDataSchema:
-        source = ExternalDataSource.objects.create(
-            source_id="test-id", connection_id="conn-id", destination_id="dest-id", team=self.team, source_type="Stripe"
-        )
-        return ExternalDataSchema.objects.create(
-            name="customers", team=self.team, source=source, latest_error="Invalid API key", **fields
-        )
-
-    def _reported_syncs(self) -> dict[str, dict]:
-        response = self.client.get(f"/api/projects/{self.team.id}/data_warehouse/data_health_issues/")
-        assert response.status_code == status.HTTP_200_OK, response.json()
-        return {r["id"]: r for r in response.json()["results"] if r["type"] == "external_data_sync"}
-
     @parameterized.expand(
         [
             ("still_retrying", ExternalDataSchema.Status.FAILED, True, False, "failed"),
@@ -828,13 +833,14 @@ class TestDataHealthIssuesSyncVisibility(APIBaseTest):
     def test_a_sync_is_reported_unless_the_user_switched_it_off(
         self, _name, schema_status, should_sync, halted_by_posthog, expected_status
     ):
-        schema = self._schema(
+        schema = _failing_schema(
+            self.team,
             status=schema_status,
             should_sync=should_sync,
-            auto_disabled_at=self.HALTED_AT if halted_by_posthog else None,
+            auto_disabled_at=HALTED_AT if halted_by_posthog else None,
         )
 
-        reported = self._reported_syncs()
+        reported = _reported_syncs(self.client, self.team.id)
 
         if expected_status is None:
             assert str(schema.id) not in reported
@@ -842,14 +848,34 @@ class TestDataHealthIssuesSyncVisibility(APIBaseTest):
             assert reported[str(schema.id)]["status"] == expected_status
 
     def test_a_halted_sync_reports_the_time_posthog_stopped_it(self):
-        schema = self._schema(
+        schema = _failing_schema(
+            self.team,
             status=ExternalDataSchema.Status.FAILED,
             should_sync=False,
-            auto_disabled_at=self.HALTED_AT,
-            last_synced_at=self.HALTED_AT - timedelta(days=3),
+            auto_disabled_at=HALTED_AT,
+            last_synced_at=HALTED_AT - timedelta(days=3),
         )
 
-        reported = self._reported_syncs()[str(schema.id)]
+        reported = _reported_syncs(self.client, self.team.id)[str(schema.id)]
 
-        assert reported["failed_at"] == self.HALTED_AT.isoformat()
+        assert reported["failed_at"] == HALTED_AT.isoformat()
         assert reported["error"] == "Invalid API key"
+
+
+@pytest.mark.ee
+class TestDataHealthIssuesSyncAccess(WarehouseAccessControlTestMixin):
+    resource = "external_data_source"
+
+    def test_a_member_denied_on_a_source_does_not_see_its_syncs(self):
+        granted = _failing_schema(self.team, status=ExternalDataSchema.Status.FAILED, should_sync=True)
+        denied = _failing_schema(
+            self.team, status=ExternalDataSchema.Status.FAILED, should_sync=False, auto_disabled_at=HALTED_AT
+        )
+        self._create_access_control(self.viewer_user, access_level="none")
+        self._create_access_control(self.viewer_user, resource_id=str(granted.source_id), access_level="viewer")
+
+        self.client.force_login(self.viewer_user)
+        reported = _reported_syncs(self.client, self.team.id)
+
+        assert str(granted.id) in reported
+        assert str(denied.id) not in reported

--- a/products/data_warehouse/backend/tests/api/test_data_warehouse.py
+++ b/products/data_warehouse/backend/tests/api/test_data_warehouse.py
@@ -799,3 +799,57 @@ class TestDataHealthIssuesReadsTheNewestRun(APIBaseTest):
         self._view("orders", status="Failed", latest_error="Ancient v1 error")
 
         assert "orders" not in self._reported()
+
+
+class TestDataHealthIssuesSyncVisibility(APIBaseTest):
+    HALTED_AT = datetime(2026, 1, 15, 12, 0, tzinfo=UTC)
+
+    def _schema(self, **fields) -> ExternalDataSchema:
+        source = ExternalDataSource.objects.create(
+            source_id="test-id", connection_id="conn-id", destination_id="dest-id", team=self.team, source_type="Stripe"
+        )
+        return ExternalDataSchema.objects.create(
+            name="customers", team=self.team, source=source, latest_error="Invalid API key", **fields
+        )
+
+    def _reported_syncs(self) -> dict[str, dict]:
+        response = self.client.get(f"/api/projects/{self.team.id}/data_warehouse/data_health_issues/")
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        return {r["id"]: r for r in response.json()["results"] if r["type"] == "external_data_sync"}
+
+    @parameterized.expand(
+        [
+            ("still_retrying", ExternalDataSchema.Status.FAILED, True, False, "failed"),
+            ("halted_by_posthog", ExternalDataSchema.Status.FAILED, False, True, "disabled"),
+            ("switched_off_by_user", ExternalDataSchema.Status.FAILED, False, False, None),
+            ("billing_limit", ExternalDataSchema.Status.BILLING_LIMIT_REACHED, True, False, "billing_limit"),
+        ]
+    )
+    def test_a_sync_is_reported_unless_the_user_switched_it_off(
+        self, _name, schema_status, should_sync, halted_by_posthog, expected_status
+    ):
+        schema = self._schema(
+            status=schema_status,
+            should_sync=should_sync,
+            auto_disabled_at=self.HALTED_AT if halted_by_posthog else None,
+        )
+
+        reported = self._reported_syncs()
+
+        if expected_status is None:
+            assert str(schema.id) not in reported
+        else:
+            assert reported[str(schema.id)]["status"] == expected_status
+
+    def test_a_halted_sync_reports_the_time_posthog_stopped_it(self):
+        schema = self._schema(
+            status=ExternalDataSchema.Status.FAILED,
+            should_sync=False,
+            auto_disabled_at=self.HALTED_AT,
+            last_synced_at=self.HALTED_AT - timedelta(days=3),
+        )
+
+        reported = self._reported_syncs()[str(schema.id)]
+
+        assert reported["failed_at"] == self.HALTED_AT.isoformat()
+        assert reported["error"] == "Invalid API key"


### PR DESCRIPTION
## Problem

A team whose warehouse sync PostHog stopped after repeated failures no longer sees that sync in the Pipeline status view. The view drops the sync at the moment PostHog stops retrying it, so the most persistent failures are the ones the page hides.

- The sync branch of `data_health_issues` filters on `should_sync=True`.
- The auto-disable path sets `should_sync=False` on the schema, so the filter removes it.
- One boolean carries both "the user switched this off" and "PostHog halted this", so the filter alone cannot tell them apart.

Closes #88061

## Changes

- The Pipeline status view keeps a sync that PostHog halted. The card reads "Disabled" and shows the halt time and the last error.
- A sync the user switched off stays hidden. The view uses the marker from [#93270](https://github.com/PostHog/posthog/pull/93270).
- A sync that is still retrying keeps its "Failed" card. Nothing else in the view changes.
- Users only see syncs for sources or tables they can view.

> [!NOTE]
> [#93270](https://github.com/PostHog/posthog/pull/93270) merged on September 10, 2026. This PR now targets current `master` and contains only the health-view changes.

> [!NOTE]
> [#93270](https://github.com/PostHog/posthog/pull/93270) does not backfill `auto_disabled_at`. Schemas halted before that column existed remain hidden.

Dropping the `should_sync` filter, as [#88728](https://github.com/PostHog/posthog/pull/88728) proposes, also shows failing syncs the user disabled. Criterion 3 of #88061 excludes that behavior.

## How did you test this code?

- Local: `hogli test products/data_warehouse/backend/tests/api/test_data_warehouse.py -k TestDataHealthIssues` — 15 passed, including visibility, timestamps, access restrictions, API-key scopes, and materialization regressions.
- Local: `test_repo_quarantine_file_is_valid` passed. The expired entry no longer exists on the updated branch.
- Local: Semgrep security scan against `origin/master` found no new findings. `hogli ci:preflight --strict` passed.
- Local: `hogli build:openapi` passed without changes to generated files.
- Not run: repo-wide mypy and frontend tests. The response shape and status union do not change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No page documents the selection rules of the Pipeline status view.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (Claude Code via PostHog Desktop) at the direction of the assignee. Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-code-comments`, `/announcing-behavior-changes`, `/writing-pr-descriptions`.

Codex updated the branch against `master`, kept both test groups when resolving conflicts, and checked the result. Skills: `/running-ci-preflight`, `/writing-pr-descriptions`.

Related work: [#88728](https://github.com/PostHog/posthog/pull/88728) reports the same issue. [#93270](https://github.com/PostHog/posthog/pull/93270) adds the marker and changes digest emails, not this view. `/announcing-behavior-changes` returned no notice because the card explains the state. Tests use an invented error message.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
