### PR TITLE
chore(ci): skip the image build on desktop-only master pushes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -88,7 +88,8 @@ packages/llm-normalizer/**/dist
 products/**/node_modules
 # Nested standalone workspace, not imported by any server image; `!products` above
 # would otherwise pull ~56 MiB of desktop assets into every image build context.
-# Container Images CD mirrors these lines in its push `paths` filter, so keep the two in step.
+# The `changes` job in container-images-cd.yml mirrors these lines to decide whether a push
+# can change the image, so keep the two in step.
 products/desktop/*
 !products/desktop/packages
 products/desktop/packages/*

--- a/.dockerignore
+++ b/.dockerignore
@@ -88,6 +88,7 @@ packages/llm-normalizer/**/dist
 products/**/node_modules
 # Nested standalone workspace, not imported by any server image; `!products` above
 # would otherwise pull ~56 MiB of desktop assets into every image build context.
+# Container Images CD mirrors these lines in its push `paths` filter, so keep the two in step.
 products/desktop/*
 !products/desktop/packages
 products/desktop/packages/*

--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -13,9 +13,17 @@ on:
     push:
         branches:
             - master
-        paths-ignore:
-            - 'rust/**'
-            - 'livestream/**'
+        # `paths` with negations, because GitHub refuses `paths` and `paths-ignore`
+        # on the same trigger. Later patterns win, so the last line puts back the one
+        # desktop package that stays in the image build context (see .dockerignore) —
+        # every other desktop path is stripped from the context, so a change there
+        # cannot alter the image, and a build plus its deploy fan-out is pure cost.
+        paths:
+            - '**'
+            - '!rust/**'
+            - '!livestream/**'
+            - '!products/desktop/**'
+            - 'products/desktop/packages/agent-shadow/**'
     # Break-glass: a manual dispatch must run from master. The ECR publish role
     # (AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE) is OIDC-trusted only for
     # refs/heads/master, so a dispatch from any other branch is denied at

--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -13,17 +13,15 @@ on:
     push:
         branches:
             - master
-        # `paths` with negations, because GitHub refuses `paths` and `paths-ignore`
-        # on the same trigger. Later patterns win, so the last line puts back the one
-        # desktop package that stays in the image build context (see .dockerignore) —
-        # every other desktop path is stripped from the context, so a change there
-        # cannot alter the image, and a build plus its deploy fan-out is pure cost.
-        paths:
-            - '**'
-            - '!rust/**'
-            - '!livestream/**'
-            - '!products/desktop/**'
-            - 'products/desktop/packages/agent-shadow/**'
+        # Desktop-only pushes are filtered out in the `changes` job below, not here.
+        # GitHub reads only the first 3,000 files of a push diff for a trigger-level
+        # path filter, and skips the workflow when the paths that match the filter
+        # fall outside that window. The desktop tree is larger than that window, so a
+        # push that rewrites most of it could drop the image build and every deploy
+        # for a backend change in the same push, with no failed run to show it.
+        paths-ignore:
+            - 'rust/**'
+            - 'livestream/**'
     # Break-glass: a manual dispatch must run from master. The ECR publish role
     # (AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE) is OIDC-trusted only for
     # refs/heads/master, so a dispatch from any other branch is denied at
@@ -48,12 +46,58 @@ env:
     ECR_REPOSITORY: posthog-cloud
 
 jobs:
+    changes:
+        name: Check whether the push can change the image
+        # Production build/deploy runs only from the canonical deploy repo (CD_DEPLOY_ENABLED).
+        if: github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true'
+        runs-on: ubuntu-24.04
+        timeout-minutes: 5
+        permissions:
+            contents: read
+        outputs:
+            image: ${{ steps.filter.outputs.image }}
+            agent_shadow: ${{ steps.filter.outputs.agent_shadow }}
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: .github/actions/paths-filter
+                  sparse-checkout-cone-mode: false
+
+            # On a push the action diffs the whole push range with local git, which has
+            # no file cap, so it also reads a batch push that carries several commits.
+            # continue-on-error keeps a broken filter from cancelling a production build:
+            # the step then publishes no verdict, and the empty value builds.
+            - uses: ./.github/actions/paths-filter
+              id: filter
+              continue-on-error: true
+              with:
+                  token: ${{ github.token }}
+                  # `.dockerignore` strips every desktop path from the image build
+                  # context except agent-shadow, so a change anywhere else under
+                  # products/desktop cannot alter the image. An exclude cannot be
+                  # reversed inside one filter, so agent-shadow needs its own.
+                  filters: |
+                      image:
+                        - '**'
+                        - '!products/desktop/**'
+                      agent_shadow:
+                        - 'products/desktop/packages/agent-shadow/**'
+
     posthog_build:
         name: Build and push PostHog
+        needs: changes
         outputs:
             image-digest: ${{ steps.image.outputs.digest }}
         # Production build/deploy runs only from the canonical deploy repo (CD_DEPLOY_ENABLED).
-        if: github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true'
+        # A push that only touches desktop code skips the build and its deploy fan-out.
+        # Every other verdict builds, including the empty one a failed filter leaves,
+        # so an unresolved verdict costs one build instead of a missed deploy.
+        if: |
+            github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true' && (
+                github.event_name != 'push' ||
+                needs.changes.outputs.image != 'false' ||
+                needs.changes.outputs.agent_shadow == 'true'
+            )
         runs-on: depot-ubuntu-24.04
         # Covers two bounded build attempts plus the post-build image-boot verification before
         # dispatch.

--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -16,7 +16,10 @@ on:
         # Desktop-only pushes are filtered out in the `changes` job below, not here.
         # GitHub reads only the first 3,000 files of a push diff for a trigger-level
         # path filter, and skips the workflow when the paths that match the filter
-        # fall outside that window. The desktop tree is larger than that window, so a
+        # fall outside that window. The limit is the one in "Git diff comparisons" at
+        # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax
+        # — note the neighbouring commit-count and diff-timeout limits always run the
+        # workflow, so this is the one that skips. The desktop tree is larger than that window, so a
         # push that rewrites most of it could drop the image build and every deploy
         # for a backend change in the same push, with no failed run to show it.
         paths-ignore:
@@ -48,8 +51,11 @@ env:
 jobs:
     changes:
         name: Check whether the push can change the image
-        # Production build/deploy runs only from the canonical deploy repo (CD_DEPLOY_ENABLED).
-        if: github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true'
+        # Org check only, because this job detects changes rather than pushing an
+        # image or dispatching a deploy, so the CD_DEPLOY_ENABLED gate belongs on
+        # posthog_build instead. Push only, because a manual dispatch carries no push
+        # range for the filter to read, and posthog_build already always builds there.
+        if: github.repository_owner == 'PostHog' && github.event_name == 'push'
         runs-on: ubuntu-24.04
         timeout-minutes: 5
         permissions:
@@ -65,13 +71,12 @@ jobs:
 
             # On a push the action diffs the whole push range with local git, which has
             # no file cap, so it also reads a batch push that carries several commits.
-            # continue-on-error keeps a broken filter from cancelling a production build:
-            # the step then publishes no verdict, and the empty value builds.
+            # continue-on-error covers a failing filter step: it publishes no verdict,
+            # and the empty value builds.
             - uses: ./.github/actions/paths-filter
               id: filter
               continue-on-error: true
               with:
-                  token: ${{ github.token }}
                   # `.dockerignore` strips every desktop path from the image build
                   # context except agent-shadow, so a change anywhere else under
                   # products/desktop cannot alter the image. An exclude cannot be
@@ -90,10 +95,14 @@ jobs:
             image-digest: ${{ steps.image.outputs.digest }}
         # Production build/deploy runs only from the canonical deploy repo (CD_DEPLOY_ENABLED).
         # A push that only touches desktop code skips the build and its deploy fan-out.
-        # Every other verdict builds, including the empty one a failed filter leaves,
-        # so an unresolved verdict costs one build instead of a missed deploy.
+        # Every other verdict builds, including the empty one left by a `changes` job
+        # that failed, timed out, or lost its runner, so an unresolved verdict costs one
+        # build instead of a missed deploy. `!cancelled()` is what keeps that true: a
+        # condition carrying no status function gets an implicit `success()` over
+        # `needs`, which skips this job whenever `changes` did not succeed. Cancelling
+        # the run still stops the build, which `always()` would not.
         if: |
-            github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true' && (
+            !cancelled() && github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true' && (
                 github.event_name != 'push' ||
                 needs.changes.outputs.image != 'false' ||
                 needs.changes.outputs.agent_shadow == 'true'


### PR DESCRIPTION
## Problem

A desktop-only merge rebuilds the PostHog container image and dispatches every Cloud deploy, so a change nobody outside the Electron app can see still costs a build and a fleet-wide rollout.

- [#96348](https://github.com/PostHog/posthog/pull/96348) touched six files, all under `products/desktop/packages`, and still ran [Container Images CD](https://github.com/PostHog/posthog/actions/runs/34446590938) to success.
- `.dockerignore` already strips every desktop path from the build context except `products/desktop/packages/agent-shadow`, so that build could not produce a different image.

## Changes

- A master push that only touches desktop code now skips the image build, and with it the deploy dispatches to Charts, ingestion, and the Temporal worker fleets.
- A new `changes` job makes that call, and `posthog_build` waits on its verdict. Everything downstream already keys off `posthog_build`, so no other job changed.
- Any verdict other than "desktop only" builds, including the empty one a failed filter step leaves behind. An unresolved verdict costs one build rather than a missed deploy.
- A break-glass `workflow_dispatch` ignores the verdict and always builds.
- The push trigger keeps its original `paths-ignore`, so pure rust and livestream pushes still never start a run.
- `.dockerignore` gains a comment pointing at the job that mirrors it, so the two lists stay in step. This part is mechanical.

Nothing user-visible changes.

The decision cannot live on the push trigger, which is where this PR started. GitHub reads only the first 3,000 files of a push diff for a trigger-level `paths` filter and skips the workflow when the matching paths fall outside that window. The desktop tree is larger than that window, so a push that rewrote most of it would drop the image and every deploy for a backend change in the same push, with no failed or pending check to show it. A push can also carry several commits, because the merge queue lands batches, so a desktop change and a backend change reach one diff even though the desktop coupling gate keeps them in separate PRs. The job diffs the whole push range with local git, which has no file cap.

### Before

```mermaid
flowchart LR
    Push[Desktop-only push to master] --> Build[posthog_build]
    Build --> Image[(New sha image)]
    Build --> Deploy[Deploy dispatches]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    class Push phYellow;
    class Build phBlue;
    class Image phGray;
    class Deploy phRed;
```

### After

```mermaid
flowchart LR
    Push[Push to master] --> Changes[changes job]
    Changes -->|desktop only| Skip[No build]
    Changes -->|anything else, or no verdict| Build[posthog_build]
    Dispatch[workflow_dispatch] --> Build
    Build --> Image[(New sha image)]
    Build --> Deploy[Deploy dispatches]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    class Push,Dispatch phYellow;
    class Changes,Build phBlue;
    class Image,Skip phGray;
    class Deploy phRed;
```

## How did you test this code?

The wiring only proves itself on a real push to master, so the checks here cover the parts that can be checked off master.

- The filter patterns were run against the vendored matcher in `.github/actions/paths-filter` with a throwaway Jest case, not committed. 11 cases pass: the six-file shape from #96348 and other desktop-only pushes yield no build; agent-shadow, backend, `Dockerfile`, `services/`, and `tools/` changes all build; and a 3,001-file desktop push carrying one late-sorting backend file still builds, which is the case a trigger-level filter would have skipped.
- `actionlint` 1.7.12 with `.github/actionlint.yaml`: clean.
- `hogli lint:workflows`: 9 checks pass across 136 workflows.
- Read the `ordered_image_alias` job to confirm a skipped build leaves no gap it depends on. It counts first-parent commits, so a commit without an image never gets an alias.
- Not checked: a real push to master, and the `changes` job's own runtime behavior. No committed test covers the filter patterns.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app from a thread asking whether [#96348](https://github.com/PostHog/posthog/pull/96348) had to build the monorepo image. Skills invoked: `/authoring-ci-workflows`, `/writing-code-comments`, and `/writing-pr-descriptions`.

The first version of this PR put the decision on the push trigger. Codex and PostHog Review both flagged the file cap on that approach, and PostHog Review escalated it for a human. The reachability held up on inspection, so the decision moved into a job. Codex cited the cap as 300 files, which is a stale figure from an older revision of the GitHub page; the current documented number is 3,000, and the correction does not change the conclusion, because the desktop tree exceeds either number.

One nearby issue this PR does not touch: every deploy dispatch in this workflow gates on `git diff HEAD^ HEAD` with `fetch-depth: 2`, which reads only the last commit of a push. A merge-queue batch push carries several commits, so a path that changed in an earlier commit of the batch does not fire its dispatch today. The image still contains the change, so nothing wrong ships, but the affected fleet waits for a later qualifying push. That predates this PR and wants its own change.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B1AMH2CTD/p1789023780704629?thread_ts=1789023780.704629&cid=C0B1AMH2CTD)*
