### PR TITLE
fix(redshift): recognize SSL EOF drops as retryable during setup

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/redshift.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/redshift.py
@@ -405,12 +405,18 @@ _MAX_SETUP_CONNECTION_DROP_ATTEMPTS = 3
 # Substrings psycopg uses for a transient socket drop around sync setup. "the connection is lost"
 # is the message libpq gives when an already-open connection dies. "server closed the connection
 # unexpectedly" is the message when the socket dies during the connect handshake ("connection
-# failed: ... server closed the connection unexpectedly"). Both are the same transient class — a
-# network blip or a cluster pause/resize — and recover by reconnecting. Keep this narrow so a
+# failed: ... server closed the connection unexpectedly"). "consuming input failed" is libpq's
+# wrapper when the drop is detected while reading a query's response (e.g. `get_table_metadata`'s
+# `information_schema.columns` lookup) rather than at connect time — it also prefixes "ssl syscall
+# error", the socket-level form of a TLS drop (handshake or read EOF). All are the same transient
+# class — a network blip or a cluster pause/resize — and recover by reconnecting. Mirrors the
+# equivalent Postgres source's `_CONNECTION_DROPPED_ERROR_SUBSTRINGS`. Keep this narrow so a
 # permanent failure such as "password authentication failed" is never retried in-process.
 _TRANSIENT_CONNECTION_DROP_SUBSTRINGS = (
     "the connection is lost",
     "server closed the connection unexpectedly",
+    "consuming input failed",
+    "ssl syscall error",
 )
 
 
@@ -423,7 +429,7 @@ def _is_transient_connection_drop_error(error: BaseException) -> bool:
     """
     if not isinstance(error, psycopg.OperationalError):
         return False
-    message = str(error)
+    message = str(error).lower()
     return any(substring in message for substring in _TRANSIENT_CONNECTION_DROP_SUBSTRINGS)
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/tests/test_redshift.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/tests/test_redshift.py
@@ -1390,6 +1390,17 @@ class TestIsTransientConnectionDropError:
             is True
         )
 
+    def test_matches_consuming_input_failed_ssl_syscall_error(self):
+        # Regression: a drop detected while reading a query's response (e.g. `get_table_metadata`
+        # mid-probe) surfaces as "consuming input failed: SSL SYSCALL error: EOF detected" rather
+        # than either message above, and previously fell through to a full Temporal activity retry.
+        assert (
+            _is_transient_connection_drop_error(
+                psycopg.OperationalError("consuming input failed: SSL SYSCALL error: EOF detected")
+            )
+            is True
+        )
+
     def test_does_not_match_unrelated_operational_error(self):
         # A permanent, non-actionable failure that also raises OperationalError must not be
         # swept up by the narrow "the connection is lost" match and retried in-process.


### PR DESCRIPTION
## Problem

A Redshift sync failed with `OperationalError: consuming input failed: SSL SYSCALL error: EOF detected` while reading a table's column metadata during setup, before any rows synced ([error tracking issue](https://us.posthog.com/project/2/error_tracking/01a089b9-2ecc-7253-8432-88b827714e19)).

Redshift's in-process setup retry (`_retry_on_transient_connection_drop`) only recognized two connection-drop messages. This one fell through, so the whole sync had to fail out to a full Temporal activity retry, which restarts the entire setup phase from scratch instead of just reconnecting.

## Changes

- `_TRANSIENT_CONNECTION_DROP_SUBSTRINGS` in `redshift.py` now also matches `consuming input failed` and `ssl syscall error`, the two libpq wordings for a socket drop detected while reading a query's response.
- The substring match is now case-insensitive, since libpq's `SSL SYSCALL error` wording is mixed case.
- This mirrors the Postgres source's existing `_CONNECTION_DROPPED_ERROR_SUBSTRINGS`, which already treats the same drop as transient.
- No change to `NonRetryableErrors` or the global retry policy — the error was already retryable at the Temporal activity level; this only makes recovery cheaper and faster for this one failure class.

## How did you test this code?

- Added `test_matches_consuming_input_failed_ssl_syscall_error` to `TestIsTransientConnectionDropError`, using the exact message from the error tracking issue — catches a regression where this drop stops being recognized as transient.
- Ran `pytest products/warehouse_sources/backend/temporal/data_imports/sources/redshift/tests/test_redshift.py`: 146 passed.
- Ran `ruff check`, `ruff format --check`, and `mypy` on the changed file: clean.
- Not run: a live sync against a real Redshift cluster.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal retry classification, no user-facing behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated a single-occurrence error tracking issue for the Redshift warehouse source. Confirmed the failing frame (`get_table_metadata`) sits inside `build_pipeline`'s setup phase, which already has an in-process transient-connection-drop retry for two other libpq messages, and that the equivalent Postgres source already classifies this exact SSL EOF wording as transient. Extended Redshift's classifier to match, rather than adding to `NonRetryableErrors` — the error is a network-level blip, not a user/upstream configuration problem. No open PR duplicates this fix (searched by exception type, message substring, and module path).

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
