### PR TITLE
chore(devex): stop celery beat schedules drawing their minute at random

### DIFF
--- a/.semgrep/rules/devex/beat-schedule-must-not-be-random.py
+++ b/.semgrep/rules/devex/beat-schedule-must-not-be-random.py
@@ -1,0 +1,20 @@
+# Test cases for beat-schedule-must-not-be-random.
+# ruff: noqa
+
+# ruleid: beat-schedule-must-not-be-random
+sender.add_periodic_task(crontab(hour="0", minute=str(randrange(0, 40))), send_usage_report.s())
+
+# ruleid: beat-schedule-must-not-be-random
+sender.add_periodic_task(crontab(minute=str(random.randint(0, 59))), refresh_cache.s())
+
+# ruleid: beat-schedule-must-not-be-random
+schedule = crontab(hour=str(random.choice(["1", "2"])), minute="0")
+
+# ok: beat-schedule-must-not-be-random
+sender.add_periodic_task(crontab(hour="2", minute="23"), sweep_retention.s())
+
+# ok: beat-schedule-must-not-be-random
+sender.add_periodic_task(crontab(hour="0", minute=instance_spread_minute("send license usage", 40)), send_license.s())
+
+# ok: beat-schedule-must-not-be-random
+jitter = randrange(0, 40)

--- a/.semgrep/rules/devex/beat-schedule-must-not-be-random.yaml
+++ b/.semgrep/rules/devex/beat-schedule-must-not-be-random.yaml
@@ -1,0 +1,36 @@
+rules:
+    - id: beat-schedule-must-not-be-random
+      message: |
+          A celery beat schedule must not draw its time at random.
+
+          The schedule is built when a beat process starts, so a random draw runs once
+          per process and not once per day. Beat processes restart every few minutes,
+          and each restart both draws a new time and forgets what already ran, so the
+          task runs twice on one day and skips another.
+
+          Write a fixed minute, `crontab(hour="2", minute="23")`. Where separate
+          installations must not share a minute, call `instance_spread_minute` in
+          `posthog/tasks/scheduled.py`. Its docstring carries the rules for both.
+      languages: [python]
+      severity: ERROR
+      patterns:
+          - pattern-inside: crontab(...)
+          - pattern-either:
+                - pattern: randrange(...)
+                - pattern: randint(...)
+                - pattern: choice(...)
+                - pattern: uniform(...)
+                - pattern: random.randrange(...)
+                - pattern: random.randint(...)
+                - pattern: random.choice(...)
+                - pattern: random.uniform(...)
+                - pattern: random.random()
+      paths:
+          include:
+              - ee/**/*.py
+              - posthog/**/*.py
+              - products/**/*.py
+      metadata:
+          category: correctness
+          subcategory: audit
+          confidence: HIGH

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -1,4 +1,4 @@
-from random import randrange
+import zlib
 from typing import Any
 
 from django.conf import settings
@@ -185,6 +185,31 @@ def estimate_crontab_interval_seconds(schedule: crontab) -> int:
 
     # Weekly or more complex - default to daily for safety
     return 86400
+
+
+def instance_spread_minute(key: str, window_minutes: int) -> str:
+    """Pick a minute inside the window that holds still for this installation.
+
+    Beat rebuilds its schedule every time a beat process starts, and the new
+    schedule has no record of what already ran. A minute that comes from a random
+    draw therefore changes on every restart: a restart inside the scheduled hour
+    runs the task a second time that day, and a restart that draws an earlier
+    minute skips the day. This is why no periodic schedule in this file draws its
+    time at random, and why the beat-schedule-must-not-be-random semgrep rule
+    blocks it.
+
+    Use this helper only where separate installations must not share a minute,
+    such as a task that calls an endpoint PostHog hosts. A minute derived from
+    SECRET_KEY holds still across restarts and still differs between
+    installations. Installations that leave SECRET_KEY at its default share a
+    minute with each other.
+
+    Every other task takes a fixed minute written at the call site, because a
+    reader can then tell when it runs. Pick an odd minute that is not a multiple
+    of 5 and that no other task in the same hour holds, which keeps it off both
+    the */2 and */5 entries and off its neighbours.
+    """
+    return str(zlib.crc32(f"{settings.SECRET_KEY}:{key}".encode()) % window_minutes)
 
 
 def add_periodic_task_with_expiry(
@@ -838,11 +863,13 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
 
     if settings.EE_AVAILABLE:
         sender.add_periodic_task(
-            crontab(hour="0", minute=str(randrange(0, 40))),
+            # The minute differs between installations so that they do not all call
+            # license.posthog.com in the same minute past midnight.
+            crontab(hour="0", minute=instance_spread_minute("send license usage", 40)),
             clickhouse_send_license_usage.s(),
-        )  # every day at a random minute past midnight. Randomize to avoid overloading license.posthog.com
+        )
         sender.add_periodic_task(
-            crontab(hour="4", minute=str(randrange(0, 40))),
+            crontab(hour="4", minute=instance_spread_minute("send license usage retry", 40)),
             clickhouse_send_license_usage.s(),
         )  # again a few hours later just to make sure
 
@@ -862,8 +889,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         )
 
         sender.add_periodic_task(
-            # once a day a random minute after midnight
-            crontab(hour="0", minute=str(randrange(0, 40))),
+            crontab(hour="0", minute="7"),
             delete_expired_exported_assets.s(),
             name="delete expired exported assets",
         )
@@ -871,7 +897,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         # Hourly rather than daily: until this runs, a dead video export still reads as in progress
         # to whoever is waiting on it.
         sender.add_periodic_task(
-            crontab(minute=str(randrange(0, 60))),
+            crontab(minute="33"),
             fail_stuck_video_exports.s(),
             name="fail stuck video exports",
         )
@@ -880,7 +906,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         # the delegator's onboarding, so a missed sweep strands delegators on the "waiting
         # for teammate" screen forever.
         sender.add_periodic_task(
-            crontab(hour="1", minute=str(randrange(0, 40))),
+            crontab(hour="1", minute="9"),
             delete_expired_delegation_invites.s(),
             name="delete expired delegation invites",
         )
@@ -903,7 +929,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
     )
 
     sender.add_periodic_task(
-        crontab(hour="0", minute=str(randrange(0, 40))),
+        crontab(hour="0", minute="13"),
         sync_all_remote_configs.s(),
         name="sync all remote configs",
     )
@@ -915,14 +941,14 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
     )
 
     sender.add_periodic_task(
-        crontab(hour="0", minute=str(randrange(0, 40))),
+        crontab(hour="0", minute="19"),
         sync_all_surveys_cache.s(),
         name="sync all surveys cache",
     )
 
     add_periodic_task_with_expiry(
         sender,
-        crontab(hour="1", minute=str(randrange(0, 40))),
+        crontab(hour="1", minute="27"),
         cleanup_canvas_builds.s(),
         name="apply canvas build artifact retention",
     )
@@ -1021,11 +1047,6 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         name="prune old streamlit app versions",
     )
 
-    # The minute is fixed because beat rebuilds its schedule on every start. A
-    # randrange minute draws a new value on each restart, so a restart inside the
-    # scheduled hour makes the sweep run a second time that night, and a restart
-    # that draws an earlier minute can make it skip the night. Minute 23 is odd,
-    # which also keeps the sweep off the minutes the */2 heartbeat tasks use.
     add_periodic_task_with_expiry(
         sender,
         crontab(hour="2", minute="23"),

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -200,16 +200,18 @@ def instance_spread_minute(key: str, window_minutes: int) -> str:
 
     Use this helper only where separate installations must not share a minute,
     such as a task that calls an endpoint PostHog hosts. A minute derived from
-    SECRET_KEY holds still across restarts and still differs between
-    installations. Installations that leave SECRET_KEY at its default share a
-    minute with each other.
+    SITE_URL holds still across restarts and still differs between
+    installations. Installations that leave SITE_URL at its default share a
+    minute with each other. SECRET_KEY would serve as well but is deliberately
+    not used: `.agents/security.md` keeps new code off it, and this value ends
+    up observable in the schedule.
 
     Every other task takes a fixed minute written at the call site, because a
     reader can then tell when it runs. Pick an odd minute that is not a multiple
     of 5 and that no other task in the same hour holds, which keeps it off both
     the */2 and */5 entries and off its neighbours.
     """
-    return str(zlib.crc32(f"{settings.SECRET_KEY}:{key}".encode()) % window_minutes)
+    return str(zlib.crc32(f"{settings.SITE_URL}:{key}".encode()) % window_minutes)
 
 
 def add_periodic_task_with_expiry(

--- a/posthog/tasks/test/test_scheduled.py
+++ b/posthog/tasks/test/test_scheduled.py
@@ -20,12 +20,12 @@ class TestInstanceSpreadMinute(SimpleTestCase):
         # A literal, because the minute has to survive a beat restart. A hash that
         # is only stable inside one process, such as the built-in hash(), passes an
         # equality check between two calls and still moves the schedule on restart.
-        with self.settings(SECRET_KEY="an-installation-secret"):
-            assert instance_spread_minute("send license usage", 40) == "6"
+        with self.settings(SITE_URL="https://an-installation.example.com"):
+            assert instance_spread_minute("send license usage", 40) == "18"
 
     def test_installations_do_not_all_get_the_same_minute(self) -> None:
         minutes = set()
-        for secret in ("secret-one", "secret-two", "secret-three", "secret-four"):
-            with self.settings(SECRET_KEY=secret):
+        for site_url in ("site-one", "site-two", "site-three", "site-four"):
+            with self.settings(SITE_URL=site_url):
                 minutes.add(instance_spread_minute("send license usage", 40))
         assert len(minutes) > 1

--- a/posthog/tasks/test/test_scheduled.py
+++ b/posthog/tasks/test/test_scheduled.py
@@ -1,7 +1,7 @@
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 
 from posthog.celery import app
-from posthog.tasks.scheduled import setup_periodic_tasks
+from posthog.tasks.scheduled import instance_spread_minute, setup_periodic_tasks
 
 
 class TestScheduledTasks(TestCase):
@@ -13,3 +13,19 @@ class TestScheduledTasks(TestCase):
             setup_periodic_tasks(app)
         except Exception as exc:
             assert exc is None, exc
+
+
+class TestInstanceSpreadMinute(SimpleTestCase):
+    def test_one_installation_keeps_its_minute_in_every_process(self) -> None:
+        # A literal, because the minute has to survive a beat restart. A hash that
+        # is only stable inside one process, such as the built-in hash(), passes an
+        # equality check between two calls and still moves the schedule on restart.
+        with self.settings(SECRET_KEY="an-installation-secret"):
+            assert instance_spread_minute("send license usage", 40) == "6"
+
+    def test_installations_do_not_all_get_the_same_minute(self) -> None:
+        minutes = set()
+        for secret in ("secret-one", "secret-two", "secret-three", "secret-four"):
+            with self.settings(SECRET_KEY=secret):
+                minutes.add(instance_spread_minute("send license usage", 40))
+        assert len(minutes) > 1


### PR DESCRIPTION
## Problem

Eight more daily housekeeping tasks run twice on some days and skip others, so cleanup and sync jobs land at unpredictable times.

- Each entry drew its minute with `randrange`, evaluated once when a beat process builds its schedule.
- Beat rebuilds that schedule on every process start and holds no record of what already ran.
- A restart inside the scheduled hour re-fires the task that day, and a restart that draws an earlier minute skips the day.
- The affected tasks clean up exported assets, delegation invites and canvas builds, sync remote configs and the surveys cache, fail stuck video exports, and send the license usage report.

#98118 fixes the same defect for the visual review sweep. This layer covers the rest and stops the pattern returning.

## Changes

- Seven tasks now run at a fixed minute, so a restart schedules the next run for the following day.

| Task | Runs at |
| --- | --- |
| delete expired exported assets | 00:07 |
| sync all remote configs | 00:13 |
| sync all surveys cache | 00:19 |
| delete expired delegation invites | 01:09 |
| apply canvas build artifact retention | 01:27 |
| fail stuck video exports | every hour at :33 |
| send license usage | derived from `SITE_URL` |

- Each fixed minute is odd and off the multiples of 5, which keeps it clear of the `*/2` and `*/5` entries.
- The license usage report keeps a minute that differs between installations, because every self-hosted install calls license.posthog.com and a literal would put them all on the same minute.
- That minute now comes from `SITE_URL`, so it holds still across restarts. Installations that never set `SITE_URL` share a minute with each other, which is the one property this trades away.
- `SECRET_KEY` would serve as well, but `.agents/security.md` keeps new code off it, and rotating it would move the minute.
- A semgrep rule blocks a random schedule from returning. It is `ERROR` rather than `WARNING` because the backlog is zero once this lands.
- Nothing a user sees changes. Every task keeps its hour and its behavior, and only the minute becomes stable.

Two deeper fixes were rejected. Deriving all nine minutes from the hash helper reads worse and collides: nine keys over a 40 minute window collide more often than not, while literals are collision-free by construction and say when the task runs. A persistent beat scheduler would close the residual case where a process starts inside the scheduled minute, but it adds a dependency, a schema, and a second place where schedules can disagree.

## How did you test this code?

- Ran `hogli test posthog/tasks/test/test_scheduled.py` locally, which builds the whole schedule. It passes.
- Ran `semgrep --test` on the new rule: its fixtures pass. Ran the rule over `ee/`, `posthog/` and `products/`: eight findings against the pre-fix file, none after.
- Added two cases for `instance_spread_minute`: one pins the minute to a literal for a known `SITE_URL`, which a per-process hash such as the built-in `hash()` cannot reproduce, and one checks separate installations do not all land on the same minute. Nothing else covers the helper body, since the lint only bans randomness inside a `crontab(...)` argument.
- No test for the schedule entries themselves. AGENTS.md puts linters above tests for enforcing a convention, and the rule catches the next author who copies the pattern, which a unit test on this file would not.
- Not checked: the schedules themselves. Only production runs over the following days confirm each task fires once.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code, Opus 5. Skills invoked: `/writing-code-comments`, `/stacking-prs`, `/simplify`, `/writing-pr-descriptions`.
- The defect surfaced in the visual review sweep in the layer below. This layer exists because the other eight entries share it and belong to other teams, so they were kept out of that fix.
- `/simplify` flagged that the helper docstring and the lint message restated each other, and that six bare literals taught a reader nothing. Both were fixed by moving the convention into the docstring and pointing the lint at it.
- The rule went into `.semgrep/rules/devex/`, which `ci-security.yaml` loads. `.semgrep/devex-rules/` exists too but no workflow reads it.
- No duplicate: searched open PRs for the beat schedule, found none.
- Patch coverage: the changed lines are crontab arguments and one pure function. The semgrep fixture file covers the rule.
- Public artifact: the diff is code only, and nothing from the session outside this repository appears in it.

https://claude.ai/code/session_01D6NniT429yB1Z9XEKdwUTx

