### PR TITLE
feat(desktop): track route settle time

### DIFF
--- a/products/desktop/packages/ui/src/router/navigationTiming.test.ts
+++ b/products/desktop/packages/ui/src/router/navigationTiming.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createNavigationTiming } from "./navigationTiming";
+
+describe("createNavigationTiming", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("records the duration after the destination has painted", () => {
+    const frames: FrameRequestCallback[] = [];
+    vi.spyOn(globalThis, "requestAnimationFrame").mockImplementation((cb) => {
+      frames.push(cb);
+      return frames.length;
+    });
+    vi.spyOn(performance, "now")
+      .mockReturnValueOnce(100)
+      .mockReturnValueOnce(175);
+    const timing = createNavigationTiming();
+    const record = vi.fn();
+
+    timing.start();
+    timing.settle(record);
+    frames[0]?.(0);
+
+    expect(record).not.toHaveBeenCalled();
+
+    frames[1]?.(0);
+
+    expect(record).toHaveBeenCalledWith(75);
+  });
+
+  it.each([
+    "settles before navigation starts",
+    "is replaced by a newer navigation",
+  ])("does not record when it %s", (caseName) => {
+    const frames: FrameRequestCallback[] = [];
+    vi.spyOn(globalThis, "requestAnimationFrame").mockImplementation((cb) => {
+      frames.push(cb);
+      return frames.length;
+    });
+    const timing = createNavigationTiming();
+    const record = vi.fn();
+
+    if (caseName === "is replaced by a newer navigation") {
+      timing.start();
+    }
+    timing.settle(record);
+    timing.start();
+    frames[0]?.(0);
+    frames[1]?.(0);
+
+    expect(record).not.toHaveBeenCalled();
+  });
+});

--- a/products/desktop/packages/ui/src/router/navigationTiming.test.ts
+++ b/products/desktop/packages/ui/src/router/navigationTiming.test.ts
@@ -51,4 +51,27 @@ describe("createNavigationTiming", () => {
 
     expect(record).not.toHaveBeenCalled();
   });
+
+  it("does not record while the window is hidden", () => {
+    let visibility: DocumentVisibilityState = "visible";
+    const frames: FrameRequestCallback[] = [];
+    vi.spyOn(document, "visibilityState", "get").mockImplementation(
+      () => visibility,
+    );
+    vi.spyOn(globalThis, "requestAnimationFrame").mockImplementation((cb) => {
+      frames.push(cb);
+      return frames.length;
+    });
+    const timing = createNavigationTiming();
+    const record = vi.fn();
+
+    timing.start();
+    timing.settle(record);
+    visibility = "hidden";
+    document.dispatchEvent(new Event("visibilitychange"));
+    frames[0]?.(0);
+    frames[1]?.(0);
+
+    expect(record).not.toHaveBeenCalled();
+  });
 });

--- a/products/desktop/packages/ui/src/router/navigationTiming.test.ts
+++ b/products/desktop/packages/ui/src/router/navigationTiming.test.ts
@@ -6,71 +6,48 @@ describe("createNavigationTiming", () => {
     vi.restoreAllMocks();
   });
 
-  it("records the duration after the destination has painted", () => {
-    const frames: FrameRequestCallback[] = [];
-    vi.spyOn(globalThis, "requestAnimationFrame").mockImplementation((cb) => {
-      frames.push(cb);
-      return frames.length;
-    });
+  function stubVisibility(state: DocumentVisibilityState): void {
+    vi.spyOn(document, "visibilityState", "get").mockReturnValue(state);
+  }
+
+  it.each(["visible", "hidden"] as const)(
+    "records the duration when the route settles while %s",
+    (visibility) => {
+      stubVisibility(visibility);
+      vi.spyOn(performance, "now")
+        .mockReturnValueOnce(100)
+        .mockReturnValueOnce(175);
+      const timing = createNavigationTiming();
+      const record = vi.fn();
+
+      timing.start();
+      timing.settle(record);
+
+      expect(record).toHaveBeenCalledWith(75, visibility);
+    },
+  );
+
+  it("uses the latest navigation start", () => {
+    stubVisibility("visible");
     vi.spyOn(performance, "now")
       .mockReturnValueOnce(100)
-      .mockReturnValueOnce(175);
+      .mockReturnValueOnce(200)
+      .mockReturnValueOnce(275);
     const timing = createNavigationTiming();
     const record = vi.fn();
 
     timing.start();
+    timing.start();
     timing.settle(record);
-    frames[0]?.(0);
 
-    expect(record).not.toHaveBeenCalled();
-
-    frames[1]?.(0);
-
-    expect(record).toHaveBeenCalledWith(75);
+    expect(record).toHaveBeenCalledWith(75, "visible");
   });
 
-  it.each([
-    "settles before navigation starts",
-    "is replaced by a newer navigation",
-  ])("does not record when it %s", (caseName) => {
-    const frames: FrameRequestCallback[] = [];
-    vi.spyOn(globalThis, "requestAnimationFrame").mockImplementation((cb) => {
-      frames.push(cb);
-      return frames.length;
-    });
+  it("does not record before navigation starts", () => {
     const timing = createNavigationTiming();
     const record = vi.fn();
 
-    if (caseName === "is replaced by a newer navigation") {
-      timing.start();
-    }
     timing.settle(record);
-    timing.start();
-    frames[0]?.(0);
-    frames[1]?.(0);
-
-    expect(record).not.toHaveBeenCalled();
-  });
-
-  it("does not record while the window is hidden", () => {
-    let visibility: DocumentVisibilityState = "visible";
-    const frames: FrameRequestCallback[] = [];
-    vi.spyOn(document, "visibilityState", "get").mockImplementation(
-      () => visibility,
-    );
-    vi.spyOn(globalThis, "requestAnimationFrame").mockImplementation((cb) => {
-      frames.push(cb);
-      return frames.length;
-    });
-    const timing = createNavigationTiming();
-    const record = vi.fn();
-
-    timing.start();
-    timing.settle(record);
-    visibility = "hidden";
-    document.dispatchEvent(new Event("visibilitychange"));
-    frames[0]?.(0);
-    frames[1]?.(0);
 
     expect(record).not.toHaveBeenCalled();
   });

--- a/products/desktop/packages/ui/src/router/navigationTiming.ts
+++ b/products/desktop/packages/ui/src/router/navigationTiming.ts
@@ -1,0 +1,31 @@
+type Navigation = {
+  id: number;
+  startedAt: number;
+};
+
+export function createNavigationTiming(): {
+  start: () => void;
+  settle: (record: (durationMs: number) => void) => void;
+} {
+  let nextId = 0;
+  let navigation: Navigation | null = null;
+
+  return {
+    start: () => {
+      navigation = { id: ++nextId, startedAt: performance.now() };
+    },
+    settle: (record) => {
+      const settledNavigation = navigation;
+      if (!settledNavigation) return;
+
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          if (navigation?.id !== settledNavigation.id) return;
+
+          navigation = null;
+          record(performance.now() - settledNavigation.startedAt);
+        });
+      });
+    },
+  };
+}

--- a/products/desktop/packages/ui/src/router/navigationTiming.ts
+++ b/products/desktop/packages/ui/src/router/navigationTiming.ts
@@ -1,58 +1,24 @@
-type Navigation = {
-  id: number;
-  startedAt: number;
-};
-
 export function createNavigationTiming(): {
   start: () => void;
-  settle: (record: (durationMs: number) => void) => void;
+  settle: (
+    record: (
+      durationMs: number,
+      visibilityAtSettle: DocumentVisibilityState,
+    ) => void,
+  ) => void;
 } {
-  let nextId = 0;
-  let navigation: Navigation | null = null;
-  let unsubscribeFromVisibilityChange: (() => void) | null = null;
-
-  const clearNavigation = (): void => {
-    navigation = null;
-    unsubscribeFromVisibilityChange?.();
-    unsubscribeFromVisibilityChange = null;
-  };
+  let startedAt: number | null = null;
 
   return {
     start: () => {
-      clearNavigation();
-      if (document.visibilityState !== "visible") return;
-
-      const nextNavigation = { id: ++nextId, startedAt: performance.now() };
-      navigation = nextNavigation;
-      const onVisibilityChange = (): void => {
-        if (
-          document.visibilityState !== "visible" &&
-          navigation?.id === nextNavigation.id
-        ) {
-          clearNavigation();
-        }
-      };
-      document.addEventListener("visibilitychange", onVisibilityChange);
-      unsubscribeFromVisibilityChange = () => {
-        document.removeEventListener("visibilitychange", onVisibilityChange);
-      };
+      startedAt = performance.now();
     },
     settle: (record) => {
-      const settledNavigation = navigation;
-      if (!settledNavigation) return;
+      if (startedAt === null) return;
 
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          if (navigation?.id !== settledNavigation.id) return;
-          if (document.visibilityState !== "visible") {
-            clearNavigation();
-            return;
-          }
-
-          clearNavigation();
-          record(performance.now() - settledNavigation.startedAt);
-        });
-      });
+      const durationMs = performance.now() - startedAt;
+      startedAt = null;
+      record(durationMs, document.visibilityState);
     },
   };
 }

--- a/products/desktop/packages/ui/src/router/navigationTiming.ts
+++ b/products/desktop/packages/ui/src/router/navigationTiming.ts
@@ -9,10 +9,33 @@ export function createNavigationTiming(): {
 } {
   let nextId = 0;
   let navigation: Navigation | null = null;
+  let unsubscribeFromVisibilityChange: (() => void) | null = null;
+
+  const clearNavigation = (): void => {
+    navigation = null;
+    unsubscribeFromVisibilityChange?.();
+    unsubscribeFromVisibilityChange = null;
+  };
 
   return {
     start: () => {
-      navigation = { id: ++nextId, startedAt: performance.now() };
+      clearNavigation();
+      if (document.visibilityState !== "visible") return;
+
+      const nextNavigation = { id: ++nextId, startedAt: performance.now() };
+      navigation = nextNavigation;
+      const onVisibilityChange = (): void => {
+        if (
+          document.visibilityState !== "visible" &&
+          navigation?.id === nextNavigation.id
+        ) {
+          clearNavigation();
+        }
+      };
+      document.addEventListener("visibilitychange", onVisibilityChange);
+      unsubscribeFromVisibilityChange = () => {
+        document.removeEventListener("visibilitychange", onVisibilityChange);
+      };
     },
     settle: (record) => {
       const settledNavigation = navigation;
@@ -21,8 +44,12 @@ export function createNavigationTiming(): {
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
           if (navigation?.id !== settledNavigation.id) return;
+          if (document.visibilityState !== "visible") {
+            clearNavigation();
+            return;
+          }
 
-          navigation = null;
+          clearNavigation();
           record(performance.now() - settledNavigation.startedAt);
         });
       });

--- a/products/desktop/packages/ui/src/router/router.ts
+++ b/products/desktop/packages/ui/src/router/router.ts
@@ -2,6 +2,8 @@ import {
   createHashHistory,
   createRouter as createTanStackRouter,
 } from "@tanstack/react-router";
+import { recordNavigationSettled } from "../shell/analytics";
+import { createNavigationTiming } from "./navigationTiming";
 import { RouteNotFound } from "./RouteNotFound";
 import { RoutePending } from "./RoutePending";
 import { isReportPath } from "./reportNavigation";
@@ -9,6 +11,7 @@ import { setRouter } from "./routerRef";
 import { routeTree } from "./routeTree.gen";
 
 const reportSourceEntries = new Set<string>();
+const navigationTiming = createNavigationTiming();
 
 export const router = createTanStackRouter({
   routeTree,
@@ -35,9 +38,17 @@ export const router = createTanStackRouter({
 });
 
 router.subscribe("onBeforeLoad", ({ fromLocation, toLocation }) => {
+  navigationTiming.start();
   if (fromLocation?.state.__TSR_key && isReportPath(toLocation.pathname)) {
     reportSourceEntries.add(fromLocation.state.__TSR_key);
   }
+});
+
+router.subscribe("onResolved", () => {
+  navigationTiming.settle((durationMs) => {
+    const route = router.state.matches.at(-1)?.routeId;
+    if (route) recordNavigationSettled(durationMs, route);
+  });
 });
 
 // Publish the instance to the leaf ref so imperative callers reach it without a

--- a/products/desktop/packages/ui/src/router/router.ts
+++ b/products/desktop/packages/ui/src/router/router.ts
@@ -45,9 +45,9 @@ router.subscribe("onBeforeLoad", ({ fromLocation, toLocation }) => {
 });
 
 router.subscribe("onResolved", () => {
-  navigationTiming.settle((durationMs) => {
+  navigationTiming.settle((durationMs, visibilityAtSettle) => {
     const route = router.state.matches.at(-1)?.routeId;
-    if (route) recordNavigationSettled(durationMs, route);
+    if (route) recordNavigationSettled(durationMs, route, visibilityAtSettle);
   });
 });
 

--- a/products/desktop/packages/ui/src/shell/analytics.ts
+++ b/products/desktop/packages/ui/src/shell/analytics.ts
@@ -30,7 +30,11 @@ export interface AnalyticsTracker {
   identifyUser(userId: string, properties?: UserIdentifyProperties): void;
   setUserGroups(user: AnalyticsUserGroups): void;
   resetUser(): void;
-  recordNavigationSettled(durationMs: number, route: string): void;
+  recordNavigationSettled(
+    durationMs: number,
+    route: string,
+    visibilityAtSettle: DocumentVisibilityState,
+  ): void;
   captureSurveyResponse(params: {
     surveyId: string;
     responses: Array<{ questionId: string; response: string }>;
@@ -83,10 +87,12 @@ export function resetUser(): void {
 export function recordNavigationSettled(
   durationMs: number,
   route: string,
+  visibilityAtSettle: DocumentVisibilityState,
 ): void {
   resolveService<AnalyticsTracker>(ANALYTICS_TRACKER).recordNavigationSettled(
     durationMs,
     route,
+    visibilityAtSettle,
   );
 }
 

--- a/products/desktop/packages/ui/src/shell/analytics.ts
+++ b/products/desktop/packages/ui/src/shell/analytics.ts
@@ -30,6 +30,7 @@ export interface AnalyticsTracker {
   identifyUser(userId: string, properties?: UserIdentifyProperties): void;
   setUserGroups(user: AnalyticsUserGroups): void;
   resetUser(): void;
+  recordNavigationSettled(durationMs: number, route: string): void;
   captureSurveyResponse(params: {
     surveyId: string;
     responses: Array<{ questionId: string; response: string }>;
@@ -77,6 +78,16 @@ export function setUserGroups(user: AnalyticsUserGroups): void {
 
 export function resetUser(): void {
   resolveService<AnalyticsTracker>(ANALYTICS_TRACKER).resetUser();
+}
+
+export function recordNavigationSettled(
+  durationMs: number,
+  route: string,
+): void {
+  resolveService<AnalyticsTracker>(ANALYTICS_TRACKER).recordNavigationSettled(
+    durationMs,
+    route,
+  );
 }
 
 export function captureSurveyResponse(params: {

--- a/products/desktop/packages/ui/src/shell/posthogAnalyticsImpl.test.ts
+++ b/products/desktop/packages/ui/src/shell/posthogAnalyticsImpl.test.ts
@@ -228,19 +228,25 @@ describe("recordNavigationSettled", () => {
       await loadAnalytics();
     initializePostHog();
 
-    recordNavigationSettled(125, "/tasks/$taskId");
+    recordNavigationSettled(125, "/tasks/$taskId", "hidden");
 
     expect(mockPosthog.metrics.histogram).toHaveBeenCalledWith(
       "desktop.navigation.settled.duration",
       125,
-      { unit: "ms", attributes: { route: "/tasks/$taskId" } },
+      {
+        unit: "ms",
+        attributes: {
+          route: "/tasks/$taskId",
+          visibility_at_settle: "hidden",
+        },
+      },
     );
   });
 
   it("does nothing before init", async () => {
     const { recordNavigationSettled } = await loadAnalytics();
 
-    recordNavigationSettled(125, "/tasks/$taskId");
+    recordNavigationSettled(125, "/tasks/$taskId", "visible");
 
     expect(mockPosthog.metrics.histogram).not.toHaveBeenCalled();
   });

--- a/products/desktop/packages/ui/src/shell/posthogAnalyticsImpl.test.ts
+++ b/products/desktop/packages/ui/src/shell/posthogAnalyticsImpl.test.ts
@@ -14,6 +14,7 @@ const mockPosthog = {
   reset: vi.fn(),
   captureException: vi.fn(),
   reloadFeatureFlags: vi.fn(),
+  metrics: { histogram: vi.fn() },
 };
 
 vi.mock("posthog-js/dist/module.full.no-external", () => ({
@@ -221,6 +222,30 @@ describe("track", () => {
   });
 });
 
+describe("recordNavigationSettled", () => {
+  it("records duration by route after init", async () => {
+    const { initializePostHog, recordNavigationSettled } =
+      await loadAnalytics();
+    initializePostHog();
+
+    recordNavigationSettled(125, "/tasks/$taskId");
+
+    expect(mockPosthog.metrics.histogram).toHaveBeenCalledWith(
+      "desktop.navigation.settled.duration",
+      125,
+      { unit: "ms", attributes: { route: "/tasks/$taskId" } },
+    );
+  });
+
+  it("does nothing before init", async () => {
+    const { recordNavigationSettled } = await loadAnalytics();
+
+    recordNavigationSettled(125, "/tasks/$taskId");
+
+    expect(mockPosthog.metrics.histogram).not.toHaveBeenCalled();
+  });
+});
+
 describe("initializePostHog", () => {
   it("is idempotent across repeat calls", async () => {
     const { initializePostHog } = await loadAnalytics();
@@ -252,6 +277,22 @@ describe("initializePostHog", () => {
       "test-key",
       expect.objectContaining({
         session_recording: { captureCanvas: { recordCanvas: false } },
+      }),
+    );
+  });
+
+  it("configures metrics for the desktop service", async () => {
+    const { initializePostHog } = await loadAnalytics();
+
+    initializePostHog();
+
+    expect(mockPosthog.init).toHaveBeenCalledWith(
+      "test-key",
+      expect.objectContaining({
+        metrics: {
+          serviceName: "posthog-desktop",
+          environment: "development",
+        },
       }),
     );
   });

--- a/products/desktop/packages/ui/src/shell/posthogAnalyticsImpl.ts
+++ b/products/desktop/packages/ui/src/shell/posthogAnalyticsImpl.ts
@@ -134,6 +134,10 @@ export function initializePostHog(sessionId?: string) {
     defaults: "2026-05-30",
     api_host: apiHost,
     ui_host: uiHost,
+    metrics: {
+      serviceName: "posthog-desktop",
+      environment: import.meta.env.PROD ? "production" : "development",
+    },
     // The epoch turns capture_pageview into "history_change". This app routes via
     // createHashHistory() (packages/ui/src/router/router.ts), so the route lives in
     // the URL hash and $pathname is identical for every screen — automatic pageviews
@@ -338,6 +342,20 @@ export function track<K extends keyof EventPropertyMap>(
   posthog.capture(eventName, properties);
 }
 
+export function recordNavigationSettled(
+  durationMs: number,
+  route: string,
+): void {
+  if (!isInitialized) {
+    return;
+  }
+
+  posthog.metrics.histogram("desktop.navigation.settled.duration", durationMs, {
+    unit: "ms",
+    attributes: { route },
+  });
+}
+
 /**
  * Record a survey response via posthog-js's `survey sent` event. Pass one entry
  * per answered question; they're submitted together as a single response. The
@@ -502,6 +520,7 @@ export const posthogAnalyticsTracker: AnalyticsTracker = {
   identifyUser,
   setUserGroups,
   resetUser,
+  recordNavigationSettled,
   captureSurveyResponse,
 };
 

--- a/products/desktop/packages/ui/src/shell/posthogAnalyticsImpl.ts
+++ b/products/desktop/packages/ui/src/shell/posthogAnalyticsImpl.ts
@@ -345,6 +345,7 @@ export function track<K extends keyof EventPropertyMap>(
 export function recordNavigationSettled(
   durationMs: number,
   route: string,
+  visibilityAtSettle: DocumentVisibilityState,
 ): void {
   if (!isInitialized) {
     return;
@@ -352,7 +353,7 @@ export function recordNavigationSettled(
 
   posthog.metrics.histogram("desktop.navigation.settled.duration", durationMs, {
     unit: "ms",
-    attributes: { route },
+    attributes: { route, visibility_at_settle: visibilityAtSettle },
   });
 }
 


### PR DESCRIPTION
## Problem

Desktop maintainers cannot measure route completion time by route template or window visibility.

**Why:** The metric can find slow paths without treating time spent away from the app as slow route work.

## Changes

- Route changes now send a duration histogram when the destination route resolves.
- The metric records whether the window was visible or hidden when the route resolved.
- The metric groups dynamic routes by their stable route template.
- No visible UI change.

## How did you test this code?

- Ran focused `@posthog/ui` Vitest tests, UI typecheck, and workspace lint.
- New tests cover visible and hidden route completion, latest navigation starts, and metric attributes.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None. This change adds internal telemetry only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- [robot] A PostHog Desktop agent created and shepherded this PR.
- Used `posthog-desktop`, `instrument-metrics`, `writing-pr-descriptions`, and `pr-shepherd` with its review and CI steps.
- No matching open PR or issue was found.
- No non-public data was added.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*