### PR TITLE
feat(insights): add SQL donut charts

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -3204,6 +3204,10 @@ snapshots:
         hash: v1.k794b7964.5d9407311260cf6d60e52217801013baf5523971043d3a384399661606956094.gY3eS5hEKko3Uw025q_K8VD0OY4XUOo6iNkvdlzwrnA
     insights-sqlpiegraph--default--light:
         hash: v1.k794b7964.cb8ad5af06a0440258a2aad8b7a5531e83bed58ee3e1dfe019e9fcb549569b96.n6v4Nqqfp1KvW3ouAH4u2gEwzMI3eDb3hA3y2hHbBxY
+    insights-sqlpiegraph--donut--dark:
+        hash: v1.k794b7964.82aaa0a087924f644605cd2d5f30bda7be4c61920bcca32c5045648c7cb9e619.bU8E_cnb9DE-6jtn_ZFWs7rrOy4H7w0yOIB330Bhow4
+    insights-sqlpiegraph--donut--light:
+        hash: v1.k794b7964.9d198b0b5b60cc715b556997c7f4bca3bf5f3af702e0f5eb6cf26ab6348c9a0b.ePE-V3iAQvrNcUzXtXfMNkhRrSxjR4EhvgAs5K_XcZA
     insights-sqlpiegraph--legend-at-bottom--dark:
         hash: v1.k794b7964.c47d48ad6a252d8a5dfc135b3d269bc028523df242a7b79c5b96d9d111ae0376._DhCXEiBO9wMl5fx3iWvB8BVIaxe19bUBzUQb55bkAo
     insights-sqlpiegraph--legend-at-bottom--light:

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/PieChart.test.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/PieChart.test.tsx
@@ -48,4 +48,18 @@ describe('PieChart wrapper', () => {
         // The quill PieChart canvas carries this accessible name.
         expect(await screen.findByLabelText(/pie chart with/i, {}, { timeout: 5000 })).toBeInTheDocument()
     })
+
+    it('renders a donut total in the chart center', async () => {
+        render(
+            <PieChart
+                {...props}
+                visualizationType={ChartDisplayType.ActionsDonut}
+                chartSettings={{ pie: { sliceContent: 'labels', showTotal: true } }}
+            />
+        )
+
+        await screen.findByLabelText(/pie chart with/i, {}, { timeout: 5000 })
+
+        expect((await screen.findByText('100')).closest('[data-attr="sql-pie-chart"]')).toBeInTheDocument()
+    })
 })

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/PieChart.test.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/PieChart.test.tsx
@@ -5,6 +5,7 @@ import { cleanup, render, screen } from '@testing-library/react'
 import { setupJsdom, setupSyncRaf } from '@posthog/quill-charts/testing'
 
 import { initKeaTests } from '~/test/init'
+import { ChartDisplayType } from '~/types'
 
 import { AxisSeries } from '../../dataVisualizationLogic'
 import { PieChart, PieChartProps } from './PieChart'
@@ -36,6 +37,7 @@ const props: PieChartProps = {
             settings: {},
         },
     ],
+    visualizationType: ChartDisplayType.ActionsPie,
     chartSettings: {},
 }
 

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/PieChart.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/PieChart.tsx
@@ -9,6 +9,7 @@ import { SqlPieGraph } from './SqlPieGraph'
 export interface PieChartProps {
     xData: AxisSeries<string> | null
     yData: AxisSeries<number | null>[] | AxisBreakdownSeries<number | null>[]
+    visualizationType: ChartDisplayType
     chartSettings: ChartSettings
     presetChartHeight?: boolean
     className?: string
@@ -18,7 +19,7 @@ export function PieChart(props: PieChartProps): JSX.Element {
     const sqlPieProps: SqlChartProps = {
         xData: props.xData,
         yData: props.yData,
-        visualizationType: ChartDisplayType.ActionsPie,
+        visualizationType: props.visualizationType,
         chartSettings: props.chartSettings,
         presetChartHeight: props.presetChartHeight,
         className: props.className,

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlPieGraph.stories.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlPieGraph.stories.tsx
@@ -76,6 +76,16 @@ export const WithLegend: Story = {
         }),
 }
 
+export const Donut: Story = {
+    render: () =>
+        render({
+            xData,
+            yData: singleSeries,
+            visualizationType: ChartDisplayType.ActionsDonut,
+            chartSettings: baseSettings,
+        }),
+}
+
 export const LegendAtBottom: Story = {
     render: () =>
         render({

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlPieGraph.test.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlPieGraph.test.tsx
@@ -42,10 +42,14 @@ const yData = (data: (number | null)[]): AxisSeries<number | null>[] => [
     },
 ]
 
-const baseProps = (chartSettings: ChartSettings, data: (number | null)[]): SqlChartProps => ({
+const baseProps = (
+    chartSettings: ChartSettings,
+    data: (number | null)[],
+    visualizationType = ChartDisplayType.ActionsPie
+): SqlChartProps => ({
     xData,
     yData: yData(data),
-    visualizationType: ChartDisplayType.ActionsPie,
+    visualizationType,
     chartSettings,
 })
 
@@ -96,6 +100,39 @@ describe('SqlPieGraph', () => {
         await waitForSlices()
 
         expect(sliceLabelLines()).toEqual([['40'], ['30'], ['20'], ['10']])
+        expect(screen.queryByText('100')).not.toBeInTheDocument()
+    })
+
+    it('shows the total in the center of a donut', async () => {
+        render(
+            <SqlPieGraph
+                {...baseProps(
+                    { pie: { sliceContent: 'labels', showTotal: true } },
+                    [40, 30, 20, 10],
+                    ChartDisplayType.ActionsDonut
+                )}
+            />
+        )
+
+        await waitForSlices()
+
+        expect(screen.getByText('100')).toHaveClass('text-center')
+        expect(document.querySelector('.text-5xl')).not.toBeInTheDocument()
+    })
+
+    it('hides the donut center total when showTotal is false', async () => {
+        render(
+            <SqlPieGraph
+                {...baseProps(
+                    { pie: { sliceContent: 'labels', showTotal: false } },
+                    [40, 30, 20, 10],
+                    ChartDisplayType.ActionsDonut
+                )}
+            />
+        )
+
+        await waitForSlices()
+
         expect(screen.queryByText('100')).not.toBeInTheDocument()
     })
 

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlPieGraph.test.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlPieGraph.test.tsx
@@ -116,8 +116,7 @@ describe('SqlPieGraph', () => {
 
         await waitForSlices()
 
-        expect(screen.getByText('100')).toHaveClass('text-center')
-        expect(document.querySelector('.text-5xl')).not.toBeInTheDocument()
+        expect(screen.getByText('100').closest('[data-attr="sql-pie-chart"]')).toBeInTheDocument()
     })
 
     it('hides the donut center total when showTotal is false', async () => {

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlPieGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlPieGraph.tsx
@@ -7,7 +7,10 @@ import type { ChartLegendConfig, PieChartConfig, TooltipContext } from '@posthog
 import { useChartTheme } from 'lib/charts/hooks'
 import { useChartLegendSeriesMenu } from 'lib/components/ChartLegendSeriesMenu/useChartLegendSeriesMenu'
 
+import { ChartDisplayType } from '~/types'
+
 import { makeChartErrorHandler } from 'products/product_analytics/frontend/insights/trends/shared/chartErrorHandler'
+import { DonutCenterLabel } from 'products/product_analytics/frontend/insights/trends/TrendsPieChart/DonutCenterLabel'
 
 import { SqlChartProps } from './SqlChart'
 import { formatSqlSeriesValue } from './sqlLineGraphAdapter'
@@ -18,17 +21,19 @@ const handleChartError = makeChartErrorHandler('sql-pie-chart')
 /**
  * SQL pie graph on @posthog/quill-charts' {@link PieChart}. The chart core and the legend are
  * quill's; the aggregation total stays here as chrome. The legend is driven from here rather than
- * through `config.legend` so the total sits in the layout's chart slot, centered under the pie
+ * through `config.legend` so a pie total sits in the layout's chart slot, centered under the pie
  * instead of under the pie-plus-legend pair.
  */
 export const SqlPieGraph = ({
     xData,
     yData,
+    visualizationType,
     chartSettings,
     presetChartHeight,
     className,
 }: SqlChartProps): JSX.Element => {
     const theme = useChartTheme()
+    const isDonut = visualizationType === ChartDisplayType.ActionsDonut
 
     const slices = useMemo(() => buildPieSlices(xData, yData), [xData, yData])
     const formattingSettings = yData[0]?.settings
@@ -76,7 +81,7 @@ export const SqlPieGraph = ({
     const { visibleSeries, legendProps } = useChartLegend(series, theme, legendConfig)
 
     // `isPercent` makes the chart render on-slice values and tooltips as a share of the total; the
-    // total below the chart keeps using the raw value formatter.
+    // total keeps using the raw value formatter.
     // Labels sit toward the rim (on the wider part of each wedge) and skip slices under 10% so a
     // long tail of thin slices doesn't pile labels up at the center.
     const pieConfig: PieChartConfig = useMemo(
@@ -86,8 +91,9 @@ export const SqlPieGraph = ({
             isPercent: asPercent,
             labelRadiusRatio: 0.72,
             minSlicePercentForLabel: 0.1,
+            innerRadiusRatio: isDonut ? 0.6 : undefined,
         }),
-        [sliceContent, asPercent]
+        [sliceContent, asPercent, isDonut]
     )
 
     const renderTooltip = useCallback(
@@ -119,14 +125,18 @@ export const SqlPieGraph = ({
         )
     }
 
-    const totalDisplay = showPieTotal ? (
-        <div className="pt-4 text-center shrink-0">
-            <div className="text-5xl font-bold">{absoluteFormatter(total)}</div>
-        </div>
-    ) : null
+    const centerLabel =
+        isDonut && showPieTotal ? <DonutCenterLabel>{absoluteFormatter(total)}</DonutCenterLabel> : undefined
 
-    // A side legend narrows the chart column, so the total belongs inside it to stay centered under
-    // the pie. A top/bottom legend leaves the column full-width, and the total goes below both.
+    const totalDisplay =
+        !isDonut && showPieTotal ? (
+            <div className="pt-4 text-center shrink-0">
+                <div className="text-5xl font-bold">{absoluteFormatter(total)}</div>
+            </div>
+        ) : null
+
+    // For pies, a side legend narrows the chart column, so the total belongs inside it to stay
+    // centered under the pie. A top/bottom legend leaves the column full-width, and the total goes below both.
     const legendAtSide = legendProps.show && (legendProps.position === 'left' || legendProps.position === 'right')
 
     return (
@@ -138,7 +148,7 @@ export const SqlPieGraph = ({
         >
             <ChartLegend {...legendProps} legendDataAttr="hog-chart-pie-legend">
                 {/* min-h-0, not a fixed floor: in a short panel the pie has to shrink, or its box
-                    runs over the legend and the total below it. */}
+                    runs over the legend and the pie total below it. */}
                 <div className="flex flex-col flex-1 min-h-0">
                     <PieChart
                         series={visibleSeries}
@@ -146,6 +156,7 @@ export const SqlPieGraph = ({
                         config={pieConfig}
                         tooltip={renderTooltip}
                         valueFormatter={absoluteFormatter}
+                        centerLabel={centerLabel}
                         dataAttr="sql-pie-chart"
                         onError={handleChartError}
                     />

--- a/frontend/src/queries/nodes/DataVisualization/Components/DisplayTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/DisplayTab.tsx
@@ -21,6 +21,7 @@ import {
     METRIC_SHOW_CHANGE_DEFAULT,
     type MetricSummary,
 } from 'lib/components/Metric/metricSummary'
+import { PIE_DISPLAY_TYPES } from 'lib/constants'
 
 import { ChartDisplayType } from '~/types'
 
@@ -63,7 +64,8 @@ export const DisplayTab = (): JSX.Element => {
     const { addGoalLine, updateGoalLine, removeGoalLine, updateChartSettings } = useActions(displayLogic)
 
     const isStackedBarChart = effectiveVisualizationType === ChartDisplayType.ActionsStackedBar
-    const isPieChart = effectiveVisualizationType === ChartDisplayType.ActionsPie
+    const isPieChart = PIE_DISPLAY_TYPES.includes(effectiveVisualizationType)
+    const isDonutChart = effectiveVisualizationType === ChartDisplayType.ActionsDonut
     const isScatterPlot = effectiveVisualizationType === ChartDisplayType.ScatterPlot
     const isBoxPlot = effectiveVisualizationType === ChartDisplayType.BoxPlot
     const isMetric = effectiveVisualizationType === ChartDisplayType.Metric
@@ -313,7 +315,7 @@ export const DisplayTab = (): JSX.Element => {
                                         </div>
                                         <LemonSwitch
                                             className="flex-1 w-full"
-                                            label="Show total below chart"
+                                            label={isDonutChart ? 'Show total in center' : 'Show total below chart'}
                                             checked={
                                                 chartSettings.pie?.showTotal ??
                                                 (chartSettings.pie?.sliceContent ?? 'values') === 'values'

--- a/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
@@ -19,6 +19,7 @@ import {
 } from '@posthog/lemon-ui'
 
 import { DataColorToken, getSeriesColor, getSeriesColorPalette } from 'lib/colors'
+import { PIE_DISPLAY_TYPES } from 'lib/constants'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { dataThemeLogic } from 'scenes/dataThemeLogic'
 import { INSIGHT_UNIT_OPTIONS_SHORT } from 'scenes/insights/aggregationAxisFormat'
@@ -118,7 +119,7 @@ export const SeriesTab = (): JSX.Element => {
     // A scatter's x axis holds a second measure rather than a category, so only numeric columns fit.
     const xAxisOptions = isScatterPlot ? numericalColumns.map(toColumnOption) : options
 
-    if (effectiveVisualizationType === ChartDisplayType.ActionsPie) {
+    if (PIE_DISPLAY_TYPES.includes(effectiveVisualizationType)) {
         const valueColumn = selectedYAxis?.find((series) => series !== null)?.name ?? null
         const valueOptions = numericalColumns.map(({ name, type }) => ({
             value: name,
@@ -300,7 +301,7 @@ const YSeries = ({ series, index }: { series: AxisSeries<number | null>; index: 
     const { isSettingsOpen, canOpenSettings, activeSettingsTab } = useValues(seriesLogic)
     const { setSettingsOpen, submitFormatting, submitDisplay, setSettingsTab } = useActions(seriesLogic)
 
-    const isPieChart = effectiveVisualizationType === ChartDisplayType.ActionsPie
+    const isPieChart = PIE_DISPLAY_TYPES.includes(effectiveVisualizationType)
     const seriesColor = series.settings?.display?.color ?? getSeriesColor(index)
     const showSeriesColor = !showTableSettings && !selectedSeriesBreakdownColumn
 
@@ -503,7 +504,7 @@ export const YSeriesDisplayTab = ({ ySeriesLogicProps }: { ySeriesLogicProps: YS
     const { selectedSeriesBreakdownColumn } = useValues(seriesBreakdownLogic({ key: dataVisualizationProps.key }))
     const { updateSeriesIndex } = useActions(dataVisualizationLogic)
 
-    const isPieChart = effectiveVisualizationType === ChartDisplayType.ActionsPie
+    const isPieChart = PIE_DISPLAY_TYPES.includes(effectiveVisualizationType)
     const hideChartSpecificOptions =
         isPieChart ||
         effectiveVisualizationType === ChartDisplayType.ActionsBarValue ||

--- a/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.test.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.test.tsx
@@ -85,6 +85,7 @@ describe('TableDisplay', () => {
     it.each([
         ['Box plot', ChartDisplayType.BoxPlot],
         ['Horizontal bar chart', ChartDisplayType.ActionsBarValue],
+        ['Donut chart', ChartDisplayType.ActionsDonut],
     ])('offers %s and saves the selected display', async (label, display) => {
         const query = renderTableDisplay(`table-display-${display}`)
 

--- a/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.tsx
@@ -4,7 +4,7 @@ import { IconGraph, IconLifecycle, IconPieChart, IconScatter, IconTrends } from 
 import { LemonSelect, LemonSelectOptions, LemonSelectProps } from '@posthog/lemon-ui'
 
 import { FEATURE_FLAGS } from 'lib/constants'
-import { Icon123, IconAreaChart, IconHeatmap, IconTableChart, IconTrendingUp } from 'lib/lemon-ui/icons'
+import { Icon123, IconAreaChart, IconDonutChart, IconHeatmap, IconTableChart, IconTrendingUp } from 'lib/lemon-ui/icons'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { ChartDisplayType } from '~/types'
@@ -133,6 +133,11 @@ export function getTableDisplayOptions(
                     value: ChartDisplayType.ActionsPie,
                     icon: <IconPieChart />,
                     label: 'Pie chart',
+                },
+                {
+                    value: ChartDisplayType.ActionsDonut,
+                    icon: <IconDonutChart />,
+                    label: 'Donut chart',
                 },
                 {
                     value: ChartDisplayType.ScatterPlot,

--- a/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.test.ts
@@ -330,6 +330,50 @@ describe('seriesBreakdownLogic', () => {
         })
     })
 
+    it.each([
+        { xColumn: 'event', breakdownColumn: 'browser' },
+        { xColumn: 'browser', breakdownColumn: 'event' },
+    ])(
+        'shows taxonomy display names when the event column is the $xColumn x-axis or $breakdownColumn breakdown',
+        async ({ xColumn, breakdownColumn }) => {
+            logic = seriesBreakdownLogic({ key: testUniqueKey })
+            logic.mount()
+
+            const builtDataNodeLogic = dataNodeLogic({
+                key: testUniqueKey,
+                query: globalQuery.source,
+            })
+            builtDataNodeLogic.mount()
+            builtDataNodeLogic.actions.setResponse({
+                results: [
+                    ['$pageview', 'Safari', 11],
+                    ['signed_up', 'Safari', 22],
+                ],
+                columns: ['event', 'browser', 'total_count'],
+                types: [
+                    ['event', 'String'],
+                    ['browser', 'Nullable(String)'],
+                    ['total_count', 'UInt64'],
+                ],
+            })
+
+            builtDataVizLogic.actions.clearAxis()
+            builtDataVizLogic.actions.updateXSeries(xColumn)
+            builtDataVizLogic.actions.addYSeries('total_count')
+            logic.actions.addSeriesBreakdown(breakdownColumn)
+
+            const { xData, seriesData } = logic.values.seriesBreakdownData
+            if (xColumn === 'event') {
+                expect(xData.data).toEqual(['Pageview', 'signed_up'])
+                expect(seriesData.map((series) => series.name)).toEqual(['Safari'])
+            } else {
+                expect(xData.data).toEqual(['Safari'])
+                expect(seriesData.map((series) => series.name)).toEqual(['Pageview', 'signed_up'])
+                expect(seriesData.map((series) => series.breakdownValue)).toEqual(['$pageview', 'signed_up'])
+            }
+        }
+    )
+
     it('preserves missing breakdown buckets as null when showNullsAsZero is disabled', async () => {
         logic = seriesBreakdownLogic({ key: testUniqueKey })
         logic.mount()

--- a/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.ts
@@ -21,6 +21,7 @@ import type {
 } from '../../../schema/schema-general'
 import { AxisSeries, AxisSeriesSettings, SelectedYAxis, dataVisualizationLogic } from '../dataVisualizationLogic'
 import type { Column } from '../dataVisualizationLogic'
+import { humanizeEventColumnValue } from '../eventColumnLabels'
 
 /**
  * Sentinel used to key result customizations for null / undefined breakdown values.
@@ -395,9 +396,8 @@ export const seriesBreakdownLogic = kea<seriesBreakdownLogicType>([
                     }
 
                     return visibleBreakdownValues.map<AxisBreakdownSeries<number | null>>((value) => {
-                        const seriesName = multipleYSeries
-                            ? `${selectedYAxis.name} - ${value || '[No value]'}`
-                            : value || '[No value]'
+                        const valueLabel = humanizeEventColumnValue(breakdownColumn.name, value) || '[No value]'
+                        const seriesName = multipleYSeries ? `${selectedYAxis.name} - ${valueLabel}` : valueLabel
                         const breakdownValue = getBreakdownValueKey(value)
                         const customColorToken = resultCustomizations[breakdownValue]?.color
                         const customColor =
@@ -463,7 +463,7 @@ export const seriesBreakdownLogic = kea<seriesBreakdownLogicType>([
                 return {
                     xData: {
                         column: xColumn,
-                        data: xData,
+                        data: xData.map((value) => humanizeEventColumnValue(xColumn.name, value)),
                     },
                     seriesData,
                     isUnaggregated,

--- a/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
@@ -7,6 +7,7 @@ import { IconGear } from '@posthog/icons'
 import { LemonButton, LemonDivider } from '@posthog/lemon-ui'
 
 import { ExportButton } from 'lib/components/ExportButton/ExportButton'
+import { PIE_DISPLAY_TYPES } from 'lib/constants'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
 import { InsightErrorState, StatelessInsightLoadingState } from 'scenes/insights/EmptyStates'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
@@ -280,7 +281,7 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
                 />
             </BindLogic>
         )
-    } else if (effectiveVisualizationType === ChartDisplayType.ActionsPie) {
+    } else if (PIE_DISPLAY_TYPES.includes(effectiveVisualizationType)) {
         const _xData = seriesBreakdownData.xData.data.length ? seriesBreakdownData.xData : xData
         // Pie charts can consume breakdown series totals directly, even when there isn't
         // a matching breakdown x-axis to swap in like the line/bar path expects.
@@ -291,6 +292,7 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
                 className="p-3"
                 xData={_xData}
                 yData={_yData}
+                visualizationType={effectiveVisualizationType}
                 chartSettings={chartSettings}
                 presetChartHeight={presetChartHeight}
             />

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.test.ts
@@ -356,6 +356,25 @@ describe('dataVisualizationLogic', () => {
         })
     })
 
+    it('shows taxonomy display names for x-axis values of a column named event', async () => {
+        dataNodeLogic({ key: testKey, query: defaultQuery.source, dataNodeCollectionId }).actions.setResponse({
+            columns: ['event', 'count'],
+            types: [
+                ['event', 'String'],
+                ['count', 'Int64'],
+            ],
+            results: [
+                ['$pageview', 3],
+                ['signed_up', 1],
+            ],
+        })
+
+        logic.actions.clearAxis()
+        logic.actions.updateXSeries('event')
+
+        expect(logic.values.xData?.data).toEqual(['Pageview', 'signed_up'])
+    })
+
     it('does not resolve to a time-series chart when there is only one row', async () => {
         logic.actions.setVisualizationType(ChartDisplayType.ActionsLineGraph)
 

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.test.ts
@@ -416,22 +416,28 @@ describe('dataVisualizationLogic', () => {
             },
         })
     })
-    it('stamps labels onto the slices when a pie chart is newly picked', async () => {
-        logic.actions.setVisualizationType(ChartDisplayType.ActionsPie)
+    test.each([ChartDisplayType.ActionsPie, ChartDisplayType.ActionsDonut])(
+        'stamps labels onto the slices when a pie display is newly picked',
+        async (displayType) => {
+            logic.actions.setVisualizationType(displayType)
 
-        await expectLogic(logic).toMatchValues({
-            chartSettings: expect.objectContaining({ pie: { sliceContent: 'labels' } }),
-        })
-    })
+            await expectLogic(logic).toMatchValues({
+                chartSettings: expect.objectContaining({ pie: { sliceContent: 'labels' } }),
+            })
+        }
+    )
 
-    it('does not override existing pie slice content when re-picking pie', async () => {
-        logic.actions.updateChartSettings({ pie: { sliceContent: 'values' } })
-        logic.actions.setVisualizationType(ChartDisplayType.ActionsPie)
+    test.each([ChartDisplayType.ActionsPie, ChartDisplayType.ActionsDonut])(
+        'does not override existing pie slice content when re-picking a pie display',
+        async (displayType) => {
+            logic.actions.updateChartSettings({ pie: { sliceContent: 'values' } })
+            logic.actions.setVisualizationType(displayType)
 
-        await expectLogic(logic).toMatchValues({
-            chartSettings: expect.objectContaining({ pie: { sliceContent: 'values' } }),
-        })
-    })
+            await expectLogic(logic).toMatchValues({
+                chartSettings: expect.objectContaining({ pie: { sliceContent: 'values' } }),
+            })
+        }
+    )
 
     it('moves a scatter plot onto a numeric x-axis when the selected one has no coordinates', async () => {
         dataNodeLogic({ key: testKey, query: defaultQuery.source, dataNodeCollectionId }).actions.setResponse({

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.test.ts
@@ -422,7 +422,7 @@ describe('dataVisualizationLogic', () => {
             logic.actions.setVisualizationType(displayType)
 
             await expectLogic(logic).toMatchValues({
-                chartSettings: expect.objectContaining({ pie: { sliceContent: 'labels' } }),
+                chartSettings: expect.objectContaining({ pie: expect.objectContaining({ sliceContent: 'labels' }) }),
             })
         }
     )
@@ -434,10 +434,29 @@ describe('dataVisualizationLogic', () => {
             logic.actions.setVisualizationType(displayType)
 
             await expectLogic(logic).toMatchValues({
-                chartSettings: expect.objectContaining({ pie: { sliceContent: 'values' } }),
+                chartSettings: expect.objectContaining({ pie: expect.objectContaining({ sliceContent: 'values' }) }),
             })
         }
     )
+
+    it('defaults a newly selected donut total and preserves an explicit setting', async () => {
+        logic.actions.setVisualizationType(ChartDisplayType.ActionsDonut)
+
+        await expectLogic(logic).toMatchValues({
+            chartSettings: expect.objectContaining({
+                pie: expect.objectContaining({ sliceContent: 'labels', showTotal: true }),
+            }),
+        })
+
+        logic.actions.updateChartSettings({ pie: { showTotal: false } })
+        logic.actions.setVisualizationType(ChartDisplayType.ActionsDonut)
+
+        await expectLogic(logic).toMatchValues({
+            chartSettings: expect.objectContaining({
+                pie: expect.objectContaining({ sliceContent: 'labels', showTotal: false }),
+            }),
+        })
+    })
 
     it('moves a scatter plot onto a numeric x-axis when the selected one has no coordinates', async () => {
         dataNodeLogic({ key: testKey, query: defaultQuery.source, dataNodeCollectionId }).actions.setResponse({

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -17,6 +17,7 @@ import type { BreakPointFunction } from 'kea'
 import { subscriptions } from 'kea-subscriptions'
 import mergeObject from 'lodash.merge'
 
+import { PIE_DISPLAY_TYPES } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { RGBToHex, lightenDarkenColor } from 'lib/utils/colors'
 import { uuid } from 'lib/utils/dom'
@@ -538,7 +539,7 @@ export function applyVisualizationType(
     let yAxis = chartSettings.yAxis ? [...chartSettings.yAxis] : []
     const selectedYAxis = yAxis.map((series) => ({ name: series.column }))
 
-    if (visualizationType === ChartDisplayType.ActionsPie && chartSettings.pie?.sliceContent === undefined) {
+    if (PIE_DISPLAY_TYPES.includes(visualizationType) && chartSettings.pie?.sliceContent === undefined) {
         chartSettings.pie = { ...chartSettings.pie, sliceContent: 'labels' }
     }
 

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -543,6 +543,10 @@ export function applyVisualizationType(
         chartSettings.pie = { ...chartSettings.pie, sliceContent: 'labels' }
     }
 
+    if (visualizationType === ChartDisplayType.ActionsDonut && chartSettings.pie?.showTotal === undefined) {
+        chartSettings.pie = { ...chartSettings.pie, showTotal: true }
+    }
+
     if (visualizationType === ChartDisplayType.Metric) {
         yAxis = yAxis.slice(0, 1)
     }

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -61,6 +61,7 @@ import type {
 import { dataNodeLogic } from '../DataNode/dataNodeLogic'
 import { QueryFeature, getQueryFeatures } from '../DataTable/queryFeatures'
 import { getAutoBoxPlotSettings } from './Components/Charts/sqlBoxPlotAdapter'
+import { humanizeEventColumnValue } from './eventColumnLabels'
 import { ColumnScalar, FORMATTING_TEMPLATES } from './types'
 
 export enum SideBarTab {
@@ -1612,7 +1613,7 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
 
                 return {
                     column,
-                    data: data.map((n: any) => n[column.dataIndex]),
+                    data: data.map((n: any) => humanizeEventColumnValue(column.name, n[column.dataIndex])),
                 }
             },
         ],

--- a/frontend/src/queries/nodes/DataVisualization/eventColumnLabels.ts
+++ b/frontend/src/queries/nodes/DataVisualization/eventColumnLabels.ts
@@ -1,0 +1,12 @@
+import { formatEventName } from 'scenes/insights/utils'
+
+// Matches the events table: only a column literally named `event` is known to hold event names.
+const EVENT_COLUMN_NAME = 'event'
+
+/** Swap a raw PostHog event key (`$pageview`) for its display name (`Pageview`) in chart labels. */
+export function humanizeEventColumnValue<T>(columnName: string, value: T): T {
+    if (columnName !== EVENT_COLUMN_NAME || typeof value !== 'string') {
+        return value
+    }
+    return (formatEventName(value) ?? value) as T
+}

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -37,6 +37,7 @@ import { MCPUseCaseCard } from 'lib/components/MCPHint/MCPUseCaseCard'
 import { Resizer } from 'lib/components/Resizer/Resizer'
 import { type ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerLogic'
 import { TZLabel } from 'lib/components/TZLabel'
+import { PIE_DISPLAY_TYPES } from 'lib/constants'
 import { useCellCopyContextMenu } from 'lib/hooks/useCellCopyContextMenu'
 import { IconTableChart } from 'lib/lemon-ui/icons'
 import { Link } from 'lib/lemon-ui/Link'
@@ -1031,7 +1032,7 @@ function InternalDataTableVisualization(
                 />
             </BindLogic>
         )
-    } else if (effectiveVisualizationType === ChartDisplayType.ActionsPie) {
+    } else if (PIE_DISPLAY_TYPES.includes(effectiveVisualizationType)) {
         const _xData = seriesBreakdownData.xData.data.length ? seriesBreakdownData.xData : xData
         const _yData = seriesBreakdownData.seriesData.length ? seriesBreakdownData.seriesData : yData
 
@@ -1040,6 +1041,7 @@ function InternalDataTableVisualization(
                 className="p-2"
                 xData={_xData}
                 yData={_yData}
+                visualizationType={effectiveVisualizationType}
                 chartSettings={chartSettings}
                 presetChartHeight={presetChartHeight}
             />

--- a/frontend/src/scenes/data-warehouse/editor/bi/BIEditor.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/bi/BIEditor.tsx
@@ -20,7 +20,7 @@ import { HogQLDropdown } from 'lib/components/HogQLDropdown/HogQLDropdown'
 import { Resizer } from 'lib/components/Resizer/Resizer'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
-import { Icon123, IconAreaChart, IconHeatmap, IconTableChart } from 'lib/lemon-ui/icons'
+import { Icon123, IconAreaChart, IconDonutChart, IconHeatmap, IconTableChart } from 'lib/lemon-ui/icons'
 import { LemonCalendarSelectInput } from 'lib/lemon-ui/LemonCalendar/LemonCalendarSelect'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { cn } from 'lib/utils/css-classes'
@@ -54,6 +54,7 @@ const CHART_TYPE_OPTIONS: { value: ChartDisplayType; label: string; icon: JSX.El
     { value: ChartDisplayType.ActionsStackedBar, label: 'Stacked bar chart', icon: <IconLifecycle /> },
     { value: ChartDisplayType.ActionsAreaGraph, label: 'Area chart', icon: <IconAreaChart /> },
     { value: ChartDisplayType.ActionsPie, label: 'Pie chart', icon: <IconPieChart /> },
+    { value: ChartDisplayType.ActionsDonut, label: 'Donut chart', icon: <IconDonutChart /> },
     { value: ChartDisplayType.TwoDimensionalHeatmap, label: 'Pivot table', icon: <IconHeatmap /> },
     { value: ChartDisplayType.BoldNumber, label: 'Big number', icon: <Icon123 /> },
     { value: ChartDisplayType.Metric, label: 'Metric', icon: <IconTrends /> },


### PR DESCRIPTION
## Problem

SQL insight users cannot view proportional data as a donut chart.

## Changes

- SQL insights, dashboards, and the BI editor now offer a Donut chart.
- Donuts reuse pie settings and show an enabled total in the chart center.
- The existing pie renderer now handles both pie and donut displays.
- SQL charts whose x-axis or breakdown is the `event` column now show event display names, so `$pageview` reads as Pageview. Custom event names do not change.

## How did you test this code?

- Ran the focused SQL visualization Jest tests. They prevent a missing picker option, lost pie settings, or an incorrect donut total location.
- Added one case to each of the data visualization and series breakdown logic tests. They fail if a chart stops applying the display name, or if the raw breakdown key gets renamed.
- Loaded a SQL pie of events by name on a local project and saw Pageview and Feature flag called in the slices and legend.
- Ran `pnpm --filter=@posthog/frontend fix`.
- Loaded the Donut story in headless Chromium.
- Not run: the full TypeScript check. It exceeded the sandbox memory limit.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Public SQL insight documentation does not list chart types.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Desktop created this change with a General subagent.

Skills invoked: `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-tests`, `/working-with-charts`, `/writing-code-comments`, `/running-ci-preflight`, and `/writing-pr-descriptions`.

The duplicate check found no matching open pull request. The public artifact check found no task-context material in this change.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
