### PR TITLE
fix(data-warehouse): show rows synced next to the row count on the schemas table

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6654,6 +6654,8 @@ export interface ExternalDataSourceSyncSchema {
 
 export interface ExternalDataSourceSchema extends SimpleExternalDataSourceSchema {
     table?: SimpleDataWarehouseTable
+    /** Rows every sync of this schema moved, summed over all runs. The data warehouse bills this number. */
+    rows_synced_total?: number | null
     incremental: boolean
     sync_type: 'incremental' | 'full_refresh' | 'append' | 'webhook' | 'cdc' | 'xmin' | null
     sync_time_of_day: string | null

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
@@ -504,6 +504,25 @@ function ManagedSchemaTable({
                         return <span className="text-muted">—</span>
                     },
                 },
+                {
+                    title: (
+                        <span className="flex items-center gap-1">
+                            Rows synced
+                            <Tooltip title="Rows every sync of this table moved, summed over all runs. The data warehouse bills this number. It differs from the row count on merge and full refresh syncs, which rewrite rows the table already holds.">
+                                <IconInfo className="text-secondary" />
+                            </Tooltip>
+                        </span>
+                    ),
+                    key: 'rows_synced_total',
+                    align: 'right',
+                    sorter: (a, b) => (a.rows_synced_total ?? 0) - (b.rows_synced_total ?? 0),
+                    render: (_, schema) =>
+                        schema.rows_synced_total == null ? (
+                            <span className="text-muted">—</span>
+                        ) : (
+                            schema.rows_synced_total.toLocaleString()
+                        ),
+                },
                 ...(showMetrics
                     ? [
                           {

--- a/products/warehouse_sources/backend/presentation/views/external_data_schema.py
+++ b/products/warehouse_sources/backend/presentation/views/external_data_schema.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 from typing import Any, Optional, cast
 
 from django.db import transaction
+from django.db.models import BigIntegerField, OuterRef, QuerySet, Subquery, Sum
 
 import structlog
 import temporalio
@@ -282,10 +283,29 @@ def schema_display_status(schema: ExternalDataSchema) -> str | None:
     return schema.status
 
 
+ROWS_SYNCED_TOTAL_HELP = (
+    "Rows every sync of this schema moved, summed over all of its runs. The data warehouse bills this "
+    "quantity. It differs from the table's row count on merge and full-refresh syncs, which rewrite rows the "
+    "table already holds, so the two cannot be reconciled against each other."
+)
+
+
+def annotate_rows_synced_total(queryset: QuerySet[ExternalDataSchema]) -> QuerySet[ExternalDataSchema]:
+    jobs = (
+        ExternalDataJob.objects.filter(schema_id=OuterRef("pk"))
+        .order_by()
+        .values("schema_id")
+        .annotate(total=Sum("rows_synced"))
+        .values("total")[:1]
+    )
+    return queryset.annotate(rows_synced_total=Subquery(jobs, output_field=BigIntegerField()))
+
+
 class ExternalDataSchemaSerializer(UserAccessControlSerializerMixin, serializers.ModelSerializer):
     """A schema of an external data source: its sync configuration and the warehouse table it syncs into."""
 
     table = serializers.SerializerMethodField(read_only=True)
+    rows_synced_total = serializers.SerializerMethodField(read_only=True, help_text=ROWS_SYNCED_TOTAL_HELP)
     incremental = serializers.SerializerMethodField(read_only=True)
     status = serializers.SerializerMethodField(read_only=True)
     sync_type = serializers.ChoiceField(
@@ -415,6 +435,7 @@ class ExternalDataSchemaSerializer(UserAccessControlSerializerMixin, serializers
             "name",
             "label",
             "table",
+            "rows_synced_total",
             "should_sync",
             "last_synced_at",
             "latest_error",
@@ -444,6 +465,7 @@ class ExternalDataSchemaSerializer(UserAccessControlSerializerMixin, serializers
             "name",
             "label",
             "table",
+            "rows_synced_total",
             "last_synced_at",
             "latest_error",
             "status",
@@ -599,6 +621,10 @@ class ExternalDataSchemaSerializer(UserAccessControlSerializerMixin, serializers
 
     def get_incremental(self, schema: ExternalDataSchema) -> bool:
         return schema.is_incremental
+
+    @extend_schema_field(serializers.IntegerField(allow_null=True))
+    def get_rows_synced_total(self, schema: ExternalDataSchema) -> int | None:
+        return getattr(schema, "rows_synced_total", None)
 
     def get_table(self, schema: ExternalDataSchema) -> Optional[dict]:
         from products.data_warehouse.backend.presentation.views.table import SimpleTableSerializer
@@ -1398,6 +1424,7 @@ class ExternalDataSchemaListSerializer(serializers.ModelSerializer):
     table = serializers.SerializerMethodField(
         read_only=True, help_text="The synced warehouse table (id, name, row_count), or null if not yet synced."
     )
+    rows_synced_total = serializers.SerializerMethodField(read_only=True, help_text=ROWS_SYNCED_TOTAL_HELP)
     status = serializers.SerializerMethodField(read_only=True, help_text="Current sync status for this schema.")
 
     class Meta:
@@ -1412,8 +1439,13 @@ class ExternalDataSchemaListSerializer(serializers.ModelSerializer):
             "last_synced_at",
             "latest_error",
             "table",
+            "rows_synced_total",
         ]
         read_only_fields = fields
+
+    @extend_schema_field(serializers.IntegerField(allow_null=True))
+    def get_rows_synced_total(self, schema: ExternalDataSchema) -> int | None:
+        return getattr(schema, "rows_synced_total", None)
 
     @extend_schema_field(
         {
@@ -1513,7 +1545,7 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         # `table__external_data_source` is read on every schema serialization (SimpleTableSerializer
         # derives the dotted HogQL name from it), and `source` by `get_api_version_deprecation` for
         # any schema carrying a version override — join both for all actions to avoid per-row queries.
-        queryset = (
+        queryset = annotate_rows_synced_total(
             queryset.exclude(deleted=True)
             .prefetch_related("created_by")
             .select_related("source", "table__external_data_source")

--- a/products/warehouse_sources/backend/presentation/views/external_data_source.py
+++ b/products/warehouse_sources/backend/presentation/views/external_data_source.py
@@ -177,6 +177,7 @@ from products.warehouse_sources.backend.presentation.views.external_data_schema 
     ExternalDataSchemaSerializer,
     RowFiltersField,
     SimpleExternalDataSchemaSerializer,
+    annotate_rows_synced_total,
     source_supports_column_selection,
     unsupported_row_filter_reason,
 )
@@ -2206,14 +2207,23 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                 # `_active_schemas`), so the schema table is scanned once.
                 Prefetch(
                     "schemas",
-                    queryset=ExternalDataSchema.objects.filter(team_id=self.team_id)
-                    .exclude(deleted=True)
-                    .select_related(*schema_select)
-                    .order_by("name"),
+                    queryset=self._schemas_prefetch_queryset(schema_select),
                 ),
             )
             .order_by(self.ordering)
         )
+
+    def _schemas_prefetch_queryset(self, schema_select: list[str]) -> QuerySet[ExternalDataSchema]:
+        queryset = (
+            ExternalDataSchema.objects.filter(team_id=self.team_id)
+            .exclude(deleted=True)
+            .select_related(*schema_select)
+            .order_by("name")
+        )
+        # The list embeds every schema of every source, so the per-schema job sum stays off that path.
+        if self.action == "list":
+            return queryset
+        return annotate_rows_synced_total(queryset)
 
     def _resolve_stored_credential(self, source_type: str, payload: dict) -> ResolvedStoredCredential:
         """Merge a connect-link stored credential into `payload` when it carries a `credential_id`.

--- a/products/warehouse_sources/backend/tests/api/test_external_data_source.py
+++ b/products/warehouse_sources/backend/tests/api/test_external_data_source.py
@@ -3076,6 +3076,7 @@ class TestExternalDataSource(APIBaseTest):
                     "status": schema.status,
                     "sync_type": schema.sync_type,
                     "table": schema.table,
+                    "rows_synced_total": None,
                     "sync_frequency": sync_frequency_interval_to_sync_frequency(schema.sync_frequency_interval),
                     "sync_time_of_day": schema.sync_time_of_day,
                     "description": schema.description,
@@ -3092,6 +3093,28 @@ class TestExternalDataSource(APIBaseTest):
                 }
             ],
         )
+
+    def test_source_schemas_carry_rows_synced_total(self):
+        source = self._create_external_data_source()
+        schema = self._create_external_data_schema(source.pk)
+        for rows, job_status in ((100, ExternalDataJob.Status.COMPLETED), (50, ExternalDataJob.Status.FAILED)):
+            ExternalDataJob.objects.create(
+                team=self.team, pipeline=source, schema=schema, status=job_status, rows_synced=rows
+            )
+
+        response = self.client.get(f"/api/environments/{self.team.pk}/external_data_sources/{source.pk}")
+        assert response.status_code == 200
+        assert response.json()["schemas"][0]["rows_synced_total"] == 150
+
+        response = self.client.get(f"/api/environments/{self.team.pk}/external_data_schemas/{schema.pk}")
+        assert response.status_code == 200
+        assert response.json()["rows_synced_total"] == 150
+
+        # The sources list embeds every schema of every source, so it does not pay for the sum.
+        response = self.client.get(f"/api/environments/{self.team.pk}/external_data_sources/")
+        assert response.status_code == 200
+        listed = next(item for item in response.json()["results"] if item["id"] == str(source.pk))
+        assert listed["schemas"][0]["rows_synced_total"] is None
 
     @parameterized.expand(
         [

--- a/products/warehouse_sources/frontend/generated/api.schemas.ts
+++ b/products/warehouse_sources/frontend/generated/api.schemas.ts
@@ -249,6 +249,11 @@ export interface ExternalDataSchemaApi {
     readonly label: string | null
     /** @nullable */
     readonly table: ExternalDataSchemaApiTable
+    /**
+     * Rows every sync of this schema moved, summed over all of its runs. The data warehouse bills this quantity. It differs from the table's row count on merge and full-refresh syncs, which rewrite rows the table already holds, so the two cannot be reconciled against each other.
+     * @nullable
+     */
+    readonly rows_synced_total: number | null
     should_sync?: boolean
     /** @nullable */
     readonly last_synced_at: string | null
@@ -412,6 +417,11 @@ export interface PatchedExternalDataSchemaApi {
     readonly label?: string | null
     /** @nullable */
     readonly table?: PatchedExternalDataSchemaApiTable
+    /**
+     * Rows every sync of this schema moved, summed over all of its runs. The data warehouse bills this quantity. It differs from the table's row count on merge and full-refresh syncs, which rewrite rows the table already holds, so the two cannot be reconciled against each other.
+     * @nullable
+     */
+    readonly rows_synced_total?: number | null
     should_sync?: boolean
     /** @nullable */
     readonly last_synced_at?: string | null

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -37225,6 +37225,11 @@ export namespace Schemas {
       readonly label: string | null;
       /** @nullable */
       readonly table: ExternalDataSchemaTable;
+      /**
+         * Rows every sync of this schema moved, summed over all of its runs. The data warehouse bills this quantity. It differs from the table's row count on merge and full-refresh syncs, which rewrite rows the table already holds, so the two cannot be reconciled against each other.
+         * @nullable
+         */
+      readonly rows_synced_total: number | null;
       should_sync?: boolean;
       /** @nullable */
       readonly last_synced_at: string | null;
@@ -64669,6 +64674,11 @@ export namespace Schemas {
       readonly label?: string | null;
       /** @nullable */
       readonly table?: PatchedExternalDataSchemaTable;
+      /**
+         * Rows every sync of this schema moved, summed over all of its runs. The data warehouse bills this quantity. It differs from the table's row count on merge and full-refresh syncs, which rewrite rows the table already holds, so the two cannot be reconciled against each other.
+         * @nullable
+         */
+      readonly rows_synced_total?: number | null;
       should_sync?: boolean;
       /** @nullable */
       readonly last_synced_at?: string | null;


### PR DESCRIPTION
## Problem

The per-schema column on the source page showed the warehouse table's current size under the title "Rows synced" until #86986 renamed it to "Row count". The rename fixed the label and left the gap: nothing on the page shows the rows a sync moved, and that is the quantity the data warehouse bills. A merge-based incremental sync writes a row once per update while the table holds it once, and a full refresh drops every replaced snapshot from the count, so a user reconciling a source against their warehouse usage finds numbers that cannot agree.

Closes #83856

## Changes

- Each schema now carries `rows_synced_total`: the sum of `ExternalDataJob.rows_synced` over every run of that schema. The schemas endpoint and the single-source read compute it with one correlated subquery per schema.
- The sources list embeds every schema of every source, and a large project has tens of thousands, so that path leaves the field null and pays nothing. The schemas table lives on the single-source scene, which reads the annotated path.
- The schemas table shows a "Rows synced" column beside "Row count", sortable, with a tooltip that names it as the billed unit and says why it differs from the row count. The in-progress first-sync case is unchanged: "Row count" still shows the running job's live count.

The issue offered two shapes. #86986 already shipped shape 2 (rename). This ships shape 1 as well, so table size and rows synced are both on the page, because they answer different questions: how big is my table, and what am I paying for.

## How did you test this code?

- New API test `test_source_schemas_carry_rows_synced_total`: two jobs of 100 and 50 rows sum to 150 on the source read and the schema read, and the sources list returns null for the field.
- Updated the exact-payload assertion in `test_get_external_data_source_with_schema` for the new key.
- `ruff check` and `ruff format` on the Python files, `oxfmt` and `oxlint` on the two frontend files. The API tests need Postgres, which this machine does not run, so they run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
