### PR TITLE
fix(data-imports): surface direct-query host rejection as a user error

### DIFF
--- a/posthog/hogql/direct_sql/postgres_adapter.py
+++ b/posthog/hogql/direct_sql/postgres_adapter.py
@@ -158,6 +158,7 @@ class PostgresAdapter:
         with request.timings.measure("postgres_source_validation"):
             with request.timings.measure("postgres_source_helpers_import"):
                 from products.warehouse_sources.backend.facade.source_management import (
+                    HostNotAllowedError,
                     _get_sslmode,
                     source_requires_ssl,
                 )
@@ -179,7 +180,13 @@ class PostgresAdapter:
             with request.timings.measure("postgres_execute"):
                 with ExitStack() as tunnel_stack:
                     with request.timings.measure("postgres_tunnel_open", emit_span=True):
-                        host, port = tunnel_stack.enter_context(postgres_source.with_ssh_tunnel(source_config))
+                        try:
+                            host, port = tunnel_stack.enter_context(postgres_source.with_ssh_tunnel(source_config))
+                        except HostNotAllowedError as error:
+                            # `validate_source_config` already ran the host check, but a short-TTL
+                            # record can pass there and resolve private on this second lookup. Surface
+                            # it as a user query error, matching the validation-time rejection.
+                            raise ExposedHogQLError(str(error)) from error
                     connection_kwargs: PostgresConnectionKwargs = {
                         "host": host,
                         "port": port,

--- a/posthog/hogql/test/test_direct_postgres_query.py
+++ b/posthog/hogql/test/test_direct_postgres_query.py
@@ -1460,6 +1460,68 @@ class TestDirectPostgresQuery(APIBaseTest):
         mock_connect.assert_not_called()
 
     @patch("posthog.hogql.direct_sql.postgres_adapter.psycopg.connect")
+    def test_execute_direct_postgres_query_surfaces_connect_time_host_rejection_as_user_error(self, mock_connect):
+        # A host can pass the validation-layer check and still be rejected at connect time, because
+        # each check resolves the host again and a short-TTL record can answer public then private.
+        # That connect-time rejection must reach the user as an ExposedHogQLError (a 4xx that the
+        # query runner does not capture), not a bare Exception captured as a platform failure.
+        from products.warehouse_sources.backend.temporal.data_imports.sources.common.mixins import (
+            HostNotAllowedError,
+            HostResolution,
+        )
+        from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.source import PostgresSource
+
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id="source_id",
+            connection_id="connection_id",
+            status=ExternalDataSource.Status.COMPLETED,
+            source_type="Postgres",
+            access_method=ExternalDataSource.AccessMethod.DIRECT,
+            prefix="ph3",
+            job_inputs={
+                "host": "db.example.com",
+                "port": 5432,
+                "database": "postgres",
+                "user": "postgres",
+                "password": "postgres",
+                "schema": "ph3",
+            },
+        )
+        DataWarehouseTable.objects.create(
+            name="posthog_dashboard",
+            format="Parquet",
+            team=self.team,
+            external_data_source=source,
+            url_pattern="direct://postgres",
+            columns={"id": {"hogql": "IntegerDatabaseField", "clickhouse": "Int64", "valid": True}},
+        )
+
+        executor = HogQLQueryExecutor(
+            query="SELECT id FROM posthog_dashboard LIMIT 1",
+            team=self.team,
+            connection_id=str(source.id),
+        )
+
+        host_rejection = HostNotAllowedError(
+            "Database host not allowed: This host points to an internal or private IP address, "
+            "which PostHog can't reach. Use a host that's reachable from the public internet."
+        )
+        # Validation passes (host resolves public); the connect-time tunnel open rejects it.
+        with (
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.common.mixins.resolve_safe_host",
+                return_value=HostResolution(connect_host="db.example.com", error=None),
+            ),
+            patch.object(PostgresSource, "with_ssh_tunnel", side_effect=host_rejection),
+        ):
+            with self.assertRaises(ExposedHogQLError) as error:
+                executor.execute()
+
+        self.assertEqual(str(error.exception), str(host_rejection))
+        mock_connect.assert_not_called()
+
+    @patch("posthog.hogql.direct_sql.postgres_adapter.psycopg.connect")
     def test_execute_direct_postgres_query_exposes_database_errors(self, mock_connect):
         source = ExternalDataSource.objects.create(
             team=self.team,

--- a/products/warehouse_sources/backend/facade/source_management.py
+++ b/products/warehouse_sources/backend/facade/source_management.py
@@ -35,6 +35,7 @@ _LAZY = {
     "Config": "sources.common.config",
     "IntegrationAccountListingError": "sources.common.integration_accounts",
     "filter_integration_accounts": "sources.common.integration_accounts",
+    "HostNotAllowedError": "sources.common.mixins",
     "OAuthMixin": "sources.common.mixins",
     "SourceSchema": "sources.common.schema",
     "build_default_schemas": "sources.common.schema",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/mixins.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/mixins.py
@@ -13,6 +13,7 @@ import structlog
 from posthog.cloud_utils import is_cloud
 from posthog.models.integration import Integration
 from posthog.psycopg_helpers import prefer_routable_addresses
+from posthog.temporal.common.errors import NonReportableError
 from posthog.utils import get_instance_region
 
 from products.warehouse_sources.backend.models.ssh_tunnel import SSHTunnel
@@ -28,6 +29,24 @@ _INTERNAL_IP_ERROR = (
     "Use a host that's reachable from the public internet."
 )
 _DNS_FAILURE_ERROR = "Host could not be resolved"
+
+
+class HostNotAllowedError(NonReportableError):
+    """A direct database or SSH tunnel host resolved to an address PostHog won't connect to.
+
+    Raised at connect time by `_check_direct_host` and `_pinned_ssh_host`. A host can pass the
+    validation-layer check and still land here, because each check resolves the host again and a
+    short-TTL record can answer public for one lookup and private for the next. It is always the
+    customer's own DNS or network config, never a PostHog defect, and retrying re-hits the same
+    rejection, so it must fail the work without minting an error tracking issue.
+
+    Two connect paths reach it, and each suppresses reporting its own way:
+    - Import pipeline (Temporal): `NonReportableError` makes the activity interceptor fail the
+      activity without capturing. The message is unchanged so `Any_Source_Errors` still matches it
+      and pauses the schema.
+    - Direct query (HogQL): the direct-source adapter catches this and re-raises `ExposedHogQLError`
+      so the query runner returns a 4xx instead of capturing a platform failure.
+    """
 
 
 def is_team_allowlisted_for_internal_hosts(team_id: int) -> bool:
@@ -259,7 +278,7 @@ def _pinned_ssh_host(ssh_config, team_id: int | None) -> str:
     """
     resolution = resolve_safe_host(ssh_config.host, team_id)
     if resolution.connect_host is None:
-        raise Exception(f"SSH tunnel host not allowed: {resolution.error}")
+        raise HostNotAllowedError(f"SSH tunnel host not allowed: {resolution.error}")
     return resolution.connect_host
 
 
@@ -293,7 +312,7 @@ def _check_direct_host(config, team_id: int | None) -> None:
     """
     resolution = resolve_safe_host(config.host, team_id)
     if resolution.connect_host is None:
-        raise Exception(f"Database host not allowed: {resolution.error}")
+        raise HostNotAllowedError(f"Database host not allowed: {resolution.error}")
 
 
 @contextmanager

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/test_mixins.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/test_mixins.py
@@ -11,10 +11,12 @@ from django.test import SimpleTestCase, override_settings
 from parameterized import parameterized
 
 from posthog.models.integration import Integration
+from posthog.temporal.common.errors import NonReportableError
 
 from products.warehouse_sources.backend.temporal.data_imports.external_data_job import Any_Source_Errors
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import error_message_matches
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.mixins import (
+    HostNotAllowedError,
     OAuthMixin,
     SSHTunnelMixin,
     ValidateDatabaseHostMixin,
@@ -528,7 +530,7 @@ class TestDirectHostIsCheckedAtConnect(SimpleTestCase):
             patch(f"{_MIXINS_MODULE}.socket.getaddrinfo", return_value=self._resolves_to("169.254.169.254")),
             patch(f"{_MIXINS_MODULE}.logger"),
         ):
-            with pytest.raises(Exception, match="Database host not allowed"):
+            with pytest.raises(HostNotAllowedError, match="Database host not allowed"):
                 with self._connection_cm(entrypoint, config, 999):
                     pass
 
@@ -536,7 +538,9 @@ class TestDirectHostIsCheckedAtConnect(SimpleTestCase):
 class TestDirectHostRejectionIsNonRetryable(SimpleTestCase):
     # The rejection is a config problem only the customer can fix, so it has to stop the schedule
     # the way its SSH counterpart does. Raising it through the real path couples the wording to the
-    # registered pattern: reword one without the other and this fails.
+    # registered pattern: reword one without the other and this fails. It is also a
+    # `NonReportableError`, the marker the Temporal activity interceptor honors to fail the activity
+    # without opening an error tracking issue nobody on our side can act on.
     @override_settings(CLOUD_DEPLOYMENT="US")
     def test_rejection_message_matches_a_registered_non_retryable_error(self):
         config = FakeConfig(host="db.example.com", ssh_tunnel=None)
@@ -545,8 +549,9 @@ class TestDirectHostRejectionIsNonRetryable(SimpleTestCase):
             patch(f"{_MIXINS_MODULE}.socket.getaddrinfo", return_value=addrinfo),
             patch(f"{_MIXINS_MODULE}.logger"),
         ):
-            with pytest.raises(Exception) as exc:
+            with pytest.raises(HostNotAllowedError) as exc:
                 with open_ssh_tunnel(config, 999):
                     pass
 
+        assert isinstance(exc.value, NonReportableError)
         assert error_message_matches(str(exc.value), Any_Source_Errors.keys())


### PR DESCRIPTION
## Problem

- A HogQL query against a directly-connected warehouse source whose host resolves to a private or internal address fails with an opaque platform error, and every failure opens a fresh [error tracking issue](https://us.posthog.com/project/2/error_tracking/01a0879c-dde8-7e61-9801-50875724c21a) that no one on PostHog's side can act on.
- The host is checked twice: once when the query validates the source, once when it opens the connection. Each check resolves the host again, so a short-TTL record can answer public at validation and private at connect. A query that passed validation still hits the connect-time rejection.
- The connect-time check raised a bare `Exception`. The query runner classifies unrecognized exceptions as platform failures, so it captured this customer-config rejection to error tracking instead of returning it to the user.

## Changes

- A direct query to a rejected host now returns a clear query error (a 4xx the user sees), matching the wording of the validation-time rejection, instead of an opaque failure that lands in error tracking.
- The same rejection raised from the import pipeline also stops being reported: the new error is a `NonReportableError`, which the Temporal activity interceptor fails without capturing.
- Mechanical: the two connect-time host checks now raise a typed `HostNotAllowedError` in place of a bare `Exception`; the direct-source Postgres adapter catches it and re-raises `ExposedHogQLError`; the type is re-exported through the source-management facade. The message strings are unchanged, so `Any_Source_Errors` still matches them and pauses the schema.

> [!NOTE]
> [#97731](https://github.com/PostHog/posthog/pull/97731) targets the same triage noise from the import-pipeline side by raising `NonReportableError` at these sites. It does not reach the direct-query path, because the query runner does not honor `NonReportableError`. This PR makes `HostNotAllowedError` subclass `NonReportableError`, so it covers both paths and supersedes that change. The two touch the same raise sites and should be reconciled at review.

## How did you test this code?

- Added a regression test in `test_direct_postgres_query.py`: a connect-time host rejection (validation passes, the connection is rejected) surfaces as `ExposedHogQLError` and never reaches `psycopg.connect`. Before this change it raised a bare `Exception` captured as a platform failure.
- Strengthened the mixin tests in `test_mixins.py` to assert the raise sites now produce a `HostNotAllowedError` that is a `NonReportableError` and still matches a registered non-retryable pattern.
- Ran the two affected test files locally: 71 passed. Not run: the wider warehouse-sources and hogql suites, which CI covers.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing docs describe this error path.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged from a live error tracking issue in the data-warehouse import area. Read the stack trace to the raise site (`_check_direct_host` in shared code) and traced the call path from the HogQL query runner through the direct-source Postgres adapter, which is where the capture happens.
- Decision: this is a deterministic customer-config rejection, not a PostHog defect and not transient, so it must not be captured as a platform failure. Chose a typed `HostNotAllowedError` subclassing `NonReportableError` so one change covers both the direct-query capture and the import-pipeline reporting, rather than a query-only patch that would conflict with [#97731](https://github.com/PostHog/posthog/pull/97731).
- Ruled out widening retry policy: retries are unchanged, and the message still matches `Any_Source_Errors`.
- Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
