### PR TITLE
fix(warehouse-sources): type Checkout.com report columns at ingest

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/reports.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/reports.py
@@ -9,14 +9,17 @@ come from here:
   every report file of that type, discovered dynamically from the account's
   reports. Column sets vary per account because report templates are
   configurable, so rows keep the file's own (normalized) headers plus injected
-  ``report_*`` / ``file_*`` metadata columns.
+  ``report_*`` / ``file_*`` metadata columns. A CSV cell carries no type, so
+  amounts, fees and timestamps are typed by column name (see ``_typed_report_value``).
 """
 
 import re
 import csv
+import math
 import codecs
 import contextlib
-from collections.abc import Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator
+from datetime import UTC, date, datetime
 from typing import Any, Optional
 from urllib.parse import parse_qs, urlparse
 
@@ -123,6 +126,105 @@ def report_type_table_name(report_type: str) -> Optional[str]:
 def _normalize_header(header: str) -> str:
     """``Response Code`` becomes the stable column ``response_code``."""
     return re.sub(r"[^0-9a-zA-Z]+", "_", header).strip("_").lower()
+
+
+# Report templates are account-configurable, so a column set cannot be enumerated per table:
+# the type follows the normalized column name, and an unlisted name stays text. A currency
+# column names the unit of the amounts beside it, so it is excluded before the float rules.
+_CURRENCY_COLUMN_NAMES = frozenset({"currency"})
+_CURRENCY_COLUMN_SUFFIXES = ("_currency",)
+_FLOAT_COLUMN_NAMES = frozenset({"amount", "fee", "fees", "tax", "net", "gross", "balance"})
+_FLOAT_COLUMN_SUFFIXES = ("_amount", "_fee", "_fees", "_tax")
+# The three names below are the injected metadata columns, which the API sends as ISO 8601.
+_DATETIME_COLUMN_NAMES = frozenset({"report_from", "report_to", "report_created_on"})
+_DATETIME_COLUMN_SUFFIXES = ("_on", "_at", "_timestamp", "_time")
+_DATE_COLUMN_SUFFIXES = ("_date",)
+
+_DATE_FORMAT = "%Y-%m-%d"
+
+
+class _ParseFailureCounter:
+    """Counts typed cells that failed to parse and were stored as null.
+
+    One malformed cell must not fail a whole sync, and keeping the raw string would flip the
+    column's type between batches. A report body carries transaction data, so the counter logs
+    counts once per file and never logs a value.
+    """
+
+    def __init__(self, logger: FilteringBoundLogger, file_id: str) -> None:
+        self._logger = logger
+        self._file_id = file_id
+        self.counts: dict[str, int] = {}
+
+    def record(self, column: str) -> None:
+        self.counts[column] = self.counts.get(column, 0) + 1
+
+    def flush(self) -> None:
+        if not self.counts:
+            return
+        self._logger.warning(
+            "Checkout.com report values could not be parsed and were stored as null",
+            file_id=self._file_id,
+            failures=sum(self.counts.values()),
+            failures_by_column=self.counts,
+        )
+
+
+def _parse_report_float(text: str) -> Optional[float]:
+    # Commas only ever appear as US-style thousands separators; the decimal separator is a point.
+    try:
+        number = float(text.replace(",", ""))
+    except ValueError:
+        return None
+    # float() accepts "nan" and "inf", which no report legitimately contains.
+    return number if math.isfinite(number) else None
+
+
+def _parse_report_datetime(text: str) -> Optional[datetime]:
+    # A naive value reads as UTC and an offset value converts to it, so one column holds one zone.
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _parse_report_date(text: str) -> Optional[date]:
+    try:
+        return datetime.strptime(text, _DATE_FORMAT).date()
+    except ValueError:
+        return None
+
+
+def _column_parser(column: str) -> Optional[Callable[[str], Any]]:
+    if column in _CURRENCY_COLUMN_NAMES or column.endswith(_CURRENCY_COLUMN_SUFFIXES):
+        return None
+    if column in _FLOAT_COLUMN_NAMES or column.endswith(_FLOAT_COLUMN_SUFFIXES):
+        return _parse_report_float
+    if column in _DATETIME_COLUMN_NAMES or column.endswith(_DATETIME_COLUMN_SUFFIXES):
+        return _parse_report_datetime
+    if column.endswith(_DATE_COLUMN_SUFFIXES):
+        return _parse_report_date
+    return None
+
+
+def _typed_report_value(column: str, value: Any, failures: _ParseFailureCounter) -> Any:
+    """Parse one report cell into its typed value, or null when the name is typed and the text is not."""
+    if not isinstance(value, str):
+        return value
+    parse = _column_parser(column)
+    if parse is None:
+        return value
+    text = value.strip()
+    if not text:
+        # A blank cell is routine, so it is a null rather than a parse failure.
+        return None
+    parsed = parse(text)
+    if parsed is None:
+        failures.record(column)
+    return parsed
 
 
 def _make_api_session(client_secret: str) -> requests.Session:
@@ -297,6 +399,8 @@ def _parse_report_file_rows(
     # `lines` is any iterator of physical CSV lines (a live response stream or a
     # StringIO), so a large report is parsed row-by-row without buffering the file.
     reader = csv.reader(lines)
+    failures = _ParseFailureCounter(logger, str(metadata.get("file_id") or ""))
+    typed_metadata = {column: _typed_report_value(column, value, failures) for column, value in metadata.items()}
     headers: Optional[list[str]] = None
     row_index = 0
     data_row_count = 0
@@ -341,13 +445,16 @@ def _parse_report_file_rows(
                 file_id=metadata.get("file_id"),
             )
             continue
-        parsed: dict[str, Any] = dict(zip(headers, row))
+        parsed: dict[str, Any] = {
+            column: _typed_report_value(column, value, failures) for column, value in zip(headers, row)
+        }
         # The injected metadata columns carry the dedupe key and incremental watermark,
         # so they always win over a same-named column in the CSV itself.
-        parsed.update(metadata)
+        parsed.update(typed_metadata)
         parsed["file_row_index"] = row_index
         row_index += 1
         yield parsed
+    failures.flush()
     if data_row_count == 0:
         # Header-only (or empty) files occur by design when a report covers a period
         # with no activity; raising on them would wedge the sync permanently.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/reports.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/reports.py
@@ -17,7 +17,7 @@ import csv
 import math
 import codecs
 import contextlib
-from collections.abc import Callable, Iterable, Iterator
+from collections.abc import Callable, Generator, Iterable, Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
 from urllib.parse import parse_qs, urlparse
@@ -380,7 +380,7 @@ def _parse_report_file_rows(
     metadata: dict[str, Any],
     logger: FilteringBoundLogger,
     required_column: str = "",
-) -> Iterator[dict[str, Any]]:
+) -> Generator[dict[str, Any]]:
     # `lines` is any iterator of physical CSV lines (a live response stream or a
     # StringIO), so a large report is parsed row-by-row without buffering the file.
     reader = csv.reader(lines)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/reports.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/reports.py
@@ -137,6 +137,8 @@ _DATE_COLUMN_SUFFIXES = ("_date",)
 
 _DATE_FORMAT = "%Y-%m-%d"
 
+_ReportValue = str | float | datetime | date | None
+
 
 class _ParseFailureCounter:
     def __init__(self, logger: FilteringBoundLogger, file_id: str) -> None:
@@ -183,7 +185,7 @@ def _parse_report_date(text: str) -> Optional[date]:
         return None
 
 
-def _column_parser(column: str) -> Optional[Callable[[str], Any]]:
+def _column_parser(column: str) -> Optional[Callable[[str], _ReportValue]]:
     if column in _CURRENCY_COLUMN_NAMES or column.endswith(_CURRENCY_COLUMN_SUFFIXES):
         return None
     if column in _FLOAT_COLUMN_NAMES or column.endswith(_FLOAT_COLUMN_SUFFIXES):
@@ -195,7 +197,7 @@ def _column_parser(column: str) -> Optional[Callable[[str], Any]]:
     return None
 
 
-def _typed_report_value(column: str, value: Any, failures: _ParseFailureCounter) -> Any:
+def _typed_report_value(column: str, value: str | None, failures: _ParseFailureCounter) -> _ReportValue:
     if not isinstance(value, str):
         return value
     parse = _column_parser(column)
@@ -388,56 +390,58 @@ def _parse_report_file_rows(
     row_index = 0
     data_row_count = 0
     skipped_row_count = 0
-    for row in reader:
-        if headers is None:
-            headers = [_normalize_header(header) for header in row]
-            # A trailing delimiter on the header line reads as one unnamed final
-            # column; drop unnamed trailing cells so the header width means "named
-            # columns" when data-row widths are checked against it.
-            while headers and not headers[-1]:
-                headers.pop()
-            if required_column and required_column not in headers:
-                raise CheckoutComReportKeyError(
-                    f"Checkout.com report file {metadata.get('file_id')} has no "
-                    f"{required_column!r} column, so its rows cannot be deduplicated"
+    try:
+        for row in reader:
+            if headers is None:
+                headers = [_normalize_header(header) for header in row]
+                # A trailing delimiter on the header line reads as one unnamed final
+                # column; drop unnamed trailing cells so the header width means "named
+                # columns" when data-row widths are checked against it.
+                while headers and not headers[-1]:
+                    headers.pop()
+                if required_column and required_column not in headers:
+                    raise CheckoutComReportKeyError(
+                        f"Checkout.com report file {metadata.get('file_id')} has no "
+                        f"{required_column!r} column, so its rows cannot be deduplicated"
+                    )
+                continue
+            if not any(cell.strip() for cell in row):
+                continue
+            data_row_count += 1
+            # The file's own header row describes its data rows, but some report
+            # generators make the widths disagree without changing what a row means: a
+            # trailing delimiter adds an empty overflow cell to every row, and ragged
+            # writers omit trailing empty fields. Normalize both to the header's width;
+            # treating these layout variants as malformed once dropped whole report files
+            # to zero rows.
+            if len(row) > len(headers) and not any(cell.strip() for cell in row[len(headers) :]):
+                row = row[: len(headers)]
+            elif len(row) < len(headers):
+                row = [*row, *[""] * (len(headers) - len(row))]
+            # Extra cells that carry values (e.g. an unquoted embedded delimiter) cannot
+            # be assigned to columns without corrupting the data; skip the malformed line
+            # visibly instead.
+            if len(row) != len(headers):
+                skipped_row_count += 1
+                logger.warning(
+                    "Checkout.com report row length mismatch; skipping row",
+                    expected=len(headers),
+                    got=len(row),
+                    report_id=metadata.get("report_id"),
+                    file_id=metadata.get("file_id"),
                 )
-            continue
-        if not any(cell.strip() for cell in row):
-            continue
-        data_row_count += 1
-        # The file's own header row describes its data rows, but some report
-        # generators make the widths disagree without changing what a row means: a
-        # trailing delimiter adds an empty overflow cell to every row, and ragged
-        # writers omit trailing empty fields. Normalize both to the header's width;
-        # treating these layout variants as malformed once dropped whole report files
-        # to zero rows.
-        if len(row) > len(headers) and not any(cell.strip() for cell in row[len(headers) :]):
-            row = row[: len(headers)]
-        elif len(row) < len(headers):
-            row = [*row, *[""] * (len(headers) - len(row))]
-        # Extra cells that carry values (e.g. an unquoted embedded delimiter) cannot
-        # be assigned to columns without corrupting the data; skip the malformed line
-        # visibly instead.
-        if len(row) != len(headers):
-            skipped_row_count += 1
-            logger.warning(
-                "Checkout.com report row length mismatch; skipping row",
-                expected=len(headers),
-                got=len(row),
-                report_id=metadata.get("report_id"),
-                file_id=metadata.get("file_id"),
-            )
-            continue
-        parsed: dict[str, Any] = {
-            column: _typed_report_value(column, value, failures) for column, value in zip(headers, row)
-        }
-        # The injected metadata columns carry the dedupe key and incremental watermark,
-        # so they always win over a same-named column in the CSV itself.
-        parsed.update(typed_metadata)
-        parsed["file_row_index"] = row_index
-        row_index += 1
-        yield parsed
-    failures.flush()
+                continue
+            parsed: dict[str, Any] = {
+                column: _typed_report_value(column, value, failures) for column, value in zip(headers, row)
+            }
+            # The injected metadata columns carry the dedupe key and incremental watermark,
+            # so they always win over a same-named column in the CSV itself.
+            parsed.update(typed_metadata)
+            parsed["file_row_index"] = row_index
+            row_index += 1
+            yield parsed
+    finally:
+        failures.flush()
     if data_row_count == 0:
         # Header-only (or empty) files occur by design when a report covers a period
         # with no activity; raising on them would wedge the sync permanently.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/reports.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/reports.py
@@ -9,8 +9,7 @@ come from here:
   every report file of that type, discovered dynamically from the account's
   reports. Column sets vary per account because report templates are
   configurable, so rows keep the file's own (normalized) headers plus injected
-  ``report_*`` / ``file_*`` metadata columns. A CSV cell carries no type, so
-  amounts, fees and timestamps are typed by column name (see ``_typed_report_value``).
+  ``report_*`` / ``file_*`` metadata columns.
 """
 
 import re
@@ -128,14 +127,10 @@ def _normalize_header(header: str) -> str:
     return re.sub(r"[^0-9a-zA-Z]+", "_", header).strip("_").lower()
 
 
-# Report templates are account-configurable, so a column set cannot be enumerated per table:
-# the type follows the normalized column name, and an unlisted name stays text. A currency
-# column names the unit of the amounts beside it, so it is excluded before the float rules.
 _CURRENCY_COLUMN_NAMES = frozenset({"currency"})
 _CURRENCY_COLUMN_SUFFIXES = ("_currency",)
 _FLOAT_COLUMN_NAMES = frozenset({"amount", "fee", "fees", "tax", "net", "gross", "balance"})
 _FLOAT_COLUMN_SUFFIXES = ("_amount", "_fee", "_fees", "_tax")
-# The three names below are the injected metadata columns, which the API sends as ISO 8601.
 _DATETIME_COLUMN_NAMES = frozenset({"report_from", "report_to", "report_created_on"})
 _DATETIME_COLUMN_SUFFIXES = ("_on", "_at", "_timestamp", "_time")
 _DATE_COLUMN_SUFFIXES = ("_date",)
@@ -144,13 +139,6 @@ _DATE_FORMAT = "%Y-%m-%d"
 
 
 class _ParseFailureCounter:
-    """Counts typed cells that failed to parse and were stored as null.
-
-    One malformed cell must not fail a whole sync, and keeping the raw string would flip the
-    column's type between batches. A report body carries transaction data, so the counter logs
-    counts once per file and never logs a value.
-    """
-
     def __init__(self, logger: FilteringBoundLogger, file_id: str) -> None:
         self._logger = logger
         self._file_id = file_id
@@ -171,17 +159,14 @@ class _ParseFailureCounter:
 
 
 def _parse_report_float(text: str) -> Optional[float]:
-    # Commas only ever appear as US-style thousands separators; the decimal separator is a point.
     try:
         number = float(text.replace(",", ""))
     except ValueError:
         return None
-    # float() accepts "nan" and "inf", which no report legitimately contains.
     return number if math.isfinite(number) else None
 
 
 def _parse_report_datetime(text: str) -> Optional[datetime]:
-    # A naive value reads as UTC and an offset value converts to it, so one column holds one zone.
     try:
         parsed = datetime.fromisoformat(text)
     except ValueError:
@@ -211,7 +196,6 @@ def _column_parser(column: str) -> Optional[Callable[[str], Any]]:
 
 
 def _typed_report_value(column: str, value: Any, failures: _ParseFailureCounter) -> Any:
-    """Parse one report cell into its typed value, or null when the name is typed and the text is not."""
     if not isinstance(value, str):
         return value
     parse = _column_parser(column)
@@ -219,7 +203,6 @@ def _typed_report_value(column: str, value: Any, failures: _ParseFailureCounter)
         return value
     text = value.strip()
     if not text:
-        # A blank cell is routine, so it is a null rather than a parse failure.
         return None
     parsed = parse(text)
     if parsed is None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/tests/test_checkout_com_reports.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/tests/test_checkout_com_reports.py
@@ -294,7 +294,6 @@ class TestParseReportFileRows:
         assert row["payout_fee"] == -0.75
         assert row["processed_on"] == datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC)
         assert row["payout_date"] == date(2024, 1, 3)
-        # A currency code names the unit of the amounts beside it, so it is not a quantity.
         assert row["processing_currency"] == "GBP"
         assert row["fee_type"] == "scheme"
         assert row["action_id"] == "act_1"
@@ -329,7 +328,6 @@ class TestParseReportFileRows:
         ]
         logger.warning.assert_called_once()
         assert logger.warning.call_args.kwargs["failures_by_column"] == {"amount": 2}
-        # Report bodies carry transaction data, so a failure is counted and never logged.
         assert "oops" not in str(logger.warning.call_args)
 
     def test_metadata_timestamps_are_typed_and_metadata_ids_stay_text(self):
@@ -346,7 +344,6 @@ class TestParseReportFileRows:
 
         assert row["report_created_on"] == datetime(2024, 2, 1, tzinfo=UTC)
         assert row["report_from"] == datetime(2024, 1, 1, tzinfo=UTC)
-        # A report with no range sends a null `to`, which must not fail the file.
         assert row["report_to"] is None
         assert row["report_id"] == "rpt_1"
         assert row["report_entity_id"] == "ent_1"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/tests/test_checkout_com_reports.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/tests/test_checkout_com_reports.py
@@ -280,7 +280,7 @@ class TestParseReportFileRows:
     def test_file_with_no_data_lines_is_empty_not_a_defect(self, text):
         assert list(_parse_report_file_rows(io.StringIO(text), {}, mock.MagicMock())) == []
 
-    def test_column_names_decide_cell_types(self):
+    def test_column_names_decide_cell_types(self) -> None:
         text = (
             "Holding Currency Amount,Processing Currency,Payout Fee,Fee Type,"
             "Action ID,Processed On,Payout Date,Row Count\n"
@@ -308,14 +308,14 @@ class TestParseReportFileRows:
             pytest.param("2024-01-02T05:04:05+02:00", datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC), id="offset-to-utc"),
         ],
     )
-    def test_timestamp_variants_all_land_in_utc(self, value, expected):
+    def test_timestamp_variants_all_land_in_utc(self, value: str, expected: datetime) -> None:
         text = f"Action ID,Processed On\nact_1,{value}\n"
 
         (row,) = list(_parse_report_file_rows(io.StringIO(text), {"file_id": "file_1"}, mock.MagicMock()))
 
         assert row["processed_on"] == expected
 
-    def test_unparseable_typed_cell_nulls_and_counts_without_logging_the_value(self):
+    def test_unparseable_typed_cell_nulls_and_counts_without_logging_the_value(self) -> None:
         text = "Action ID,Amount\nact_1,nan\nact_2,20\nact_3,oops\n"
         logger = mock.MagicMock()
 
@@ -330,7 +330,17 @@ class TestParseReportFileRows:
         assert logger.warning.call_args.kwargs["failures_by_column"] == {"amount": 2}
         assert "oops" not in str(logger.warning.call_args)
 
-    def test_metadata_timestamps_are_typed_and_metadata_ids_stay_text(self):
+    def test_a_closed_row_iterator_still_logs_its_parse_failures(self) -> None:
+        text = "Action ID,Amount\nact_1,oops\nact_2,20\n"
+        logger = mock.MagicMock()
+        rows = _parse_report_file_rows(io.StringIO(text), {"file_id": "file_1"}, logger)
+
+        next(rows)
+        rows.close()
+
+        assert logger.warning.call_args.kwargs["failures_by_column"] == {"amount": 1}
+
+    def test_metadata_timestamps_are_typed_and_metadata_ids_stay_text(self) -> None:
         metadata = {
             "report_id": "rpt_1",
             "report_created_on": "2024-02-01T00:00:00Z",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/tests/test_checkout_com_reports.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/tests/test_checkout_com_reports.py
@@ -1,5 +1,5 @@
 import io
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from typing import Any, Optional
 
 import pytest
@@ -212,17 +212,17 @@ class TestParseReportFileRows:
         [
             pytest.param(
                 "Action ID,Amount,Payout ID\nact_1,10,pout_1,\nact_2,20,pout_2,\n",
-                [("act_1", "10", "pout_1"), ("act_2", "20", "pout_2")],
+                [("act_1", 10.0, "pout_1"), ("act_2", 20.0, "pout_2")],
                 id="trailing-delimiter-on-data-rows",
             ),
             pytest.param(
                 "Action ID,Amount,Payout ID,\nact_1,10,pout_1\nact_2,20,pout_2\n",
-                [("act_1", "10", "pout_1"), ("act_2", "20", "pout_2")],
+                [("act_1", 10.0, "pout_1"), ("act_2", 20.0, "pout_2")],
                 id="trailing-delimiter-on-header",
             ),
             pytest.param(
                 "Action ID,Amount,Payout ID\nact_1,10,pout_1\nact_2,20\n",
-                [("act_1", "10", "pout_1"), ("act_2", "20", "")],
+                [("act_1", 10.0, "pout_1"), ("act_2", 20.0, "")],
                 id="ragged-rows-omit-trailing-empty-fields",
             ),
         ],
@@ -280,6 +280,79 @@ class TestParseReportFileRows:
     def test_file_with_no_data_lines_is_empty_not_a_defect(self, text):
         assert list(_parse_report_file_rows(io.StringIO(text), {}, mock.MagicMock())) == []
 
+    def test_column_names_decide_cell_types(self):
+        text = (
+            "Holding Currency Amount,Processing Currency,Payout Fee,Fee Type,"
+            "Action ID,Processed On,Payout Date,Row Count\n"
+            '"1,234.50",GBP,-0.75,scheme,act_1,2024-01-02 03:04:05,2024-01-03,7\n'
+        )
+        logger = mock.MagicMock()
+
+        (row,) = list(_parse_report_file_rows(io.StringIO(text), {"file_id": "file_1"}, logger))
+
+        assert row["holding_currency_amount"] == 1234.50
+        assert row["payout_fee"] == -0.75
+        assert row["processed_on"] == datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC)
+        assert row["payout_date"] == date(2024, 1, 3)
+        # A currency code names the unit of the amounts beside it, so it is not a quantity.
+        assert row["processing_currency"] == "GBP"
+        assert row["fee_type"] == "scheme"
+        assert row["action_id"] == "act_1"
+        assert row["row_count"] == "7"
+        logger.warning.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            pytest.param("2024-01-02T03:04:05Z", datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC), id="iso-with-zulu"),
+            pytest.param("2024-01-02 03:04:05", datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC), id="space-separator-naive"),
+            pytest.param("2024-01-02T05:04:05+02:00", datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC), id="offset-to-utc"),
+        ],
+    )
+    def test_timestamp_variants_all_land_in_utc(self, value, expected):
+        text = f"Action ID,Processed On\nact_1,{value}\n"
+
+        (row,) = list(_parse_report_file_rows(io.StringIO(text), {"file_id": "file_1"}, mock.MagicMock()))
+
+        assert row["processed_on"] == expected
+
+    def test_unparseable_typed_cell_nulls_and_counts_without_logging_the_value(self):
+        text = "Action ID,Amount\nact_1,nan\nact_2,20\nact_3,oops\n"
+        logger = mock.MagicMock()
+
+        rows = list(_parse_report_file_rows(io.StringIO(text), {"file_id": "file_1"}, logger))
+
+        assert [(row["action_id"], row["amount"]) for row in rows] == [
+            ("act_1", None),
+            ("act_2", 20.0),
+            ("act_3", None),
+        ]
+        logger.warning.assert_called_once()
+        assert logger.warning.call_args.kwargs["failures_by_column"] == {"amount": 2}
+        # Report bodies carry transaction data, so a failure is counted and never logged.
+        assert "oops" not in str(logger.warning.call_args)
+
+    def test_metadata_timestamps_are_typed_and_metadata_ids_stay_text(self):
+        metadata = {
+            "report_id": "rpt_1",
+            "report_created_on": "2024-02-01T00:00:00Z",
+            "report_from": "2024-01-01T00:00:00Z",
+            "report_to": None,
+            "report_entity_id": "ent_1",
+            "file_id": "file_1",
+        }
+
+        (row,) = list(_parse_report_file_rows(io.StringIO("Action ID\nact_1\n"), metadata, mock.MagicMock()))
+
+        assert row["report_created_on"] == datetime(2024, 2, 1, tzinfo=UTC)
+        assert row["report_from"] == datetime(2024, 1, 1, tzinfo=UTC)
+        # A report with no range sends a null `to`, which must not fail the file.
+        assert row["report_to"] is None
+        assert row["report_id"] == "rpt_1"
+        assert row["report_entity_id"] == "ent_1"
+        assert row["file_id"] == "file_1"
+        assert row["file_row_index"] == 0
+
     def test_missing_key_column_raises_rather_than_loading_undedupable_rows(self):
         # Without the key column the merge cannot match a restated row, so every
         # regenerated file would add another copy instead of updating one.
@@ -336,7 +409,7 @@ class TestReportsMetadataTable:
 class TestReportFileSync:
     @mock.patch(SESSION_PATCH)
     def test_syncs_matching_reports_and_follows_redirect_without_credentials(self, mock_make_session):
-        csv_text = 'Action ID,Amount\nact_1,"multi\nline"\nact_2,20\n'
+        csv_text = 'Action ID,Amount,Description\nact_1,10,"multi\nline"\nact_2,20,plain\n'
         api_session = _FakeSession(
             [
                 _listing(
@@ -378,22 +451,24 @@ class TestReportFileSync:
         assert rows == [
             {
                 "action_id": "act_1",
-                "amount": "multi\nline",
+                "amount": 10.0,
+                "description": "multi\nline",
                 "report_id": "rpt_1",
-                "report_created_on": "2024-02-01T00:00:00Z",
-                "report_from": "2024-01-01T00:00:00Z",
-                "report_to": "2024-01-02T00:00:00Z",
+                "report_created_on": datetime(2024, 2, 1, tzinfo=UTC),
+                "report_from": datetime(2024, 1, 1, tzinfo=UTC),
+                "report_to": datetime(2024, 1, 2, tzinfo=UTC),
                 "report_entity_id": "ent_1",
                 "file_id": "file_1",
                 "file_row_index": 0,
             },
             {
                 "action_id": "act_2",
-                "amount": "20",
+                "amount": 20.0,
+                "description": "plain",
                 "report_id": "rpt_1",
-                "report_created_on": "2024-02-01T00:00:00Z",
-                "report_from": "2024-01-01T00:00:00Z",
-                "report_to": "2024-01-02T00:00:00Z",
+                "report_created_on": datetime(2024, 2, 1, tzinfo=UTC),
+                "report_from": datetime(2024, 1, 1, tzinfo=UTC),
+                "report_to": datetime(2024, 1, 2, tzinfo=UTC),
                 "report_entity_id": "ent_1",
                 "file_id": "file_1",
                 "file_row_index": 1,
@@ -484,9 +559,9 @@ class TestReportFileSync:
         rows = _rows(_source("financial_actions_report"))
 
         assert [(row["file_id"], row["amount"]) for row in rows] == [
-            ("file_m", "10"),
-            ("file_a", "20"),
-            ("file_z", "30"),
+            ("file_m", 10.0),
+            ("file_a", 20.0),
+            ("file_z", 30.0),
         ]
 
     @pytest.mark.parametrize("location", [None, "http://files.example.com/signed"])


### PR DESCRIPTION
## Problem

Someone querying a Checkout.com report table cannot sum a payout or filter a date range without casting first, because every column arrives as text.

`_parse_report_file_rows` builds each row with `dict(zip(headers, row))` off `csv.reader` and coerces nothing.

So `holding_currency_amount`, `payout_amount`, the 30-plus fee columns on `payout_summary_report`, and every timestamp land as strings.

Closes #82925

## Changes

- Amounts and fees now land as floats, timestamps as UTC datetimes, and `_date` columns as dates.
- A report template is account-configurable, so the type follows the normalized column name rather than a per-table column list.
- Float: a name that ends with `_amount`, `_fee`, `_fees` or `_tax`, plus `amount`, `fee`, `fees`, `tax`, `net`, `gross` and `balance`.
- Datetime: a name that ends with `_on`, `_at`, `_timestamp` or `_time`, plus the injected `report_from`, `report_to` and `report_created_on`.
- Date: a name that ends with `_date`.
- A currency column stays text, and so does every unlisted name, which keeps ids, codes, references and counts as the join keys they are.
- A timestamp accepts a `T` or a space separator, with or without an offset, and a naive value reads as UTC.
- A float drops US-style thousands separators and rejects `nan` and `inf`.
- A value that fails to parse becomes null, so one malformed cell never fails a sync.
- The counter records a failure per column and logs one warning per file with the counts. It never logs the value, because a report body carries transaction data.
- `report_created_on` is already declared a DateTime incremental field, so the cursor column now matches the type the schema claims.
- The change stays inside `checkout_com/reports.py`. It touches no shared framework code, and it leaves `payments.py` alone.

> [!NOTE]
> The load path casts every batch back to the stored table schema. An existing table keeps its string columns until the user runs a Resync, and a table created after this merge carries the real types. PR #82973 changed App Store Connect the same way.

## How did you test this code?

`pytest products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com -q` passes, 136 tests in the directory.

Four cases are new, each aimed at a regression no existing test caught:

- Column names decide the type: an amount and a fee parse as floats, a currency code and a count stay text, an `_on` column is a UTC datetime, and a `_date` column is a date.
- Three timestamp layouts all land in UTC, which catches a naive value stored with no zone and an offset value stored unconverted.
- An unparseable amount nulls, the rest of the row still loads, the failure is counted once per column, and the value never reaches the log.
- The injected metadata timestamps are datetimes, the metadata ids stay text, and a null `report_to` does not fail the file.

Three existing tests asserted string values for a column this PR types, and their expectations moved to floats and datetimes. One of them used a quoted multi-line value in the `Amount` column to prove multi-line CSV parsing; the value moved to a `Description` column so the case still proves it.

A header-only file still yields nothing. The existing parameterized case covers that and was not changed.

Not run: repo-wide mypy, and the database-backed suites. This sandbox has no database, and the change is a pure function over CSV cells.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow, API or setting changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) wrote the change. Repo skills read and applied: `/writing-tests` for the value gate on the four new cases, and `/writing-pr-descriptions` for this body. The pre-commit comment-density check flagged the first commit, and the comments were cut to the reasons the code cannot show.

The typing helpers mirror the App Store Connect pattern (`_typed_report_value`, `_ParseFailureCounter`) so the two file-based sources fail the same way. One deliberate difference: this counter logs counts only, never a sample value, because a Checkout.com report body carries transaction data while Apple's typed columns carry dates and prices.

Gates: no open PR duplicates this. `gh pr list --search "Checkout.com"` returns only #91424, which touches `payments.py` and `source.py` and does not overlap. The new tests cover the added lines. Nothing here carries material from the agent session: the fixture CSVs use column names taken from the public issue, and the values are invented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
