### PR TITLE
fix(cdp): allow creating functions from deprecated templates via the api

### DIFF
--- a/posthog/cdp/migrations.py
+++ b/posthog/cdp/migrations.py
@@ -81,9 +81,6 @@ def migrate_batch(legacy_plugins: Any, kind: str, test_mode: bool, dry_run: bool
                 "team": team,
                 "get_team": (lambda t=team: t),
                 "is_create": True,
-                # The plugin templates this migrates from are deprecated, which the serializer
-                # otherwise blocks on create.
-                "allow_deprecated_template": True,
             }
 
             template = HogFunctionTemplate.objects.get(template_id=f"plugin-{plugin_id}")

--- a/products/cdp/backend/api/hog_function.py
+++ b/products/cdp/backend/api/hog_function.py
@@ -464,15 +464,6 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
                     "template_id": f"Template '{template.template_id}' is internal and cannot be used to create a function."
                 }
             )
-        # Deprecated templates are only hidden from the template listing, so a direct API call with the
-        # template id could still create one. Block that too; existing functions keep running, and the
-        # legacy plugin migration (posthog/cdp/migrations.py) is the one internal caller allowed through.
-        if template.status == "deprecated" and not self.context.get("allow_deprecated_template"):
-            raise serializers.ValidationError(
-                {
-                    "template_id": f"Template '{template.template_id}' is deprecated and cannot be used to create a new function."
-                }
-            )
 
     def _validate_hidden_template_not_enabled(self, attrs: dict, is_create: bool) -> None:
         # Creating from a hidden template is already blocked outright. For an existing function built from

--- a/products/cdp/backend/api/test/test_hog_function.py
+++ b/products/cdp/backend/api/test/test_hog_function.py
@@ -364,36 +364,6 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         assert response.json()["attr"] == "template_id"
         assert not HogFunction.objects.filter(template_id="template-hidden-dest").exists()
 
-    def test_create_from_deprecated_template_is_blocked(self):
-        # Deprecated templates are excluded from the template listing but stay resolvable by id,
-        # so the create path must reject them explicitly.
-        HogFunctionTemplate.objects.create(
-            template_id="plugin-deprecated-transformation",
-            sha="1.0.0",
-            name="Deprecated transformation",
-            description="Legacy plugin",
-            code="return event",
-            code_language="hog",
-            inputs_schema=[],
-            type="transformation",
-            status="deprecated",
-            category=["Other"],
-            free=True,
-        )
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/hog_functions/",
-            data={
-                "type": "transformation",
-                "name": "X",
-                "template_id": "plugin-deprecated-transformation",
-                "inputs": {},
-            },
-        )
-        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
-        assert response.json()["attr"] == "template_id"
-        assert "deprecated" in response.json()["detail"]
-        assert not HogFunction.objects.filter(template_id="plugin-deprecated-transformation").exists()
-
     @parameterized.expand(
         [
             # An existing hidden-template function (created before the create-path block) can be disabled

--- a/products/cdp/backend/api/test/test_hog_function.py
+++ b/products/cdp/backend/api/test/test_hog_function.py
@@ -364,6 +364,34 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         assert response.json()["attr"] == "template_id"
         assert not HogFunction.objects.filter(template_id="template-hidden-dest").exists()
 
+    def test_create_from_deprecated_template_is_allowed(self):
+        # Deprecated templates are hidden from the listing but stay resolvable by id, so the API must
+        # keep creating from them - integrations reference legacy plugin template ids directly.
+        HogFunctionTemplate.objects.create(
+            template_id="plugin-deprecated-transformation",
+            sha="1.0.0",
+            name="Deprecated transformation",
+            description="Legacy plugin",
+            code="return event",
+            code_language="hog",
+            inputs_schema=[],
+            type="transformation",
+            status="deprecated",
+            category=["Other"],
+            free=True,
+        )
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/hog_functions/",
+            data={
+                "type": "transformation",
+                "name": "X",
+                "template_id": "plugin-deprecated-transformation",
+                "inputs": {},
+            },
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        assert HogFunction.objects.filter(template_id="plugin-deprecated-transformation").exists()
+
     @parameterized.expand(
         [
             # An existing hidden-template function (created before the create-path block) can be disabled


### PR DESCRIPTION
## Problem

Anyone creating a hog function from a deprecated template id got a 400 and could not create it. That blocked integrations and API callers that still reference a deprecated legacy-plugin template by id.

The create path rejected any template with `status == "deprecated"`. Deprecated templates stay hidden from the template listing but remain resolvable by id, so a direct API call is a valid way to create one.

## Changes

- Deprecated templates are creatable through the API again, for both transformations and destinations.
- Reverts the create-path deprecated block in the hog function serializer.
- Drops the now-unused `allow_deprecated_template` escape hatch in the legacy plugin migration.
- The hidden-template block is unchanged: internal templates still cannot be created.

Existing functions were never affected. This only restores the create path.

## How did you test this code?

- Removed `test_create_from_deprecated_template_is_blocked`, which asserted the behavior this PR reverts.
- Ran the neighboring create-path tests in `test_hog_function.py` (hidden-template block, transformation creation): 7 passed. The hidden-template block still rejects internal templates.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.8). Skills invoked: `/writing-tests` (confirmed the removed test guarded only the reverted behavior) and `/writing-pr-descriptions`.

This reverts only the "block deprecated templates" half of #93919; the property-flattening speedup from that PR stays in place. The block was lifted for all deprecated templates, not scoped to transformations, since it was applied to all.
