### PR TITLE
fix(warehouse-sources): stop the Northpass webhooks walk on an empty page

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/northpass_lms/northpass_lms.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/northpass_lms/northpass_lms.py
@@ -1,7 +1,9 @@
 import dataclasses
-from collections.abc import Callable
+from collections.abc import Callable, Iterable, Iterator
 from typing import Any, Optional
 from urllib.parse import urlencode
+
+from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import (
@@ -23,6 +25,8 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.typ
 from products.warehouse_sources.backend.temporal.data_imports.sources.northpass_lms.settings import (
     NORTHPASS_ENDPOINTS,
     QUIZ_COMPLETED_EVENT_TYPE,
+    QUIZ_LOG_EMPTY_MESSAGE,
+    QUIZ_LOG_ENDPOINTS,
     NorthpassEndpointConfig,
 )
 
@@ -33,6 +37,36 @@ NORTHPASS_BASE_URL = "https://api.northpass.com/v2"
 NORTHPASS_HOST = "api.northpass.com"
 # Northpass doesn't publish its max page size; 100 is a conventional cap that keeps payloads small.
 PAGE_SIZE = 100
+
+
+class NorthpassQuizLogEmptyError(Exception):
+    """The sent-webhooks log served no quiz-completed event, so the quiz tables have nothing to build from."""
+
+
+class NorthpassPaginator(JSONResponsePaginator):
+    """Follow JSON:API ``links.next``, and stop on an empty page even when a next link is present.
+
+    ``/webhooks`` keeps serving a next link after its last message, so a walk that trusts the link
+    alone never ends.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(next_url_path="links.next")
+
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
+        if not data:
+            self._has_next_page = False
+            return
+        super().update_state(response, data)
+
+
+def _require_rows(pages: Iterable[list[dict[str, Any]]], endpoint: str) -> Iterator[list[dict[str, Any]]]:
+    found = False
+    for page in pages:
+        found = found or bool(page)
+        yield page
+    if not found:
+        raise NorthpassQuizLogEmptyError(f"{QUIZ_LOG_EMPTY_MESSAGE}, so {endpoint} has no rows to sync")
 
 
 @dataclasses.dataclass
@@ -215,7 +249,7 @@ def _client_config(api_key: str) -> ClientConfig:
         "headers": {"Accept": "application/json"},
         "auth": {"type": "api_key", "api_key": api_key, "name": "X-Api-Key", "location": "header"},
         # JSON:API paginates via a `links.next` URL embedded in the response body.
-        "paginator": JSONResponsePaginator(next_url_path="links.next"),
+        "paginator": NorthpassPaginator(),
         # Pin every request to Northpass's host and refuse redirects, so a spoofed `next` link or a
         # 30x can't forward the credentialed X-Api-Key header off-host.
         "allowed_hosts": [NORTHPASS_HOST],
@@ -370,9 +404,15 @@ def northpass_source(
             api_key, endpoint, config, team_id, job_id, resumable_source_manager, db_incremental_field_last_value
         )
 
+    items: Callable[[], Iterable[list[dict[str, Any]]]]
+    if endpoint in QUIZ_LOG_ENDPOINTS:
+        items = lambda: _require_rows(resource, endpoint)
+    else:
+        items = lambda: resource
+
     return SourceResponse(
         name=endpoint,
-        items=lambda: resource,
+        items=items,
         primary_keys=config.primary_keys,
         partition_count=1,
         partition_size=1,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/northpass_lms/northpass_lms.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/northpass_lms/northpass_lms.py
@@ -60,12 +60,11 @@ class NorthpassPaginator(JSONResponsePaginator):
         super().update_state(response, data)
 
 
-def _require_rows(pages: Iterable[list[dict[str, Any]]], endpoint: str) -> Iterator[list[dict[str, Any]]]:
-    found = False
-    for page in pages:
-        found = found or bool(page)
-        yield page
-    if not found:
+def _require_quiz_attempts(
+    pages: Iterable[list[dict[str, Any]]], endpoint: str, attempts_seen: set[str]
+) -> Iterator[list[dict[str, Any]]]:
+    yield from pages
+    if not attempts_seen:
         raise NorthpassQuizLogEmptyError(f"{QUIZ_LOG_EMPTY_MESSAGE}, so {endpoint} has no rows to sync")
 
 
@@ -159,7 +158,7 @@ def _promote_relationship_ids(row: dict[str, Any], relationship_id_fields: dict[
     return row
 
 
-def _make_quiz_attempt_flattener() -> Callable[[dict[str, Any]], dict[str, Any] | list[dict[str, Any]]]:
+def _make_quiz_attempt_flattener(seen: set[str]) -> Callable[[dict[str, Any]], dict[str, Any] | list[dict[str, Any]]]:
     """Reshape sent-webhooks log messages into completed-quiz-attempt rows.
 
     The v2 API lists no quiz attempts directly; the quiz-completed event a ``/webhooks`` message
@@ -171,7 +170,6 @@ def _make_quiz_attempt_flattener() -> Callable[[dict[str, Any]], dict[str, Any] 
     attempt UUID, or when the attempt was already seen this run — the log stores one message per
     subscribed webhook endpoint, so the same attempt can appear more than once.
     """
-    seen: set[str] = set()
 
     def _flatten(item: dict[str, Any]) -> dict[str, Any] | list[dict[str, Any]]:
         message = item.get("attributes")
@@ -225,11 +223,11 @@ def _collection_params(config: NorthpassEndpointConfig) -> dict[str, Any]:
 
 
 def _collection_data_map(
-    endpoint: str,
+    endpoint: str, attempts_seen: set[str]
 ) -> Optional[Callable[[dict[str, Any]], dict[str, Any] | list[dict[str, Any]]]]:
     """Bespoke row transform for a collection endpoint, or None when raw JSON:API items are fine."""
     if endpoint == "quiz_attempts":
-        return _make_quiz_attempt_flattener()
+        return _make_quiz_attempt_flattener(attempts_seen)
     return None
 
 
@@ -265,8 +263,9 @@ def _top_level_source(
     job_id: str,
     resumable_source_manager: ResumableSourceManager[NorthpassResumeConfig],
     db_incremental_field_last_value: Optional[Any],
+    attempts_seen: set[str],
 ) -> Resource:
-    data_map = _collection_data_map(endpoint) or (
+    data_map = _collection_data_map(endpoint, attempts_seen) or (
         _make_relationship_flattener(config.relationship_id_fields) if config.relationship_id_fields else _flatten_item
     )
     rest_config: RESTAPIConfig = {
@@ -320,6 +319,7 @@ def _fan_out_source(
     job_id: str,
     resumable_source_manager: ResumableSourceManager[NorthpassResumeConfig],
     db_incremental_field_last_value: Optional[Any],
+    attempts_seen: set[str],
 ) -> Resource:
     if config.fan_out_parent is None or config.parent_id_field is None:
         raise ValueError(f"_fan_out_source called with non-fan-out config: {config.name}")
@@ -342,7 +342,7 @@ def _fan_out_source(
                 },
                 # Parents that aren't plain JSON:API collections (the sent-webhooks log backing
                 # quiz_attempts) are reshaped before the child resolves ids from their rows.
-                "data_map": _collection_data_map(parent_name),
+                "data_map": _collection_data_map(parent_name, attempts_seen),
             },
             {
                 "name": endpoint,
@@ -394,19 +394,34 @@ def northpass_source(
     db_incremental_field_last_value: Optional[Any] = None,
 ) -> SourceResponse:
     config = NORTHPASS_ENDPOINTS[endpoint]
+    attempts_seen: set[str] = set()
 
     if config.fan_out_parent is not None:
         resource = _fan_out_source(
-            api_key, endpoint, config, team_id, job_id, resumable_source_manager, db_incremental_field_last_value
+            api_key,
+            endpoint,
+            config,
+            team_id,
+            job_id,
+            resumable_source_manager,
+            db_incremental_field_last_value,
+            attempts_seen,
         )
     else:
         resource = _top_level_source(
-            api_key, endpoint, config, team_id, job_id, resumable_source_manager, db_incremental_field_last_value
+            api_key,
+            endpoint,
+            config,
+            team_id,
+            job_id,
+            resumable_source_manager,
+            db_incremental_field_last_value,
+            attempts_seen,
         )
 
     items: Callable[[], Iterable[list[dict[str, Any]]]]
     if endpoint in QUIZ_LOG_ENDPOINTS:
-        items = lambda: _require_rows(resource, endpoint)
+        items = lambda: _require_quiz_attempts(resource, endpoint, attempts_seen)
     else:
         items = lambda: resource
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/northpass_lms/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/northpass_lms/settings.py
@@ -41,6 +41,10 @@ class NorthpassEndpointConfig:
 QUIZ_COMPLETED_EVENT_TYPE = "quiz_completed_events"
 # `/webhooks` documents a maximum page size of 50, unlike the other list endpoints.
 WEBHOOKS_PAGE_SIZE = 50
+# Raised when the log walk ends with no quiz-completed event. `source.py` maps it to the operator
+# message, so the two must share this prefix.
+QUIZ_LOG_EMPTY_MESSAGE = "Northpass sent-webhooks log returned no quiz-completed events"
+QUIZ_LOG_ENDPOINTS = ("quiz_attempts", "quiz_attempt_answers")
 
 NORTHPASS_ENDPOINTS: dict[str, NorthpassEndpointConfig] = {
     "people": NorthpassEndpointConfig(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/northpass_lms/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/northpass_lms/source.py
@@ -29,6 +29,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.northpass_
     ENDPOINTS,
     INCREMENTAL_FIELDS,
     NORTHPASS_ENDPOINTS,
+    QUIZ_LOG_EMPTY_MESSAGE,
 )
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -89,6 +90,9 @@ You can create an API key in your Northpass admin panel under **Apps → API Acc
             # sibling tables when Northpass gates an endpoint on an account plan (#87959). The
             # message points the operator at the sibling-table check instead of blaming the key.
             "403 Client Error: Forbidden for url: https://api.northpass.com": "Northpass refused access to the endpoint behind this table. If your other Northpass tables are syncing, the API key works and your Northpass plan likely does not include this endpoint. Ask Northpass support to enable it, then re-enable the sync. If every table is failing, check the key's permissions in your Northpass admin panel, then reconnect.",
+            # The quiz tables are built from the sent-webhooks log. A log with no quiz-completed
+            # event yields nothing on every run, and retrying cannot add a message to it.
+            QUIZ_LOG_EMPTY_MESSAGE: "Your Northpass sent-webhooks log holds no quiz-completed events, and the quiz_attempts and quiz_attempt_answers tables are built from that log. Subscribe a webhook endpoint to quiz-completed events in your Northpass admin panel, wait for a quiz completion, then re-enable the sync. The log keeps three months of messages.",
         }
 
     def get_schemas(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/northpass_lms/tests/test_northpass_lms.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/northpass_lms/tests/test_northpass_lms.py
@@ -446,7 +446,7 @@ def _message_without_payload() -> dict[str, Any]:
 
 class TestQuizAttemptFlattener:
     def test_reshapes_webhook_message_into_attempt_row(self):
-        row = _make_quiz_attempt_flattener()(_quiz_message("at1"))
+        row = _make_quiz_attempt_flattener(set())(_quiz_message("at1"))
 
         assert isinstance(row, dict)
         # The attempt UUID must land as `id` — it is the primary key and what the answers fan-out
@@ -470,10 +470,10 @@ class TestQuizAttemptFlattener:
     def test_drops_unusable_messages(self, _name, message):
         # A message that can't yield an attempt row must be dropped, not emitted — a row without an
         # `id` would fail the fan-out's parent resolution and corrupt the primary key.
-        assert _make_quiz_attempt_flattener()(message) == []
+        assert _make_quiz_attempt_flattener(set())(message) == []
 
     def test_dedupes_attempts_across_messages_within_a_run(self):
-        flatten = _make_quiz_attempt_flattener()
+        flatten = _make_quiz_attempt_flattener(set())
 
         first = flatten(_quiz_message("at1", message_id="m1"))
         second = flatten(_quiz_message("at1", message_id="m2"))
@@ -486,11 +486,11 @@ class TestQuizAttemptFlattener:
     def test_seen_state_is_fresh_per_flattener(self):
         # Each sync builds its own flattener; a shared seen-set would make every sync after the
         # first in a long-lived worker yield an empty table.
-        assert isinstance(_make_quiz_attempt_flattener()(_quiz_message("at1")), dict)
-        assert isinstance(_make_quiz_attempt_flattener()(_quiz_message("at1")), dict)
+        assert isinstance(_make_quiz_attempt_flattener(set())(_quiz_message("at1")), dict)
+        assert isinstance(_make_quiz_attempt_flattener(set())(_quiz_message("at1")), dict)
 
     def test_missing_relationships_still_emit_id_columns(self):
-        row = _make_quiz_attempt_flattener()(_quiz_message("at1", relationships={}))
+        row = _make_quiz_attempt_flattener(set())(_quiz_message("at1", relationships={}))
 
         assert isinstance(row, dict)
         # Columns must exist (as None) even when a reference is absent, so the table schema stays
@@ -592,6 +592,24 @@ class TestQuizAttemptsAndAnswers:
             _rows("quiz_attempt_answers", _make_manager())
 
         assert sent == [WEBHOOKS_URL]
+
+    @parameterized.expand(
+        [
+            ("empty_page", _page([])),
+            ("ignored_404", _resp({"errors": []}, status=404)),
+        ]
+    )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_answers_yield_nothing_when_the_log_attempt_has_no_answers(
+        self, _name: str, answers: Response, mock_make_session: mock.MagicMock
+    ) -> None:
+        answers_url = "https://api.northpass.com/v2/quiz_attempts/at1/answers?limit=100"
+        sent = _wire(mock_make_session, {WEBHOOKS_URL: _page([_quiz_message("at1")]), answers_url: answers})
+
+        rows = _rows("quiz_attempt_answers", _make_manager())
+
+        assert rows == []
+        assert sent == [WEBHOOKS_URL, answers_url]
 
 
 class TestNorthpassSource:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/northpass_lms/tests/test_northpass_lms.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/northpass_lms/tests/test_northpass_lms.py
@@ -10,6 +10,7 @@ from parameterized import parameterized
 from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.northpass_lms.northpass_lms import (
+    NorthpassQuizLogEmptyError,
     NorthpassResumeConfig,
     _build_url,
     _flatten_item,
@@ -17,6 +18,9 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.northpass_
     _make_quiz_attempt_flattener,
     _make_relationship_flattener,
     northpass_source,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.northpass_lms.settings import (
+    QUIZ_LOG_EMPTY_MESSAGE,
 )
 
 # RESTClient builds its session via make_tracked_session in the rest_client module.
@@ -232,6 +236,22 @@ class TestTopLevelPagination:
         rows = _rows("courses", _make_manager())
 
         assert rows == []
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_page_stops_even_with_next_link(self, mock_make_session):
+        pages = {
+            COURSES_P1: _page([{"id": "1"}], next_url=COURSES_P2),
+            COURSES_P2: _page([], next_url="https://api.northpass.com/v2/courses?page=3&limit=100"),
+        }
+        sent = _wire(mock_make_session, pages)
+        manager = _make_manager()
+
+        rows = _rows("courses", manager)
+
+        assert [r["id"] for r in rows] == ["1"]
+        assert sent == [COURSES_P1, COURSES_P2]
+        saved = [call.args[0] for call in manager.save_state.call_args_list]
+        assert saved == [NorthpassResumeConfig(next_url=COURSES_P2)]
 
 
 class TestFanOut:
@@ -544,6 +564,34 @@ class TestQuizAttemptsAndAnswers:
             "https://api.northpass.com/v2/quiz_attempts/at1/answers?limit=100",
             "https://api.northpass.com/v2/quiz_attempts/at2/answers?limit=100",
         ]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_empty_log_with_next_link_stops_and_raises(self, mock_make_session):
+        pages = {WEBHOOKS_URL: _page([], next_url="https://api.northpass.com/v2/webhooks?page=2&limit=50")}
+        sent = _wire(mock_make_session, pages)
+
+        with pytest.raises(NorthpassQuizLogEmptyError, match=QUIZ_LOG_EMPTY_MESSAGE):
+            _rows("quiz_attempts", _make_manager())
+
+        assert sent == [WEBHOOKS_URL]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_log_holding_only_other_event_types_raises(self, mock_make_session):
+        pages = {WEBHOOKS_URL: _page([_quiz_message("at9", message_id="m3", event_type="course_completed_events")])}
+        _wire(mock_make_session, pages)
+
+        with pytest.raises(NorthpassQuizLogEmptyError, match="quiz_attempts has no rows to sync"):
+            _rows("quiz_attempts", _make_manager())
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_answers_raise_when_the_log_holds_no_attempt(self, mock_make_session):
+        pages = {WEBHOOKS_URL: _page([])}
+        sent = _wire(mock_make_session, pages)
+
+        with pytest.raises(NorthpassQuizLogEmptyError, match="quiz_attempt_answers has no rows to sync"):
+            _rows("quiz_attempt_answers", _make_manager())
+
+        assert sent == [WEBHOOKS_URL]
 
 
 class TestNorthpassSource:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/northpass_lms/tests/test_northpass_lms_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/northpass_lms/tests/test_northpass_lms_source.py
@@ -32,6 +32,10 @@ class TestNorthpassLMSSource:
         [
             ("unauthorized", "401 Client Error: Unauthorized for url: https://api.northpass.com/v2/people?limit=100"),
             ("forbidden", "403 Client Error: Forbidden for url: https://api.northpass.com/v2/courses?limit=100"),
+            (
+                "empty_quiz_log",
+                "Northpass sent-webhooks log returned no quiz-completed events, so quiz_attempts has no rows to sync",
+            ),
         ]
     )
     def test_non_retryable_errors_match_auth_failures(self, _name, observed_error):


### PR DESCRIPTION
## Problem

`quiz_attempts` and `quiz_attempt_answers` on the Northpass LMS source have never completed a sync. Both tables read the sent-webhooks log (`GET /v2/webhooks`). Northpass keeps serving a `links.next` URL after the last message, so the walk never reaches a last page. A production run walked the log with zero rows until Temporal killed it, and the next run started again at page 1. The schema sat on `Running` for days, which reads as healthy work in progress.

Refs #85781

## Changes

- The Northpass paginator stops on the first empty page, even when the page carries a next link. This is the same guard the Personio source already uses. It applies to every Northpass endpoint, because a JSON:API collection that returns `data: []` has no more rows.
- A quiz table whose walk ends with no quiz-completed event now raises `NorthpassQuizLogEmptyError`. The source maps it to a non-retryable operator message: subscribe a webhook endpoint to quiz-completed events, wait for a quiz completion, then re-enable the sync. Retrying cannot add a message to the log, so the sync stops instead of completing with zero rows.
- The two error strings share one constant in `settings.py`, so the raised message and the mapped message cannot drift apart.

This does not checkpoint the fan-out parent walk. With a bounded walk a restart is cheap, and the parent cursor belongs to the shared fan-out layer, not to this module.

## How did you test this code?

```
pytest products/warehouse_sources/backend/temporal/data_imports/sources/northpass_lms -q
63 passed
```

New tests: an empty page with a next link ends the walk and saves no checkpoint past it; an empty quiz log raises with one request sent; a log holding only other event types raises; the answers table raises when the log holds no attempt; the source maps the new message as non-retryable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

