### PR TITLE
feat(slack_app): capture usage events across bot surfaces

### DIFF
--- a/products/slack_app/backend/analytics.py
+++ b/products/slack_app/backend/analytics.py
@@ -1,16 +1,23 @@
 """Reusable analytics helpers for the Slack app.
 
-Uses ``ph_scoped_capture`` (not ``posthoganalytics.capture``) so events survive being emitted from a
-Temporal worker, where the global client's background flush may never run before the worker exits.
+Uses ``ph_background_capture`` (not ``posthoganalytics.capture``) so events survive being emitted
+from a Temporal worker, where the global client's background flush may never run before the worker
+exits. Unlike ``ph_scoped_capture`` it doesn't block on a per-call flush, so the same helper is
+safe on the Slack webhook request path and its 3-second ack budget.
 """
 
 from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import structlog
 
 from posthog.event_usage import groups
 from posthog.models.integration import Integration
-from posthog.ph_client import ph_scoped_capture
+from posthog.ph_client import ph_background_capture
+
+if TYPE_CHECKING:
+    from posthog.models.user import User
 
 logger = structlog.get_logger(__name__)
 
@@ -30,19 +37,38 @@ def slack_event_props(integration: Integration, *, slack_user_id: str | None = N
 
 
 def capture_slack_event(
-    integration: Integration, event: str, *, slack_user_id: str | None = None, **props: object
+    integration: Integration,
+    event: str,
+    *,
+    slack_user_id: str | None = None,
+    posthog_user: User | None = None,
+    **props: object,
 ) -> None:
-    """Capture a Slack app event, keyed on the team (``distinct_id`` = team uuid) with org/team groups.
-    Best-effort: analytics never breaks the flow."""
+    """Capture a Slack app event with org/team groups. Best-effort: analytics never breaks the flow.
+
+    ``distinct_id`` ladder: a resolved PostHog user's distinct id, else a stable Slack-derived id
+    (``slack:{team}:{user}``) when the acting Slack user is known, else the team uuid — matching
+    the mention funnel's attribution so per-user analysis works across every Slack app event.
+    """
     try:
         team = integration.team
-        with ph_scoped_capture() as capture:
-            capture(
-                distinct_id=str(team.uuid),
-                event=event,
-                properties=slack_event_props(integration, slack_user_id=slack_user_id, **props),
-                groups=groups(team.organization, team),
-            )
+        if posthog_user is not None:
+            distinct_id = posthog_user.distinct_id
+        elif slack_user_id:
+            distinct_id = f"slack:{integration.integration_id}:{slack_user_id}"
+        else:
+            distinct_id = str(team.uuid)
+        properties = slack_event_props(integration, slack_user_id=slack_user_id, **props)
+        properties["posthog_user_identified"] = posthog_user is not None
+        if posthog_user is not None:
+            properties["$set"] = posthog_user.get_analytics_metadata()
+        capture = ph_background_capture()
+        capture(
+            distinct_id=distinct_id,
+            event=event,
+            properties=properties,
+            groups=groups(team.organization, team),
+        )
     except Exception:
         # NB: structlog's first positional arg is named ``event``, so pass the Slack event under a
         # different key — otherwise this best-effort handler itself raises and defeats the swallow.

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -89,6 +89,7 @@ from products.slack_app.backend.services.slack_messages import (
     SLACK_WEBHOOK_TIMEOUT_SECONDS,
     TURN_FEEDBACK_ACTION_ID,
     SlackThreadMessage,
+    parse_slack_file_refs,
     post_slack_thread_reply,
 )
 from products.slack_app.backend.services.slack_settings import resolve_untagged_followup_mode
@@ -1325,6 +1326,24 @@ def _app_mention_ignore_reason(event: dict[str, Any]) -> str | None:
 def _thread_message_event_has_files(event: dict[str, Any]) -> bool:
     files = event.get("files")
     return isinstance(files, list) and len(files) > 0
+
+
+def _slack_attachment_props(event: dict[str, Any]) -> dict[str, Any]:
+    """Analytics context for whatever a message carried alongside its text.
+
+    The agent reads images now, so how often people send one is the question the mention
+    event has to answer, and it can only do that by counting the uploads as they arrive.
+    Distinct mimetypes ride along so a screenshot is separable from a log or a CSV without
+    a second event.
+    """
+    files = parse_slack_file_refs(event.get("files"))
+    image_count = sum(1 for file in files if file.mimetype.startswith("image/"))
+    return {
+        "slack_attachment_count": len(files),
+        "slack_image_count": image_count,
+        "slack_has_image": image_count > 0,
+        "slack_attachment_mimetypes": sorted({file.mimetype for file in files if file.mimetype}),
+    }
 
 
 def _thread_message_ignore_reason(event: dict[str, Any]) -> str | None:
@@ -3415,6 +3434,7 @@ def _report_slack_mention_received(
             # "im" marks an assistant DM; channel mentions carry "channel"/"group" or no type at all.
             "slack_channel_type": event.get("channel_type"),
             "posthog_user_identified": identified_distinct_id is not None,
+            **_slack_attachment_props(event),
         }
         if posthog_user is not None and identified_distinct_id is not None:
             properties["$set"] = posthog_user.get_analytics_metadata()

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -2137,12 +2137,21 @@ def _handle_app_uninstalled(request: HttpRequest, slack_team_id: str) -> str:
     """
     deleted = clear_workspace_profile_cache(slack_team_id)
     logger.info("slack_app_uninstalled_profile_cache_cleared", slack_team_id=slack_team_id, rows_deleted=deleted)
-    # Each region captures against its own rows, so a dual-owned workspace reports the
-    # uninstall once per region; `was_proxied` lets analysis separate the mirrored copy.
-    for uninstalled in Integration.objects.filter(
-        kind=SLACK_INTEGRATION_KIND, integration_id=slack_team_id
-    ).select_related("team", "team__organization"):
-        capture_slack_event(uninstalled, "slack app uninstalled", was_proxied=was_proxied(request))
+    # A workspace linked to several projects matches several rows, but the uninstall is
+    # one act: capture once per region so plain event counts stay honest, with
+    # `linked_project_count` carrying how many links it severed.
+    linked_integrations = list(
+        Integration.objects.filter(kind=SLACK_INTEGRATION_KIND, integration_id=slack_team_id)
+        .select_related("team", "team__organization")
+        .order_by("id")
+    )
+    if linked_integrations:
+        capture_slack_event(
+            linked_integrations[0],
+            "slack app uninstalled",
+            was_proxied=was_proxied(request),
+            linked_project_count=len(linked_integrations),
+        )
     if not was_proxied(request) and cross_region_routing_enabled():
         _proxy_event_to_region(request, other_region_domain(request.get_host()))
     return ROUTE_HANDLED_LOCALLY
@@ -3358,15 +3367,26 @@ def _handle_untagged_followup_dismiss(payload: dict) -> HttpResponse:
     """Drop the message the replier declined. Nothing is persisted — the choice
     covers this one message, not the thread."""
     context_token = _extract_context_token(payload)
+    context = _decode_picker_context(context_token) if context_token else None
     if context_token:
         cache.delete(_picker_context_cache_key(context_token))
     _delete_ephemeral_via_response_url(payload.get("response_url", ""))
+    # Only a live untagged-followup context names the integration that raised the prompt,
+    # so resolving it there matches the confirm path's attribution instead of an
+    # arbitrary row of a multi-project workspace.
+    if not context or context.get("kind") != UNTAGGED_FOLLOWUP_CONTEXT_KIND:
+        return HttpResponse(status=200)
     slack_team_id = payload.get("team", {}).get("id", "")
+    integration_id = context.get("integration_id")
     dismissing_integration = (
-        Integration.objects.filter(kind=SLACK_INTEGRATION_KIND, integration_id=slack_team_id)
+        Integration.objects.filter(  # nosemgrep: idor-lookup-without-team
+            id=integration_id,  # nosemgrep: idor-taint-user-input-to-model-get
+            kind=SLACK_INTEGRATION_KIND,
+            integration_id=slack_team_id,
+        )
         .select_related("team", "team__organization")
         .first()
-        if slack_team_id
+        if integration_id and slack_team_id
         else None
     )
     if dismissing_integration is not None:

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -56,6 +56,7 @@ from posthog.user_permissions import UserPermissions
 from posthog.utils import get_instance_region
 
 from products.slack_app.backend import inbox_channel, onboarding
+from products.slack_app.backend.analytics import capture_slack_event
 from products.slack_app.backend.discussion_replies import try_ingest_discussion_reply
 from products.slack_app.backend.feature_flags import (
     ASSISTANT_REQUIRED_SCOPES,
@@ -1971,6 +1972,9 @@ def _route_assistant_event(
     posthog_user = resolution.user
 
     if event_type == "assistant_thread_started":
+        capture_slack_event(
+            probe, "slack app assistant thread started", slack_user_id=fields.slack_user_id, posthog_user=posthog_user
+        )
         return _handle_assistant_thread_started(SlackIntegration(probe), fields.dm_channel_id, fields.thread_ts)
     if event_type == "assistant_thread_context_changed":
         _store_assistant_channel_context(probe.id, fields.dm_channel_id, fields.thread_ts, fields.viewed_channel_id)
@@ -2114,6 +2118,12 @@ def _handle_app_uninstalled(request: HttpRequest, slack_team_id: str) -> str:
     """
     deleted = clear_workspace_profile_cache(slack_team_id)
     logger.info("slack_app_uninstalled_profile_cache_cleared", slack_team_id=slack_team_id, rows_deleted=deleted)
+    # Each region captures against its own rows, so a dual-owned workspace reports the
+    # uninstall once per region; `was_proxied` lets analysis separate the mirrored copy.
+    for uninstalled in Integration.objects.filter(
+        kind=SLACK_INTEGRATION_KIND, integration_id=slack_team_id
+    ).select_related("team", "team__organization"):
+        capture_slack_event(uninstalled, "slack app uninstalled", was_proxied=was_proxied(request))
     if not was_proxied(request) and cross_region_routing_enabled():
         _proxy_event_to_region(request, other_region_domain(request.get_host()))
     return ROUTE_HANDLED_LOCALLY
@@ -3382,6 +3392,8 @@ def _report_slack_mention_received(
             "slack_channel": channel,
             "slack_thread_ts": thread_ts,
             "slack_user_id": slack_user_id,
+            # "im" marks an assistant DM; channel mentions carry "channel"/"group" or no type at all.
+            "slack_channel_type": event.get("channel_type"),
             "posthog_user_identified": identified_distinct_id is not None,
         }
         if posthog_user is not None and identified_distinct_id is not None:

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -3450,7 +3450,16 @@ def _report_slack_mention_received(
             "slack_team_id": slack_team_id,
             "slack_channel": channel,
             "slack_thread_ts": thread_ts,
+            # Identifies the individual message, so an accepted mention can be ordered against
+            # the drops in its thread and joined to the agent turn that answered it.
+            "slack_message_ts": message_ts,
             "slack_user_id": slack_user_id,
+            # Whether the message tagged the bot. ``app_mention`` is a tagged message;
+            # ``message`` is an untagged thread reply that the follow-up mode let through,
+            # because the ``message`` copy of a tagged reply drops earlier as ``tagged_reply``.
+            # ``posthog code slack mention dropped`` reports the same field, so the two sides
+            # add up to a funnel.
+            "slack_event_type": event.get("type"),
             # "im" marks an assistant DM; channel mentions carry "channel"/"group" or no type at all.
             "slack_channel_type": event.get("channel_type"),
             "posthog_user_identified": identified_distinct_id is not None,

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -3325,6 +3325,12 @@ def _handle_untagged_followup_run(payload: dict) -> HttpResponse:
         slack_channel_id=context.get("slack_channel_id"),
         slack_user_id=clicker_slack_user_id,
     )
+    capture_slack_event(
+        integration,
+        "slack app untagged followup confirmed",
+        slack_user_id=clicker_slack_user_id,
+        posthog_user=posthog_user,
+    )
     _delete_ephemeral_via_response_url(response_url)
     return HttpResponse(status=200)
 
@@ -3336,6 +3342,20 @@ def _handle_untagged_followup_dismiss(payload: dict) -> HttpResponse:
     if context_token:
         cache.delete(_picker_context_cache_key(context_token))
     _delete_ephemeral_via_response_url(payload.get("response_url", ""))
+    slack_team_id = payload.get("team", {}).get("id", "")
+    dismissing_integration = (
+        Integration.objects.filter(kind=SLACK_INTEGRATION_KIND, integration_id=slack_team_id)
+        .select_related("team", "team__organization")
+        .first()
+        if slack_team_id
+        else None
+    )
+    if dismissing_integration is not None:
+        capture_slack_event(
+            dismissing_integration,
+            "slack app untagged followup dismissed",
+            slack_user_id=payload.get("user", {}).get("id"),
+        )
     return HttpResponse(status=200)
 
 

--- a/products/slack_app/backend/services/commands.py
+++ b/products/slack_app/backend/services/commands.py
@@ -545,6 +545,19 @@ def dispatch_rules_command(
     defaults, the help listing. The answer concerns whoever ran the command, so
     every reply below goes out ephemerally, on both surfaces.
     """
+    from posthog.models.user import User
+
+    from products.slack_app.backend.analytics import capture_slack_event
+
+    capture_slack_event(
+        integration,
+        "slack app command used",
+        slack_user_id=slack_user_id,
+        posthog_user=User.objects.filter(id=user_id).first(),
+        action=command.action,
+        source="mention" if command_prefix == MENTION_COMMAND_PREFIX else "slash_command",
+    )
+
     if command.action == "help":
         # The slash command owns the listing, so a mention only points at it. Answering here
         # rather than inside the handler keeps the Slack users.info call the listing needs off

--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -91,6 +91,10 @@ ACTION_TASKS_PAGE_NEXT = "slack_app_home:tasks_page_next"
 ACTION_STATS_WINDOW = "slack_app_home:stats_window"
 ACTION_STATS_REFRESH = "slack_app_home:stats_refresh"
 ACTION_SET_UNTAGGED_FOLLOWUP_MODE = "slack_app_home:set_untagged_followup_mode"
+# URL buttons: Slack opens the link itself and posts a block_actions payload we
+# only ack — the ids exist so the clicks still reach the usage-analytics capture.
+ACTION_GITHUB_SETTINGS = "slack_app_home:github_settings"
+ACTION_CONNECT_ACCOUNT = "slack_app_home:connect_account"
 
 # Every control the Home tab renders, in one place. The interactivity endpoint reads
 # this to claim region ownership and to dispatch, so a control that isn't listed here
@@ -112,6 +116,8 @@ HOME_ACTION_IDS: frozenset[str] = frozenset(
         ACTION_STATS_WINDOW,
         ACTION_STATS_REFRESH,
         ACTION_SET_UNTAGGED_FOLLOWUP_MODE,
+        ACTION_GITHUB_SETTINGS,
+        ACTION_CONNECT_ACCOUNT,
     }
 )
 
@@ -791,6 +797,7 @@ def _posthog_account_button(account_state: AccountState) -> dict | None:
         return None
     return {
         "type": "button",
+        "action_id": ACTION_CONNECT_ACCOUNT,
         "url": account_state.link_url,
         "text": {"type": "plain_text", "text": "Connect to PostHog", "emoji": True},
         "style": "primary",
@@ -820,6 +827,8 @@ def _github_account_button(github_state: GitHubState) -> dict | None:
         label, style = "Manage GitHub", ""
     button: dict[str, Any] = {
         "type": "button",
+        "action_id": ACTION_GITHUB_SETTINGS,
+        "value": label.lower().replace(" ", "_"),
         "url": github_state.settings_url,
         "text": {"type": "plain_text", "text": label, "emoji": True},
     }
@@ -1572,7 +1581,15 @@ def handle_ai_preferences_block_action(payload: dict, action: dict) -> HttpRespo
     if integration is None:
         return HttpResponse(status=200)
 
-    capture_slack_event(integration, "slack app home action clicked", slack_user_id=slack_user_id, action=action_id)
+    capture_slack_event(
+        integration,
+        "slack app home action clicked",
+        slack_user_id=slack_user_id,
+        action=action_id,
+        # Which option the control carried: the follow-up mode, the picked project id,
+        # the stats window, the tasks page, or the GitHub button's connect/manage state.
+        value=(action.get("selected_option") or {}).get("value") or action.get("value"),
+    )
 
     # The Home tab keeps no server-side view state — every payload carries the whole
     # view's inputs instead. Read them all back once so any action republishes with the

--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -32,6 +32,7 @@ from posthog.models.user import User
 from posthog.models.user_integration import UserIntegration
 from posthog.user_permissions import UserPermissions
 
+from products.slack_app.backend.analytics import capture_slack_event
 from products.slack_app.backend.feature_flags import is_slack_app_oauth_enabled
 from products.slack_app.backend.models import SlackSettings, SlackUserProfileCache, UntaggedFollowupMode
 from products.slack_app.backend.services.integration_resolver import load_integrations, resolve_from_candidates
@@ -1550,6 +1551,13 @@ def handle_app_home_opened(event: dict, slack_team_id: str, *, integration: Inte
             slack_user_id=slack_user_id,
             slack_team_id=slack_team_id,
         )
+        capture_slack_event(
+            integration,
+            "slack app home opened",
+            slack_user_id=slack_user_id,
+            account_linked=bool(account_state.linked_email),
+            has_project_access=bool(accessible),
+        )
 
 
 def handle_ai_preferences_block_action(payload: dict, action: dict) -> HttpResponse:
@@ -1563,6 +1571,8 @@ def handle_ai_preferences_block_action(payload: dict, action: dict) -> HttpRespo
     integration = _resolve_interaction_integration(slack_team_id, slack_user_id)
     if integration is None:
         return HttpResponse(status=200)
+
+    capture_slack_event(integration, "slack app home action clicked", slack_user_id=slack_user_id, action=action_id)
 
     # The Home tab keeps no server-side view state — every payload carries the whole
     # view's inputs instead. Read them all back once so any action republishes with the
@@ -1670,6 +1680,15 @@ def handle_app_home_view_submission(payload: dict) -> HttpResponse | JsonRespons
 
     _write_row(
         integration,
+        slack_user_id=slack_user_id,
+        runtime_adapter=runtime_adapter,
+        model=model,
+        reasoning_effort=reasoning_effort,
+    )
+
+    capture_slack_event(
+        integration,
+        "slack app ai preferences saved",
         slack_user_id=slack_user_id,
         runtime_adapter=runtime_adapter,
         model=model,

--- a/products/slack_app/backend/slack_link_unfurl.py
+++ b/products/slack_app/backend/slack_link_unfurl.py
@@ -23,6 +23,7 @@ from products.access_control.backend.facade.user_access_control import (
 from products.conversations.backend.models.ticket import Ticket
 from products.dashboards.backend.models.dashboard import Dashboard
 from products.product_analytics.backend.facade.models import Insight
+from products.slack_app.backend.analytics import capture_slack_event
 from products.slack_app.backend.services.slack_messages import UNFURL_OPT_OUT_PARAM
 from products.tasks.backend.facade import api as tasks_facade
 from products.tasks.backend.facade.contracts import TaskSlackUnfurlDTO
@@ -427,6 +428,7 @@ def handle_posthog_link_unfurl(event: dict, integration: Integration) -> None:
     uac = UserAccessControl(user, team=team)
 
     unfurls: dict[str, dict] = {}
+    unfurled_kinds: list[str] = []
     # Every resource we recognized but chose not to unfurl, so a report of "no unfurl appeared"
     # can be answered from logs instead of by re-deriving the path by hand.
     skipped: list[dict[str, str]] = []
@@ -531,6 +533,9 @@ def handle_posthog_link_unfurl(event: dict, integration: Integration) -> None:
             except Exception:
                 logger.exception("slack_task_reference_attach_failed", task_id=str(task.id), team_id=team.pk)
 
+        if raw_url in unfurls:
+            unfurled_kinds.append(kind)
+
     logger.info(
         "slack_app_link_unfurl_result",
         team_id=team.pk,
@@ -553,3 +558,13 @@ def handle_posthog_link_unfurl(event: dict, integration: Integration) -> None:
         slack.client.chat_unfurl(**unfurl_kwargs)
     except Exception:
         logger.exception("slack_link_unfurl_chat_unfurl_failed", team_id=team.pk)
+    else:
+        capture_slack_event(
+            integration,
+            "slack app link unfurled",
+            slack_user_id=slack_user_id,
+            posthog_user=user,
+            kinds=sorted(set(unfurled_kinds)),
+            unfurled_count=len(unfurls),
+            skipped_count=len(skipped),
+        )

--- a/products/slack_app/backend/tests/services/test_slack_app_home.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home.py
@@ -283,6 +283,9 @@ def _action_ids(view: dict) -> list[str]:
         for el in block.get("elements", []) or []:
             if "action_id" in el:
                 out.append(el["action_id"])
+        accessory = block.get("accessory")
+        if accessory and "action_id" in accessory:
+            out.append(accessory["action_id"])
     return out
 
 
@@ -448,6 +451,7 @@ class TestRenderHomeView:
             user_row=_make_row(runtime_adapter="claude", model="claude-opus-4-7"),
             is_admin=True,
             account_state=AccountState(enabled=True, link_url="https://app/link"),
+            github_state=GitHubState(user_resolved=True, settings_url="https://app/settings"),
             project_state=ProjectState(
                 candidates=(ProjectChoice(team_id=1, label="Org · Team"),),
                 personal_team_id=1,

--- a/products/slack_app/backend/tests/test_analytics.py
+++ b/products/slack_app/backend/tests/test_analytics.py
@@ -1,0 +1,61 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from parameterized import parameterized
+
+from posthog.models.integration import Integration
+from posthog.models.organization import Organization
+from posthog.models.team.team import Team
+from posthog.models.user import User
+
+from products.slack_app.backend.analytics import capture_slack_event
+
+
+class TestCaptureSlackEvent:
+    @pytest.fixture(autouse=True)
+    def setup(self, db):
+        self.organization = Organization.objects.create(name="Test Org")
+        self.team = Team.objects.create(organization=self.organization, name="Test Team")
+        self.user = User.objects.create(email="dev@example.com", distinct_id="user-distinct-1")
+        self.integration = Integration.objects.create(
+            team=self.team,
+            kind="slack",
+            integration_id="T12345",
+            sensitive_config={"access_token": "xoxb-test"},
+        )
+
+    @parameterized.expand(
+        [
+            # name, with_posthog_user, slack_user_id, expected_distinct_id, expected_identified
+            ("resolved_user_wins", True, "U123", "user-distinct-1", True),
+            ("slack_user_fallback", False, "U123", "slack:T12345:U123", False),
+            ("team_fallback", False, None, None, False),  # expected_distinct_id filled in from team uuid
+        ]
+    )
+    @patch("products.slack_app.backend.analytics.ph_background_capture")
+    def test_distinct_id_ladder(
+        self, _name, with_posthog_user, slack_user_id, expected_distinct_id, expected_identified, mock_background
+    ):
+        capture = MagicMock()
+        mock_background.return_value = capture
+
+        capture_slack_event(
+            self.integration,
+            "slack app test event",
+            slack_user_id=slack_user_id,
+            posthog_user=self.user if with_posthog_user else None,
+            extra_prop="value",
+        )
+
+        kwargs = capture.call_args.kwargs
+        assert kwargs["distinct_id"] == (expected_distinct_id or str(self.team.uuid))
+        assert kwargs["event"] == "slack app test event"
+        properties = kwargs["properties"]
+        assert properties["posthog_user_identified"] is expected_identified
+        assert properties["team_id"] == self.team.id
+        assert properties["extra_prop"] == "value"
+        assert ("$set" in properties) is with_posthog_user
+
+    @patch("products.slack_app.backend.analytics.ph_background_capture", side_effect=RuntimeError("boom"))
+    def test_capture_failure_is_swallowed(self, _mock_background):
+        capture_slack_event(self.integration, "slack app test event")

--- a/products/slack_app/backend/tests/test_mention_analytics.py
+++ b/products/slack_app/backend/tests/test_mention_analytics.py
@@ -30,42 +30,55 @@ class TestReportSlackMentionReceived:
 
     @parameterized.expand(
         [
-            # name, event, user_resolved, thread_reply_count, exp_first, exp_count, exp_identified
+            # name, event, user_resolved, thread_reply_count, exp_first, exp_count, exp_identified,
+            # exp_event_type
             (
                 "first_message_resolved",
-                {"channel": "C001", "ts": "1700.0001", "user": "U123"},
+                {"type": "app_mention", "channel": "C001", "ts": "1700.0001", "user": "U123"},
                 True,
                 None,
                 True,
                 1,
                 True,
+                "app_mention",
             ),
             (
                 "thread_root_is_the_mention_itself",
-                {"channel": "C001", "ts": "1700.0001", "thread_ts": "1700.0001", "user": "U123"},
+                {
+                    "type": "app_mention",
+                    "channel": "C001",
+                    "ts": "1700.0001",
+                    "thread_ts": "1700.0001",
+                    "user": "U123",
+                },
                 True,
                 None,
                 True,
                 1,
                 True,
+                "app_mention",
             ),
+            # An untagged reply the follow-up mode let through arrives as ``message``, and is the
+            # only shape here whose own ts differs from its thread's.
             (
-                "followup_counts_thread_messages",
-                {"channel": "C001", "ts": "1700.0009", "thread_ts": "1700.0001", "user": "U123"},
+                "untagged_followup_counts_thread_messages",
+                {"type": "message", "channel": "C001", "ts": "1700.0009", "thread_ts": "1700.0001", "user": "U123"},
                 True,
                 3,
                 False,
                 3,
                 True,
+                "message",
             ),
             (
                 "first_message_unresolved_user",
-                {"channel": "C001", "ts": "1700.0001", "user": "U999"},
+                {"type": "app_mention", "channel": "C001", "ts": "1700.0001", "user": "U999"},
                 False,
                 None,
                 True,
                 1,
                 False,
+                "app_mention",
             ),
         ]
     )
@@ -81,6 +94,7 @@ class TestReportSlackMentionReceived:
         exp_first,
         exp_count,
         exp_identified,
+        exp_event_type,
         mock_resolve,
         mock_capture,
         mock_slack_integration,
@@ -108,6 +122,10 @@ class TestReportSlackMentionReceived:
         assert props["session_message_count"] == exp_count
         assert props["slack_session_id"] == f"T12345:{event['channel']}:{thread_ts}"
         assert props["slack_thread_ts"] == thread_ts
+        # Must track the message, not its thread: the two only diverge on a follow-up, so wiring
+        # this to ``thread_ts`` would still look right on every thread-opening mention.
+        assert props["slack_message_ts"] == event["ts"]
+        assert props["slack_event_type"] == exp_event_type
         assert props["slack_user_id"] == event["user"]
         assert props["posthog_user_identified"] is exp_identified
         assert ("$set" in props) is exp_identified

--- a/products/slack_app/backend/tests/test_mention_analytics.py
+++ b/products/slack_app/backend/tests/test_mention_analytics.py
@@ -112,6 +112,46 @@ class TestReportSlackMentionReceived:
         assert props["posthog_user_identified"] is exp_identified
         assert ("$set" in props) is exp_identified
 
+    @parameterized.expand(
+        [
+            # name, files, exp_attachments, exp_images, exp_mimetypes
+            ("no_files_key", None, 0, 0, []),
+            ("empty_list", [], 0, 0, []),
+            ("one_screenshot", [{"id": "F1", "name": "shot.png", "mimetype": "image/png"}], 1, 1, ["image/png"]),
+            (
+                "image_and_log",
+                [
+                    {"id": "F1", "name": "shot.png", "mimetype": "image/png"},
+                    {"id": "F2", "name": "server.log", "mimetype": "text/plain"},
+                ],
+                2,
+                1,
+                ["image/png", "text/plain"],
+            ),
+            ("non_image_only", [{"id": "F1", "name": "rows.csv", "mimetype": "text/csv"}], 1, 0, ["text/csv"]),
+            ("two_images_one_mimetype", [{"mimetype": "image/png"}, {"mimetype": "image/png"}], 2, 2, ["image/png"]),
+            # Slack omits ``mimetype`` on some uploads; the file still counts, unlabeled.
+            ("mimetype_missing", [{"id": "F1", "name": "unknown"}], 1, 0, []),
+        ]
+    )
+    @patch("products.slack_app.backend.api.posthoganalytics.capture")
+    @patch("products.slack_app.backend.api.resolve_posthog_user_from_event")
+    def test_capture_attachment_properties(
+        self, _name, files, exp_attachments, exp_images, exp_mimetypes, mock_resolve, mock_capture
+    ):
+        mock_resolve.return_value = self.user
+        event: dict = {"channel": "C001", "ts": "1700.0001", "user": "U123"}
+        if files is not None:
+            event["files"] = files
+
+        _report_slack_mention_received(event, self.integration, "T12345")
+
+        props = mock_capture.call_args.kwargs["properties"]
+        assert props["slack_attachment_count"] == exp_attachments
+        assert props["slack_image_count"] == exp_images
+        assert props["slack_has_image"] is (exp_images > 0)
+        assert props["slack_attachment_mimetypes"] == exp_mimetypes
+
     @patch("products.slack_app.backend.api.posthoganalytics.capture")
     @patch("products.slack_app.backend.api.resolve_posthog_user_from_event")
     def test_capture_failure_is_swallowed(self, mock_resolve, mock_capture):

--- a/products/slack_app/backend/tests/test_posthog_code_event_handler.py
+++ b/products/slack_app/backend/tests/test_posthog_code_event_handler.py
@@ -286,6 +286,29 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
         assert Integration.objects.filter(id=self.posthog_code_integration.id).exists()
         assert mock_proxy.call_count == expected_proxy_calls
 
+    @patch("products.slack_app.backend.api.capture_slack_event")
+    @patch("products.slack_app.backend.api._proxy_event_to_region")
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
+    def test_app_uninstalled_captures_once_for_multi_project_workspace(self, _mock_proxy, mock_capture):
+        # A workspace linked to several projects has several rows here; capturing per
+        # row would let one uninstall inflate a plain count of the event.
+        second_team = Team.objects.create(organization=self.organization, name="Second Team")
+        Integration.objects.create(
+            team=second_team,
+            kind="slack",
+            integration_id="T12345",
+            sensitive_config={"access_token": "xoxb-second"},
+        )
+
+        from products.slack_app.backend.api import route_posthog_code_event_to_relevant_region
+
+        request = self.factory.post("/slack/event-callback/", HTTP_HOST="us.posthog.com")
+        route_posthog_code_event_to_relevant_region(request, {"type": "app_uninstalled"}, "T12345")
+
+        mock_capture.assert_called_once()
+        assert mock_capture.call_args.args[1] == "slack app uninstalled"
+        assert mock_capture.call_args.kwargs["linked_project_count"] == 2
+
     @patch("products.slack_app.backend.api._proxy_event_to_region")
     @patch("products.slack_app.backend.services.slack_user_info.SlackUserProfileCache.objects.filter")
     @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")

--- a/products/slack_app/backend/tests/test_untagged_followup_interactivity.py
+++ b/products/slack_app/backend/tests/test_untagged_followup_interactivity.py
@@ -167,6 +167,29 @@ class TestUntaggedFollowupInteractivity(TestCase):
         assert cache.get(_picker_context_cache_key(self.context_token)) is None
         assert mock_post.call_args.kwargs["json"] == {"delete_original": True}
 
+    def test_dismissal_attributes_to_the_prompts_integration(self, mock_slack_cls, mock_post):
+        # A workspace can be linked to several projects; the dismissal must land on the
+        # integration that raised the prompt, not on whichever row a lookup returns first.
+        mock_slack_cls.slack_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
+        second_team = Team.objects.create(organization=self.organization, name="Second Team")
+        second_integration = Integration.objects.create(
+            team=second_team,
+            kind="slack",
+            integration_id=self.slack_team_id,
+            sensitive_config={"access_token": "xoxb-second"},
+        )
+        context = cache.get(_picker_context_cache_key(self.context_token))
+        context["integration_id"] = second_integration.id
+        cache.set(_picker_context_cache_key(self.context_token), context, timeout=900)
+
+        with patch("products.slack_app.backend.api.capture_slack_event") as mock_capture:
+            response = self._click(UNTAGGED_FOLLOWUP_ACTION_DISMISS, "U_BOB")
+
+        assert response.status_code == 200
+        mock_capture.assert_called_once()
+        assert mock_capture.call_args.args[0].id == second_integration.id
+        assert mock_capture.call_args.args[1] == "slack app untagged followup dismissed"
+
     def test_click_from_anyone_but_the_message_author_dispatches_nothing(self, mock_slack_cls, mock_post):
         # The prompt is ephemeral, so this shouldn't be reachable — but the run
         # would execute as the clicker against somebody else's message.

--- a/products/slack_app/backend/tests/views/test_slack_user_link.py
+++ b/products/slack_app/backend/tests/views/test_slack_user_link.py
@@ -259,8 +259,13 @@ class TestCallbackView:
         with (
             patch("products.slack_app.backend.views.slack_user_link.is_slack_app_oauth_enabled", return_value=True),
             patch("products.slack_app.backend.views.slack_user_link.exchange_code", return_value=self._identity()),
+            patch("products.slack_app.backend.views.slack_user_link.capture_slack_event") as mock_capture,
         ):
             response = client.get(f"/complete/slack-link/?code=abc&state={state}")
 
         self._assert_settings_redirect_error(response, "org_mismatch")
         assert not UserIntegration.objects.filter(user=outsider).exists()
+        # The session check has passed here, so the failure keys to the same distinct id
+        # a later success would use; otherwise one person's linking funnel splits in two.
+        mock_capture.assert_called_once()
+        assert mock_capture.call_args.kwargs["posthog_user"] == outsider

--- a/products/slack_app/backend/views/slack_user_link.py
+++ b/products/slack_app/backend/views/slack_user_link.py
@@ -44,6 +44,7 @@ from posthog.models.user import User
 from posthog.models.user_integration import user_slack_integration_from_identity
 from posthog.views import login_required
 
+from products.slack_app.backend.analytics import capture_slack_event
 from products.slack_app.backend.feature_flags import is_slack_app_oauth_enabled
 from products.slack_app.backend.services.slack_user_oauth import (
     CallbackState,
@@ -75,6 +76,16 @@ def _settings_redirect(*, error: str | None = None) -> HttpResponseRedirect:
     """
     param = {"slack_link_error": error} if error else {"slack_link_success": "1"}
     return redirect(f"{PERSONAL_INTEGRATIONS_SETTINGS_PATH}?{urlencode(param)}")
+
+
+def _link_failed(integration: Integration, reason: str, *, slack_user_id: str | None = None) -> HttpResponseRedirect:
+    """Report a link attempt that got far enough to name a workspace, then bounce to settings.
+
+    Failures before the workspace lookup stay uncaptured — there is no integration to
+    attribute them to.
+    """
+    capture_slack_event(integration, "slack app user link failed", slack_user_id=slack_user_id, reason=reason)
+    return _settings_redirect(error=reason)
 
 
 def _load_workspace_integration(posthog_team_id: int, slack_team_id: str) -> Integration | None:
@@ -154,13 +165,13 @@ def slack_user_link_callback(request: HttpRequest) -> HttpResponse:
     if workspace_integration is None:
         return _settings_redirect(error="workspace_not_found")
     if not is_slack_app_oauth_enabled(workspace_integration):
-        return _settings_redirect(error="flag_off")
+        return _link_failed(workspace_integration, "flag_off", slack_user_id=state.slack_user_id)
 
     try:
         identity = exchange_code(code=code, redirect_uri=_callback_redirect_uri())
     except SlackUserOAuthError as exc:
         logger.warning("slack_app_user_link_callback_exchange_failed", error=str(exc))
-        return _settings_redirect(error="exchange_failed")
+        return _link_failed(workspace_integration, "exchange_failed", slack_user_id=state.slack_user_id)
 
     # Hard-bind to the workspace from the original invite: if the user
     # authorized in a different Slack workspace tab, refuse rather than
@@ -171,7 +182,7 @@ def slack_user_link_callback(request: HttpRequest) -> HttpResponse:
             expected=state.slack_team_id,
             actual=identity.slack_team_id,
         )
-        return _settings_redirect(error="team_mismatch")
+        return _link_failed(workspace_integration, "team_mismatch", slack_user_id=identity.slack_user_id)
 
     # `state.slack_user_id` is informational — if the user clicks an invite
     # meant for a different person but authorizes as themselves, that's fine
@@ -202,7 +213,7 @@ def slack_user_link_callback(request: HttpRequest) -> HttpResponse:
             state_posthog_user_id=state.posthog_user_id,
             request_posthog_user_id=posthog_user.id,
         )
-        return _settings_redirect(error="session_mismatch")
+        return _link_failed(workspace_integration, "session_mismatch", slack_user_id=identity.slack_user_id)
 
     # Refuse to write a link row for a PostHog user who isn't a member of
     # the workspace's org. The org-scope filter in `find_linked_posthog_user`
@@ -219,7 +230,7 @@ def slack_user_link_callback(request: HttpRequest) -> HttpResponse:
             posthog_team_id=workspace_integration.team_id,
             organization_id=workspace_integration.team.organization_id,
         )
-        return _settings_redirect(error="org_mismatch")
+        return _link_failed(workspace_integration, "org_mismatch", slack_user_id=identity.slack_user_id)
 
     user_slack_integration_from_identity(
         posthog_user,
@@ -230,6 +241,13 @@ def slack_user_link_callback(request: HttpRequest) -> HttpResponse:
         user_access_token=identity.user_access_token,
         user_refresh_token=identity.user_refresh_token,
         user_scopes=identity.user_scopes,
+    )
+
+    capture_slack_event(
+        workspace_integration,
+        "slack app user linked",
+        slack_user_id=identity.slack_user_id,
+        posthog_user=posthog_user,
     )
 
     _post_link_success_followup(

--- a/products/slack_app/backend/views/slack_user_link.py
+++ b/products/slack_app/backend/views/slack_user_link.py
@@ -78,13 +78,24 @@ def _settings_redirect(*, error: str | None = None) -> HttpResponseRedirect:
     return redirect(f"{PERSONAL_INTEGRATIONS_SETTINGS_PATH}?{urlencode(param)}")
 
 
-def _link_failed(integration: Integration, reason: str, *, slack_user_id: str | None = None) -> HttpResponseRedirect:
+def _link_failed(
+    integration: Integration,
+    reason: str,
+    *,
+    slack_user_id: str | None = None,
+    posthog_user: User | None = None,
+) -> HttpResponseRedirect:
     """Report a link attempt that got far enough to name a workspace, then bounce to settings.
 
     Failures before the workspace lookup stay uncaptured — there is no integration to
-    attribute them to.
+    attribute them to. ``posthog_user`` keys the failure to the same distinct id a later
+    success would use, so one person's linking funnel doesn't split across ids; pass it
+    only once the state's session check has proven the requester initiated the flow,
+    because before that ``request.user`` may be a victim of a forwarded callback URL.
     """
-    capture_slack_event(integration, "slack app user link failed", slack_user_id=slack_user_id, reason=reason)
+    capture_slack_event(
+        integration, "slack app user link failed", slack_user_id=slack_user_id, posthog_user=posthog_user, reason=reason
+    )
     return _settings_redirect(error=reason)
 
 
@@ -230,7 +241,9 @@ def slack_user_link_callback(request: HttpRequest) -> HttpResponse:
             posthog_team_id=workspace_integration.team_id,
             organization_id=workspace_integration.team.organization_id,
         )
-        return _link_failed(workspace_integration, "org_mismatch", slack_user_id=identity.slack_user_id)
+        return _link_failed(
+            workspace_integration, "org_mismatch", slack_user_id=identity.slack_user_id, posthog_user=posthog_user
+        )
 
     user_slack_integration_from_identity(
         posthog_user,


### PR DESCRIPTION
## Problem

The team can see Slack bot mentions in analytics, but not which other features people use.
Commands, the Home tab, the assistant DM pane, link unfurls, account linking, and uninstalls emit no events, so there is no feature-usage or activation view for the Slack app.

Nobody can tell how often PostHog ignores a Slack follow-up because it did not tag the bot.
The drop event records the reason, but the accepted-mention event carries no matching field, so there is no denominator.

## Changes

- Captures new events at each surface: `slack app command used` (with action and mention/slash source), `slack app home opened`, `slack app home action clicked`, `slack app ai preferences saved`, `slack app assistant thread started`, `slack app link unfurled`, `slack app untagged followup confirmed` / `dismissed`, `slack app user linked` / `slack app user link failed` (with reason), and `slack app uninstalled`.
- `slack app home action clicked` carries a `value` property: the picked follow-up mode, project id, stats window, or tasks page.
- The GitHub and Connect-to-PostHog Home tab buttons gain action ids, so those clicks reach the capture; Slack still opens the URL itself, nothing changes visually.
- Events now attribute to the resolved PostHog user where one is known, else to a stable `slack:{team}:{user}` distinct id, matching the mention funnel. Existing `capture_slack_event` callers (onboarding, fork) move from a team-keyed to a Slack-user-keyed distinct id as a result.
- `posthog code slack mention received` gains a `slack_channel_type` property, so assistant DM messages ("im") can be split from channel mentions without a duplicate event.
- `posthog code slack mention received` gains `slack_event_type`: `app_mention` is a tagged message, `message` is an untagged thread reply the follow-up mode let through.
- `posthog code slack mention dropped` already reports that field, so the two events now add up to a funnel and ignored follow-ups can be read as a rate.
- `posthog code slack mention received` gains `slack_message_ts`, so accepted and dropped messages in one thread can be ordered, and joined to the agent turn that answered them.
- `posthog code slack mention received` also gains `slack_attachment_count`, `slack_image_count`, `slack_has_image`, and the distinct `slack_attachment_mimetypes`, read off the same `files` payload the agent already parses. The agent can read images now, and until this lands the mention event has no attachment field at all, so how often people send one can't be measured against mention volume — `is_first_message_in_session` then splits "opened with a screenshot" from "pasted one mid-thread".
- The shared helper now sends through `ph_background_capture` instead of `ph_scoped_capture`, dropping the per-call blocking flush that `posthog/ph_client.py` warns against for Temporal workers, and making the helper safe on the webhook request path.
- Nothing user-visible changes; the diff is capture calls, two button ids, and the helper change.

## How did you test this code?

- New `test_analytics.py` locks the distinct-id ladder (resolved user > Slack fallback > team uuid) and the swallow-all contract - a regression there would silently break per-user attribution or make analytics errors take down Slack handlers.
- The Home tab routability guard now also walks section accessories, so it covers the two URL buttons that gained action ids.
- `test_mention_analytics.py` covers the attachment counters over no `files` key, an empty list, an image, an image mixed with a non-image, a non-image alone, and an upload Slack sent without a `mimetype`.
- The mention-property cases now assert `slack_message_ts` and `slack_event_type`. Reverting the capture fails all four.
- The untagged-followup case guards `slack_message_ts`: only there does a message's own ts differ from its thread's. Wiring it to `thread_ts` would pass every other case.
- Ran the full `products/slack_app` and `posthog/temporal/tests/ai/slack_app` suites locally; one pre-existing failure (`test_link_shared_logs_unfurl_context`) also fails on clean master when both directories run together (structlog cross-test interference), and passes alone.
- Not checked: events arriving in the dogfood project - capture is disabled in dev/test by design.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code from an analysis of untracked Slack app surfaces; the human picked the priority set, then asked for coverage of follow-up settings, GitHub/link buttons, and the untagged-followup prompt.
Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/instrumenting-first-party-metrics` (consulted; this PR uses event capture, not the Metrics product).
An `assistant message sent` event was planned but dropped: DM messages already fire `posthog code slack mention received`, so a property covers it without double counting.
A later session added `slack_event_type` and `slack_message_ts`, after tracing a thread where an untagged follow-up went unanswered and the two mention events had no common field to join on.


