### PR TITLE
chore(ci): inspect CI report sections during triage

### DIFF
--- a/.agents/skills/debugging-ci-failures/SKILL.md
+++ b/.agents/skills/debugging-ci-failures/SKILL.md
@@ -175,15 +175,17 @@ Inspect every `ci-report:section` block, including unknown sections. Record its
 title, status, summary, and links. Do not stop at the first `fail` section or
 treat the comment heading as an overall verdict.
 
-- Treat `fail` and `alert` as leads, and match them to the current job.
-- Treat `warn` as a non-blocking finding. Review its details and follow its
-  stated action, but do not call it a failed job unless its job failed.
+- Treat `fail` as a lead, and match it to the current job.
+- Treat `alert` and `warn` as non-blocking findings. Review their details and
+  follow their stated action, but do not call either a failed job unless its
+  job failed.
 - `ok` and `info` are not test results.
 - A missing report means the reporter did not run or could not write. It does
   not prove the PR is healthy.
 
-The report is a summary. Confirm its head SHA and job status. If it disagrees
-with the current logs, report the mismatch and use the logs for the cause.
+The report is a summary. A section without a head SHA or run link can be stale.
+Confirm it against the current job. If it disagrees with the current logs,
+report the mismatch and use the logs for the cause.
 
 Inspect read-only:
 

--- a/.agents/skills/debugging-ci-failures/SKILL.md
+++ b/.agents/skills/debugging-ci-failures/SKILL.md
@@ -160,39 +160,29 @@ practice that is most of the queue. So:
 
 ### 3. Read the CI report comment (for a PR)
 
-Before reading job logs, read the shared CI report comment when the target is a
-PR. It collects independent CI signals in many sections. A red run may have a
-useful report section, and a green run can still carry an advisory that needs
-review.
+Before reading logs, read the shared CI report comment. It collects independent
+CI signals and advisories in many sections.
 
-Read the complete raw comment, not only GitHub's collapsed view. The marker
-identifies the report that CI owns; its section markers preserve each section's
-status and summary. This command returns every page, so it does not miss the
-report when a PR has many comments:
+Read the full raw comment, not GitHub's collapsed view. This command finds it
+even when the PR has many comments:
 
 ```bash
 gh api --paginate "repos/<owner>/<repo>/issues/<pr>/comments?per_page=100" \
   --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("<!-- posthog-ci-report -->"))) | .body'
 ```
 
-Inspect every `ci-report:section` block, including an unknown section. New
-checks can add sections before this skill changes. Record each section's title,
-status, summary, and any linked run or failed command. Do not stop at the first
-`fail` section or treat the comment heading as an overall verdict.
+Inspect every `ci-report:section` block, including unknown sections. Record its
+title, status, summary, and links. Do not stop at the first `fail` section or
+treat the comment heading as an overall verdict.
 
-- `fail` and `alert` sections are investigation leads. Match them to the
-  current check or job before naming a cause.
-- `warn` sections are advisory unless the linked check or job failed. Explain
-  them separately from a blocking CI failure.
-- `ok` and `info` sections can show that a previous warning has cleared or that
-  a check did not measure this push. Do not call either a passing test result.
-- No matching comment means the reporter did not run or could not write. Carry
-  on with the checks and logs; it is not proof that the PR is healthy.
+- Treat `fail` and `alert` as leads, and match them to the current job.
+- Treat `warn` as advisory unless its job failed. `ok` and `info` are not test
+  results.
+- A missing report means the reporter did not run or could not write. It does
+  not prove the PR is healthy.
 
-The report is a summary, not the source of truth for current job state. Check
-the head SHA and current check status before relying on it, especially after a
-new push or a re-run. If the comment and logs disagree, report the mismatch and
-prefer the current run's logs for the failure cause.
+The report is a summary. Confirm its head SHA and job status. If it disagrees
+with the current logs, report the mismatch and use the logs for the cause.
 
 Inspect read-only:
 

--- a/.agents/skills/debugging-ci-failures/SKILL.md
+++ b/.agents/skills/debugging-ci-failures/SKILL.md
@@ -176,8 +176,9 @@ title, status, summary, and links. Do not stop at the first `fail` section or
 treat the comment heading as an overall verdict.
 
 - Treat `fail` and `alert` as leads, and match them to the current job.
-- Treat `warn` as advisory unless its job failed. `ok` and `info` are not test
-  results.
+- Treat `warn` as a non-blocking finding. Review its details and follow its
+  stated action, but do not call it a failed job unless its job failed.
+- `ok` and `info` are not test results.
 - A missing report means the reporter did not run or could not write. It does
   not prove the PR is healthy.
 

--- a/.agents/skills/debugging-ci-failures/SKILL.md
+++ b/.agents/skills/debugging-ci-failures/SKILL.md
@@ -158,6 +158,42 @@ practice that is most of the queue. So:
   merge commits are the first suspects.
 - In the digest this is the `blocking_merge_queue` state.
 
+### 3. Read the CI report comment (for a PR)
+
+Before reading job logs, read the shared CI report comment when the target is a
+PR. It collects independent CI signals in many sections. A red run may have a
+useful report section, and a green run can still carry an advisory that needs
+review.
+
+Read the complete raw comment, not only GitHub's collapsed view. The marker
+identifies the report that CI owns; its section markers preserve each section's
+status and summary. This command returns every page, so it does not miss the
+report when a PR has many comments:
+
+```bash
+gh api --paginate "repos/<owner>/<repo>/issues/<pr>/comments?per_page=100" \
+  --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("<!-- posthog-ci-report -->"))) | .body'
+```
+
+Inspect every `ci-report:section` block, including an unknown section. New
+checks can add sections before this skill changes. Record each section's title,
+status, summary, and any linked run or failed command. Do not stop at the first
+`fail` section or treat the comment heading as an overall verdict.
+
+- `fail` and `alert` sections are investigation leads. Match them to the
+  current check or job before naming a cause.
+- `warn` sections are advisory unless the linked check or job failed. Explain
+  them separately from a blocking CI failure.
+- `ok` and `info` sections can show that a previous warning has cleared or that
+  a check did not measure this push. Do not call either a passing test result.
+- No matching comment means the reporter did not run or could not write. Carry
+  on with the checks and logs; it is not proof that the PR is healthy.
+
+The report is a summary, not the source of truth for current job state. Check
+the head SHA and current check status before relying on it, especially after a
+new push or a re-run. If the comment and logs disagree, report the mismatch and
+prefer the current run's logs for the failure cause.
+
 Inspect read-only:
 
 ```bash


### PR DESCRIPTION
[robot]

## Problem

People who investigate CI can miss important signals when the report has many collapsed sections.

**Why:** The CI debugging skill needs the complete report before it reaches a verdict.

## Changes

- The CI debugging skill reads every section in the shared report comment before log analysis.
- The skill separates advisory notes from failing checks and confirms them with current run data.
- This guidance change does not alter CI jobs or report publishing.

## How did you test this code?

- Ran `uv run ./bin/hogli lint:skills`.
- Ran `git diff --check`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- Updated the CI debugging skill.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex used `/writing-skills`, skill-store `/simplify`, `/review-triage`, QA Swarm, Paul Pair, and `/writing-pr-descriptions`.
- The change uses the existing CI report marker and section format.
- Search found no matching open pull request.
- Public artifact check: The change uses repository-only CI report design.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*