### PR TITLE
chore(replay): cover both player frame paths in the e2e spec

### DIFF
--- a/products/replay/frontend/e2e/player.spec.ts
+++ b/products/replay/frontend/e2e/player.spec.ts
@@ -1,7 +1,9 @@
+import { mockFeatureFlags } from '@playwright-utils/mockApi'
 import { PlaywrightWorkspaceSetupResult, expect, test } from '@playwright-utils/workspace-test-base'
 import { Locator, Page } from '@playwright/test'
 import snappy from 'snappyjs'
 
+import { FEATURE_FLAGS } from 'lib/constants'
 import { recordingMetaJson } from 'scenes/session-recordings/__mocks__/recording_meta'
 import {
     lateFullSnapshotAsJSONLines,
@@ -145,8 +147,14 @@ async function mockRecordingApi(page: Page): Promise<void> {
     }
 }
 
-function playerFrame(page: Page): Locator {
-    return page.locator('.PlayerFrame__content .replayer-wrapper iframe')
+// The frame shell (posthog/templates/replay_player_frame/index.html) reuses these class names, so
+// only the document boundary differs between paths, and a Locator searches one document.
+const PLAYER_CONTENT_SELECTOR = '.PlayerFrame__content .replayer-wrapper iframe'
+
+function playerFrame(page: Page, ownDocument = false): Locator {
+    return ownDocument
+        ? page.frameLocator('iframe.PlayerFrame__document').locator(PLAYER_CONTENT_SELECTOR)
+        : page.locator(PLAYER_CONTENT_SELECTOR)
 }
 
 // One button whose data-attr reflects player state and stays assertable while the auto-hiding controls chrome is hidden (hover via revealControls before clicking it).
@@ -170,16 +178,47 @@ async function scrubTo(page: Page, fraction: number): Promise<void> {
     await page.mouse.click(box.x + box.width * fraction, box.y + box.height / 2)
 }
 
+// featureFlagLogic merges the server's `persisted_feature_flags` list as an always-on baseline over
+// posthog-js flags, so an instance that force-enables this flag picks the path on its own.
+// Pinning has to override both sources.
+async function pinOwnDocumentFlag(page: Page, enabled: boolean): Promise<void> {
+    await page.addInitScript(
+        ({ flag, enabled }: { flag: string; enabled: boolean }) => {
+            let context: Record<string, any> | undefined
+            // The app context lands in a later inline script, so intercept the assignment.
+            Object.defineProperty(window, 'POSTHOG_APP_CONTEXT', {
+                configurable: true,
+                get: () => context,
+                set: (value: Record<string, any> | undefined) => {
+                    const persisted = value?.persisted_feature_flags
+                    if (!value || !Array.isArray(persisted)) {
+                        context = value
+                        return
+                    }
+                    const withoutFlag = persisted.filter((f: string) => f !== flag)
+                    context = {
+                        ...value,
+                        persisted_feature_flags: enabled ? [...withoutFlag, flag] : withoutFlag,
+                    }
+                },
+            })
+        },
+        { flag: FEATURE_FLAGS.REPLAY_PLAYER_OWN_DOCUMENT, enabled }
+    )
+    await mockFeatureFlags(page, { [FEATURE_FLAGS.REPLAY_PLAYER_OWN_DOCUMENT]: enabled })
+}
+
 test.describe.configure({ mode: 'serial' })
 
+let workspace: PlaywrightWorkspaceSetupResult | null = null
+
+test.beforeAll(async ({ playwrightSetup }) => {
+    workspace = await playwrightSetup.createWorkspace({ skip_onboarding: true })
+})
+
 test.describe('Session replay player', () => {
-    let workspace: PlaywrightWorkspaceSetupResult | null = null
-
-    test.beforeAll(async ({ playwrightSetup }) => {
-        workspace = await playwrightSetup.createWorkspace({ skip_onboarding: true })
-    })
-
     test.beforeEach(async ({ page, playwrightSetup }) => {
+        await pinOwnDocumentFlag(page, false)
         await playwrightSetup.loginAndNavigateToTeam(page, workspace!)
         await mockRecordingApi(page)
     })
@@ -278,5 +317,27 @@ test.describe('Session replay player', () => {
         await expect(playerFrame(page)).toBeVisible({ timeout: 30000 })
         await expect(page.getByTestId('recording-timestamp')).toHaveText(/00:09.*00:11/)
         await expect(bufferingIndicator(page)).not.toBeVisible()
+    })
+})
+
+test.describe('Session replay player in its own document', () => {
+    test.beforeEach(async ({ page, playwrightSetup }) => {
+        await pinOwnDocumentFlag(page, true)
+        await playwrightSetup.loginAndNavigateToTeam(page, workspace!)
+        await mockRecordingApi(page)
+    })
+
+    test('mounts the player inside the frame document and plays', async ({ page }) => {
+        await page.goto(`/replay/${SESSION_ID}?t=0`)
+
+        await expect(page.locator('iframe.PlayerFrame__document')).toBeVisible({ timeout: 30000 })
+        // PlayerFrame swaps in this container when the frame loads without its mount node. Its absence
+        // proves no fallback, which would otherwise satisfy the assertions below and hide a broken frame.
+        await expect(page.locator('div.PlayerFrame__content')).toHaveCount(0)
+
+        await expect(playerFrame(page, true)).toBeVisible({ timeout: 30000 })
+
+        await expect(playPauseButton(page)).toHaveAttribute('data-attr', 'recording-pause')
+        await expect(page.getByTestId('recording-timestamp')).toHaveText(/00:0[1-9]|00:1[01]/, { timeout: 15000 })
     })
 })


### PR DESCRIPTION
## Problem

The session replay player has two rendering paths behind a flag, and the e2e suite covers only one of them.

- With `REPLAY_PLAYER_OWN_DOCUMENT` on, rrweb mounts inside a nested same-origin document.
- A Playwright `Locator` searches one document, so the spec's selector matches nothing on that path and every assertion times out.
- The spec never pins the flag, so it asserts against whichever path the instance it runs on happens to serve.

## Changes

- `playerFrame` crosses the frame boundary with `frameLocator` when the flag is on.
- Each suite pins the flag, so each one tests a known path.
- A new test covers the flag-on path: the frame mounts, the app-document container is absent, rrweb renders inside the frame, and playback advances.
- Pinning overrides both flag sources. `featureFlagLogic` merges the server's `persisted_feature_flags` list as an always-on baseline, so mocking posthog-js alone does not hold on an instance that force-enables the flag.
- The new test asserts the app-document container is absent, because the fallback path satisfies the other assertions and would hide a broken frame.
- One new test covers the mount, not a second copy of the suite. The playback assertions exercise app-document UI that the flag does not change.

Nothing user-visible changes. The diff is one test file, and no product code moves.

## How did you test this code?

The new test catches a player that mounts its frame but never renders a recording inside it, which no existing test could reach. Removing the `frameLocator` from `playerFrame` makes it fail, so the boundary crossing is load-bearing rather than incidental.

The flag pin catches a suite that silently swaps arms. Before this change the existing tests failed on a dev instance that force-enables the flag, because they asserted on the app-document shape while the app served the frame.

Ran locally against a dev stack: the full spec, both suites.

Not checked: the final commit only rewrote comments, and that revision did not re-run, because switching this branch to a master base left the local dev database behind the code and the workspace setup endpoint refused to run. The revision is comment-only, verified by diffing both revisions with comment lines stripped.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior, API, or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus 5) in a session where a person asked for both flag paths to be covered.

Skills invoked: `/writing-tests` to gate whether the coverage earned a browser test and to keep it to one case rather than a duplicated suite, `/writing-code-comments` for the comments, and `/writing-pr-descriptions` for this body.

The first attempt pinned the flag with `mockFeatureFlags` alone. That failed against a local instance, which led to the `persisted_feature_flags` baseline in `featureFlagLogic` and the two-source pin the PR ships.

No duplicate: `gh pr list --state open --search` over "frameLocator replay player", "player.spec", and "replay-player-own-document" returned no PR touching this spec. #97804 changes `PlayerFrame.tsx` frame-load handling and does not overlap this diff.

Public artifact: the session also monitored a production rollout. None of that data reaches this PR. The diff is test code written against this repository.
