### PR TITLE
feat(tasks): choose the Modal sandbox region per deployment with a flag

### DIFF
--- a/docs/published/handbook/engineering/ai/sandboxed-agents.md
+++ b/docs/published/handbook/engineering/ai/sandboxed-agents.md
@@ -286,6 +286,15 @@ which carries two origin allowlists and an optional default image:
   A user- or environment-selected custom image always wins over this default,
   and provisioning falls back to the plain VM base if the named image is missing.
 
+### Region selection
+
+Each deployment pins its sandboxes to one Modal region (`MODAL_REGION_BY_DEPLOYMENT` in `modal_sandbox.py`: `us-east` for US, `eu-west` for EU).
+The `tasks-modal-sandbox-region` flag overrides that per deployment.
+Its JSON payload is keyed by `CLOUD_DEPLOYMENT`, for example `{"EU": "eu"}` or `{"EU": ["eu-west", "eu-north"]}`, so a value for one deployment cannot move another's compute.
+Values must be Modal region ids (`MODAL_REGIONS` in `constants.py`); a payload with an unknown id is ignored and the default region stays.
+Modal's broad regions (`eu`, `us`, `ap`) pool every narrow region under them and carry a lower price multiplier than a single narrow region, so prefer them when a narrow pool runs short of hosts.
+The decision is captured once per run in `TaskProcessingContext.modal_sandbox_region`, so provisioning retries stay in the same region, and the run log records the override.
+
 #### The prebaked dev-stack image
 
 `hogli start` on a fresh VM pays for multi-gigabyte docker pulls and the full Django + persons +

--- a/docs/published/handbook/engineering/ai/sandboxed-agents.md
+++ b/docs/published/handbook/engineering/ai/sandboxed-agents.md
@@ -288,12 +288,10 @@ which carries two origin allowlists and an optional default image:
 
 ### Region selection
 
-Each deployment pins its sandboxes to one Modal region (`MODAL_REGION_BY_DEPLOYMENT` in `modal_sandbox.py`: `us-east` for US, `eu-west` for EU).
-The `tasks-modal-sandbox-region` flag overrides that per deployment.
-Its JSON payload is keyed by `CLOUD_DEPLOYMENT`, for example `{"EU": "eu"}` or `{"EU": ["eu-west", "eu-north"]}`, so a value for one deployment cannot move another's compute.
-Values must be Modal region ids (`MODAL_REGIONS` in `constants.py`); a payload with an unknown id is ignored and the default region stays.
-Modal's broad regions (`eu`, `us`, `ap`) pool every narrow region under them and carry a lower price multiplier than a single narrow region, so prefer them when a narrow pool runs short of hosts.
-The decision is captured once per run in `TaskProcessingContext.modal_sandbox_region`, so provisioning retries stay in the same region, and the run log records the override.
+Each deployment pins its sandboxes to one Modal region (`MODAL_REGION_BY_DEPLOYMENT`: `us-east` for US, `eu-west` for EU).
+The `tasks-modal-sandbox-region` flag overrides that per deployment: its payload is keyed by `CLOUD_DEPLOYMENT`, for example `{"EU": "eu"}` or `{"EU": ["eu-west", "eu-north"]}`.
+Values must be Modal region ids (`MODAL_REGIONS`); an unknown id leaves the default in place.
+Modal's broad regions (`eu`, `us`, `ap`) pool the narrow ones under them at a lower price multiplier, so prefer them when a narrow pool runs short of hosts.
 
 #### The prebaked dev-stack image
 

--- a/docs/published/handbook/engineering/ai/sandboxed-agents.md
+++ b/docs/published/handbook/engineering/ai/sandboxed-agents.md
@@ -290,8 +290,8 @@ which carries two origin allowlists and an optional default image:
 
 Each deployment pins its sandboxes to one Modal region (`MODAL_REGION_BY_DEPLOYMENT`: `us-east` for US, `eu-west` for EU).
 The `tasks-modal-sandbox-region` flag overrides that per deployment: its payload is keyed by `CLOUD_DEPLOYMENT`, for example `{"EU": "eu"}` or `{"EU": ["eu-west", "eu-north"]}`.
-Values must be Modal region ids (`MODAL_REGIONS`); an unknown id leaves the default in place.
-Modal's broad regions (`eu`, `us`, `ap`) pool the narrow ones under them at a lower price multiplier, so prefer them when a narrow pool runs short of hosts.
+Values must be Modal region ids the deployment is allowed to use (`MODAL_REGIONS_BY_DEPLOYMENT` lists the EU and US pools); anything else leaves the default in place, so the flag can only widen a deployment's pool inside its residency boundary.
+Modal's broad regions (`eu`, `us`) pool the narrow ones under them at a lower price multiplier, so prefer them when a narrow pool runs short of hosts.
 
 #### The prebaked dev-stack image
 

--- a/products/tasks/backend/constants.py
+++ b/products/tasks/backend/constants.py
@@ -27,33 +27,12 @@ DEV_STACK_IMAGE_BAKE_FEATURE_FLAG = "tasks-dev-stack-image-bake"
 MODAL_NETWORK_ALLOWLIST_FEATURE_FLAG = "tasks-modal-network-allowlist"
 # Payload keyed by CLOUD_DEPLOYMENT, e.g. `{"EU": "eu"}` or `{"EU": ["eu-west", "eu-north"]}`.
 MODAL_SANDBOX_REGION_FEATURE_FLAG = "tasks-modal-sandbox-region"
-# Region ids Modal accepts on Sandbox.create (modal.com/docs/guide/region-selection).
-MODAL_REGIONS: frozenset[str] = frozenset(
-    {
-        "us",
-        "us-east",
-        "us-central",
-        "us-south",
-        "us-west",
-        "eu",
-        "eu-west",
-        "eu-north",
-        "eu-south",
-        "ap",
-        "ap-northeast",
-        "ap-southeast",
-        "ap-south",
-        "ap-melbourne",
-        "jp",
-        "au",
-        "uk",
-        "ca",
-        "me",
-        "sa",
-        "af",
-        "mx",
-    }
-)
+# Modal region ids (modal.com/docs/guide/region-selection) each deployment may pick, so the
+# flag can widen the pool but never move a sandbox out of the deployment's residency boundary.
+MODAL_REGIONS_BY_DEPLOYMENT: dict[str, frozenset[str]] = {
+    "EU": frozenset({"eu", "eu-west", "eu-north", "eu-south"}),
+    "US": frozenset({"us", "us-east", "us-central", "us-south", "us-west"}),
+}
 # Routes a plain default-template run onto the hogland (Firecracker) sandbox backend.
 HOGLAND_SANDBOX_FEATURE_FLAG = "tasks-hogland-sandbox"
 AGENT_RUN_OTEL_TELEMETRY_FEATURE_FLAG = "tasks-agent-run-otel-telemetry"
@@ -143,19 +122,22 @@ def _decode_vm_sandbox_payload(payload: object) -> object:
 
 
 def modal_sandbox_region_from_payload(payload: object, deployment: str | None) -> list[str] | None:
-    # Keyed by deployment so a value meant for EU can never move US compute.
     payload = _decode_vm_sandbox_payload(payload)
     if not isinstance(payload, dict):
         return None
-    return _validated_modal_regions(payload.get(deployment or ""))
+    allowed = MODAL_REGIONS_BY_DEPLOYMENT.get(deployment or "")
+    if not allowed:
+        return None
+    return _validated_modal_regions(payload.get(deployment), allowed)
 
 
-def _validated_modal_regions(value: object) -> list[str] | None:
-    # An id Modal does not know would fail every create in the deployment, so drop the whole value.
+def _validated_modal_regions(value: object, allowed: frozenset[str]) -> list[str] | None:
+    # One unusable id drops the whole value: a partial list would still send some sandboxes
+    # to a region the deployment must not use, or to one Modal rejects on every create.
     regions = [value] if isinstance(value, str) else value
     if not isinstance(regions, list) or not regions:
         return None
-    if not all(isinstance(region, str) and region in MODAL_REGIONS for region in regions):
+    if not all(isinstance(region, str) and region in allowed for region in regions):
         return None
     return list(regions)
 

--- a/products/tasks/backend/constants.py
+++ b/products/tasks/backend/constants.py
@@ -147,10 +147,10 @@ def modal_sandbox_region_from_payload(payload: object, deployment: str | None) -
     payload = _decode_vm_sandbox_payload(payload)
     if not isinstance(payload, dict):
         return None
-    return validated_modal_regions(payload.get(deployment or ""))
+    return _validated_modal_regions(payload.get(deployment or ""))
 
 
-def validated_modal_regions(value: object) -> list[str] | None:
+def _validated_modal_regions(value: object) -> list[str] | None:
     # An id Modal does not know would fail every create in the deployment, so drop the whole value.
     regions = [value] if isinstance(value, str) else value
     if not isinstance(regions, list) or not regions:

--- a/products/tasks/backend/constants.py
+++ b/products/tasks/backend/constants.py
@@ -25,12 +25,9 @@ MODAL_VM_SANDBOX_FEATURE_FLAG = "tasks-modal-vm-sandbox"
 # Gates the nightly prebaked dev-stack image bake (see logic/services/dev_stack_image.py).
 DEV_STACK_IMAGE_BAKE_FEATURE_FLAG = "tasks-dev-stack-image-bake"
 MODAL_NETWORK_ALLOWLIST_FEATURE_FLAG = "tasks-modal-network-allowlist"
-# Overrides the Modal region a sandbox is placed in. The payload is keyed by CLOUD_DEPLOYMENT
-# (`{"EU": "eu"}` or `{"EU": ["eu-west", "eu-north"]}`), so one flag cannot move a region's
-# compute by accident. Values must be Modal region ids (MODAL_REGIONS); anything else is ignored.
+# Payload keyed by CLOUD_DEPLOYMENT, e.g. `{"EU": "eu"}` or `{"EU": ["eu-west", "eu-north"]}`.
 MODAL_SANDBOX_REGION_FEATURE_FLAG = "tasks-modal-sandbox-region"
-# Region ids Modal accepts on Sandbox.create. Broad ids (`us`, `eu`, `ap`) pool every narrow
-# region under them and price at a lower multiplier. See modal.com/docs/guide/region-selection.
+# Region ids Modal accepts on Sandbox.create (modal.com/docs/guide/region-selection).
 MODAL_REGIONS: frozenset[str] = frozenset(
     {
         "us",

--- a/products/tasks/backend/constants.py
+++ b/products/tasks/backend/constants.py
@@ -25,6 +25,38 @@ MODAL_VM_SANDBOX_FEATURE_FLAG = "tasks-modal-vm-sandbox"
 # Gates the nightly prebaked dev-stack image bake (see logic/services/dev_stack_image.py).
 DEV_STACK_IMAGE_BAKE_FEATURE_FLAG = "tasks-dev-stack-image-bake"
 MODAL_NETWORK_ALLOWLIST_FEATURE_FLAG = "tasks-modal-network-allowlist"
+# Overrides the Modal region a sandbox is placed in. The payload is keyed by CLOUD_DEPLOYMENT
+# (`{"EU": "eu"}` or `{"EU": ["eu-west", "eu-north"]}`), so one flag cannot move a region's
+# compute by accident. Values must be Modal region ids (MODAL_REGIONS); anything else is ignored.
+MODAL_SANDBOX_REGION_FEATURE_FLAG = "tasks-modal-sandbox-region"
+# Region ids Modal accepts on Sandbox.create. Broad ids (`us`, `eu`, `ap`) pool every narrow
+# region under them and price at a lower multiplier. See modal.com/docs/guide/region-selection.
+MODAL_REGIONS: frozenset[str] = frozenset(
+    {
+        "us",
+        "us-east",
+        "us-central",
+        "us-south",
+        "us-west",
+        "eu",
+        "eu-west",
+        "eu-north",
+        "eu-south",
+        "ap",
+        "ap-northeast",
+        "ap-southeast",
+        "ap-south",
+        "ap-melbourne",
+        "jp",
+        "au",
+        "uk",
+        "ca",
+        "me",
+        "sa",
+        "af",
+        "mx",
+    }
+)
 # Routes a plain default-template run onto the hogland (Firecracker) sandbox backend.
 HOGLAND_SANDBOX_FEATURE_FLAG = "tasks-hogland-sandbox"
 AGENT_RUN_OTEL_TELEMETRY_FEATURE_FLAG = "tasks-agent-run-otel-telemetry"

--- a/products/tasks/backend/constants.py
+++ b/products/tasks/backend/constants.py
@@ -142,6 +142,24 @@ def _decode_vm_sandbox_payload(payload: object) -> object:
     return payload
 
 
+def modal_sandbox_region_from_payload(payload: object, deployment: str | None) -> list[str] | None:
+    # Keyed by deployment so a value meant for EU can never move US compute.
+    payload = _decode_vm_sandbox_payload(payload)
+    if not isinstance(payload, dict):
+        return None
+    return validated_modal_regions(payload.get(deployment or ""))
+
+
+def validated_modal_regions(value: object) -> list[str] | None:
+    # An id Modal does not know would fail every create in the deployment, so drop the whole value.
+    regions = [value] if isinstance(value, str) else value
+    if not isinstance(regions, list) or not regions:
+        return None
+    if not all(isinstance(region, str) and region in MODAL_REGIONS for region in regions):
+        return None
+    return list(regions)
+
+
 def vm_sandbox_allowed_origin_products(payload: object) -> set[str]:
     """Origin products allowed on the Modal VM runtime, parsed from the flag's payload."""
     payload = _decode_vm_sandbox_payload(payload)

--- a/products/tasks/backend/feature_flags.py
+++ b/products/tasks/backend/feature_flags.py
@@ -43,7 +43,6 @@ def is_workflow_dispatch_shadow_enabled() -> bool:
 
 
 def get_org_flag_payload(flag: str, *, distinct_id: str, organization_id: str) -> object | None:
-    """Payload of an org-targeted flag, or None when the flag is off or the check fails."""
     try:
         return posthoganalytics.get_feature_flag_payload(
             flag,

--- a/products/tasks/backend/feature_flags.py
+++ b/products/tasks/backend/feature_flags.py
@@ -42,6 +42,22 @@ def is_workflow_dispatch_shadow_enabled() -> bool:
         return False
 
 
+def get_org_flag_payload(flag: str, *, distinct_id: str, organization_id: str) -> object | None:
+    """Payload of an org-targeted flag, or None when the flag is off or the check fails."""
+    try:
+        return posthoganalytics.get_feature_flag_payload(
+            flag,
+            distinct_id=distinct_id,
+            groups={"organization": organization_id},
+            group_properties={"organization": {"id": organization_id}},
+            only_evaluate_locally=False,
+            send_feature_flag_events=False,
+        )
+    except Exception:
+        logger.exception("org_flag_payload_check_failed", extra={"flag": flag})
+        return None
+
+
 def _is_workflow_dispatch_org_flag_enabled(flag: str, organization_id: str, distinct_id: str) -> bool:
     try:
         return bool(

--- a/products/tasks/backend/logic/services/modal_sandbox.py
+++ b/products/tasks/backend/logic/services/modal_sandbox.py
@@ -806,7 +806,7 @@ class ModalSandbox(AgentServerLaunchMixin):
 
             sandbox_name = f"{config.name}-{uuid.uuid4().hex[:6]}"
 
-            region: str | list[str] = config.region or _get_modal_region()
+            region = config.region or _get_modal_region()
 
             create_kwargs: dict[str, object] = {
                 "app": app,

--- a/products/tasks/backend/logic/services/modal_sandbox.py
+++ b/products/tasks/backend/logic/services/modal_sandbox.py
@@ -806,7 +806,7 @@ class ModalSandbox(AgentServerLaunchMixin):
 
             sandbox_name = f"{config.name}-{uuid.uuid4().hex[:6]}"
 
-            region = _get_modal_region()
+            region: str | list[str] = config.region or _get_modal_region()
 
             create_kwargs: dict[str, object] = {
                 "app": app,

--- a/products/tasks/backend/logic/services/sandbox.py
+++ b/products/tasks/backend/logic/services/sandbox.py
@@ -166,7 +166,7 @@ class SandboxConfig(BaseModel):
     cpu_request_cores: float = BURSTABLE_REQUEST_CPU_CORES
     memory_request_mb: int = BURSTABLE_REQUEST_MEMORY_MB
     vm_runtime: bool = False
-    # Modal region ids to place the box in. None means the deployment's default region.
+    # None keeps the deployment's default Modal region.
     region: list[str] | None = None
     outbound_domain_allowlist: list[str] | None = None
     network_policy_fingerprint: str | None = None

--- a/products/tasks/backend/logic/services/sandbox.py
+++ b/products/tasks/backend/logic/services/sandbox.py
@@ -166,6 +166,8 @@ class SandboxConfig(BaseModel):
     cpu_request_cores: float = BURSTABLE_REQUEST_CPU_CORES
     memory_request_mb: int = BURSTABLE_REQUEST_MEMORY_MB
     vm_runtime: bool = False
+    # Modal region ids to place the box in. None means the deployment's default region.
+    region: list[str] | None = None
     outbound_domain_allowlist: list[str] | None = None
     network_policy_fingerprint: str | None = None
     # gVisor only. An empty domain allowlist means unrestricted network in

--- a/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
+++ b/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
@@ -1532,6 +1532,20 @@ class TestModalSandboxCreateAllowlist:
 
         assert "outbound_domain_allowlist" not in mock_create.call_args.kwargs
 
+    @pytest.mark.parametrize(
+        "region_override, expected_region",
+        [(None, "eu-west"), (["eu"], ["eu"]), (["eu-west", "eu-north"], ["eu-west", "eu-north"])],
+    )
+    def test_create_places_the_box_in_the_config_region_over_the_deployment_default(
+        self, region_override: list[str] | None, expected_region: str | list[str]
+    ):
+        config = SandboxConfig(name="t", region=region_override)
+
+        with patch("products.tasks.backend.logic.services.modal_sandbox.CLOUD_DEPLOYMENT", "EU"):
+            mock_create = self._create_with_config(config)
+
+        assert mock_create.call_args.kwargs["region"] == expected_region
+
     def test_create_forwards_empty_allowlist_when_explicitly_set(self):
         config = SandboxConfig(name="t", outbound_domain_allowlist=[])
 

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -26,6 +26,8 @@ from products.tasks.backend.constants import (
     DEV_STACK_PREVIEW_FEATURE_FLAG,
     HOGLAND_SANDBOX_FEATURE_FLAG,
     MODAL_NETWORK_ALLOWLIST_FEATURE_FLAG,
+    MODAL_REGIONS,
+    MODAL_SANDBOX_REGION_FEATURE_FLAG,
     OVERLAP_CLONE_BOOT_FEATURE_FLAG,
     PR_BABYSIT_SNAPSHOT_FEATURE_FLAG,
     PR_LOOP_ENABLED_STATE_KEY,
@@ -132,6 +134,9 @@ class TaskProcessingContext:
     agent_otel_telemetry_enabled: bool = False
     use_modal_vm_sandbox: bool = False
     use_modal_network_allowlist: bool = False
+    # Modal region override for this run, or None for the deployment default. Captured at
+    # workflow start so every provisioning retry places the box in the same region.
+    modal_sandbox_region: list[str] | None = None
     # Burstable by default; the per-run state can opt out to pin a fixed-size box
     # (request == limit). Captured at workflow start so it's stable across activity retries.
     burstable_sandbox_resources_enabled: bool = True
@@ -869,6 +874,63 @@ def _is_dev_stack_preview_enabled(
     return enabled
 
 
+def _resolve_modal_sandbox_region(
+    *,
+    distinct_id: str,
+    organization_id: str,
+    run_id: str,
+    state: dict | None = None,
+) -> list[str] | None:
+    state_override = _validated_modal_regions((state or {}).get("modal_sandbox_region"))
+    if state_override is not None:
+        log_with_activity_context("modal_sandbox_region_state_override", run_id=run_id, region=state_override)
+        return state_override
+
+    try:
+        payload = posthoganalytics.get_feature_flag_payload(
+            MODAL_SANDBOX_REGION_FEATURE_FLAG,
+            distinct_id=distinct_id,
+            groups={"organization": organization_id},
+            group_properties={"organization": {"id": organization_id}},
+            only_evaluate_locally=False,
+            send_feature_flag_events=False,
+        )
+    except Exception as e:
+        log_with_activity_context("modal_sandbox_region_flag_check_failed", run_id=run_id, error=str(e))
+        return None
+
+    region = _modal_sandbox_region_from_payload(payload)
+    if region is not None:
+        log_with_activity_context("modal_sandbox_region_flag_override", run_id=run_id, region=region)
+    return region
+
+
+def _modal_sandbox_region_from_payload(payload: object, deployment: str | None = None) -> list[str] | None:
+    """Read this deployment's region list out of the flag payload, or None to keep the default.
+
+    The payload is keyed by CLOUD_DEPLOYMENT so a value meant for EU can never move US compute.
+    A region id Modal does not know is dropped with the rest of the value, because a typo that
+    reached Sandbox.create would fail every provisioning in the deployment.
+    """
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except json.JSONDecodeError:
+            return None
+    if not isinstance(payload, dict):
+        return None
+    return _validated_modal_regions(payload.get(deployment or settings.CLOUD_DEPLOYMENT or ""))
+
+
+def _validated_modal_regions(value: object) -> list[str] | None:
+    regions = [value] if isinstance(value, str) else value
+    if not isinstance(regions, list) or not regions:
+        return None
+    if not all(isinstance(region, str) and region in MODAL_REGIONS for region in regions):
+        return None
+    return list(regions)
+
+
 def _is_modal_network_allowlist_enabled(
     *,
     distinct_id: str,
@@ -1301,6 +1363,12 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         run_id=run_id,
         state=state,
     )
+    modal_sandbox_region = _resolve_modal_sandbox_region(
+        distinct_id=distinct_id,
+        organization_id=organization_id,
+        run_id=run_id,
+        state=state,
+    )
     emit_agent_log(
         run_id,
         "debug",
@@ -1542,6 +1610,7 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         agent_otel_telemetry_enabled=agent_otel_telemetry_enabled,
         use_modal_vm_sandbox=use_modal_vm_sandbox,
         use_modal_network_allowlist=use_modal_network_allowlist,
+        modal_sandbox_region=modal_sandbox_region,
         burstable_sandbox_resources_enabled=burstable_sandbox_resources_enabled,
         overlap_clone_boot_enabled=overlap_clone_boot_enabled,
         desktop_workspace_warm_enabled=desktop_workspace_warm_enabled,

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -50,7 +50,7 @@ from products.tasks.backend.exceptions import (
     TaskRunNotReadyError,
 )
 from products.tasks.backend.facade.api import ensure_task_run_session
-from products.tasks.backend.feature_flags import is_agent_otel_telemetry_enabled
+from products.tasks.backend.feature_flags import get_org_flag_payload, is_agent_otel_telemetry_enabled
 from products.tasks.backend.logic.services.agentsh import (
     _get_debug_only_domains,
     _get_debug_only_ports,
@@ -134,8 +134,7 @@ class TaskProcessingContext:
     agent_otel_telemetry_enabled: bool = False
     use_modal_vm_sandbox: bool = False
     use_modal_network_allowlist: bool = False
-    # Modal region override for this run, or None for the deployment default. Captured at
-    # workflow start so every provisioning retry places the box in the same region.
+    # Captured at workflow start so provisioning retries stay in one region.
     modal_sandbox_region: list[str] | None = None
     # Burstable by default; the per-run state can opt out to pin a fixed-size box
     # (request == limit). Captured at workflow start so it's stable across activity retries.
@@ -886,19 +885,9 @@ def _resolve_modal_sandbox_region(
         log_with_activity_context("modal_sandbox_region_state_override", run_id=run_id, region=state_override)
         return state_override
 
-    try:
-        payload = posthoganalytics.get_feature_flag_payload(
-            MODAL_SANDBOX_REGION_FEATURE_FLAG,
-            distinct_id=distinct_id,
-            groups={"organization": organization_id},
-            group_properties={"organization": {"id": organization_id}},
-            only_evaluate_locally=False,
-            send_feature_flag_events=False,
-        )
-    except Exception as e:
-        log_with_activity_context("modal_sandbox_region_flag_check_failed", run_id=run_id, error=str(e))
-        return None
-
+    payload = get_org_flag_payload(
+        MODAL_SANDBOX_REGION_FEATURE_FLAG, distinct_id=distinct_id, organization_id=organization_id
+    )
     region = _modal_sandbox_region_from_payload(payload)
     if region is not None:
         log_with_activity_context("modal_sandbox_region_flag_override", run_id=run_id, region=region)
@@ -906,12 +895,7 @@ def _resolve_modal_sandbox_region(
 
 
 def _modal_sandbox_region_from_payload(payload: object, deployment: str | None = None) -> list[str] | None:
-    """Read this deployment's region list out of the flag payload, or None to keep the default.
-
-    The payload is keyed by CLOUD_DEPLOYMENT so a value meant for EU can never move US compute.
-    A region id Modal does not know is dropped with the rest of the value, because a typo that
-    reached Sandbox.create would fail every provisioning in the deployment.
-    """
+    # Keyed by deployment so a value meant for EU can never move US compute.
     if isinstance(payload, str):
         try:
             payload = json.loads(payload)
@@ -923,6 +907,7 @@ def _modal_sandbox_region_from_payload(payload: object, deployment: str | None =
 
 
 def _validated_modal_regions(value: object) -> list[str] | None:
+    # An id Modal does not know would fail every create in the deployment, so drop the whole value.
     regions = [value] if isinstance(value, str) else value
     if not isinstance(regions, list) or not regions:
         return None

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -26,7 +26,6 @@ from products.tasks.backend.constants import (
     DEV_STACK_PREVIEW_FEATURE_FLAG,
     HOGLAND_SANDBOX_FEATURE_FLAG,
     MODAL_NETWORK_ALLOWLIST_FEATURE_FLAG,
-    MODAL_REGIONS,
     MODAL_SANDBOX_REGION_FEATURE_FLAG,
     OVERLAP_CLONE_BOOT_FEATURE_FLAG,
     PR_BABYSIT_SNAPSHOT_FEATURE_FLAG,
@@ -37,6 +36,8 @@ from products.tasks.backend.constants import (
     STORE_SKILLS_STATE_KEY,
     get_vm_sandbox_flag_payload,
     is_same_run_resume_state,
+    modal_sandbox_region_from_payload,
+    validated_modal_regions,
     vm_sandbox_allowed_origin_products,
     vm_sandbox_default_base_origin_products,
     vm_sandbox_default_custom_image,
@@ -880,7 +881,7 @@ def _resolve_modal_sandbox_region(
     run_id: str,
     state: dict | None = None,
 ) -> list[str] | None:
-    state_override = _validated_modal_regions((state or {}).get("modal_sandbox_region"))
+    state_override = validated_modal_regions((state or {}).get("modal_sandbox_region"))
     if state_override is not None:
         log_with_activity_context("modal_sandbox_region_state_override", run_id=run_id, region=state_override)
         return state_override
@@ -888,32 +889,10 @@ def _resolve_modal_sandbox_region(
     payload = get_org_flag_payload(
         MODAL_SANDBOX_REGION_FEATURE_FLAG, distinct_id=distinct_id, organization_id=organization_id
     )
-    region = _modal_sandbox_region_from_payload(payload)
+    region = modal_sandbox_region_from_payload(payload, settings.CLOUD_DEPLOYMENT)
     if region is not None:
         log_with_activity_context("modal_sandbox_region_flag_override", run_id=run_id, region=region)
     return region
-
-
-def _modal_sandbox_region_from_payload(payload: object, deployment: str | None = None) -> list[str] | None:
-    # Keyed by deployment so a value meant for EU can never move US compute.
-    if isinstance(payload, str):
-        try:
-            payload = json.loads(payload)
-        except json.JSONDecodeError:
-            return None
-    if not isinstance(payload, dict):
-        return None
-    return _validated_modal_regions(payload.get(deployment or settings.CLOUD_DEPLOYMENT or ""))
-
-
-def _validated_modal_regions(value: object) -> list[str] | None:
-    # An id Modal does not know would fail every create in the deployment, so drop the whole value.
-    regions = [value] if isinstance(value, str) else value
-    if not isinstance(regions, list) or not regions:
-        return None
-    if not all(isinstance(region, str) and region in MODAL_REGIONS for region in regions):
-        return None
-    return list(regions)
 
 
 def _is_modal_network_allowlist_enabled(

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -880,6 +880,10 @@ def _resolve_modal_sandbox_region(*, distinct_id: str, organization_id: str, run
     region = modal_sandbox_region_from_payload(payload, settings.CLOUD_DEPLOYMENT)
     if region is not None:
         log_with_activity_context("modal_sandbox_region_flag_override", run_id=run_id, region=region)
+    elif payload is not None:
+        # A payload the deployment cannot use is silent otherwise, and it looks the same as
+        # a flag that never matched the org.
+        log_with_activity_context("modal_sandbox_region_flag_ignored", run_id=run_id, payload=payload)
     return region
 
 

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -37,7 +37,6 @@ from products.tasks.backend.constants import (
     get_vm_sandbox_flag_payload,
     is_same_run_resume_state,
     modal_sandbox_region_from_payload,
-    validated_modal_regions,
     vm_sandbox_allowed_origin_products,
     vm_sandbox_default_base_origin_products,
     vm_sandbox_default_custom_image,
@@ -874,18 +873,7 @@ def _is_dev_stack_preview_enabled(
     return enabled
 
 
-def _resolve_modal_sandbox_region(
-    *,
-    distinct_id: str,
-    organization_id: str,
-    run_id: str,
-    state: dict | None = None,
-) -> list[str] | None:
-    state_override = validated_modal_regions((state or {}).get("modal_sandbox_region"))
-    if state_override is not None:
-        log_with_activity_context("modal_sandbox_region_state_override", run_id=run_id, region=state_override)
-        return state_override
-
+def _resolve_modal_sandbox_region(*, distinct_id: str, organization_id: str, run_id: str) -> list[str] | None:
     payload = get_org_flag_payload(
         MODAL_SANDBOX_REGION_FEATURE_FLAG, distinct_id=distinct_id, organization_id=organization_id
     )
@@ -1328,10 +1316,7 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         state=state,
     )
     modal_sandbox_region = _resolve_modal_sandbox_region(
-        distinct_id=distinct_id,
-        organization_id=organization_id,
-        run_id=run_id,
-        state=state,
+        distinct_id=distinct_id, organization_id=organization_id, run_id=run_id
     )
     emit_agent_log(
         run_id,
@@ -1487,7 +1472,7 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         has_user_custom_image=environment_custom_image_name is not None,
     )
     if sandbox_backend == "hogland":
-        # Hogland runs are plain golden-template runs, so the Modal VM-runtime,
+        # Hogland runs are plain golden-template runs, so the Modal VM-runtime, region,
         # network-allowlist, and org-default-image preferences don't apply. Force them off
         # so provisioning builds a plain hogland box on the golden (not a Modal VM_BASE
         # config with a default image) and skips the Modal provider-layer allowlist. Egress
@@ -1495,6 +1480,7 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         # independently of use_modal_network_allowlist.
         use_modal_vm_sandbox = False
         use_modal_network_allowlist = False
+        modal_sandbox_region = None
         custom_image_name = None
     emit_agent_log(
         run_id,

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -801,8 +801,11 @@ def _create_sandbox_for_repository(input: CreateSandboxForRepositoryInput) -> Cr
             snapshot_source=prepared.snapshot_source,
             metadata=_build_sandbox_tags(ctx, prepared, use_vm_sandbox),
             vm_runtime=use_vm_sandbox,
+            region=ctx.modal_sandbox_region,
             **resource_overrides,
         )
+        if ctx.modal_sandbox_region:
+            emit_agent_log(ctx.run_id, "debug", f"Sandbox region override: {', '.join(ctx.modal_sandbox_region)}")
 
         # Request a small slice and let the box burst up to the configured size. Burstable by
         # default, but the per-run state can opt out to pin a fixed-size box (request == limit).

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
@@ -1677,15 +1677,19 @@ class TestResolveModalSandboxRegion:
             ({"EU": ["eu-west", "eu-north"]}, "EU", ["eu-west", "eu-north"]),
             ('{"EU": "eu"}', "EU", ["eu"]),
             ({"EU": "eu"}, "US", None),
+            ({"EU": "us-east"}, "EU", None),
+            ({"EU": ["eu-west", "us-east"]}, "EU", None),
+            ({"US": "eu"}, "US", None),
             ({"EU": "eu-central"}, "EU", None),
             ({"EU": ["eu", "europe"]}, "EU", None),
             ({"EU": []}, "EU", None),
             ({"EU": 1}, "EU", None),
+            ({"": "eu"}, None, None),
             ("not json", "EU", None),
             (None, "EU", None),
         ],
     )
-    def test_reads_only_this_deployments_known_regions(self, payload, deployment, expected):
+    def test_reads_only_regions_inside_this_deployments_boundary(self, payload, deployment, expected):
         assert modal_sandbox_region_from_payload(payload, deployment) == expected
 
     def test_flag_failure_keeps_the_deployment_default(self):

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
@@ -1688,18 +1688,6 @@ class TestResolveModalSandboxRegion:
     def test_reads_only_this_deployments_known_regions(self, payload, deployment, expected):
         assert modal_sandbox_region_from_payload(payload, deployment) == expected
 
-    def test_state_override_wins_without_consulting_the_flag(self):
-        with patch(ORG_FLAG_PAYLOAD_TARGET) as payload_mock:
-            region = _resolve_modal_sandbox_region(
-                distinct_id="distinct-id",
-                organization_id="organization-id",
-                run_id="run-id",
-                state={"modal_sandbox_region": ["eu-north"]},
-            )
-
-        assert region == ["eu-north"]
-        payload_mock.assert_not_called()
-
     def test_flag_failure_keeps_the_deployment_default(self):
         with patch(ORG_FLAG_PAYLOAD_TARGET, side_effect=RuntimeError("flags unavailable")):
             assert (

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
@@ -24,6 +24,7 @@ from products.tasks.backend.constants import (
     RTK_DISABLED_FEATURE_FLAG,
     SANDBOX_EVENT_INGEST_FEATURE_FLAG,
     STORE_SKILLS_STATE_KEY,
+    modal_sandbox_region_from_payload,
     vm_sandbox_allowed_origin_products,
     vm_sandbox_default_base_origin_products,
     vm_sandbox_default_custom_image,
@@ -46,7 +47,6 @@ from products.tasks.backend.temporal.process_task.activities.get_task_processing
     _is_pr_babysit_snapshot_enabled,
     _is_rtk_enabled,
     _is_sandbox_event_ingest_enabled,
-    _modal_sandbox_region_from_payload,
     _resolve_claude_model_access,
     _resolve_modal_sandbox_region,
     _resolve_modal_vm_sandbox,
@@ -1676,9 +1676,7 @@ class TestResolveModalSandboxRegion:
             ({"EU": "eu"}, "EU", ["eu"]),
             ({"EU": ["eu-west", "eu-north"]}, "EU", ["eu-west", "eu-north"]),
             ('{"EU": "eu"}', "EU", ["eu"]),
-            # A value for another deployment never moves this one's compute.
             ({"EU": "eu"}, "US", None),
-            # A region id Modal does not know drops the whole value rather than failing every create.
             ({"EU": "eu-central"}, "EU", None),
             ({"EU": ["eu", "europe"]}, "EU", None),
             ({"EU": []}, "EU", None),
@@ -1688,7 +1686,7 @@ class TestResolveModalSandboxRegion:
         ],
     )
     def test_reads_only_this_deployments_known_regions(self, payload, deployment, expected):
-        assert _modal_sandbox_region_from_payload(payload, deployment) == expected
+        assert modal_sandbox_region_from_payload(payload, deployment) == expected
 
     def test_state_override_wins_without_consulting_the_flag(self):
         with patch(ORG_FLAG_PAYLOAD_TARGET) as payload_mock:

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
@@ -46,7 +46,9 @@ from products.tasks.backend.temporal.process_task.activities.get_task_processing
     _is_pr_babysit_snapshot_enabled,
     _is_rtk_enabled,
     _is_sandbox_event_ingest_enabled,
+    _modal_sandbox_region_from_payload,
     _resolve_claude_model_access,
+    _resolve_modal_sandbox_region,
     _resolve_modal_vm_sandbox,
     _resolve_sandbox_backend,
     get_task_processing_context,
@@ -1664,6 +1666,49 @@ class TestGetTaskProcessingContextActivity:
 
 
 _HOGLAND_SETTINGS = {"HOGLAND_API_URL": "https://hogland.example", "HOGLAND_API_TOKEN": "hog-tok"}
+
+
+class TestResolveModalSandboxRegion:
+    @pytest.mark.parametrize(
+        "payload, deployment, expected",
+        [
+            ({"EU": "eu"}, "EU", ["eu"]),
+            ({"EU": ["eu-west", "eu-north"]}, "EU", ["eu-west", "eu-north"]),
+            ('{"EU": "eu"}', "EU", ["eu"]),
+            # A value for another deployment never moves this one's compute.
+            ({"EU": "eu"}, "US", None),
+            # A region id Modal does not know drops the whole value rather than failing every create.
+            ({"EU": "eu-central"}, "EU", None),
+            ({"EU": ["eu", "europe"]}, "EU", None),
+            ({"EU": []}, "EU", None),
+            ({"EU": 1}, "EU", None),
+            ("not json", "EU", None),
+            (None, "EU", None),
+        ],
+    )
+    def test_reads_only_this_deployments_known_regions(self, payload, deployment, expected):
+        assert _modal_sandbox_region_from_payload(payload, deployment) == expected
+
+    def test_state_override_wins_without_consulting_the_flag(self):
+        with patch(BENJAMIN_PAYLOAD_TARGET) as payload_mock:
+            region = _resolve_modal_sandbox_region(
+                distinct_id="distinct-id",
+                organization_id="organization-id",
+                run_id="run-id",
+                state={"modal_sandbox_region": ["eu-north"]},
+            )
+
+        assert region == ["eu-north"]
+        payload_mock.assert_not_called()
+
+    def test_flag_failure_keeps_the_deployment_default(self):
+        with patch(BENJAMIN_PAYLOAD_TARGET, side_effect=RuntimeError("flags unavailable")):
+            assert (
+                _resolve_modal_sandbox_region(
+                    distinct_id="distinct-id", organization_id="organization-id", run_id="run-id"
+                )
+                is None
+            )
 
 
 class TestResolveSandboxBackend:

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
@@ -60,6 +60,7 @@ BENJAMIN_PAYLOAD_TARGET = (
     "products.tasks.backend.temporal.process_task.activities."
     "get_task_processing_context.posthoganalytics.get_feature_flag_payload"
 )
+ORG_FLAG_PAYLOAD_TARGET = "products.tasks.backend.feature_flags.posthoganalytics.get_feature_flag_payload"
 
 
 @pytest.mark.parametrize(
@@ -1690,7 +1691,7 @@ class TestResolveModalSandboxRegion:
         assert _modal_sandbox_region_from_payload(payload, deployment) == expected
 
     def test_state_override_wins_without_consulting_the_flag(self):
-        with patch(BENJAMIN_PAYLOAD_TARGET) as payload_mock:
+        with patch(ORG_FLAG_PAYLOAD_TARGET) as payload_mock:
             region = _resolve_modal_sandbox_region(
                 distinct_id="distinct-id",
                 organization_id="organization-id",
@@ -1702,7 +1703,7 @@ class TestResolveModalSandboxRegion:
         payload_mock.assert_not_called()
 
     def test_flag_failure_keeps_the_deployment_default(self):
-        with patch(BENJAMIN_PAYLOAD_TARGET, side_effect=RuntimeError("flags unavailable")):
+        with patch(ORG_FLAG_PAYLOAD_TARGET, side_effect=RuntimeError("flags unavailable")):
             assert (
                 _resolve_modal_sandbox_region(
                     distinct_id="distinct-id", organization_id="organization-id", run_id="run-id"


### PR DESCRIPTION
## Problem

EU sandboxes are pinned to Modal's narrow `eu-west` region, which serves us with about three worker hosts. When a scout burst overflows them, the extra boxes land on hosts that give them a fraction of a core and the agent server never starts ([error tracking issue](https://us.posthog.com/project/2/error_tracking/01a02559-40a4-79e2-bfdb-db8f0bfe48b6), EU only). US spreads the same load over 200+ hosts in `us-east`.

Modal's broad `eu` region pools `eu-west`, `eu-north`, and `eu-south` inside the EEA at a lower price multiplier ([docs](https://modal.com/docs/guide/region-selection)). Changing region today needs a deploy and cannot be tried on part of the traffic.

## Changes

- New flag `tasks-modal-sandbox-region` overrides the Modal region per deployment. Payload keyed by `CLOUD_DEPLOYMENT`: `{"EU": "eu"}` or `{"EU": ["eu-west", "eu-north"]}`.
- The flag can only widen a deployment inside its own region pool. EU picks from `eu`, `eu-west`, `eu-north` and `eu-south`, US from the five `us-*` ids.
- Any other value is ignored and the deployment default stays, so neither a typo nor a US region id moves EU compute out of the EEA. The run log records the dropped payload.
- Decision captured once per run, so retries stay in one region, and logged in the run log. The flag is the only source; run state cannot set a region. Hogland runs ignore it like the other Modal-only preferences.
- `get_org_flag_payload` in `feature_flags.py` is the shared payload call for run-scoped flags; the other 16 call sites can move onto it in a follow-up.

Nothing changes until the flag has a payload.

## How did you test this code?

- `TestResolveModalSandboxRegion`: payload shapes, another deployment's key, unknown ids, region ids outside the deployment's pool, flag failure.
- `test_create_places_the_box_in_the_config_region_over_the_deployment_default`: the region reaches `Sandbox.create`.
- Ran the context and provision activity tests (Postgres-backed cases skipped here) and mypy.


