### PR TITLE
fix(tasks): stop reporting a timed-out egress probe as a policy block

### DIFF
--- a/products/tasks/backend/logic/services/agent_server_launcher.py
+++ b/products/tasks/backend/logic/services/agent_server_launcher.py
@@ -110,10 +110,10 @@ def _session_init_probe_hosts() -> list[str]:
 def _egress_failure_reason(egress: str) -> str | None:
     """Name the failure the egress probe saw, or None when every host answered.
 
-    A refused connection (curl exit 7) or a failed lookup (exit 6) is a network policy block.
-    A timeout (exit 28) is not: the probe ran on a box that could not finish a TLS handshake
-    inside its budget, which is what a CPU-starved sandbox looks like. The two must read
-    differently, because the first sends a reader to the allowlist and the second to the host.
+    A refused connection (curl exit 7) or a failed lookup (exit 6) proves a network policy block.
+    A timeout (exit 28) proves nothing on its own: a slow sandbox and a policy that drops packets
+    silently both look like one. So a timeout is reported as a timeout, and the reader is sent to
+    the host-pressure probe in the same diagnostics rather than to the allowlist.
     """
     failed = [line for line in egress.splitlines() if "http_code=000" in line or line.endswith("FAILED")]
     if not failed:
@@ -121,9 +121,9 @@ def _egress_failure_reason(egress: str) -> str | None:
     timed_out = [line for line in failed if line.endswith(f"curl_exit={CURL_EXIT_OPERATION_TIMEOUT}")]
     if len(timed_out) == len(failed):
         return (
-            f"egress probe timed out after {EGRESS_PROBE_MAX_TIME_SECONDS}s to session-init host(s), not refused; "
-            "the sandbox is too slow to complete a TLS handshake, which points at CPU starvation rather than a "
-            "network policy block: " + "; ".join(failed)
+            f"egress probe timed out after {EGRESS_PROBE_MAX_TIME_SECONDS}s to every session-init host it could "
+            "not reach, and none refused the connection; read the host-pressure probe before the allowlist, "
+            "because a starved sandbox and a policy that drops packets silently both time out: " + "; ".join(failed)
         )
     return "egress blocked to required session-init host(s): " + "; ".join(failed)
 

--- a/products/tasks/backend/logic/services/agent_server_launcher.py
+++ b/products/tasks/backend/logic/services/agent_server_launcher.py
@@ -79,6 +79,10 @@ HOST_PRESSURE_PROBE_SCRIPT = (
     'else echo "cold_read_ms=unavailable file=${probe_file:-none} size=$probe_size"; fi'
 )
 
+EGRESS_PROBE_MAX_TIME_SECONDS = 3
+# curl(1): "Operation timeout. The specified time-out period was reached according to the conditions."
+CURL_EXIT_OPERATION_TIMEOUT = 28
+
 SESSION_INIT_PROBE_HOSTS = (
     "gateway.us.posthog.com",
     "gateway.eu.posthog.com",
@@ -101,6 +105,27 @@ def _session_init_probe_hosts() -> list[str]:
         if gateway_host and gateway_host not in hosts:
             hosts.insert(0, gateway_host)
     return hosts
+
+
+def _egress_failure_reason(egress: str) -> str | None:
+    """Name the failure the egress probe saw, or None when every host answered.
+
+    A refused connection (curl exit 7) or a failed lookup (exit 6) is a network policy block.
+    A timeout (exit 28) is not: the probe ran on a box that could not finish a TLS handshake
+    inside its budget, which is what a CPU-starved sandbox looks like. The two must read
+    differently, because the first sends a reader to the allowlist and the second to the host.
+    """
+    failed = [line for line in egress.splitlines() if "http_code=000" in line or line.endswith("FAILED")]
+    if not failed:
+        return None
+    timed_out = [line for line in failed if line.endswith(f"curl_exit={CURL_EXIT_OPERATION_TIMEOUT}")]
+    if len(timed_out) == len(failed):
+        return (
+            f"egress probe timed out after {EGRESS_PROBE_MAX_TIME_SECONDS}s to session-init host(s), not refused; "
+            "the sandbox is too slow to complete a TLS handshake, which points at CPU starvation rather than a "
+            "network policy block: " + "; ".join(failed)
+        )
+    return "egress blocked to required session-init host(s): " + "; ".join(failed)
 
 
 def _start_and_wait_command(command: str, max_attempts: int = AGENT_SERVER_HEALTH_MAX_ATTEMPTS) -> str:
@@ -282,9 +307,9 @@ class AgentServerLaunchMixin(SandboxBase):
 
             egress = self._probe_session_init_egress()
             diagnostics["egress_probe"] = egress
-            blocked = [line for line in egress.splitlines() if "http_code=000" in line or line.endswith("FAILED")]
-            if blocked:
-                diagnostics["failure_reason"] = "egress blocked to required session-init host(s): " + "; ".join(blocked)
+            egress_reason = _egress_failure_reason(egress)
+            if egress_reason:
+                diagnostics["failure_reason"] = egress_reason
             else:
                 diagnostics["failure_reason"] = (
                     "agent server alive but never reported hasSession=true; no egress block detected, "
@@ -313,7 +338,9 @@ class AgentServerLaunchMixin(SandboxBase):
         hosts = _session_init_probe_hosts()
         checks = "; ".join(
             f"printf '%s ' {shlex.quote(host)}; "
-            f"curl -sS --max-time 3 -o /dev/null -w 'http_code=%{{http_code}}\\n' https://{host}/ 2>/dev/null || echo FAILED"
+            f"curl -sS --max-time {EGRESS_PROBE_MAX_TIME_SECONDS} -o /dev/null -w 'http_code=%{{http_code}}' "
+            f"https://{host}/ 2>/dev/null; "
+            'echo " curl_exit=$?"'
             for host in hosts
         )
         return self.execute(checks, timeout_seconds=30).stdout.strip()

--- a/products/tasks/backend/logic/services/agent_server_launcher.py
+++ b/products/tasks/backend/logic/services/agent_server_launcher.py
@@ -132,7 +132,7 @@ def _egress_failure_reason(egress: str) -> str | None:
         if exit_code == 0:
             continue
         curl_reported_no_response = "http_code=000" in line or line.endswith("FAILED")
-        if exit_code is None and not curl_reported_no_response:
+        if not curl_reported_no_response and (exit_code is None or "http_code=" in line):
             continue
         failed.append(line)
         if exit_code == CURL_EXIT_OPERATION_TIMEOUT:

--- a/products/tasks/backend/logic/services/agent_server_launcher.py
+++ b/products/tasks/backend/logic/services/agent_server_launcher.py
@@ -8,6 +8,7 @@ inherit it unchanged.
 
 from __future__ import annotations
 
+import re
 import json
 import time
 import shlex
@@ -82,6 +83,7 @@ HOST_PRESSURE_PROBE_SCRIPT = (
 EGRESS_PROBE_MAX_TIME_SECONDS = 3
 # curl(1): "Operation timeout. The specified time-out period was reached according to the conditions."
 CURL_EXIT_OPERATION_TIMEOUT = 28
+CURL_EXIT_PATTERN = re.compile(r"curl_exit=(\d+)$")
 
 SESSION_INIT_PROBE_HOSTS = (
     "gateway.us.posthog.com",
@@ -107,25 +109,52 @@ def _session_init_probe_hosts() -> list[str]:
     return hosts
 
 
+def _curl_exit_code(line: str) -> int | None:
+    """Read the exit code the probe appends, or None for output from an image that predates it."""
+    match = CURL_EXIT_PATTERN.search(line)
+    return int(match.group(1)) if match else None
+
+
 def _egress_failure_reason(egress: str) -> str | None:
     """Name the failure the egress probe saw, or None when every host answered.
 
     A refused connection (curl exit 7) or a failed lookup (exit 6) proves a network policy block.
     A timeout (exit 28) proves nothing on its own: a slow sandbox and a policy that drops packets
     silently both look like one. So a timeout is reported as a timeout, and the reader is sent to
-    the host-pressure probe in the same diagnostics rather than to the allowlist.
+    the host-pressure probe in the same diagnostics rather than to the allowlist. A nonzero exit
+    with no HTTP code means curl never ran or was killed, so that host was never probed at all.
     """
-    failed = [line for line in egress.splitlines() if "http_code=000" in line or line.endswith("FAILED")]
+    failed: list[str] = []
+    blocked: list[str] = []
+    unprobed: list[str] = []
+    for line in egress.splitlines():
+        exit_code = _curl_exit_code(line)
+        if exit_code == 0:
+            continue
+        curl_reported_no_response = "http_code=000" in line or line.endswith("FAILED")
+        if exit_code is None and not curl_reported_no_response:
+            continue
+        failed.append(line)
+        if exit_code == CURL_EXIT_OPERATION_TIMEOUT:
+            continue
+        if curl_reported_no_response:
+            blocked.append(line)
+        else:
+            unprobed.append(line)
     if not failed:
         return None
-    timed_out = [line for line in failed if line.endswith(f"curl_exit={CURL_EXIT_OPERATION_TIMEOUT}")]
-    if len(timed_out) == len(failed):
+    if blocked:
+        return "egress blocked to required session-init host(s): " + "; ".join(failed)
+    if unprobed:
         return (
-            f"egress probe timed out after {EGRESS_PROBE_MAX_TIME_SECONDS}s to every session-init host it could "
-            "not reach, and none refused the connection; read the host-pressure probe before the allowlist, "
-            "because a starved sandbox and a policy that drops packets silently both time out: " + "; ".join(failed)
+            "egress probe did not run for required session-init host(s); curl exited without an HTTP code, "
+            "so nothing here rules an allowlist block in or out: " + "; ".join(failed)
         )
-    return "egress blocked to required session-init host(s): " + "; ".join(failed)
+    return (
+        f"egress probe timed out after {EGRESS_PROBE_MAX_TIME_SECONDS}s to every session-init host it could "
+        "not reach, and none refused the connection; read the host-pressure probe before the allowlist, "
+        "because a starved sandbox and a policy that drops packets silently both time out: " + "; ".join(failed)
+    )
 
 
 def _start_and_wait_command(command: str, max_attempts: int = AGENT_SERVER_HEALTH_MAX_ATTEMPTS) -> str:

--- a/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
+++ b/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
@@ -35,6 +35,7 @@ from products.tasks.backend.logic.services.agent_server_launcher import (
     AGENT_SERVER_HEALTH_MAX_ATTEMPTS,
     HOST_PRESSURE_PROBE_SCRIPT,
     STARTUP_LOG_MAX_BYTES,
+    _egress_failure_reason,
 )
 from products.tasks.backend.logic.services.local_packages import LocalPackage
 from products.tasks.backend.logic.services.local_skills import ENV_DISABLE_BUNDLED_SKILLS
@@ -1448,6 +1449,9 @@ class TestStartupFailureDiagnostics:
         assert expected in diagnostics["failure_reason"]
         assert unexpected not in diagnostics["failure_reason"]
         assert "mcp-eu.posthog.com" in diagnostics["failure_reason"]
+
+    def test_transfer_error_after_a_response_is_not_an_egress_failure(self):
+        assert _egress_failure_reason("api.anthropic.com http_code=200 curl_exit=56") is None
 
     def test_reports_alive_without_session_when_no_block(self):
         sandbox = self._sandbox()

--- a/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
+++ b/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
@@ -1390,18 +1390,42 @@ class TestStartupFailureDiagnostics:
         assert "poll=137" in diagnostics["failure_reason"]
         sandbox._sandbox.exec.assert_not_called()
 
+    @pytest.mark.parametrize(
+        "probe_stdout, expected, unexpected",
+        [
+            # Refused: the connection never opened, so a policy blocked it.
+            (
+                "api.anthropic.com http_code=200 curl_exit=0\nmcp-eu.posthog.com http_code=000 curl_exit=7",
+                "egress blocked",
+                "timed out",
+            ),
+            # Lines from an image that predates the curl_exit suffix still read as a block.
+            (
+                "api.anthropic.com http_code=200\nmcp-eu.posthog.com http_code=000\nFAILED",
+                "egress blocked",
+                "timed out",
+            ),
+            # Timed out: the box was too slow to finish the handshake, so nothing was blocked.
+            (
+                "api.anthropic.com http_code=000 curl_exit=28\nmcp-eu.posthog.com http_code=000 curl_exit=28",
+                "timed out",
+                "egress blocked",
+            ),
+            # One refused host is a block even when another host only timed out.
+            (
+                "api.anthropic.com http_code=000 curl_exit=28\nmcp-eu.posthog.com http_code=000 curl_exit=7",
+                "egress blocked",
+                "timed out",
+            ),
+        ],
+    )
     @override_settings(SITE_URL="https://eu.posthog.com", SANDBOX_MCP_URL=None)
-    def test_reports_blocked_egress_host(self):
+    def test_reports_blocked_egress_host(self, probe_stdout: str, expected: str, unexpected: str):
         sandbox = self._sandbox()
 
         def _exec(command: str, timeout_seconds: Any = None) -> ExecutionResult:
             if "http_code=" in command:
-                return ExecutionResult(
-                    stdout="api.anthropic.com http_code=200\nmcp-eu.posthog.com http_code=000",
-                    stderr="",
-                    exit_code=0,
-                    error=None,
-                )
+                return ExecutionResult(stdout=probe_stdout, stderr="", exit_code=0, error=None)
             if "agent-server.log" in command:
                 return ExecutionResult(stdout="agent log tail", stderr="", exit_code=0, error=None)
             return ExecutionResult(stdout='{"status":"ok","hasSession":false}', stderr="", exit_code=0, error=None)
@@ -1413,7 +1437,8 @@ class TestStartupFailureDiagnostics:
             diagnostics = sandbox._diagnose_startup_failure(allowed_domains=["github.com"])
 
         assert diagnostics["sandbox_terminated"] == "false"
-        assert "egress blocked" in diagnostics["failure_reason"]
+        assert expected in diagnostics["failure_reason"]
+        assert unexpected not in diagnostics["failure_reason"]
         assert "mcp-eu.posthog.com" in diagnostics["failure_reason"]
 
     def test_reports_alive_without_session_when_no_block(self):

--- a/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
+++ b/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
@@ -1413,8 +1413,19 @@ class TestStartupFailureDiagnostics:
                 "egress blocked",
                 "timed out",
             ),
+            (
+                "api.anthropic.com http_code=200 curl_exit=0\nmcp-eu.posthog.com  curl_exit=127",
+                "did not run",
+                "no egress block detected",
+            ),
         ],
-        ids=["refused", "legacy_image_without_curl_exit", "every_host_timed_out", "one_refused_one_timed_out"],
+        ids=[
+            "refused",
+            "legacy_image_without_curl_exit",
+            "every_host_timed_out",
+            "one_refused_one_timed_out",
+            "curl_never_ran",
+        ],
     )
     @override_settings(SITE_URL="https://eu.posthog.com", SANDBOX_MCP_URL=None)
     def test_reports_blocked_egress_host(self, probe_stdout: str, expected: str, unexpected: str):

--- a/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
+++ b/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
@@ -1393,31 +1393,28 @@ class TestStartupFailureDiagnostics:
     @pytest.mark.parametrize(
         "probe_stdout, expected, unexpected",
         [
-            # Refused: the connection never opened, so a policy blocked it.
             (
                 "api.anthropic.com http_code=200 curl_exit=0\nmcp-eu.posthog.com http_code=000 curl_exit=7",
                 "egress blocked",
                 "timed out",
             ),
-            # Lines from an image that predates the curl_exit suffix still read as a block.
             (
                 "api.anthropic.com http_code=200\nmcp-eu.posthog.com http_code=000\nFAILED",
                 "egress blocked",
                 "timed out",
             ),
-            # Timed out: the box was too slow to finish the handshake, so nothing was blocked.
             (
                 "api.anthropic.com http_code=000 curl_exit=28\nmcp-eu.posthog.com http_code=000 curl_exit=28",
                 "timed out",
                 "egress blocked",
             ),
-            # One refused host is a block even when another host only timed out.
             (
                 "api.anthropic.com http_code=000 curl_exit=28\nmcp-eu.posthog.com http_code=000 curl_exit=7",
                 "egress blocked",
                 "timed out",
             ),
         ],
+        ids=["refused", "legacy_image_without_curl_exit", "every_host_timed_out", "one_refused_one_timed_out"],
     )
     @override_settings(SITE_URL="https://eu.posthog.com", SANDBOX_MCP_URL=None)
     def test_reports_blocked_egress_host(self, probe_stdout: str, expected: str, unexpected: str):


### PR DESCRIPTION
## Problem

When a sandbox agent-server fails to start, the diagnostics probe the session-init hosts with `curl --max-time 3`. Any host that returns `http_code=000` is reported as `egress blocked to required session-init host(s)`.

On a CPU-starved box the probe times out before the TLS handshake completes, and the same message appears with a different host each time, including our own gateways. About a third of the EU failures in the [error tracking issue](https://us.posthog.com/project/2/error_tracking/01a02559-40a4-79e2-bfdb-db8f0bfe48b6) carry it. Nothing is blocked; the wording sends the reader to the network allowlist instead of the host.

## Changes

- The probe records curl's exit code per host: `<host> http_code=<code> curl_exit=<n>`.
- A refused connection or failed lookup still reads as `egress blocked to required session-init host(s)`.
- When every failed host timed out (exit 28), the reason says the probe timed out and sends the reader to the host-pressure probe in the same diagnostics. It names no cause, because a starved box and a policy that drops packets silently both time out.
- A curl that exits without an HTTP code (missing binary, or killed) reads as a probe that did not run. It used to look like a host that answered, so a run that learned nothing reported "no egress block detected".
- A mix of refused and timed-out hosts still reads as a block, because the refused host is the real signal.
- Lines from an image that predates the suffix (`FAILED`, no `curl_exit`) keep the old reading.

No user-visible change; this text lands in error tracking and run logs.

## How did you test this code?

- `test_reports_blocked_egress_host` is now parameterized over refused, legacy-format, all-timed-out, mixed, and curl-never-ran probe output. The all-timed-out case catches the regression this PR fixes. The mixed case catches a timeout hiding a real block. The curl-never-ran case catches a silent probe reported as a clean one.
- Ran the probe line format in real bash against a refused port, a reachable host, and an unroutable address: exit codes 7, 0, and 28 as expected.
- Ran `TestStartupFailureDiagnostics`, `TestModalSandboxAgentServer`, `TestSessionInitProbeHosts`, and mypy on the launcher.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (PostHog Desktop) found the misleading reason while reading diagnosed EU failures after #98043 and #98046 deployed: on one box the probe reported three different "blocked" hosts across three retries while the egress policy never changed. Skills: `writing-tests`, `writing-code-comments`, `writing-pr-descriptions`. Review follow-ups: the timeout wording lost its CPU-starvation claim, and the curl-never-ran case became its own reason.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

