### PR TITLE
fix(conversations): durably process slack callbacks

### DIFF
--- a/docs/internal/conversations-reliability.md
+++ b/docs/internal/conversations-reliability.md
@@ -66,6 +66,12 @@ Workers claim a row with a fencing token and a short lease, then release the row
 A stale worker cannot complete or retry after a later claim of the same receipt.
 Redis is not the dedupe record: losing Redis must not drop or suppress a callback.
 
+Receipt workers use task names separate from the legacy payload tasks.
+During a rolling deploy, an old worker can discard a new receipt-task hint, but the committed row remains pending for the sweeper.
+Keep the legacy task names registered until payload tasks from the old endpoint have drained.
+If S1 is rolled back, its additive table and pending rows remain safe, but the old workers cannot drain them.
+Restore S1 workers to process those rows.
+
 ## Outbound email (already in Postgres)
 
 `EmailOutboxMessage` remains the outbound email outbox.

--- a/docs/internal/conversations-reliability.md
+++ b/docs/internal/conversations-reliability.md
@@ -56,7 +56,15 @@ Terminal states require `terminal_at`; non-terminal states require it to be null
 Queue transitions that use `QuerySet.update()` must set `updated_at` and the appropriate terminal timestamp explicitly.
 
 Partial indexes cover pending due work, expired processing leases, payload cleanup, and terminal-row deletion.
-The table ships empty; later PRs persist on the Slack endpoints and run the sweeper.
+Slack Events API and interactivity endpoints persist a receipt before they acknowledge Slack.
+`X-Slack-Retry-Num` is stored as metadata; it is never used to drop a callback.
+Owning-region proxy failure returns 502 so Slack retries.
+Celery `on_commit` dispatch is a wake-up hint.
+`sweep_inbound_events` (every minute) re-drives due and expired-lease rows, nulls payloads after 24 hours, and deletes tombstones after 30 days.
+
+Workers claim a row with a fencing token and a short lease, then release the row lock before Slack API calls.
+A stale worker cannot complete or retry after a later claim of the same receipt.
+Redis is not the dedupe record: losing Redis must not drop or suppress a callback.
 
 ## Outbound email (already in Postgres)
 

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -78,6 +78,7 @@ from products.approvals.backend.tasks import expire_old_change_requests, validat
 from products.canvas.backend.tasks import cleanup_canvas_builds, sweep_canvas_builds
 from products.conversations.backend.tasks.email import flush_pending_email_replies
 from products.conversations.backend.tasks.maintenance import wake_snoozed_tickets
+from products.conversations.backend.tasks.slack import sweep_inbound_events
 from products.conversations.backend.tasks.teams import poll_teams_shared_channels
 from products.data_modeling.backend.facade.tasks import cleanup_expired_test_saved_queries
 from products.data_warehouse.backend.facade.tasks import (
@@ -974,6 +975,14 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         crontab(minute="*"),
         flush_pending_email_replies.s(),
         name="flush pending conversation email replies",
+    )
+
+    # Re-drive due Slack inbound receipts when the Celery hint was dropped
+    add_periodic_task_with_expiry(
+        sender,
+        crontab(minute="*"),
+        sweep_inbound_events.s(),
+        name="sweep conversation inbound events",
     )
 
     # Pull ambient messages from MS Teams shared channels (which never push them

--- a/products/conversations/backend/api/slack_events.py
+++ b/products/conversations/backend/api/slack_events.py
@@ -19,7 +19,7 @@ from products.conversations.backend.services.inbound_events import (
 )
 from products.conversations.backend.services.region_routing import is_primary_region, proxy_to_secondary_region
 from products.conversations.backend.support_slack import team_for_slack_workspace, validate_support_request
-from products.conversations.backend.tasks.slack import process_supporthog_event
+from products.conversations.backend.tasks.slack import process_supporthog_event_receipt
 
 logger = structlog.get_logger(__name__)
 
@@ -34,7 +34,7 @@ SUPPORT_EVENT_TYPES = [
 
 
 def _wake_slack_event(row: ConversationInboundEvent) -> None:
-    cast(Any, process_supporthog_event).delay(inbound_event_id=str(row.id))
+    cast(Any, process_supporthog_event_receipt).delay(inbound_event_id=str(row.id))
 
 
 def _accept_event_callback(request: HttpRequest, data: dict[str, Any]) -> HttpResponse:

--- a/products/conversations/backend/api/slack_events.py
+++ b/products/conversations/backend/api/slack_events.py
@@ -11,8 +11,14 @@ import structlog
 
 from posthog.models.integration import SlackIntegrationError
 
+from products.conversations.backend.models import ConversationInboundEvent, ConversationInboundEventSource
+from products.conversations.backend.services.inbound_events import (
+    accept_inbound_event,
+    slack_events_source_id,
+    slack_retry_metadata,
+)
 from products.conversations.backend.services.region_routing import is_primary_region, proxy_to_secondary_region
-from products.conversations.backend.support_slack import team_exists_for_slack_workspace, validate_support_request
+from products.conversations.backend.support_slack import team_for_slack_workspace, validate_support_request
 from products.conversations.backend.tasks.slack import process_supporthog_event
 
 logger = structlog.get_logger(__name__)
@@ -27,30 +33,50 @@ SUPPORT_EVENT_TYPES = [
 ]
 
 
-def _route_event_to_relevant_region(request: HttpRequest, data: dict) -> None:
-    event_id = data.get("event_id") if isinstance(data.get("event_id"), str) else None
-    event = data.get("event", {})
-    slack_team_id = data.get("team_id", "")
+def _wake_slack_event(row: ConversationInboundEvent) -> None:
+    cast(Any, process_supporthog_event).delay(inbound_event_id=str(row.id))
+
+
+def _accept_event_callback(request: HttpRequest, data: dict[str, Any]) -> HttpResponse:
+    event = data.get("event") if isinstance(data.get("event"), dict) else {}
+    slack_team_id = data.get("team_id", "") if isinstance(data.get("team_id"), str) else ""
     inner_event_type = event.get("type")
+    retry_num, retry_reason = slack_retry_metadata(request)
 
     logger.info(
         "supporthog_event_callback",
         inner_event_type=inner_event_type,
         slack_team_id=slack_team_id,
         channel=event.get("channel"),
+        retry_num=retry_num,
     )
 
     if inner_event_type not in SUPPORT_EVENT_TYPES:
-        return
+        return HttpResponse(status=202)
 
-    team_exists = team_exists_for_slack_workspace(slack_team_id) if slack_team_id else False
+    team = team_for_slack_workspace(slack_team_id) if slack_team_id else None
 
-    if team_exists and not (settings.DEBUG and is_primary_region(request)):
-        cast(Any, process_supporthog_event).delay(event=event, slack_team_id=slack_team_id, event_id=event_id)
-    elif is_primary_region(request):
-        proxy_to_secondary_region(request, log_prefix="supporthog")
-    else:
-        logger.warning("supporthog_no_team_any_region", slack_team_id=slack_team_id)
+    if team is not None and not (settings.DEBUG and is_primary_region(request)):
+        event_id = data.get("event_id") if isinstance(data.get("event_id"), str) else None
+        accept_inbound_event(
+            team=team,
+            source=ConversationInboundEventSource.SLACK_EVENTS,
+            source_id=slack_events_source_id(event_id=event_id, signed_body=request.body),
+            provider_account_id=slack_team_id,
+            payload=data,
+            provider_retry_num=retry_num,
+            provider_retry_reason=retry_reason,
+            wake=_wake_slack_event,
+        )
+        return HttpResponse(status=202)
+
+    if is_primary_region(request):
+        if not proxy_to_secondary_region(request, log_prefix="supporthog"):
+            return HttpResponse("Failed to reach owning region", status=502)
+        return HttpResponse(status=202)
+
+    logger.warning("supporthog_no_team_any_region", slack_team_id=slack_team_id)
+    return HttpResponse(status=202)
 
 
 @csrf_exempt
@@ -64,6 +90,8 @@ def supporthog_event_handler(request: HttpRequest) -> HttpResponse:
 
     Regional routing: EU is the primary region. If the workspace isn't found
     locally, the request is proxied to the secondary region (US).
+    A 2xx means the owning region's Postgres receipt committed, not that a
+    worker has processed the callback.
     """
     if request.method != "POST":
         return HttpResponse(status=405)
@@ -74,14 +102,11 @@ def supporthog_event_handler(request: HttpRequest) -> HttpResponse:
         logger.warning("supporthog_event_invalid_request", error=str(e))
         return HttpResponse("Invalid request", status=403)
 
-    retry_num = request.headers.get("X-Slack-Retry-Num")
-    if retry_num:
-        logger.info("supporthog_event_retry_skipped", retry_num=retry_num)
-        return HttpResponse(status=200)
-
     try:
         data = json.loads(request.body)
     except json.JSONDecodeError:
+        return HttpResponse("Invalid JSON", status=400)
+    if not isinstance(data, dict):
         return HttpResponse("Invalid JSON", status=400)
 
     logger.info("supporthog_event_received", event_type=data.get("type"))
@@ -94,7 +119,6 @@ def supporthog_event_handler(request: HttpRequest) -> HttpResponse:
         return JsonResponse({"challenge": challenge})
 
     if event_type == "event_callback":
-        _route_event_to_relevant_region(request, data)
-        return HttpResponse(status=202)
+        return _accept_event_callback(request, data)
 
     return HttpResponse(status=200)

--- a/products/conversations/backend/api/slack_events.py
+++ b/products/conversations/backend/api/slack_events.py
@@ -38,7 +38,8 @@ def _wake_slack_event(row: ConversationInboundEvent) -> None:
 
 
 def _accept_event_callback(request: HttpRequest, data: dict[str, Any]) -> HttpResponse:
-    event = data.get("event") if isinstance(data.get("event"), dict) else {}
+    raw_event = data.get("event")
+    event: dict[str, Any] = raw_event if isinstance(raw_event, dict) else {}
     slack_team_id = data.get("team_id", "") if isinstance(data.get("team_id"), str) else ""
     inner_event_type = event.get("type")
     retry_num, retry_reason = slack_retry_metadata(request)

--- a/products/conversations/backend/api/slack_interactivity.py
+++ b/products/conversations/backend/api/slack_interactivity.py
@@ -25,13 +25,13 @@ from products.conversations.backend.services.inbound_events import (
 )
 from products.conversations.backend.services.region_routing import is_primary_region, proxy_to_secondary_region
 from products.conversations.backend.support_slack import team_for_slack_workspace, validate_support_request
-from products.conversations.backend.tasks.slack import process_supporthog_interactivity
+from products.conversations.backend.tasks.slack import process_supporthog_interactivity_receipt
 
 logger = structlog.get_logger(__name__)
 
 
 def _wake_slack_interactivity(row: ConversationInboundEvent) -> None:
-    cast(Any, process_supporthog_interactivity).delay(inbound_event_id=str(row.id))
+    cast(Any, process_supporthog_interactivity_receipt).delay(inbound_event_id=str(row.id))
 
 
 @csrf_exempt
@@ -52,14 +52,17 @@ def supporthog_interactivity_handler(request: HttpRequest) -> HttpResponse:
         logger.warning("supporthog_interactivity_invalid_request", error=str(e))
         return HttpResponse("Invalid request", status=403)
 
+    signed_body = request.body
+    raw_payload = request.POST.get("payload", "{}")
     try:
-        payload = json.loads(request.POST.get("payload", "{}"))
+        payload = json.loads(raw_payload)
     except (json.JSONDecodeError, TypeError):
         return HttpResponse("Invalid JSON", status=400)
     if not isinstance(payload, dict):
         return HttpResponse("Invalid payload", status=400)
 
-    slack_team_id = (payload.get("team") or {}).get("id", "")
+    slack_team = payload.get("team")
+    slack_team_id = slack_team.get("id", "") if isinstance(slack_team, dict) else ""
     if not slack_team_id:
         return HttpResponse(status=200)
 
@@ -76,7 +79,10 @@ def supporthog_interactivity_handler(request: HttpRequest) -> HttpResponse:
         accept_inbound_event(
             team=team,
             source=ConversationInboundEventSource.SLACK_INTERACTIVITY,
-            source_id=slack_interactivity_source_id(payload=payload, signed_body=request.body),
+            source_id=slack_interactivity_source_id(
+                payload=payload,
+                signed_body=signed_body,
+            ),
             provider_account_id=slack_team_id,
             payload=payload,
             provider_retry_num=retry_num,

--- a/products/conversations/backend/api/slack_interactivity.py
+++ b/products/conversations/backend/api/slack_interactivity.py
@@ -17,11 +17,21 @@ import structlog
 
 from posthog.models.integration import SlackIntegrationError
 
+from products.conversations.backend.models import ConversationInboundEvent, ConversationInboundEventSource
+from products.conversations.backend.services.inbound_events import (
+    accept_inbound_event,
+    slack_interactivity_source_id,
+    slack_retry_metadata,
+)
 from products.conversations.backend.services.region_routing import is_primary_region, proxy_to_secondary_region
-from products.conversations.backend.support_slack import team_exists_for_slack_workspace, validate_support_request
+from products.conversations.backend.support_slack import team_for_slack_workspace, validate_support_request
 from products.conversations.backend.tasks.slack import process_supporthog_interactivity
 
 logger = structlog.get_logger(__name__)
+
+
+def _wake_slack_interactivity(row: ConversationInboundEvent) -> None:
+    cast(Any, process_supporthog_interactivity).delay(inbound_event_id=str(row.id))
 
 
 @csrf_exempt
@@ -30,6 +40,8 @@ def supporthog_interactivity_handler(request: HttpRequest) -> HttpResponse:
 
     Regional routing matches the events endpoint: EU is the primary region. If the
     workspace isn't found locally, the request is proxied to the secondary region (US).
+    A 2xx means the owning region's Postgres receipt committed, not that a worker has
+    processed the click.
     """
     if request.method != "POST":
         return HttpResponse(status=405)
@@ -51,17 +63,35 @@ def supporthog_interactivity_handler(request: HttpRequest) -> HttpResponse:
     if not slack_team_id:
         return HttpResponse(status=200)
 
-    logger.info("supporthog_interactivity_received", payload_type=payload.get("type"), slack_team_id=slack_team_id)
+    retry_num, retry_reason = slack_retry_metadata(request)
+    logger.info(
+        "supporthog_interactivity_received",
+        payload_type=payload.get("type"),
+        slack_team_id=slack_team_id,
+        retry_num=retry_num,
+    )
 
-    if team_exists_for_slack_workspace(slack_team_id) and not (settings.DEBUG and is_primary_region(request)):
-        cast(Any, process_supporthog_interactivity).delay(payload=payload, slack_team_id=slack_team_id)
-    elif is_primary_region(request):
+    team = team_for_slack_workspace(slack_team_id)
+    if team is not None and not (settings.DEBUG and is_primary_region(request)):
+        accept_inbound_event(
+            team=team,
+            source=ConversationInboundEventSource.SLACK_INTERACTIVITY,
+            source_id=slack_interactivity_source_id(payload=payload, signed_body=request.body),
+            provider_account_id=slack_team_id,
+            payload=payload,
+            provider_retry_num=retry_num,
+            provider_retry_reason=retry_reason,
+            wake=_wake_slack_interactivity,
+        )
+        return HttpResponse(status=200)
+
+    if is_primary_region(request):
         # Acking a failed proxy with 200 makes the click silently vanish — Slack shows the
         # clicker nothing and never resends. Surface the failure so Slack displays a
         # delivery error and the user knows to click again.
         if not proxy_to_secondary_region(request, log_prefix="supporthog_interactivity"):
             return HttpResponse("Failed to reach owning region", status=502)
-    else:
-        logger.warning("supporthog_interactivity_no_team_any_region", slack_team_id=slack_team_id)
+        return HttpResponse(status=200)
 
+    logger.warning("supporthog_interactivity_no_team_any_region", slack_team_id=slack_team_id)
     return HttpResponse(status=200)

--- a/products/conversations/backend/api/tests/test_reaction_backfill.py
+++ b/products/conversations/backend/api/tests/test_reaction_backfill.py
@@ -71,6 +71,72 @@ class TestBackfillThreadReplies(BaseTest):
         self.ticket.refresh_from_db()
         assert self.ticket.unread_team_count == 3  # 1 original + 2 backfilled
 
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.get_bot_user_id", return_value="U_OWN_BOT")
+    @patch(f"{MODULE}.resolve_slack_user", return_value={"name": "Alice", "email": "a@x.com", "avatar": None})
+    @patch(f"{MODULE}.extract_slack_files", return_value=[])
+    def test_backfilled_reply_is_not_delivered_again_live(self, _mock_files, _mock_user, _mock_bot, mock_client):
+        mock_client.return_value = MagicMock()
+        replies = [
+            _make_slack_reply(PARENT_TS, text="parent"),
+            _make_slack_reply("1700000000.000200", user="U1", text="first reply"),
+        ]
+
+        _backfill_thread_replies(
+            self._mock_client(replies), self.team, self.ticket, CHANNEL, PARENT_TS, slack_team_id="T123"
+        )
+
+        comments = Comment.objects.filter(item_id=str(self.ticket.id))
+        assert comments.get().item_context["slack_message_ts"] == "1700000000.000200"
+
+        create_or_update_slack_ticket(
+            team=self.team,
+            slack_channel_id=CHANNEL,
+            thread_ts=PARENT_TS,
+            slack_user_id="U1",
+            text="first reply",
+            is_thread_reply=True,
+            slack_team_id=SLACK_TEAM,
+            slack_message_ts="1700000000.000200",
+        )
+
+        assert comments.count() == 1
+        self.ticket.refresh_from_db()
+        assert self.ticket.unread_team_count == 2  # 1 original + 1 backfilled
+
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.get_bot_user_id", return_value="U_OWN_BOT")
+    @patch(f"{MODULE}.resolve_slack_user", return_value={"name": "Alice", "email": "a@x.com", "avatar": None})
+    @patch(f"{MODULE}.extract_slack_files", return_value=[])
+    def test_backfill_skips_reply_already_delivered_live(self, _mock_files, _mock_user, _mock_bot, mock_client):
+        mock_client.return_value = MagicMock()
+        create_or_update_slack_ticket(
+            team=self.team,
+            slack_channel_id=CHANNEL,
+            thread_ts=PARENT_TS,
+            slack_user_id="U1",
+            text="first reply",
+            is_thread_reply=True,
+            slack_team_id=SLACK_TEAM,
+            slack_message_ts="1700000000.000200",
+        )
+        replies = [
+            _make_slack_reply(PARENT_TS, text="parent"),
+            _make_slack_reply("1700000000.000200", user="U1", text="first reply"),
+            _make_slack_reply("1700000000.000300", user="U2", text="second reply"),
+        ]
+
+        _backfill_thread_replies(
+            self._mock_client(replies), self.team, self.ticket, CHANNEL, PARENT_TS, slack_team_id="T123"
+        )
+
+        contents = list(
+            Comment.objects.filter(item_id=str(self.ticket.id)).order_by("created_at").values_list("content", flat=True)
+        )
+        assert contents == ["first reply", "second reply"]
+        self.ticket.refresh_from_db()
+        assert self.ticket.unread_team_count == 3  # 1 original + 1 live + 1 backfilled
+
     @patch(f"{MODULE}.get_bot_user_id", return_value="U_OWN_BOT")
     @patch(f"{MODULE}.resolve_slack_user", return_value={"name": "Alice", "email": "a@x.com", "avatar": None})
     @patch(f"{MODULE}.extract_slack_files", return_value=[])
@@ -270,6 +336,7 @@ class TestBackfillThreadReplies(BaseTest):
             "author_type": "customer",
             "is_private": False,
             "from_slack": True,
+            "slack_message_ts": "1700000000.000200",
             "slack_user_id": "U_BOB",
             "slack_author_name": "Bob",
             "slack_author_email": "b@x.com",

--- a/products/conversations/backend/api/tests/test_reaction_backfill.py
+++ b/products/conversations/backend/api/tests/test_reaction_backfill.py
@@ -472,7 +472,7 @@ class TestHandleSupportReactionBackfill(BaseTest):
 
 
 class TestSlackTicketCreateLockDedup(BaseTest):
-    """Verify that the Redis lock in create_or_update_slack_ticket prevents duplicate tickets."""
+    """Verify that the Slack thread lock prevents duplicate tickets."""
 
     def setUp(self):
         super().setUp()
@@ -509,6 +509,103 @@ class TestSlackTicketCreateLockDedup(BaseTest):
         assert ticket2 is None
         # Only one confirmation message posted (second call short-circuits)
         assert mock_client.return_value.chat_postMessage.call_count == 1
+
+    @patch("products.conversations.backend.cache.cache.add", side_effect=ConnectionError("redis down"))
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.resolve_slack_user", return_value={"name": "Alice", "email": "a@x.com", "avatar": None})
+    @patch(f"{MODULE}.extract_slack_files", return_value=[])
+    def test_postgres_lock_allows_creation_when_redis_is_unavailable(
+        self,
+        _files: MagicMock,
+        _user: MagicMock,
+        mock_client: MagicMock,
+        _cache_add: MagicMock,
+    ) -> None:
+        mock_client.return_value = MagicMock()
+        kwargs: dict[str, Any] = {
+            "team": self.team,
+            "slack_channel_id": CHANNEL,
+            "thread_ts": PARENT_TS,
+            "slack_user_id": "U_SOMEONE",
+            "text": "Help me please",
+            "is_thread_reply": False,
+            "slack_team_id": SLACK_TEAM,
+            "channel_detail": ChannelDetail.SLACK_EMOJI_REACTION,
+        }
+
+        first = create_or_update_slack_ticket(**kwargs)
+        second = create_or_update_slack_ticket(**kwargs)
+
+        assert first is not None
+        assert second is None
+        assert Ticket.objects.filter(team=self.team, slack_channel_id=CHANNEL, slack_thread_ts=PARENT_TS).count() == 1
+
+    @patch(f"{MODULE}.Comment.objects.create", side_effect=RuntimeError("comment insert failed"))
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.resolve_slack_user", return_value={"name": "Alice", "email": "a@x.com", "avatar": None})
+    @patch(f"{MODULE}.extract_slack_files", return_value=[])
+    def test_comment_failure_rolls_back_new_ticket(
+        self,
+        _files: MagicMock,
+        _user: MagicMock,
+        mock_client: MagicMock,
+        _comment_create: MagicMock,
+    ) -> None:
+        mock_client.return_value = MagicMock()
+
+        with self.assertRaisesRegex(RuntimeError, "comment insert failed"):
+            create_or_update_slack_ticket(
+                team=self.team,
+                slack_channel_id=CHANNEL,
+                thread_ts=PARENT_TS,
+                slack_user_id="U_SOMEONE",
+                text="Help me please",
+                is_thread_reply=False,
+                slack_team_id=SLACK_TEAM,
+                channel_detail=ChannelDetail.SLACK_EMOJI_REACTION,
+            )
+
+        assert not Ticket.objects.filter(
+            team=self.team,
+            slack_channel_id=CHANNEL,
+            slack_thread_ts=PARENT_TS,
+        ).exists()
+
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.resolve_slack_user", return_value={"name": "Alice", "email": "a@x.com", "avatar": None})
+    @patch(f"{MODULE}.extract_slack_files", return_value=[])
+    def test_replayed_thread_message_does_not_duplicate_comment(
+        self,
+        _files: MagicMock,
+        _user: MagicMock,
+        mock_client: MagicMock,
+    ) -> None:
+        mock_client.return_value = MagicMock()
+        ticket = Ticket.objects.create_with_number(
+            team=self.team,
+            channel_source=Channel.SLACK,
+            widget_session_id="",
+            distinct_id="",
+            slack_channel_id=CHANNEL,
+            slack_thread_ts=PARENT_TS,
+        )
+        kwargs: dict[str, Any] = {
+            "team": self.team,
+            "slack_channel_id": CHANNEL,
+            "thread_ts": PARENT_TS,
+            "slack_user_id": "U_SOMEONE",
+            "text": "More context",
+            "is_thread_reply": True,
+            "slack_team_id": SLACK_TEAM,
+            "slack_message_ts": "1700000000.000200",
+        }
+
+        create_or_update_slack_ticket(**kwargs)
+        create_or_update_slack_ticket(**kwargs)
+
+        comments = Comment.objects.filter(scope="conversations_ticket", item_id=str(ticket.id))
+        assert comments.count() == 1
+        assert comments.get().item_context["slack_message_ts"] == "1700000000.000200"
 
     @patch(f"{MODULE}.get_slack_client")
     @patch(f"{MODULE}.resolve_slack_user", return_value={"name": "Bob", "email": "b@x.com", "avatar": None})

--- a/products/conversations/backend/api/tests/test_reaction_backfill.py
+++ b/products/conversations/backend/api/tests/test_reaction_backfill.py
@@ -695,6 +695,48 @@ class TestSlackTicketCreateLockDedup(BaseTest):
         assert comments.count() == 1
         assert comments.get().item_context["slack_message_ts"] == "1700000000.000200"
 
+    @patch(f"{MODULE}._slack_comment_exists", side_effect=[False, True])
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.resolve_slack_user", return_value={"name": "Dana", "email": "d@x.com", "avatar": None})
+    @patch(f"{MODULE}.extract_slack_files", return_value=[])
+    def test_thread_reply_comment_a_racing_callback_committed_is_not_duplicated(
+        self,
+        _files: MagicMock,
+        _user: MagicMock,
+        mock_client: MagicMock,
+        _exists: MagicMock,
+    ) -> None:
+        # A mention posted as a thread reply arrives as both a `message` and an
+        # `app_mention` callback, so two workers reach this insert with one message ts.
+        # The loser's fast-path check misses, and its re-check under the lock has to see
+        # the winner's committed comment.
+        mock_client.return_value = MagicMock()
+        ticket = Ticket.objects.create_with_number(
+            team=self.team,
+            channel_source=Channel.SLACK,
+            widget_session_id="",
+            distinct_id="",
+            slack_channel_id=CHANNEL,
+            slack_thread_ts=PARENT_TS,
+            unread_team_count=0,
+        )
+
+        result = create_or_update_slack_ticket(
+            team=self.team,
+            slack_channel_id=CHANNEL,
+            thread_ts=PARENT_TS,
+            slack_user_id="U_SOMEONE",
+            text="More context",
+            is_thread_reply=True,
+            slack_team_id=SLACK_TEAM,
+            slack_message_ts="1700000000.000200",
+        )
+
+        assert result is not None
+        assert not Comment.objects.filter(scope="conversations_ticket", item_id=str(ticket.id)).exists()
+        ticket.refresh_from_db()
+        assert ticket.unread_team_count == 0
+
     @patch(f"{MODULE}.get_slack_client")
     @patch(f"{MODULE}.resolve_slack_user", return_value={"name": "Bob", "email": "b@x.com", "avatar": None})
     @patch(f"{MODULE}.extract_slack_files", return_value=[])

--- a/products/conversations/backend/api/tests/test_reaction_backfill.py
+++ b/products/conversations/backend/api/tests/test_reaction_backfill.py
@@ -4,12 +4,14 @@ from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, call, patch
 
 from parameterized import parameterized
+from slack_sdk.errors import SlackApiError
 
 from posthog.models.comment import Comment
 
 from products.conversations.backend.cache import slack_ticket_create_lock
 from products.conversations.backend.models import Ticket
 from products.conversations.backend.models.constants import Channel, ChannelDetail
+from products.conversations.backend.services.inbound_events import TransientInboundError
 from products.conversations.backend.slack import (
     _backfill_thread_replies,
     create_or_update_slack_ticket,
@@ -536,6 +538,25 @@ class TestHandleSupportReactionBackfill(BaseTest):
         mock_client.assert_not_called()
         mock_create.assert_not_called()
         mock_backfill.assert_not_called()
+
+    @parameterized.expand([("thread_fetch",), ("history_fallback",)])
+    @patch(f"{MODULE}.create_or_update_slack_ticket")
+    @patch(f"{MODULE}.get_slack_client")
+    def test_seed_fetch_failure_asks_for_another_attempt(self, failing_call, mock_client, mock_create):
+        rate_limited = SlackApiError(message="ratelimited", response={"error": "ratelimited"})
+        client = MagicMock()
+        if failing_call == "thread_fetch":
+            client.conversations_replies.side_effect = rate_limited
+        else:
+            # An empty thread falls back to conversations.history for the reacted message.
+            client.conversations_replies.return_value = {"messages": []}
+            client.conversations_history.side_effect = rate_limited
+        mock_client.return_value = client
+
+        with self.assertRaises(TransientInboundError):
+            handle_support_reaction(self._reaction_event(), self.team, SLACK_TEAM)
+
+        mock_create.assert_not_called()
 
 
 class TestSlackTicketCreateLockDedup(BaseTest):

--- a/products/conversations/backend/api/tests/test_slack_endpoints.py
+++ b/products/conversations/backend/api/tests/test_slack_endpoints.py
@@ -64,8 +64,6 @@ class TestSupportSlackEventsAPI(BaseTest):
     @patch("products.conversations.backend.api.slack_events.process_supporthog_event_receipt")
     @patch("products.conversations.backend.api.slack_events.validate_support_request")
     def test_slack_retry_is_recorded_and_processed(self, mock_validate: MagicMock, mock_process: MagicMock):
-        # Slack retries used to be discarded, so a timeout after Postgres accepted the
-        # callback permanently dropped the message. The retry header is metadata only.
         mock_validate.return_value = None
         payload = {
             "type": "event_callback",

--- a/products/conversations/backend/api/tests/test_slack_endpoints.py
+++ b/products/conversations/backend/api/tests/test_slack_endpoints.py
@@ -14,7 +14,12 @@ from slack_sdk.errors import SlackApiError
 from posthog.models.integration import SlackIntegrationError
 from posthog.models.organization import OrganizationMembership
 
-from products.conversations.backend.models import TeamConversationsSlackConfig
+from products.conversations.backend.models import (
+    ConversationInboundEvent,
+    ConversationInboundEventSource,
+    TeamConversationsSlackConfig,
+)
+from products.conversations.backend.models.inbound_event import INBOUND_PAYLOAD_MAX_BYTES
 
 
 class TestSupportSlackEventsAPI(BaseTest):
@@ -40,6 +45,13 @@ class TestSupportSlackEventsAPI(BaseTest):
             **kwargs,
         )
 
+    def _post_committed(self, payload: dict[str, Any], **kwargs):
+        with self.captureOnCommitCallbacks(execute=True):
+            return self._post(payload, **kwargs)
+
+    def _event_row(self) -> ConversationInboundEvent:
+        return ConversationInboundEvent.objects.for_team(self.team.id).get()
+
     @patch("products.conversations.backend.api.slack_events.validate_support_request")
     def test_invalid_signature_returns_403(self, mock_validate: MagicMock):
         mock_validate.side_effect = SlackIntegrationError("Invalid")
@@ -50,18 +62,28 @@ class TestSupportSlackEventsAPI(BaseTest):
 
     @patch("products.conversations.backend.api.slack_events.process_supporthog_event")
     @patch("products.conversations.backend.api.slack_events.validate_support_request")
-    def test_slack_retry_returns_200_without_processing(self, mock_validate: MagicMock, mock_process: MagicMock):
+    def test_slack_retry_is_recorded_and_processed(self, mock_validate: MagicMock, mock_process: MagicMock):
+        # Slack retries used to be discarded, so a timeout after Postgres accepted the
+        # callback permanently dropped the message. The retry header is metadata only.
         mock_validate.return_value = None
+        payload = {
+            "type": "event_callback",
+            "event_id": "Ev_retry",
+            "team_id": "T123",
+            "event": {"type": "message", "channel": "C1"},
+        }
 
-        response = self.client.post(
-            "/api/conversations/v1/slack/events",
-            data=json.dumps({"type": "event_callback", "team_id": "T123", "event": {"type": "message"}}),
-            content_type="application/json",
-            headers={"x-slack-retry-num": "1"},
+        response = self._post_committed(
+            payload,
+            headers={"x-slack-retry-num": "2", "x-slack-retry-reason": "http_timeout"},
         )
 
-        assert response.status_code == 200
-        mock_process.delay.assert_not_called()
+        assert response.status_code == 202
+        mock_process.delay.assert_called_once_with(inbound_event_id=str(self._event_row().id))
+        row = self._event_row()
+        assert row.provider_retry_num == 2
+        assert row.provider_retry_reason == "http_timeout"
+        assert row.status == ConversationInboundEvent.Status.PENDING
 
     @patch("products.conversations.backend.api.slack_events.validate_support_request")
     def test_invalid_json_returns_400(self, mock_validate: MagicMock):
@@ -95,19 +117,22 @@ class TestSupportSlackEventsAPI(BaseTest):
             "event": {"type": "message", "channel": "C1"},
         }
 
-        first = self._post(payload)
-        second = self._post(payload)
+        first = self._post_committed(payload)
+        second = self._post_committed(payload)
 
         assert first.status_code == 202
         assert second.status_code == 202
+        assert ConversationInboundEvent.objects.for_team(self.team.id).count() == 1
         assert mock_process.delay.call_count == 2
+        inbound_event_id = str(self._event_row().id)
+        mock_process.delay.assert_called_with(inbound_event_id=inbound_event_id)
 
     @patch("products.conversations.backend.api.slack_events.process_supporthog_event")
     @patch("products.conversations.backend.api.slack_events.validate_support_request")
     def test_event_callback_routes_to_handler(self, mock_validate: MagicMock, mock_process: MagicMock):
         mock_validate.return_value = None
 
-        response = self._post(
+        response = self._post_committed(
             {
                 "type": "event_callback",
                 "event_id": "Ev_456",
@@ -119,6 +144,47 @@ class TestSupportSlackEventsAPI(BaseTest):
         assert response.status_code == 202
         mock_process.delay.assert_called_once()
 
+    @patch("products.conversations.backend.api.slack_events.process_supporthog_event")
+    @patch("products.conversations.backend.api.slack_events.validate_support_request")
+    def test_broker_failure_after_commit_still_acknowledges(self, mock_validate: MagicMock, mock_process: MagicMock):
+        # Celery is a hint. A broker outage after the receipt commits must still 2xx so
+        # Slack does not need the row to be inserted again; the sweeper re-drives it.
+        mock_validate.return_value = None
+        mock_process.delay.side_effect = ConnectionError("broker down")
+        payload = {
+            "type": "event_callback",
+            "event_id": "Ev_broker",
+            "team_id": "T123",
+            "event": {"type": "message", "channel": "C1"},
+        }
+
+        response = self._post_committed(payload)
+
+        assert response.status_code == 202
+        row = self._event_row()
+        assert row.status == ConversationInboundEvent.Status.PENDING
+        assert row.source_id == "Ev_broker"
+
+    @patch("products.conversations.backend.api.slack_events.process_supporthog_event")
+    @patch("products.conversations.backend.api.slack_events.validate_support_request")
+    def test_oversized_payload_is_tombstoned_and_acknowledged(self, mock_validate: MagicMock, mock_process: MagicMock):
+        mock_validate.return_value = None
+        payload = {
+            "type": "event_callback",
+            "event_id": "Ev_poison",
+            "team_id": "T123",
+            "event": {"type": "message", "text": "x" * (INBOUND_PAYLOAD_MAX_BYTES + 1)},
+        }
+
+        response = self._post_committed(payload)
+
+        assert response.status_code == 202
+        mock_process.delay.assert_not_called()
+        row = self._event_row()
+        assert row.payload is None
+        assert row.status == ConversationInboundEvent.Status.FAILED
+        assert row.last_error_code == "payload_too_large"
+
     @patch("products.conversations.backend.api.slack_events.proxy_to_secondary_region")
     @patch("products.conversations.backend.api.slack_events.process_supporthog_event")
     @patch("products.conversations.backend.api.slack_events.validate_support_request")
@@ -126,6 +192,7 @@ class TestSupportSlackEventsAPI(BaseTest):
         self, mock_validate: MagicMock, mock_process: MagicMock, mock_proxy: MagicMock
     ):
         mock_validate.return_value = None
+        mock_proxy.return_value = True
 
         with patch("products.conversations.backend.api.slack_events.is_primary_region", return_value=True):
             response = self._post(
@@ -140,6 +207,29 @@ class TestSupportSlackEventsAPI(BaseTest):
         assert response.status_code == 202
         mock_process.delay.assert_not_called()
         mock_proxy.assert_called_once()
+        assert not ConversationInboundEvent.objects.unscoped().filter(source_id="Ev_proxy").exists()
+
+    @patch("products.conversations.backend.api.slack_events.proxy_to_secondary_region")
+    @patch("products.conversations.backend.api.slack_events.process_supporthog_event")
+    @patch("products.conversations.backend.api.slack_events.validate_support_request")
+    def test_returns_502_when_event_proxy_to_secondary_fails(
+        self, mock_validate: MagicMock, mock_process: MagicMock, mock_proxy: MagicMock
+    ):
+        mock_validate.return_value = None
+        mock_proxy.return_value = False
+
+        with patch("products.conversations.backend.api.slack_events.is_primary_region", return_value=True):
+            response = self._post(
+                {
+                    "type": "event_callback",
+                    "event_id": "Ev_proxy_fail",
+                    "team_id": "T_UNKNOWN",
+                    "event": {"type": "message", "channel": "C1"},
+                },
+            )
+
+        assert response.status_code == 502
+        mock_process.delay.assert_not_called()
 
     @patch("products.conversations.backend.api.slack_events.proxy_to_secondary_region")
     @patch("products.conversations.backend.api.slack_events.process_supporthog_event")
@@ -191,6 +281,10 @@ class TestSupportSlackInteractivityAPI(BaseTest):
     def _post(self, payload: Any, **kwargs):
         return self._post_raw(json.dumps(payload), **kwargs)
 
+    def _post_committed(self, payload: Any, **kwargs):
+        with self.captureOnCommitCallbacks(execute=True):
+            return self._post(payload, **kwargs)
+
     @patch("products.conversations.backend.api.slack_interactivity.validate_support_request")
     def test_invalid_signature_returns_403(self, mock_validate: MagicMock):
         mock_validate.side_effect = SlackIntegrationError("Invalid")
@@ -229,12 +323,25 @@ class TestSupportSlackInteractivityAPI(BaseTest):
     @patch("products.conversations.backend.api.slack_interactivity.validate_support_request")
     def test_block_actions_enqueues_processing(self, mock_validate: MagicMock, mock_process: MagicMock):
         mock_validate.return_value = None
-        payload = {"type": "block_actions", "team": {"id": "T123"}, "actions": []}
+        payload = {
+            "type": "block_actions",
+            "team": {"id": "T123"},
+            "trigger_id": "trig.1",
+            "actions": [{"action_id": "open"}],
+            "container": {"type": "message", "message_ts": "1.0", "channel_id": "C1"},
+        }
 
-        response = self._post(payload)
+        first = self._post_committed(payload)
+        second = self._post_committed(payload)
 
-        assert response.status_code == 200
-        mock_process.delay.assert_called_once_with(payload=payload, slack_team_id="T123")
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert ConversationInboundEvent.objects.for_team(self.team.id).count() == 1
+        row = ConversationInboundEvent.objects.for_team(self.team.id).get()
+        assert row.source == ConversationInboundEventSource.SLACK_INTERACTIVITY
+        assert row.source_id.startswith("trig.1:")
+        mock_process.delay.assert_called_with(inbound_event_id=str(row.id))
+        assert mock_process.delay.call_count == 2
 
     @patch("products.conversations.backend.api.slack_interactivity.proxy_to_secondary_region")
     @patch("products.conversations.backend.api.slack_interactivity.process_supporthog_interactivity")

--- a/products/conversations/backend/api/tests/test_slack_endpoints.py
+++ b/products/conversations/backend/api/tests/test_slack_endpoints.py
@@ -1,4 +1,5 @@
 import json
+import hashlib
 from typing import Any
 from urllib.parse import parse_qs, urlencode, urlparse
 
@@ -60,7 +61,7 @@ class TestSupportSlackEventsAPI(BaseTest):
 
         assert response.status_code == 403
 
-    @patch("products.conversations.backend.api.slack_events.process_supporthog_event")
+    @patch("products.conversations.backend.api.slack_events.process_supporthog_event_receipt")
     @patch("products.conversations.backend.api.slack_events.validate_support_request")
     def test_slack_retry_is_recorded_and_processed(self, mock_validate: MagicMock, mock_process: MagicMock):
         # Slack retries used to be discarded, so a timeout after Postgres accepted the
@@ -106,7 +107,7 @@ class TestSupportSlackEventsAPI(BaseTest):
         assert response.status_code == 200
         assert response.json() == {"challenge": "challenge123"}
 
-    @patch("products.conversations.backend.api.slack_events.process_supporthog_event")
+    @patch("products.conversations.backend.api.slack_events.process_supporthog_event_receipt")
     @patch("products.conversations.backend.api.slack_events.validate_support_request")
     def test_event_callback_enqueues_processing(self, mock_validate: MagicMock, mock_process: MagicMock):
         mock_validate.return_value = None
@@ -127,7 +128,7 @@ class TestSupportSlackEventsAPI(BaseTest):
         inbound_event_id = str(self._event_row().id)
         mock_process.delay.assert_called_with(inbound_event_id=inbound_event_id)
 
-    @patch("products.conversations.backend.api.slack_events.process_supporthog_event")
+    @patch("products.conversations.backend.api.slack_events.process_supporthog_event_receipt")
     @patch("products.conversations.backend.api.slack_events.validate_support_request")
     def test_event_callback_routes_to_handler(self, mock_validate: MagicMock, mock_process: MagicMock):
         mock_validate.return_value = None
@@ -144,7 +145,7 @@ class TestSupportSlackEventsAPI(BaseTest):
         assert response.status_code == 202
         mock_process.delay.assert_called_once()
 
-    @patch("products.conversations.backend.api.slack_events.process_supporthog_event")
+    @patch("products.conversations.backend.api.slack_events.process_supporthog_event_receipt")
     @patch("products.conversations.backend.api.slack_events.validate_support_request")
     def test_broker_failure_after_commit_still_acknowledges(self, mock_validate: MagicMock, mock_process: MagicMock):
         # Celery is a hint. A broker outage after the receipt commits must still 2xx so
@@ -165,7 +166,7 @@ class TestSupportSlackEventsAPI(BaseTest):
         assert row.status == ConversationInboundEvent.Status.PENDING
         assert row.source_id == "Ev_broker"
 
-    @patch("products.conversations.backend.api.slack_events.process_supporthog_event")
+    @patch("products.conversations.backend.api.slack_events.process_supporthog_event_receipt")
     @patch("products.conversations.backend.api.slack_events.validate_support_request")
     def test_oversized_payload_is_tombstoned_and_acknowledged(self, mock_validate: MagicMock, mock_process: MagicMock):
         mock_validate.return_value = None
@@ -186,7 +187,7 @@ class TestSupportSlackEventsAPI(BaseTest):
         assert row.last_error_code == "payload_too_large"
 
     @patch("products.conversations.backend.api.slack_events.proxy_to_secondary_region")
-    @patch("products.conversations.backend.api.slack_events.process_supporthog_event")
+    @patch("products.conversations.backend.api.slack_events.process_supporthog_event_receipt")
     @patch("products.conversations.backend.api.slack_events.validate_support_request")
     def test_proxies_to_secondary_when_team_not_found_on_primary(
         self, mock_validate: MagicMock, mock_process: MagicMock, mock_proxy: MagicMock
@@ -210,7 +211,7 @@ class TestSupportSlackEventsAPI(BaseTest):
         assert not ConversationInboundEvent.objects.unscoped().filter(source_id="Ev_proxy").exists()
 
     @patch("products.conversations.backend.api.slack_events.proxy_to_secondary_region")
-    @patch("products.conversations.backend.api.slack_events.process_supporthog_event")
+    @patch("products.conversations.backend.api.slack_events.process_supporthog_event_receipt")
     @patch("products.conversations.backend.api.slack_events.validate_support_request")
     def test_returns_502_when_event_proxy_to_secondary_fails(
         self, mock_validate: MagicMock, mock_process: MagicMock, mock_proxy: MagicMock
@@ -232,7 +233,7 @@ class TestSupportSlackEventsAPI(BaseTest):
         mock_process.delay.assert_not_called()
 
     @patch("products.conversations.backend.api.slack_events.proxy_to_secondary_region")
-    @patch("products.conversations.backend.api.slack_events.process_supporthog_event")
+    @patch("products.conversations.backend.api.slack_events.process_supporthog_event_receipt")
     @patch("products.conversations.backend.api.slack_events.validate_support_request")
     def test_drops_event_when_team_not_found_on_secondary(
         self, mock_validate: MagicMock, mock_process: MagicMock, mock_proxy: MagicMock
@@ -309,7 +310,7 @@ class TestSupportSlackInteractivityAPI(BaseTest):
 
         assert response.status_code == 400
 
-    @patch("products.conversations.backend.api.slack_interactivity.process_supporthog_interactivity")
+    @patch("products.conversations.backend.api.slack_interactivity.process_supporthog_interactivity_receipt")
     @patch("products.conversations.backend.api.slack_interactivity.validate_support_request")
     def test_missing_team_id_returns_200_without_processing(self, mock_validate: MagicMock, mock_process: MagicMock):
         mock_validate.return_value = None
@@ -319,7 +320,7 @@ class TestSupportSlackInteractivityAPI(BaseTest):
         assert response.status_code == 200
         mock_process.delay.assert_not_called()
 
-    @patch("products.conversations.backend.api.slack_interactivity.process_supporthog_interactivity")
+    @patch("products.conversations.backend.api.slack_interactivity.process_supporthog_interactivity_receipt")
     @patch("products.conversations.backend.api.slack_interactivity.validate_support_request")
     def test_block_actions_enqueues_processing(self, mock_validate: MagicMock, mock_process: MagicMock):
         mock_validate.return_value = None
@@ -343,8 +344,26 @@ class TestSupportSlackInteractivityAPI(BaseTest):
         mock_process.delay.assert_called_with(inbound_event_id=str(row.id))
         assert mock_process.delay.call_count == 2
 
+    @patch("products.conversations.backend.api.slack_interactivity.process_supporthog_interactivity_receipt")
+    @patch("products.conversations.backend.api.slack_interactivity.validate_support_request")
+    def test_block_actions_without_trigger_id_still_persists(self, mock_validate: MagicMock, mock_process: MagicMock):
+        mock_validate.return_value = None
+        payload = {
+            "type": "block_actions",
+            "team": {"id": "T123"},
+            "actions": [{"action_id": "open"}],
+        }
+
+        response = self._post_committed(payload)
+
+        assert response.status_code == 200
+        row = ConversationInboundEvent.objects.for_team(self.team.id).get()
+        signed_body = urlencode({"payload": json.dumps(payload)}).encode()
+        assert row.source_id == hashlib.sha256(signed_body).hexdigest()
+        mock_process.delay.assert_called_once_with(inbound_event_id=str(row.id))
+
     @patch("products.conversations.backend.api.slack_interactivity.proxy_to_secondary_region")
-    @patch("products.conversations.backend.api.slack_interactivity.process_supporthog_interactivity")
+    @patch("products.conversations.backend.api.slack_interactivity.process_supporthog_interactivity_receipt")
     @patch("products.conversations.backend.api.slack_interactivity.validate_support_request")
     def test_proxies_to_secondary_when_team_not_found_on_primary(
         self, mock_validate: MagicMock, mock_process: MagicMock, mock_proxy: MagicMock
@@ -360,7 +379,7 @@ class TestSupportSlackInteractivityAPI(BaseTest):
         mock_proxy.assert_called_once()
 
     @patch("products.conversations.backend.api.slack_interactivity.proxy_to_secondary_region")
-    @patch("products.conversations.backend.api.slack_interactivity.process_supporthog_interactivity")
+    @patch("products.conversations.backend.api.slack_interactivity.process_supporthog_interactivity_receipt")
     @patch("products.conversations.backend.api.slack_interactivity.validate_support_request")
     def test_returns_502_when_proxy_to_secondary_fails(
         self, mock_validate: MagicMock, mock_process: MagicMock, mock_proxy: MagicMock
@@ -377,7 +396,7 @@ class TestSupportSlackInteractivityAPI(BaseTest):
         mock_process.delay.assert_not_called()
 
     @patch("products.conversations.backend.api.slack_interactivity.proxy_to_secondary_region")
-    @patch("products.conversations.backend.api.slack_interactivity.process_supporthog_interactivity")
+    @patch("products.conversations.backend.api.slack_interactivity.process_supporthog_interactivity_receipt")
     @patch("products.conversations.backend.api.slack_interactivity.validate_support_request")
     def test_drops_click_when_team_not_found_on_secondary(
         self, mock_validate: MagicMock, mock_process: MagicMock, mock_proxy: MagicMock

--- a/products/conversations/backend/cache.py
+++ b/products/conversations/backend/cache.py
@@ -12,6 +12,7 @@ from collections.abc import Generator
 from contextlib import contextmanager
 
 from django.core.cache import cache
+from django.db import connection
 
 import structlog
 
@@ -305,29 +306,50 @@ RESOLVED_GROUPS_CACHE_TTL = 12 * 60 * 60  # 12 hours
 RESOLVED_GROUPS_NEGATIVE_CACHE_TTL = 60 * 60  # 1 hour
 
 
-# Slack Ticket Creation Lock
-# Serializes concurrent ticket creation for the same Slack thread so two reaction_added
-# events from different users can't both pass the existence checks and create duplicate
-# tickets. cache.add is atomic (Redis SETNX): only one worker acquires. Short TTL is a
-# safety net so a crashed worker can't wedge a thread permanently.
+# Slack ticket creation lock
+# PostgreSQL provides correctness when Redis is unavailable. The Redis lock keeps
+# workers from the previous deployment coordinated with workers that use PostgreSQL.
 
 SLACK_TICKET_CREATE_LOCK_TTL = 30  # seconds
 
 
 @contextmanager
 def slack_ticket_create_lock(team_id: int, channel: str, thread_ts: str) -> Generator[bool]:
-    """Atomic Redis lock to serialize ticket creation for a Slack thread.
+    """Serialize ticket creation for a Slack thread.
 
     Yields True if the lock was acquired, False if another worker holds it.
     Releases the lock on exit when acquired.
     """
     key = _make_cache_key("slack_ticket_create_lock", str(team_id), channel, thread_ts)
-    acquired = cache.add(key, True, timeout=SLACK_TICKET_CREATE_LOCK_TTL)
+    redis_acquired = False
+    redis_available = True
     try:
-        yield acquired
+        redis_acquired = cache.add(key, True, timeout=SLACK_TICKET_CREATE_LOCK_TTL)
+    except Exception:
+        redis_available = False
+        logger.warning("slack_ticket_create_redis_lock_error", key=key)
+
+    if redis_available and not redis_acquired:
+        yield False
+        return
+
+    lock_id = int.from_bytes(hashlib.sha256(key.encode()).digest()[:8], byteorder="big", signed=True)
+    postgres_acquired = False
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT pg_try_advisory_lock(%s)", [lock_id])
+            result = cursor.fetchone()
+            postgres_acquired = bool(result and result[0])
+        yield postgres_acquired
     finally:
-        if acquired:
-            cache.delete(key)
+        if postgres_acquired:
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT pg_advisory_unlock(%s)", [lock_id])
+        if redis_acquired:
+            try:
+                cache.delete(key)
+            except Exception:
+                logger.warning("slack_ticket_create_redis_unlock_error", key=key)
 
 
 def _resolved_groups_cache_key(team_id: int, distinct_ids: list[str]) -> str:

--- a/products/conversations/backend/cache.py
+++ b/products/conversations/backend/cache.py
@@ -355,6 +355,37 @@ def slack_ticket_create_lock(team_id: int, channel: str, thread_ts: str) -> Gene
                 logger.warning("slack_ticket_create_redis_unlock_error", key=key)
 
 
+# Slack thread-reply comment lock
+# One Slack message can reach the reply path twice: a mention posted as a thread reply
+# arrives as both a `message` and an `app_mention` callback, each with its own event id,
+# so each gets its own receipt and its own worker.
+
+
+@contextmanager
+def slack_comment_create_lock(team_id: int, ticket_id: str, slack_message_ts: str | None) -> Generator[None]:
+    """Serialize the dedupe check and the insert for one Slack message on one ticket.
+
+    The caller must run its existence check and its writes inside the yielded block —
+    they share the transaction opened here. The advisory lock is transaction scoped, so
+    it holds for exactly as long as those writes, and it survives PgBouncer transaction
+    pooling, where a session-scoped lock and the later insert can land on different
+    backend sessions.
+
+    The wait is blocking, not a try: the loser has to re-read after the winner commits.
+    Skipping on a held lock would drop the comment when the winner rolls back.
+
+    Without a ``slack_message_ts`` there is no dedupe key to serialize on, so the writes
+    only get their transaction.
+    """
+    with transaction.atomic():
+        if slack_message_ts:
+            key = _make_cache_key("slack_comment_create_lock", str(team_id), ticket_id, slack_message_ts)
+            lock_id = int.from_bytes(hashlib.sha256(key.encode()).digest()[:8], byteorder="big", signed=True)
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT pg_advisory_xact_lock(%s)", [lock_id])
+        yield
+
+
 def _resolved_groups_cache_key(team_id: int, distinct_ids: list[str]) -> str:
     # JSON-encode for an unambiguous preimage: joining with a separator collides
     # when distinct_ids themselves contain it (["a|b", "c"] vs ["a", "b|c"]).

--- a/products/conversations/backend/cache.py
+++ b/products/conversations/backend/cache.py
@@ -12,7 +12,7 @@ from collections.abc import Generator
 from contextlib import contextmanager
 
 from django.core.cache import cache
-from django.db import connection
+from django.db import connection, transaction
 
 import structlog
 
@@ -318,7 +318,12 @@ def slack_ticket_create_lock(team_id: int, channel: str, thread_ts: str) -> Gene
     """Serialize ticket creation for a Slack thread.
 
     Yields True if the lock was acquired, False if another worker holds it.
-    Releases the lock on exit when acquired.
+
+    The Postgres guard is a transaction-scoped advisory lock, so the caller must
+    run its existence check and insert inside the yielded block — they share the
+    transaction opened here. A session-scoped lock would not serialize under
+    PgBouncer transaction pooling: the lock statement and the later insert can
+    land on different backend sessions, so two workers could both pass.
     """
     key = _make_cache_key("slack_ticket_create_lock", str(team_id), channel, thread_ts)
     redis_acquired = False
@@ -334,17 +339,15 @@ def slack_ticket_create_lock(team_id: int, channel: str, thread_ts: str) -> Gene
         return
 
     lock_id = int.from_bytes(hashlib.sha256(key.encode()).digest()[:8], byteorder="big", signed=True)
-    postgres_acquired = False
     try:
-        with connection.cursor() as cursor:
-            cursor.execute("SELECT pg_try_advisory_lock(%s)", [lock_id])
-            result = cursor.fetchone()
-            postgres_acquired = bool(result and result[0])
-        yield postgres_acquired
-    finally:
-        if postgres_acquired:
+        # The xact lock releases automatically when this transaction commits or
+        # rolls back, so it holds for exactly as long as the caller's writes.
+        with transaction.atomic():
             with connection.cursor() as cursor:
-                cursor.execute("SELECT pg_advisory_unlock(%s)", [lock_id])
+                cursor.execute("SELECT pg_try_advisory_xact_lock(%s)", [lock_id])
+                result = cursor.fetchone()
+            yield bool(result and result[0])
+    finally:
         if redis_acquired:
             try:
                 cache.delete(key)

--- a/products/conversations/backend/metrics.py
+++ b/products/conversations/backend/metrics.py
@@ -1,4 +1,4 @@
-from prometheus_client import Counter, Histogram
+from prometheus_client import Counter, Gauge, Histogram
 
 # Cutover observability for #82564: the CDP worker's ticket actions move from
 # secret_api_token on the external route to scoped JWTs on the internal route.
@@ -14,4 +14,24 @@ TICKET_SEARCH_DURATION_SECONDS = Histogram(
     "End-to-end duration of support ticket list requests that include a search term",
     labelnames=["search_path"],  # ticket_number | text
     buckets=(0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, float("inf")),
+)
+
+INBOUND_BACKLOG = Gauge(
+    "posthog_conversations_inbound_backlog",
+    "Non-terminal inbound callback receipts by status and source",
+    labelnames=["status", "source"],
+)
+INBOUND_OLDEST_READY_AGE_SECONDS = Gauge(
+    "posthog_conversations_inbound_oldest_ready_age_seconds",
+    "Age in seconds of the oldest due or expired-lease inbound receipt",
+)
+INBOUND_ATTEMPTS_TOTAL = Counter(
+    "posthog_conversations_inbound_attempts_total",
+    "Inbound receipt processing attempts by source and result",
+    labelnames=["source", "result"],  # processed | retry | failed | claimed
+)
+INBOUND_LEASES_TOTAL = Counter(
+    "posthog_conversations_inbound_leases_total",
+    "Inbound receipt lease outcomes",
+    labelnames=["result"],  # claimed | expired_reclaim | busy
 )

--- a/products/conversations/backend/metrics.py
+++ b/products/conversations/backend/metrics.py
@@ -1,4 +1,4 @@
-from prometheus_client import Counter, Gauge, Histogram
+from prometheus_client import Counter, Histogram
 
 # Cutover observability for #82564: the CDP worker's ticket actions move from
 # secret_api_token on the external route to scoped JWTs on the internal route.
@@ -16,17 +16,6 @@ TICKET_SEARCH_DURATION_SECONDS = Histogram(
     buckets=(0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, float("inf")),
 )
 
-INBOUND_BACKLOG = Gauge(
-    "posthog_conversations_inbound_backlog",
-    "Non-terminal inbound callback receipts by status and source",
-    labelnames=["status", "source"],
-    multiprocess_mode="mostrecent",
-)
-INBOUND_OLDEST_READY_AGE_SECONDS = Gauge(
-    "posthog_conversations_inbound_oldest_ready_age_seconds",
-    "Age in seconds of the oldest due or expired-lease inbound receipt",
-    multiprocess_mode="mostrecent",
-)
 INBOUND_ATTEMPTS_TOTAL = Counter(
     "posthog_conversations_inbound_attempts_total",
     "Inbound receipt processing attempts by source and result",

--- a/products/conversations/backend/metrics.py
+++ b/products/conversations/backend/metrics.py
@@ -20,10 +20,12 @@ INBOUND_BACKLOG = Gauge(
     "posthog_conversations_inbound_backlog",
     "Non-terminal inbound callback receipts by status and source",
     labelnames=["status", "source"],
+    multiprocess_mode="mostrecent",
 )
 INBOUND_OLDEST_READY_AGE_SECONDS = Gauge(
     "posthog_conversations_inbound_oldest_ready_age_seconds",
     "Age in seconds of the oldest due or expired-lease inbound receipt",
+    multiprocess_mode="mostrecent",
 )
 INBOUND_ATTEMPTS_TOTAL = Counter(
     "posthog_conversations_inbound_attempts_total",

--- a/products/conversations/backend/services/inbound_events.py
+++ b/products/conversations/backend/services/inbound_events.py
@@ -210,6 +210,7 @@ def claim_inbound_event(inbound_event_id: str) -> InboundClaim | None:
     lease_until = now + timedelta(seconds=INBOUND_LEASE_SECONDS)
     with transaction.atomic():
         row = (
+            # nosemgrep: idor-lookup-without-team (cross-team worker; ID comes from the committed receipt dispatch)
             ConversationInboundEvent.objects.unscoped()
             .select_for_update(skip_locked=True)
             .filter(id=inbound_event_id)
@@ -349,6 +350,7 @@ def cleanup_inbound_payloads(now: datetime, *, limit: int = INBOUND_SWEEP_BATCH_
         .order_by("terminal_at")
         .values_list("id", flat=True)[:limit]
     )
+    # nosemgrep: idor-lookup-without-team (IDs come from the cross-team retention query above)
     return ConversationInboundEvent.objects.unscoped().filter(id__in=event_ids).update(payload=None, updated_at=now)
 
 
@@ -363,6 +365,7 @@ def delete_inbound_tombstones(now: datetime, *, limit: int = INBOUND_SWEEP_BATCH
         .order_by("terminal_at")
         .values_list("id", flat=True)[:limit]
     )
+    # nosemgrep: idor-lookup-without-team (IDs come from the cross-team retention query above)
     deleted, _ = ConversationInboundEvent.objects.unscoped().filter(id__in=event_ids).delete()
     return deleted
 

--- a/products/conversations/backend/services/inbound_events.py
+++ b/products/conversations/backend/services/inbound_events.py
@@ -4,7 +4,7 @@ import random
 import hashlib
 from collections.abc import Callable
 from datetime import datetime, timedelta
-from typing import Any
+from typing import Any, cast
 from uuid import UUID
 
 from django.db import IntegrityError, transaction
@@ -87,9 +87,11 @@ def slack_interactivity_source_id(*, payload: dict[str, Any], signed_body: bytes
     if not trigger_id:
         return hashlib.sha256(signed_body).hexdigest()
     actions = payload.get("actions") or []
-    action = actions[0] if actions and isinstance(actions[0], dict) else {}
+    raw_action = actions[0] if actions else None
+    action: dict[str, Any] = raw_action if isinstance(raw_action, dict) else {}
     action_id = str(action.get("action_id") or "")
-    container = payload.get("container") if isinstance(payload.get("container"), dict) else {}
+    raw_container = payload.get("container")
+    container: dict[str, Any] = raw_container if isinstance(raw_container, dict) else {}
     container_key = ":".join(str(container.get(key) or "") for key in ("type", "message_ts", "channel_id", "thread_ts"))
     composed = f"{trigger_id}:{action_id}:{container_key}"
     if len(composed) <= 512:
@@ -334,7 +336,7 @@ def due_inbound_event_ids(*, limit: int, now: datetime) -> list[tuple[UUID, str]
         .order_by("lease_expires_at")
         .values_list("id", "source", "lease_expires_at")[:limit]
     )
-    ready = sorted([*pending, *expired], key=lambda row: row[2])
+    ready = sorted([*pending, *expired], key=lambda row: cast(datetime, row[2]))
     return [(event_id, source) for event_id, source, _ in ready[:limit]]
 
 

--- a/products/conversations/backend/services/inbound_events.py
+++ b/products/conversations/backend/services/inbound_events.py
@@ -8,7 +8,7 @@ from typing import Any
 from uuid import UUID
 
 from django.db import IntegrityError, transaction
-from django.db.models import Case, DateTimeField, F, Q, QuerySet, When
+from django.db.models import Q, QuerySet
 from django.http import HttpRequest
 from django.utils import timezone
 
@@ -53,6 +53,13 @@ class InboundClaim:
     event: ConversationInboundEvent
     allow_retry: bool
     expired_reclaim: bool
+
+
+@frozen
+class InboundQueueMetrics:
+    pending_count: int
+    processing_count: int
+    oldest_ready_age_seconds: float
 
 
 def slack_retry_metadata(request: HttpRequest) -> tuple[int | None, str]:
@@ -215,6 +222,24 @@ def claim_inbound_event(inbound_event_id: str) -> InboundClaim | None:
         if row is None:
             INBOUND_LEASES_TOTAL.labels(result="busy").inc()
             return None
+        if row.attempts >= INBOUND_MAX_ATTEMPTS:
+            row.status = ConversationInboundEvent.Status.FAILED
+            row.terminal_at = now
+            row.lease_expires_at = None
+            row.last_error_code = "max_attempts"
+            row.last_error = f"Exceeded {INBOUND_MAX_ATTEMPTS} processing attempts"
+            row.save(
+                update_fields=[
+                    "status",
+                    "terminal_at",
+                    "lease_expires_at",
+                    "last_error_code",
+                    "last_error",
+                    "updated_at",
+                ]
+            )
+            transaction.on_commit(lambda: INBOUND_ATTEMPTS_TOTAL.labels(source=row.source, result="failed").inc())
+            return None
         expired_reclaim = row.status == ConversationInboundEvent.Status.PROCESSING
         row.status = ConversationInboundEvent.Status.PROCESSING
         row.lease_expires_at = lease_until
@@ -287,67 +312,85 @@ def schedule_inbound_retry(claim: InboundClaim, *, error_code: str, error: str) 
     return delay
 
 
-def _ready_inbound_events(*, now: datetime) -> QuerySet[ConversationInboundEvent]:
-    return (
-        ConversationInboundEvent.objects.unscoped()
-        .filter(
-            Q(status=ConversationInboundEvent.Status.PENDING, due_at__lte=now)
-            | Q(status=ConversationInboundEvent.Status.PROCESSING, lease_expires_at__lte=now)
-        )
-        .annotate(
-            ready_at=Case(
-                When(
-                    status=ConversationInboundEvent.Status.PROCESSING,
-                    then=F("lease_expires_at"),
-                ),
-                default=F("due_at"),
-                output_field=DateTimeField(),
-            )
-        )
+def _pending_inbound_events(*, now: datetime) -> QuerySet[ConversationInboundEvent]:
+    return ConversationInboundEvent.objects.unscoped().filter(
+        status=ConversationInboundEvent.Status.PENDING,
+        due_at__lte=now,
+    )
+
+
+def _expired_inbound_events(*, now: datetime) -> QuerySet[ConversationInboundEvent]:
+    return ConversationInboundEvent.objects.unscoped().filter(
+        status=ConversationInboundEvent.Status.PROCESSING,
+        lease_expires_at__lte=now,
     )
 
 
 def due_inbound_event_ids(*, limit: int, now: datetime) -> list[tuple[UUID, str]]:
-    return list(_ready_inbound_events(now=now).order_by("ready_at").values_list("id", "source")[:limit])
+    pending = list(_pending_inbound_events(now=now).order_by("due_at").values_list("id", "source", "due_at")[:limit])
+    expired = list(
+        _expired_inbound_events(now=now)
+        .order_by("lease_expires_at")
+        .values_list("id", "source", "lease_expires_at")[:limit]
+    )
+    ready = sorted([*pending, *expired], key=lambda row: row[2])
+    return [(event_id, source) for event_id, source, _ in ready[:limit]]
 
 
-def cleanup_inbound_payloads(now: datetime) -> int:
+def cleanup_inbound_payloads(now: datetime, *, limit: int = INBOUND_SWEEP_BATCH_SIZE) -> int:
     cutoff = now - INBOUND_PAYLOAD_TTL
-    return (
+    event_ids = list(
         ConversationInboundEvent.objects.unscoped()
         .filter(
             status__in=ConversationInboundEvent.TERMINAL_STATUSES,
             payload__isnull=False,
             terminal_at__lte=cutoff,
         )
-        .update(payload=None, updated_at=now)
+        .order_by("terminal_at")
+        .values_list("id", flat=True)[:limit]
     )
+    return ConversationInboundEvent.objects.unscoped().filter(id__in=event_ids).update(payload=None, updated_at=now)
 
 
-def delete_inbound_tombstones(now: datetime) -> int:
+def delete_inbound_tombstones(now: datetime, *, limit: int = INBOUND_SWEEP_BATCH_SIZE) -> int:
     cutoff = now - INBOUND_TOMBSTONE_TTL
-    deleted, _ = (
+    event_ids = list(
         ConversationInboundEvent.objects.unscoped()
         .filter(
             status__in=ConversationInboundEvent.TERMINAL_STATUSES,
             terminal_at__lte=cutoff,
         )
-        .delete()
+        .order_by("terminal_at")
+        .values_list("id", flat=True)[:limit]
     )
+    deleted, _ = ConversationInboundEvent.objects.unscoped().filter(id__in=event_ids).delete()
     return deleted
 
 
-def record_inbound_queue_metrics(now: datetime) -> float:
+def record_inbound_queue_metrics(now: datetime) -> InboundQueueMetrics:
     oldest_age = 0.0
+    counts = {
+        ConversationInboundEvent.Status.PENDING: 0,
+        ConversationInboundEvent.Status.PROCESSING: 0,
+    }
     for source in ConversationInboundEventSource.values:
         for status in (ConversationInboundEvent.Status.PENDING, ConversationInboundEvent.Status.PROCESSING):
             count = ConversationInboundEvent.objects.unscoped().filter(source=source, status=status).count()
             INBOUND_BACKLOG.labels(status=status, source=source).set(count)
-    oldest = _ready_inbound_events(now=now).order_by("ready_at").values_list("ready_at", flat=True).first()
+            counts[status] += count
+    oldest_pending = _pending_inbound_events(now=now).order_by("due_at").values_list("due_at", flat=True).first()
+    oldest_expired = (
+        _expired_inbound_events(now=now).order_by("lease_expires_at").values_list("lease_expires_at", flat=True).first()
+    )
+    oldest = min((ready_at for ready_at in (oldest_pending, oldest_expired) if ready_at is not None), default=None)
     if oldest is not None:
         oldest_age = max((now - oldest).total_seconds(), 0.0)
     INBOUND_OLDEST_READY_AGE_SECONDS.set(oldest_age)
-    return oldest_age
+    return InboundQueueMetrics(
+        pending_count=counts[ConversationInboundEvent.Status.PENDING],
+        processing_count=counts[ConversationInboundEvent.Status.PROCESSING],
+        oldest_ready_age_seconds=oldest_age,
+    )
 
 
 def emit_inbound_sweep_event(

--- a/products/conversations/backend/services/inbound_events.py
+++ b/products/conversations/backend/services/inbound_events.py
@@ -8,7 +8,7 @@ from typing import Any
 from uuid import UUID
 
 from django.db import IntegrityError, transaction
-from django.db.models import Q
+from django.db.models import Case, DateTimeField, F, Q, QuerySet, When
 from django.http import HttpRequest
 from django.utils import timezone
 
@@ -40,7 +40,7 @@ INBOUND_MAX_ATTEMPTS = 10
 INBOUND_BACKOFF_BASE_SECONDS = 2
 INBOUND_BACKOFF_MAX_SECONDS = 60
 INBOUND_SWEEP_BATCH_SIZE = 100
-# pinned: analytics event name — renaming breaks historical ClickHouse queries
+# pinned: analytics event name. Renaming breaks historical ClickHouse queries.
 INBOUND_SWEEP_EVENT = "conversations_inbound_sweep"
 
 
@@ -106,7 +106,7 @@ def _safe_wake(wake: Callable[[ConversationInboundEvent], None], row: Conversati
 
 def _should_wake(row: ConversationInboundEvent, *, now: datetime) -> bool:
     if row.status == ConversationInboundEvent.Status.PENDING:
-        return True
+        return row.due_at <= now
     return (
         row.status == ConversationInboundEvent.Status.PROCESSING
         and row.lease_expires_at is not None
@@ -157,8 +157,12 @@ def persist_inbound_event(
                 source_id=source_id,
                 **defaults,
             )
-    except IntegrityError:
-        row = ConversationInboundEvent.objects.for_team(team.id).get(source=source, source_id=source_id)
+    except IntegrityError as exc:
+        try:
+            row = ConversationInboundEvent.objects.for_team(team.id).get(source=source, source_id=source_id)
+        except ConversationInboundEvent.DoesNotExist:
+            # Unique conflict is the only IntegrityError that leaves a row to replay.
+            raise exc from None
         ConversationInboundEvent.objects.for_team(team.id).filter(id=row.id).update(
             provider_retry_num=provider_retry_num,
             provider_retry_reason=provider_retry_reason,
@@ -179,7 +183,6 @@ def accept_inbound_event(
     provider_retry_reason: str,
     wake: Callable[[ConversationInboundEvent], None],
 ) -> ConversationInboundEvent:
-    now = timezone.now()
     with transaction.atomic():
         row = persist_inbound_event(
             team=team,
@@ -190,7 +193,7 @@ def accept_inbound_event(
             provider_retry_num=provider_retry_num,
             provider_retry_reason=provider_retry_reason,
         )
-        if _should_wake(row, now=now):
+        if _should_wake(row, now=timezone.now()):
             transaction.on_commit(lambda: _safe_wake(wake, row))
     return row
 
@@ -227,10 +230,13 @@ def claim_inbound_event(inbound_event_id: str) -> InboundClaim | None:
     )
 
 
-def _fenced(claim: InboundClaim) -> Any:
+def _fenced(claim: InboundClaim) -> QuerySet[ConversationInboundEvent]:
+    # Retry leaves the same fencing token on a PENDING row. Status must still be
+    # PROCESSING so a later complete or fail cannot settle work that was released.
     return ConversationInboundEvent.objects.unscoped().filter(
         id=claim.event.id,
         fencing_token=claim.event.fencing_token,
+        status=ConversationInboundEvent.Status.PROCESSING,
     )
 
 
@@ -281,16 +287,28 @@ def schedule_inbound_retry(claim: InboundClaim, *, error_code: str, error: str) 
     return delay
 
 
-def due_inbound_event_ids(*, limit: int, now: datetime) -> list[tuple[UUID, str]]:
-    return list(
+def _ready_inbound_events(*, now: datetime) -> QuerySet[ConversationInboundEvent]:
+    return (
         ConversationInboundEvent.objects.unscoped()
         .filter(
             Q(status=ConversationInboundEvent.Status.PENDING, due_at__lte=now)
             | Q(status=ConversationInboundEvent.Status.PROCESSING, lease_expires_at__lte=now)
         )
-        .order_by("due_at")
-        .values_list("id", "source")[:limit]
+        .annotate(
+            ready_at=Case(
+                When(
+                    status=ConversationInboundEvent.Status.PROCESSING,
+                    then=F("lease_expires_at"),
+                ),
+                default=F("due_at"),
+                output_field=DateTimeField(),
+            )
+        )
     )
+
+
+def due_inbound_event_ids(*, limit: int, now: datetime) -> list[tuple[UUID, str]]:
+    return list(_ready_inbound_events(now=now).order_by("ready_at").values_list("id", "source")[:limit])
 
 
 def cleanup_inbound_payloads(now: datetime) -> int:
@@ -325,16 +343,7 @@ def record_inbound_queue_metrics(now: datetime) -> float:
         for status in (ConversationInboundEvent.Status.PENDING, ConversationInboundEvent.Status.PROCESSING):
             count = ConversationInboundEvent.objects.unscoped().filter(source=source, status=status).count()
             INBOUND_BACKLOG.labels(status=status, source=source).set(count)
-    oldest = (
-        ConversationInboundEvent.objects.unscoped()
-        .filter(
-            Q(status=ConversationInboundEvent.Status.PENDING, due_at__lte=now)
-            | Q(status=ConversationInboundEvent.Status.PROCESSING, lease_expires_at__lte=now)
-        )
-        .order_by("due_at")
-        .values_list("due_at", flat=True)
-        .first()
-    )
+    oldest = _ready_inbound_events(now=now).order_by("ready_at").values_list("ready_at", flat=True).first()
     if oldest is not None:
         oldest_age = max((now - oldest).total_seconds(), 0.0)
     INBOUND_OLDEST_READY_AGE_SECONDS.set(oldest_age)

--- a/products/conversations/backend/services/inbound_events.py
+++ b/products/conversations/backend/services/inbound_events.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import random
+import hashlib
+from collections.abc import Callable
+from datetime import datetime, timedelta
+from typing import Any
+from uuid import UUID
+
+from django.db import IntegrityError, transaction
+from django.db.models import Q
+from django.http import HttpRequest
+from django.utils import timezone
+
+import structlog
+
+from posthog.dataclasses import frozen
+from posthog.models.team import Team
+from posthog.ph_client import ph_scoped_capture
+
+from products.conversations.backend.metrics import (
+    INBOUND_ATTEMPTS_TOTAL,
+    INBOUND_BACKLOG,
+    INBOUND_LEASES_TOTAL,
+    INBOUND_OLDEST_READY_AGE_SECONDS,
+)
+from products.conversations.backend.models import ConversationInboundEvent, ConversationInboundEventSource
+from products.conversations.backend.models.inbound_event import (
+    INBOUND_ERROR_MAX_LENGTH,
+    INBOUND_PAYLOAD_TTL,
+    INBOUND_TOMBSTONE_TTL,
+    InboundPayloadTooLargeError,
+    reject_oversized_inbound_payload,
+)
+
+logger = structlog.get_logger(__name__)
+
+INBOUND_LEASE_SECONDS = 120
+INBOUND_MAX_ATTEMPTS = 10
+INBOUND_BACKOFF_BASE_SECONDS = 2
+INBOUND_BACKOFF_MAX_SECONDS = 60
+INBOUND_SWEEP_BATCH_SIZE = 100
+# pinned: analytics event name — renaming breaks historical ClickHouse queries
+INBOUND_SWEEP_EVENT = "conversations_inbound_sweep"
+
+
+class TransientInboundError(Exception):
+    """Work that should be retried from the Postgres receipt rather than Celery retry."""
+
+
+@frozen
+class InboundClaim:
+    event: ConversationInboundEvent
+    allow_retry: bool
+    expired_reclaim: bool
+
+
+def slack_retry_metadata(request: HttpRequest) -> tuple[int | None, str]:
+    raw_num = request.headers.get("X-Slack-Retry-Num")
+    reason = (request.headers.get("X-Slack-Retry-Reason") or "")[:64]
+    if not raw_num:
+        return None, reason
+    try:
+        retry_num = int(raw_num)
+    except ValueError:
+        return None, reason
+    if retry_num < 0:
+        return None, reason
+    return retry_num, reason
+
+
+def slack_events_source_id(*, event_id: str | None, signed_body: bytes) -> str:
+    if event_id:
+        return event_id[:512]
+    return hashlib.sha256(signed_body).hexdigest()
+
+
+def slack_interactivity_source_id(*, payload: dict[str, Any], signed_body: bytes) -> str:
+    trigger_id = str(payload.get("trigger_id") or "")
+    if not trigger_id:
+        return hashlib.sha256(signed_body).hexdigest()
+    actions = payload.get("actions") or []
+    action = actions[0] if actions and isinstance(actions[0], dict) else {}
+    action_id = str(action.get("action_id") or "")
+    container = payload.get("container") if isinstance(payload.get("container"), dict) else {}
+    container_key = ":".join(str(container.get(key) or "") for key in ("type", "message_ts", "channel_id", "thread_ts"))
+    composed = f"{trigger_id}:{action_id}:{container_key}"
+    if len(composed) <= 512:
+        return composed
+    return hashlib.sha256(composed.encode()).hexdigest()
+
+
+def retry_delay_seconds(attempts: int) -> int:
+    exponent = max(attempts - 1, 0)
+    backoff = min(INBOUND_BACKOFF_BASE_SECONDS * (2 ** min(exponent, 8)), INBOUND_BACKOFF_MAX_SECONDS)
+    jitter = random.uniform(0, backoff * 0.5)
+    return max(int(backoff + jitter), 1)
+
+
+def _safe_wake(wake: Callable[[ConversationInboundEvent], None], row: ConversationInboundEvent) -> None:
+    try:
+        wake(row)
+    except Exception:
+        logger.exception("inbound_event_dispatch_failed", inbound_event_id=str(row.id), source=row.source)
+
+
+def _should_wake(row: ConversationInboundEvent, *, now: datetime) -> bool:
+    if row.status == ConversationInboundEvent.Status.PENDING:
+        return True
+    return (
+        row.status == ConversationInboundEvent.Status.PROCESSING
+        and row.lease_expires_at is not None
+        and row.lease_expires_at <= now
+    )
+
+
+def persist_inbound_event(
+    *,
+    team: Team,
+    source: str,
+    source_id: str,
+    provider_account_id: str,
+    payload: dict[str, Any] | None,
+    provider_retry_num: int | None,
+    provider_retry_reason: str,
+) -> ConversationInboundEvent:
+    status = ConversationInboundEvent.Status.PENDING
+    error_code = ""
+    error = ""
+    terminal_at = None
+    stored_payload: dict[str, Any] | None = payload
+    try:
+        reject_oversized_inbound_payload(payload)
+    except InboundPayloadTooLargeError as exc:
+        stored_payload = None
+        status = ConversationInboundEvent.Status.FAILED
+        error_code = "payload_too_large"
+        error = str(exc)[:INBOUND_ERROR_MAX_LENGTH]
+        terminal_at = timezone.now()
+
+    defaults = {
+        "provider_account_id": provider_account_id,
+        "provider_retry_num": provider_retry_num,
+        "provider_retry_reason": provider_retry_reason,
+        "status": status,
+        "payload": stored_payload,
+        "last_error_code": error_code,
+        "last_error": error,
+        "terminal_at": terminal_at,
+        "due_at": timezone.now(),
+    }
+    try:
+        with transaction.atomic():
+            return ConversationInboundEvent.objects.for_team(team.id).create(
+                team=team,
+                source=source,
+                source_id=source_id,
+                **defaults,
+            )
+    except IntegrityError:
+        row = ConversationInboundEvent.objects.for_team(team.id).get(source=source, source_id=source_id)
+        ConversationInboundEvent.objects.for_team(team.id).filter(id=row.id).update(
+            provider_retry_num=provider_retry_num,
+            provider_retry_reason=provider_retry_reason,
+            updated_at=timezone.now(),
+        )
+        row.refresh_from_db()
+        return row
+
+
+def accept_inbound_event(
+    *,
+    team: Team,
+    source: str,
+    source_id: str,
+    provider_account_id: str,
+    payload: dict[str, Any] | None,
+    provider_retry_num: int | None,
+    provider_retry_reason: str,
+    wake: Callable[[ConversationInboundEvent], None],
+) -> ConversationInboundEvent:
+    now = timezone.now()
+    with transaction.atomic():
+        row = persist_inbound_event(
+            team=team,
+            source=source,
+            source_id=source_id,
+            provider_account_id=provider_account_id,
+            payload=payload,
+            provider_retry_num=provider_retry_num,
+            provider_retry_reason=provider_retry_reason,
+        )
+        if _should_wake(row, now=now):
+            transaction.on_commit(lambda: _safe_wake(wake, row))
+    return row
+
+
+def claim_inbound_event(inbound_event_id: str) -> InboundClaim | None:
+    now = timezone.now()
+    lease_until = now + timedelta(seconds=INBOUND_LEASE_SECONDS)
+    with transaction.atomic():
+        row = (
+            ConversationInboundEvent.objects.unscoped()
+            .select_for_update(skip_locked=True)
+            .filter(id=inbound_event_id)
+            .filter(
+                Q(status=ConversationInboundEvent.Status.PENDING, due_at__lte=now)
+                | Q(status=ConversationInboundEvent.Status.PROCESSING, lease_expires_at__lte=now)
+            )
+            .first()
+        )
+        if row is None:
+            INBOUND_LEASES_TOTAL.labels(result="busy").inc()
+            return None
+        expired_reclaim = row.status == ConversationInboundEvent.Status.PROCESSING
+        row.status = ConversationInboundEvent.Status.PROCESSING
+        row.lease_expires_at = lease_until
+        row.fencing_token += 1
+        row.attempts += 1
+        row.save(update_fields=["status", "lease_expires_at", "fencing_token", "attempts", "updated_at"])
+    INBOUND_LEASES_TOTAL.labels(result="expired_reclaim" if expired_reclaim else "claimed").inc()
+    INBOUND_ATTEMPTS_TOTAL.labels(source=row.source, result="claimed").inc()
+    return InboundClaim(
+        event=row,
+        allow_retry=row.attempts < INBOUND_MAX_ATTEMPTS,
+        expired_reclaim=expired_reclaim,
+    )
+
+
+def _fenced(claim: InboundClaim) -> Any:
+    return ConversationInboundEvent.objects.unscoped().filter(
+        id=claim.event.id,
+        fencing_token=claim.event.fencing_token,
+    )
+
+
+def complete_inbound_event(claim: InboundClaim, *, error_code: str = "", error: str = "") -> bool:
+    now = timezone.now()
+    updated = _fenced(claim).update(
+        status=ConversationInboundEvent.Status.PROCESSED,
+        terminal_at=now,
+        lease_expires_at=None,
+        last_error_code=error_code,
+        last_error=error[:INBOUND_ERROR_MAX_LENGTH],
+        updated_at=now,
+    )
+    if updated:
+        INBOUND_ATTEMPTS_TOTAL.labels(source=claim.event.source, result="processed").inc()
+    return updated == 1
+
+
+def fail_inbound_event(claim: InboundClaim, *, error_code: str, error: str) -> bool:
+    now = timezone.now()
+    updated = _fenced(claim).update(
+        status=ConversationInboundEvent.Status.FAILED,
+        terminal_at=now,
+        lease_expires_at=None,
+        last_error_code=error_code,
+        last_error=error[:INBOUND_ERROR_MAX_LENGTH],
+        updated_at=now,
+    )
+    if updated:
+        INBOUND_ATTEMPTS_TOTAL.labels(source=claim.event.source, result="failed").inc()
+    return updated == 1
+
+
+def schedule_inbound_retry(claim: InboundClaim, *, error_code: str, error: str) -> int | None:
+    delay = retry_delay_seconds(claim.event.attempts)
+    now = timezone.now()
+    updated = _fenced(claim).update(
+        status=ConversationInboundEvent.Status.PENDING,
+        due_at=now + timedelta(seconds=delay),
+        lease_expires_at=None,
+        last_error_code=error_code,
+        last_error=error[:INBOUND_ERROR_MAX_LENGTH],
+        updated_at=now,
+    )
+    if not updated:
+        return None
+    INBOUND_ATTEMPTS_TOTAL.labels(source=claim.event.source, result="retry").inc()
+    return delay
+
+
+def due_inbound_event_ids(*, limit: int, now: datetime) -> list[tuple[UUID, str]]:
+    return list(
+        ConversationInboundEvent.objects.unscoped()
+        .filter(
+            Q(status=ConversationInboundEvent.Status.PENDING, due_at__lte=now)
+            | Q(status=ConversationInboundEvent.Status.PROCESSING, lease_expires_at__lte=now)
+        )
+        .order_by("due_at")
+        .values_list("id", "source")[:limit]
+    )
+
+
+def cleanup_inbound_payloads(now: datetime) -> int:
+    cutoff = now - INBOUND_PAYLOAD_TTL
+    return (
+        ConversationInboundEvent.objects.unscoped()
+        .filter(
+            status__in=ConversationInboundEvent.TERMINAL_STATUSES,
+            payload__isnull=False,
+            terminal_at__lte=cutoff,
+        )
+        .update(payload=None, updated_at=now)
+    )
+
+
+def delete_inbound_tombstones(now: datetime) -> int:
+    cutoff = now - INBOUND_TOMBSTONE_TTL
+    deleted, _ = (
+        ConversationInboundEvent.objects.unscoped()
+        .filter(
+            status__in=ConversationInboundEvent.TERMINAL_STATUSES,
+            terminal_at__lte=cutoff,
+        )
+        .delete()
+    )
+    return deleted
+
+
+def record_inbound_queue_metrics(now: datetime) -> float:
+    oldest_age = 0.0
+    for source in ConversationInboundEventSource.values:
+        for status in (ConversationInboundEvent.Status.PENDING, ConversationInboundEvent.Status.PROCESSING):
+            count = ConversationInboundEvent.objects.unscoped().filter(source=source, status=status).count()
+            INBOUND_BACKLOG.labels(status=status, source=source).set(count)
+    oldest = (
+        ConversationInboundEvent.objects.unscoped()
+        .filter(
+            Q(status=ConversationInboundEvent.Status.PENDING, due_at__lte=now)
+            | Q(status=ConversationInboundEvent.Status.PROCESSING, lease_expires_at__lte=now)
+        )
+        .order_by("due_at")
+        .values_list("due_at", flat=True)
+        .first()
+    )
+    if oldest is not None:
+        oldest_age = max((now - oldest).total_seconds(), 0.0)
+    INBOUND_OLDEST_READY_AGE_SECONDS.set(oldest_age)
+    return oldest_age
+
+
+def emit_inbound_sweep_event(
+    *,
+    pending_count: int,
+    processing_count: int,
+    dispatched_count: int,
+    payload_gc_count: int,
+    tombstone_delete_count: int,
+    oldest_ready_age_seconds: float,
+) -> None:
+    with ph_scoped_capture() as capture:
+        capture(
+            distinct_id="conversations-inbound-sweeper",
+            event=INBOUND_SWEEP_EVENT,
+            properties={
+                "pending_count": pending_count,
+                "processing_count": processing_count,
+                "dispatched_count": dispatched_count,
+                "payload_gc_count": payload_gc_count,
+                "tombstone_delete_count": tombstone_delete_count,
+                "oldest_ready_age_seconds": oldest_ready_age_seconds,
+            },
+        )
+
+
+def inbound_event_payload_event(row: ConversationInboundEvent) -> dict[str, Any] | None:
+    payload = row.payload
+    if not isinstance(payload, dict):
+        return None
+    inner = payload.get("event")
+    if isinstance(inner, dict):
+        return inner
+    return None

--- a/products/conversations/backend/services/inbound_events.py
+++ b/products/conversations/backend/services/inbound_events.py
@@ -13,17 +13,14 @@ from django.http import HttpRequest
 from django.utils import timezone
 
 import structlog
+from prometheus_client import Gauge
 
 from posthog.dataclasses import frozen
+from posthog.metrics import pushed_metrics_registry
 from posthog.models.team import Team
 from posthog.ph_client import ph_scoped_capture
 
-from products.conversations.backend.metrics import (
-    INBOUND_ATTEMPTS_TOTAL,
-    INBOUND_BACKLOG,
-    INBOUND_LEASES_TOTAL,
-    INBOUND_OLDEST_READY_AGE_SECONDS,
-)
+from products.conversations.backend.metrics import INBOUND_ATTEMPTS_TOTAL, INBOUND_LEASES_TOTAL
 from products.conversations.backend.models import ConversationInboundEvent, ConversationInboundEventSource
 from products.conversations.backend.models.inbound_event import (
     INBOUND_ERROR_MAX_LENGTH,
@@ -372,16 +369,53 @@ def delete_inbound_tombstones(now: datetime, *, limit: int = INBOUND_SWEEP_BATCH
     return deleted
 
 
+def _push_inbound_queue_gauges(*, backlog: list[tuple[str, str, int]], oldest_age: float, now: datetime) -> None:
+    """Push the inbound queue snapshot as region-scoped gauges.
+
+    These values describe the whole receipt table, not the pod that measured them, so one
+    value per region is the only correct reading. The sweep runs on any worker, so a
+    module-level gauge makes every pod that swept export its own snapshot from a different
+    minute — a sum then multiplies the backlog and a maximum holds a stale value after the
+    queue drains. ``multiprocess_mode`` stays: the workers re-export the value from the
+    pod's multiproc directory whatever registry it was created against.
+    """
+    with pushed_metrics_registry("conversations_inbound_queue") as registry:
+        backlog_gauge = Gauge(
+            "posthog_conversations_inbound_backlog",
+            "Non-terminal inbound callback receipts by status and source",
+            labelnames=["status", "source"],
+            registry=registry,
+            multiprocess_mode="mostrecent",
+        )
+        for status, source, count in backlog:
+            backlog_gauge.labels(status=status, source=source).set(count)
+        Gauge(
+            "posthog_conversations_inbound_oldest_ready_age_seconds",
+            "Age in seconds of the oldest due or expired-lease inbound receipt",
+            registry=registry,
+            multiprocess_mode="mostrecent",
+        ).set(oldest_age)
+        # Pushgateway gauges never expire. Without this, a dead sweeper freezes an empty
+        # backlog forever and a backlog alert can never fire.
+        Gauge(
+            "posthog_conversations_inbound_last_sweep_timestamp_seconds",
+            "Unix timestamp of the last completed inbound queue sweep",
+            registry=registry,
+            multiprocess_mode="mostrecent",
+        ).set(now.timestamp())
+
+
 def record_inbound_queue_metrics(now: datetime) -> InboundQueueMetrics:
     oldest_age = 0.0
     counts = {
         ConversationInboundEvent.Status.PENDING: 0,
         ConversationInboundEvent.Status.PROCESSING: 0,
     }
+    backlog: list[tuple[str, str, int]] = []
     for source in ConversationInboundEventSource.values:
         for status in (ConversationInboundEvent.Status.PENDING, ConversationInboundEvent.Status.PROCESSING):
             count = ConversationInboundEvent.objects.unscoped().filter(source=source, status=status).count()
-            INBOUND_BACKLOG.labels(status=status, source=source).set(count)
+            backlog.append((status, source, count))
             counts[status] += count
     oldest_pending = _pending_inbound_events(now=now).order_by("due_at").values_list("due_at", flat=True).first()
     oldest_expired = (
@@ -390,7 +424,7 @@ def record_inbound_queue_metrics(now: datetime) -> InboundQueueMetrics:
     oldest = min((ready_at for ready_at in (oldest_pending, oldest_expired) if ready_at is not None), default=None)
     if oldest is not None:
         oldest_age = max((now - oldest).total_seconds(), 0.0)
-    INBOUND_OLDEST_READY_AGE_SECONDS.set(oldest_age)
+    _push_inbound_queue_gauges(backlog=backlog, oldest_age=oldest_age, now=now)
     return InboundQueueMetrics(
         pending_count=counts[ConversationInboundEvent.Status.PENDING],
         processing_count=counts[ConversationInboundEvent.Status.PROCESSING],

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -56,6 +56,7 @@ from .services.attachments import (
     sanitize_attachment_filename,
     save_file_to_uploaded_media,
 )
+from .services.inbound_events import TransientInboundError
 from .support_slack import (
     SUPPORT_SLACK_ALLOWED_HOST_SUFFIXES,
     SUPPORT_SLACK_FILE_READ_SCOPE,
@@ -1502,7 +1503,8 @@ def handle_support_reaction(event: dict, team: Team, slack_team_id: str) -> None
         thread_messages: list[dict] = result.get("messages", [])
     except Exception:
         logger.warning("slack_support_reaction_fetch_failed", channel=channel, message_ts=message_ts)
-        return
+        # No ticket exists yet, so a later attempt can seed it from scratch.
+        raise TransientInboundError
 
     # A standalone message with no thread can come back empty from conversations.replies —
     # fetch just that message, bounded to its exact ts so we never grab a neighbour.
@@ -1518,7 +1520,7 @@ def handle_support_reaction(event: dict, team: Team, slack_team_id: str) -> None
             thread_messages = history.get("messages", [])
         except Exception:
             logger.warning("slack_support_reaction_fetch_failed", channel=channel, message_ts=message_ts)
-            return
+            raise TransientInboundError
 
     if not thread_messages:
         return

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -1338,6 +1338,17 @@ def _backfill_thread_replies(
     )
 
     own_bot_user_id = get_bot_user_id(client)
+    # A live thread-reply delivery of the same message can commit before or after this
+    # backfill. Both paths key on slack_message_ts, so skip what is already stored.
+    already_stored = {
+        stored_ts
+        for stored_ts in Comment.objects.filter(
+            team=team,
+            scope="conversations_ticket",
+            item_id=str(ticket.id),
+        ).values_list("item_context__slack_message_ts", flat=True)
+        if stored_ts
+    }
     user_cache: dict[str, dict] = {}
     posthog_user_cache: dict[str, User | None] = {}
     comments_to_create: list[Comment] = []
@@ -1345,6 +1356,10 @@ def _backfill_thread_replies(
     team_message_count = 0
 
     for reply in thread_replies:
+        reply_ts = reply.get("ts") or ""
+        if reply_ts in already_stored:
+            continue
+
         reply_is_bot = bool(reply.get("bot_id") or reply.get("subtype") == "bot_message")
         if not _is_ticketable_message(reply, is_bot=reply_is_bot):
             continue
@@ -1408,6 +1423,7 @@ def _backfill_thread_replies(
                     "author_type": "support" if is_team_member else "customer",
                     "is_private": False,
                     "from_slack": True,
+                    "slack_message_ts": reply_ts,
                     "slack_user_id": reply_user,
                     "slack_author_name": user_info["name"],
                     "slack_author_email": user_info.get("email"),

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -43,6 +43,7 @@ from .cache import (
     get_cached_bot_user_id,
     is_nudge_suppressed,
     set_cached_bot_user_id,
+    slack_comment_create_lock,
     slack_ticket_create_lock,
     suppress_nudge,
 )
@@ -389,6 +390,16 @@ def extract_slack_files(files: list[dict] | None, team: Team, client: WebClient 
     return attachments
 
 
+def _slack_comment_exists(team: Team, ticket_id: str, slack_message_ts: str) -> bool:
+    """Report whether this Slack message is already stored as a comment on this ticket."""
+    return Comment.objects.filter(
+        team=team,
+        scope="conversations_ticket",
+        item_id=ticket_id,
+        item_context__slack_message_ts=slack_message_ts,
+    ).exists()
+
+
 def create_or_update_slack_ticket(
     *,
     team: Team,
@@ -468,15 +479,7 @@ def create_or_update_slack_ticket(
         if slack_team_id and not ticket.slack_team_id:
             Ticket.objects.filter(id=ticket.id, team=team).update(slack_team_id=slack_team_id)
 
-        if (
-            slack_message_ts
-            and Comment.objects.filter(
-                team=team,
-                scope="conversations_ticket",
-                item_id=str(ticket.id),
-                item_context__slack_message_ts=slack_message_ts,
-            ).exists()
-        ):
+        if slack_message_ts and _slack_comment_exists(team, str(ticket.id), slack_message_ts):
             return ticket
 
         # Allow messages with only attachments (no text)
@@ -494,7 +497,12 @@ def create_or_update_slack_ticket(
             cleaned_text, rich_content, attachments.images, attachments.files
         )
 
-        with transaction.atomic():
+        with slack_comment_create_lock(team_id, str(ticket.id), slack_message_ts):
+            # Re-check under the lock because the other callback for this same Slack
+            # message can commit between the check above and this insert.
+            if slack_message_ts and _slack_comment_exists(team, str(ticket.id), slack_message_ts):
+                return ticket
+
             Comment.objects.create(
                 team=team,
                 scope="conversations_ticket",

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -505,7 +505,7 @@ def create_or_update_slack_ticket(
                     "author_type": "support" if is_team_member else "customer",
                     "is_private": False,
                     "from_slack": True,
-                    "slack_message_ts": slack_message_ts,
+                    **({"slack_message_ts": slack_message_ts} if slack_message_ts else {}),
                     "slack_user_id": slack_user_id,
                     "slack_author_name": user_info["name"],
                     "slack_author_email": user_info.get("email"),
@@ -1129,6 +1129,7 @@ def _create_ticket_and_backfill(
         slack_team_id=slack_team_id,
         channel_detail=channel_detail,
         post_confirmation=post_confirmation,
+        slack_message_ts=source_message.get("ts"),
     )
     if ticket:
         _backfill_thread_replies(
@@ -1294,6 +1295,7 @@ def handle_support_mention(event: dict, team: Team, slack_team_id: str) -> None:
         is_thread_reply=existing,
         slack_team_id=slack_team_id,
         channel_detail=ChannelDetail.SLACK_BOT_MENTION,
+        slack_message_ts=message_ts,
     )
 
 

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -18,6 +18,7 @@ from urllib.parse import urljoin, urlparse
 from urllib.request import HTTPRedirectHandler, Request, build_opener
 
 from django.conf import settings
+from django.db import transaction
 from django.db.models import F
 
 import structlog
@@ -400,6 +401,7 @@ def create_or_update_slack_ticket(
     slack_team_id: str | None = None,
     channel_detail: ChannelDetail | None = None,
     post_confirmation: bool = True,
+    slack_message_ts: str | None = None,
 ) -> Ticket | None:
     """
     Core function: create a new ticket or add a message to an existing one.
@@ -465,6 +467,17 @@ def create_or_update_slack_ticket(
         if slack_team_id and not ticket.slack_team_id:
             Ticket.objects.filter(id=ticket.id, team=team).update(slack_team_id=slack_team_id)
 
+        if (
+            slack_message_ts
+            and Comment.objects.filter(
+                team=team,
+                scope="conversations_ticket",
+                item_id=str(ticket.id),
+                item_context__slack_message_ts=slack_message_ts,
+            ).exists()
+        ):
+            return ticket
+
         # Allow messages with only attachments (no text)
         if not cleaned_text and not attachments.images and not attachments.files:
             logger.warning(
@@ -480,30 +493,31 @@ def create_or_update_slack_ticket(
             cleaned_text, rich_content, attachments.images, attachments.files
         )
 
-        Comment.objects.create(
-            team=team,
-            scope="conversations_ticket",
-            item_id=str(ticket.id),
-            content=content,
-            rich_content=rich_content,
-            created_by=posthog_user,
-            item_context={
-                "author_type": "support" if is_team_member else "customer",
-                "is_private": False,
-                "from_slack": True,
-                "slack_user_id": slack_user_id,
-                "slack_author_name": user_info["name"],
-                "slack_author_email": user_info.get("email"),
-                "slack_author_avatar": user_info.get("avatar"),
-                "slack_images": attachments.images if attachments.images else None,
-                "slack_files": attachments.files if attachments.files else None,
-            },
-        )
-
-        if not is_team_member:
-            Ticket.objects.filter(id=ticket.id, team=team).update(
-                unread_team_count=F("unread_team_count") + 1,
+        with transaction.atomic():
+            Comment.objects.create(
+                team=team,
+                scope="conversations_ticket",
+                item_id=str(ticket.id),
+                content=content,
+                rich_content=rich_content,
+                created_by=posthog_user,
+                item_context={
+                    "author_type": "support" if is_team_member else "customer",
+                    "is_private": False,
+                    "from_slack": True,
+                    "slack_message_ts": slack_message_ts,
+                    "slack_user_id": slack_user_id,
+                    "slack_author_name": user_info["name"],
+                    "slack_author_email": user_info.get("email"),
+                    "slack_author_avatar": user_info.get("avatar"),
+                    "slack_images": attachments.images if attachments.images else None,
+                    "slack_files": attachments.files if attachments.files else None,
+                },
             )
+            if not is_team_member:
+                Ticket.objects.filter(id=ticket.id, team=team).update(
+                    unread_team_count=F("unread_team_count") + 1,
+                )
 
         return ticket
 
@@ -521,9 +535,7 @@ def create_or_update_slack_ticket(
 
     content, rich_content = build_content_with_images(cleaned_text, rich_content, attachments.images, attachments.files)
 
-    # Serialize concurrent ticket creation for the same Slack thread via Redis lock.
-    # Without this, two reaction_added events from different users race through the
-    # .exists() checks above and both create a ticket.
+    # Serialize concurrent ticket creation for the same Slack thread.
     with slack_ticket_create_lock(team_id, slack_channel_id, thread_ts) as acquired:
         # Return None (not the existing ticket) on every dedup path: the winning worker
         # owns the create-side effects (first comment, confirmation message, and the
@@ -538,49 +550,54 @@ def create_or_update_slack_ticket(
             )
             return None
 
-        # Re-check after acquiring — the winner may have committed between our earlier
-        # .exists() call and now.
-        if Ticket.objects.filter(team=team, slack_channel_id=slack_channel_id, slack_thread_ts=thread_ts).exists():
-            return None
+        with transaction.atomic():
+            # Re-check after acquiring because the winner can commit before this worker enters.
+            if Ticket.objects.filter(
+                team=team,
+                slack_channel_id=slack_channel_id,
+                slack_thread_ts=thread_ts,
+            ).exists():
+                return None
 
-        ticket = Ticket.objects.create_with_number(
-            team=team,
-            channel_source=Channel.SLACK,
-            channel_detail=channel_detail,
-            widget_session_id="",  # Not used for Slack tickets
-            distinct_id=user_info.get("email") or "",
-            status=Status.NEW,
-            anonymous_traits={
-                "name": user_info["name"],
-                **({"email": user_info["email"]} if user_info["email"] else {}),
-            },
-            slack_channel_id=slack_channel_id,
-            slack_thread_ts=thread_ts,
-            slack_team_id=slack_team_id,
-            unread_team_count=0 if is_team_member else 1,
-            # Created from a signature-validated Slack webhook — platform-attested identity.
-            identity_verified=True,
-        )
+            ticket = Ticket.objects.create_with_number(
+                team=team,
+                channel_source=Channel.SLACK,
+                channel_detail=channel_detail,
+                widget_session_id="",  # Not used for Slack tickets
+                distinct_id=user_info.get("email") or "",
+                status=Status.NEW,
+                anonymous_traits={
+                    "name": user_info["name"],
+                    **({"email": user_info["email"]} if user_info["email"] else {}),
+                },
+                slack_channel_id=slack_channel_id,
+                slack_thread_ts=thread_ts,
+                slack_team_id=slack_team_id,
+                unread_team_count=0 if is_team_member else 1,
+                # Created from a signature-validated Slack webhook — platform-attested identity.
+                identity_verified=True,
+            )
 
-    Comment.objects.create(
-        team=team,
-        scope="conversations_ticket",
-        item_id=str(ticket.id),
-        content=content,
-        rich_content=rich_content,
-        created_by=posthog_user,
-        item_context={
-            "author_type": "support" if is_team_member else "customer",
-            "is_private": False,
-            "from_slack": True,
-            "slack_user_id": slack_user_id,
-            "slack_author_name": user_info["name"],
-            "slack_author_email": user_info.get("email"),
-            "slack_author_avatar": user_info.get("avatar"),
-            "slack_images": attachments.images if attachments.images else None,
-            "slack_files": attachments.files if attachments.files else None,
-        },
-    )
+            Comment.objects.create(
+                team=team,
+                scope="conversations_ticket",
+                item_id=str(ticket.id),
+                content=content,
+                rich_content=rich_content,
+                created_by=posthog_user,
+                item_context={
+                    "author_type": "support" if is_team_member else "customer",
+                    "is_private": False,
+                    "from_slack": True,
+                    "slack_message_ts": slack_message_ts or thread_ts,
+                    "slack_user_id": slack_user_id,
+                    "slack_author_name": user_info["name"],
+                    "slack_author_email": user_info.get("email"),
+                    "slack_author_avatar": user_info.get("avatar"),
+                    "slack_images": attachments.images if attachments.images else None,
+                    "slack_files": attachments.files if attachments.files else None,
+                },
+            )
 
     # Post a confirmation reply in the Slack thread. Skipped when the caller will surface
     # the confirmation itself (e.g. the confirm-prompt flow updates its prompt in place).
@@ -732,6 +749,7 @@ def handle_support_message(event: dict, team: Team, slack_team_id: str) -> None:
             files=files,
             is_thread_reply=True,
             slack_team_id=slack_team_id,
+            slack_message_ts=message_ts,
         )
         return
 
@@ -781,6 +799,7 @@ def handle_support_message(event: dict, team: Team, slack_team_id: str) -> None:
         is_thread_reply=False,
         slack_team_id=slack_team_id,
         channel_detail=ChannelDetail.SLACK_CHANNEL_MESSAGE,
+        slack_message_ts=message_ts,
     )
 
 

--- a/products/conversations/backend/support_slack.py
+++ b/products/conversations/backend/support_slack.py
@@ -58,15 +58,23 @@ def get_support_slack_workspace_id(team: "Team") -> str | None:
     return config.slack_team_id or None
 
 
+def team_for_slack_workspace(slack_team_id: str) -> "Team | None":
+    """Return the team that owns this Slack workspace, if SupportHog is connected."""
+    config = (
+        TeamConversationsSlackConfig.objects.filter(slack_team_id=slack_team_id, slack_bot_token__isnull=False)
+        .select_related("team")
+        .first()
+    )
+    return config.team if config else None
+
+
 def team_exists_for_slack_workspace(slack_team_id: str) -> bool:
     """Whether any team has SupportHog connected to this Slack workspace.
 
     Used by the webhook endpoints for region routing — the Celery task re-resolves
     the full config, so only existence matters here.
     """
-    return TeamConversationsSlackConfig.objects.filter(
-        slack_team_id=slack_team_id, slack_bot_token__isnull=False
-    ).exists()
+    return team_for_slack_workspace(slack_team_id) is not None
 
 
 def validate_support_request(request: HttpRequest | Request) -> None:

--- a/products/conversations/backend/tasks/slack.py
+++ b/products/conversations/backend/tasks/slack.py
@@ -67,12 +67,21 @@ from ..support_slack import SUPPORT_SLACK_ALLOWED_HOST_SUFFIXES, supporthog_miss
 logger = structlog.get_logger(__name__)
 
 
-def _slack_config_for_workspace(slack_team_id: str) -> TeamConversationsSlackConfig | None:
-    return (
-        TeamConversationsSlackConfig.objects.filter(slack_team_id=slack_team_id, slack_bot_token__isnull=False)
+def _slack_config_for_workspace(
+    slack_team_id: str, *, receipt_team_id: int | None = None
+) -> TeamConversationsSlackConfig | None:
+    config = (
+        TeamConversationsSlackConfig.objects.filter(
+            slack_team_id=slack_team_id,
+            slack_bot_token__isnull=False,
+        )
         .select_related("team")
         .first()
     )
+    if config is None or receipt_team_id is None:
+        return config
+    config_root_team_id = config.team.parent_team_id or config.team_id
+    return config if config_root_team_id == receipt_team_id else None
 
 
 def _handle_supporthog_event(event: dict[str, Any], team: Team, slack_team_id: str) -> None:
@@ -91,9 +100,9 @@ def _handle_supporthog_event(event: dict[str, Any], team: Team, slack_team_id: s
 
 def _wake_inbound_event(row: ConversationInboundEvent, *, countdown: int | None = None) -> None:
     task = (
-        process_supporthog_event
+        process_supporthog_event_receipt
         if row.source == ConversationInboundEventSource.SLACK_EVENTS
-        else process_supporthog_interactivity
+        else process_supporthog_interactivity_receipt
     )
     kwargs = {"inbound_event_id": str(row.id)}
     try:
@@ -124,7 +133,10 @@ def _process_event_from_receipt(inbound_event_id: str) -> None:
             claim, error_code="poison_payload", error="inbound event payload is missing or not an object"
         )
         return
-    config = _slack_config_for_workspace(claim.event.provider_account_id)
+    config = _slack_config_for_workspace(
+        claim.event.provider_account_id,
+        receipt_team_id=claim.event.team_id,
+    )
     if not config:
         fail_inbound_event(claim, error_code="no_team", error="slack workspace is not connected")
         return
@@ -146,6 +158,15 @@ def _process_event_from_receipt(inbound_event_id: str) -> None:
 
 
 @shared_task(
+    name="products.conversations.backend.tasks.process_supporthog_event_receipt",
+    ignore_result=True,
+)
+@skip_team_scope_audit
+def process_supporthog_event_receipt(inbound_event_id: str) -> None:
+    _process_event_from_receipt(inbound_event_id)
+
+
+@shared_task(
     name="products.conversations.backend.tasks.process_supporthog_event",
     ignore_result=True,
     max_retries=3,
@@ -156,11 +177,7 @@ def process_supporthog_event(
     event: dict[str, Any] | None = None,
     slack_team_id: str = "",
     event_id: str | None = None,
-    inbound_event_id: str | None = None,
 ) -> None:
-    if inbound_event_id:
-        _process_event_from_receipt(inbound_event_id)
-        return
     if not event:
         return
 
@@ -258,9 +275,10 @@ def _handle_supporthog_interactivity(
     *,
     is_retry: bool,
     allow_retry: bool,
+    receipt_team_id: int | None = None,
 ) -> None:
     """Handle a button click from the opt-in "open a ticket?" confirmation prompt."""
-    config = _slack_config_for_workspace(slack_team_id)
+    config = _slack_config_for_workspace(slack_team_id, receipt_team_id=receipt_team_id)
     if not config:
         logger.warning("supporthog_interactivity_no_team", slack_team_id=slack_team_id)
         return
@@ -391,6 +409,7 @@ def _process_interactivity_from_receipt(inbound_event_id: str) -> None:
             claim.event.provider_account_id,
             is_retry=claim.event.attempts > 1,
             allow_retry=claim.allow_retry,
+            receipt_team_id=claim.event.team_id,
         )
         complete_inbound_event(claim)
     except TransientInboundError:
@@ -398,6 +417,15 @@ def _process_interactivity_from_receipt(inbound_event_id: str) -> None:
     except Exception as exc:
         logger.exception("supporthog_interactivity_handler_failed", inbound_event_id=inbound_event_id, error=str(exc))
         _retry_inbound_claim(claim, error_code="handler_failed", error=str(exc)[:INBOUND_ERROR_MAX_LENGTH])
+
+
+@shared_task(
+    name="products.conversations.backend.tasks.process_supporthog_interactivity_receipt",
+    ignore_result=True,
+)
+@skip_team_scope_audit
+def process_supporthog_interactivity_receipt(inbound_event_id: str) -> None:
+    _process_interactivity_from_receipt(inbound_event_id)
 
 
 @shared_task(
@@ -410,12 +438,8 @@ def _process_interactivity_from_receipt(inbound_event_id: str) -> None:
 def process_supporthog_interactivity(
     payload: dict[str, Any] | None = None,
     slack_team_id: str = "",
-    inbound_event_id: str | None = None,
 ) -> None:
     """Handle a button click from the opt-in "open a ticket?" confirmation prompt."""
-    if inbound_event_id:
-        _process_interactivity_from_receipt(inbound_event_id)
-        return
     if not payload:
         return
     celery_retries = int(getattr(cast(Any, process_supporthog_interactivity).request, "retries", 0) or 0)
@@ -446,9 +470,12 @@ def sweep_inbound_events() -> None:
     for inbound_event_id, source in due_rows:
         try:
             if source == ConversationInboundEventSource.SLACK_EVENTS:
-                cast(Any, process_supporthog_event).delay(inbound_event_id=str(inbound_event_id))
+                cast(Any, process_supporthog_event_receipt).delay(inbound_event_id=str(inbound_event_id))
             elif source == ConversationInboundEventSource.SLACK_INTERACTIVITY:
-                cast(Any, process_supporthog_interactivity).delay(inbound_event_id=str(inbound_event_id))
+                cast(Any, process_supporthog_interactivity_receipt).delay(inbound_event_id=str(inbound_event_id))
+            else:
+                logger.warning("inbound_sweep_unknown_source", inbound_event_id=str(inbound_event_id), source=source)
+                continue
             dispatched += 1
         except Exception:
             logger.exception("inbound_sweep_dispatch_failed", inbound_event_id=str(inbound_event_id), source=source)

--- a/products/conversations/backend/tasks/slack.py
+++ b/products/conversations/backend/tasks/slack.py
@@ -5,12 +5,12 @@ from typing import Any, cast, get_args
 from urllib.parse import urlparse
 from uuid import UUID
 
-from django.core.cache import cache
+from django.utils import timezone
 
 import requests
 import structlog
 from celery import shared_task
-from celery.exceptions import MaxRetriesExceededError, Retry
+from celery.exceptions import MaxRetriesExceededError
 
 from posthog.comment.formatting import extract_images_from_rich_content, rich_content_to_slack_payload
 from posthog.helpers.slack_identity import resolve_slack_avatar_by_email
@@ -20,9 +20,29 @@ from posthog.scoping_audit import skip_team_scope_audit
 from posthog.storage import object_storage
 
 from products.conversations.backend.cache import NUDGE_DISMISS_TTL, suppress_nudge
-from products.conversations.backend.models import TeamConversationsSlackConfig
+from products.conversations.backend.models import (
+    ConversationInboundEvent,
+    ConversationInboundEventSource,
+    TeamConversationsSlackConfig,
+)
+from products.conversations.backend.models.inbound_event import INBOUND_ERROR_MAX_LENGTH
 from products.conversations.backend.models.ticket import Ticket
 from products.conversations.backend.services.attachments import CONVERSATIONS_MAX_IMAGE_BYTES
+from products.conversations.backend.services.inbound_events import (
+    INBOUND_SWEEP_BATCH_SIZE,
+    InboundClaim,
+    TransientInboundError,
+    claim_inbound_event,
+    cleanup_inbound_payloads,
+    complete_inbound_event,
+    delete_inbound_tombstones,
+    due_inbound_event_ids,
+    emit_inbound_sweep_event,
+    fail_inbound_event,
+    inbound_event_payload_event,
+    record_inbound_queue_metrics,
+    schedule_inbound_retry,
+)
 from products.conversations.backend.slack import (
     TICKET_CONFIRM_ACTION_DISMISS,
     TICKET_CONFIRM_ACTION_OPEN,
@@ -45,13 +65,84 @@ from products.conversations.backend.slack import (
 from ..support_slack import SUPPORT_SLACK_ALLOWED_HOST_SUFFIXES, supporthog_missing_file_scopes
 
 logger = structlog.get_logger(__name__)
-SUPPORTHOG_EVENT_IDEMPOTENCY_TTL_SECONDS = 6 * 60
-SUPPORTHOG_EVENT_IDEMPOTENCY_KEY_PREFIX = "supporthog:slack:event:"
 
 
-def _is_duplicate_supporthog_event(event_id: str) -> bool:
-    key = f"{SUPPORTHOG_EVENT_IDEMPOTENCY_KEY_PREFIX}{event_id}"
-    return not cache.add(key, True, timeout=SUPPORTHOG_EVENT_IDEMPOTENCY_TTL_SECONDS)
+def _slack_config_for_workspace(slack_team_id: str) -> TeamConversationsSlackConfig | None:
+    return (
+        TeamConversationsSlackConfig.objects.filter(slack_team_id=slack_team_id, slack_bot_token__isnull=False)
+        .select_related("team")
+        .first()
+    )
+
+
+def _handle_supporthog_event(event: dict[str, Any], team: Team, slack_team_id: str) -> None:
+    event_type = event.get("type")
+    if event_type == "message":
+        handle_support_message(event, team, slack_team_id)
+    elif event_type == "app_mention":
+        handle_support_mention(event, team, slack_team_id)
+    elif event_type == "reaction_added":
+        handle_support_reaction(event, team, slack_team_id)
+    elif event_type == "member_joined_channel":
+        handle_member_joined_channel(event, team, slack_team_id)
+    elif event_type == "member_left_channel":
+        handle_member_left_channel(event, team, slack_team_id)
+
+
+def _wake_inbound_event(row: ConversationInboundEvent, *, countdown: int | None = None) -> None:
+    task = (
+        process_supporthog_event
+        if row.source == ConversationInboundEventSource.SLACK_EVENTS
+        else process_supporthog_interactivity
+    )
+    kwargs = {"inbound_event_id": str(row.id)}
+    try:
+        if countdown:
+            cast(Any, task).apply_async(kwargs=kwargs, countdown=countdown)
+        else:
+            cast(Any, task).delay(**kwargs)
+    except Exception:
+        logger.exception("inbound_event_redrive_failed", inbound_event_id=str(row.id), source=row.source)
+
+
+def _retry_inbound_claim(claim: InboundClaim, *, error_code: str, error: str) -> None:
+    if not claim.allow_retry:
+        fail_inbound_event(claim, error_code=error_code, error=error)
+        return
+    delay = schedule_inbound_retry(claim, error_code=error_code, error=error)
+    if delay is not None:
+        _wake_inbound_event(claim.event, countdown=delay)
+
+
+def _process_event_from_receipt(inbound_event_id: str) -> None:
+    claim = claim_inbound_event(inbound_event_id)
+    if claim is None:
+        return
+    event = inbound_event_payload_event(claim.event)
+    if event is None:
+        fail_inbound_event(
+            claim, error_code="poison_payload", error="inbound event payload is missing or not an object"
+        )
+        return
+    config = _slack_config_for_workspace(claim.event.provider_account_id)
+    if not config:
+        fail_inbound_event(claim, error_code="no_team", error="slack workspace is not connected")
+        return
+    team = config.team
+    if not (team.conversations_settings or {}).get("slack_enabled"):
+        complete_inbound_event(claim)
+        return
+    try:
+        _handle_supporthog_event(event, team, claim.event.provider_account_id)
+        complete_inbound_event(claim)
+    except Exception as exc:
+        logger.exception(
+            "supporthog_event_handler_failed",
+            event_type=event.get("type"),
+            inbound_event_id=inbound_event_id,
+            error=str(exc),
+        )
+        _retry_inbound_claim(claim, error_code="handler_failed", error=str(exc)[:INBOUND_ERROR_MAX_LENGTH])
 
 
 @shared_task(
@@ -61,16 +152,19 @@ def _is_duplicate_supporthog_event(event_id: str) -> bool:
     default_retry_delay=5,
 )
 @skip_team_scope_audit
-def process_supporthog_event(event: dict[str, Any], slack_team_id: str, event_id: str | None = None) -> None:
-    if event_id and _is_duplicate_supporthog_event(event_id):
-        logger.info("supporthog_event_duplicate_skipped", event_id=event_id)
+def process_supporthog_event(
+    event: dict[str, Any] | None = None,
+    slack_team_id: str = "",
+    event_id: str | None = None,
+    inbound_event_id: str | None = None,
+) -> None:
+    if inbound_event_id:
+        _process_event_from_receipt(inbound_event_id)
+        return
+    if not event:
         return
 
-    config = (
-        TeamConversationsSlackConfig.objects.filter(slack_team_id=slack_team_id, slack_bot_token__isnull=False)
-        .select_related("team")
-        .first()
-    )
+    config = _slack_config_for_workspace(slack_team_id)
     if not config:
         logger.warning("supporthog_no_team", slack_team_id=slack_team_id)
         return
@@ -85,22 +179,12 @@ def process_supporthog_event(event: dict[str, Any], slack_team_id: str, event_id
         )
         return
 
-    event_type = event.get("type")
     try:
-        if event_type == "message":
-            handle_support_message(event, team, slack_team_id)
-        elif event_type == "app_mention":
-            handle_support_mention(event, team, slack_team_id)
-        elif event_type == "reaction_added":
-            handle_support_reaction(event, team, slack_team_id)
-        elif event_type == "member_joined_channel":
-            handle_member_joined_channel(event, team, slack_team_id)
-        elif event_type == "member_left_channel":
-            handle_member_left_channel(event, team, slack_team_id)
+        _handle_supporthog_event(event, team, slack_team_id)
     except Exception as e:
         logger.exception(
             "supporthog_event_handler_failed",
-            event_type=event_type,
+            event_type=event.get("type"),
             error=str(e),
         )
         raise cast(Any, process_supporthog_event).retry(exc=e)
@@ -163,20 +247,20 @@ def _post_dismiss_acknowledgment(team: Team, channel: str, user: str, thread_ts:
         logger.warning("supporthog_interactivity_dismiss_ack_failed", exc_info=True)
 
 
-@shared_task(
-    name="products.conversations.backend.tasks.process_supporthog_interactivity",
-    ignore_result=True,
-    max_retries=3,
-    default_retry_delay=5,
-)
-@skip_team_scope_audit
-def process_supporthog_interactivity(payload: dict[str, Any], slack_team_id: str) -> None:
+def _raise_if_retry_allowed(allow_retry: bool) -> None:
+    if allow_retry:
+        raise TransientInboundError
+
+
+def _handle_supporthog_interactivity(
+    payload: dict[str, Any],
+    slack_team_id: str,
+    *,
+    is_retry: bool,
+    allow_retry: bool,
+) -> None:
     """Handle a button click from the opt-in "open a ticket?" confirmation prompt."""
-    config = (
-        TeamConversationsSlackConfig.objects.filter(slack_team_id=slack_team_id, slack_bot_token__isnull=False)
-        .select_related("team")
-        .first()
-    )
+    config = _slack_config_for_workspace(slack_team_id)
     if not config:
         logger.warning("supporthog_interactivity_no_team", slack_team_id=slack_team_id)
         return
@@ -231,7 +315,6 @@ def process_supporthog_interactivity(payload: dict[str, Any], slack_team_id: str
                 # a progress line right away so the click visibly landed and repeat clicks
                 # stop. First attempt only, and only while no sibling delivery has already
                 # resolved the prompt (a stale placeholder must not overwrite a confirmation).
-                is_retry = bool(getattr(cast(Any, process_supporthog_interactivity).request, "retries", 0))
                 ticket_already_open = Ticket.objects.filter(
                     team=team, slack_channel_id=source_channel, slack_thread_ts=source_message_ts
                 ).exists()
@@ -253,21 +336,16 @@ def process_supporthog_interactivity(payload: dict[str, Any], slack_team_id: str
                         # false failure — the re-run resolves to the committed ticket via
                         # the existing-ticket check in create_ticket_from_confirmation.
                         # Genuine failures exhaust retries into the error update below.
-                        raise cast(Any, process_supporthog_interactivity).retry()
-                except Retry:
+                        _raise_if_retry_allowed(allow_retry)
+                except TransientInboundError:
                     raise
-                except MaxRetriesExceededError:
-                    pass
                 except Exception as e:
                     logger.exception("supporthog_interactivity_create_failed", error=str(e))
                     # Retry transient failures — the retried run redoes the whole handler,
                     # so the prompt still resolves on eventual success. Once retries are
                     # exhausted, fall through to the error update below rather than leaving
                     # the user staring at live buttons forever.
-                    try:
-                        raise cast(Any, process_supporthog_interactivity).retry(exc=e)
-                    except MaxRetriesExceededError:
-                        pass
+                    _raise_if_retry_allowed(allow_retry)
             # Replace the prompt in place: a confirmation when we have a ticket (created or
             # already open), or an explicit error so a failed open never reads as success.
             # post_confirmation=False above means no separate confirmation was posted.
@@ -282,10 +360,7 @@ def process_supporthog_interactivity(payload: dict[str, Any], slack_team_id: str
                 # final update fails transiently, retry the task (creation is idempotent,
                 # the re-run re-attempts just this update). Once retries are exhausted,
                 # fall through so the funnel event still records the outcome.
-                try:
-                    raise cast(Any, process_supporthog_interactivity).retry()
-                except MaxRetriesExceededError:
-                    pass
+                _raise_if_retry_allowed(allow_retry)
             # Captured after all retry exits (each retry re-raise leaves the task first),
             # so the event fires once with the final outcome.
             capture_nudge_event(
@@ -298,6 +373,110 @@ def process_supporthog_interactivity(payload: dict[str, Any], slack_team_id: str
                 },
             )
             return
+
+
+def _process_interactivity_from_receipt(inbound_event_id: str) -> None:
+    claim = claim_inbound_event(inbound_event_id)
+    if claim is None:
+        return
+    payload = claim.event.payload
+    if not isinstance(payload, dict):
+        fail_inbound_event(
+            claim, error_code="poison_payload", error="inbound interactivity payload is missing or not an object"
+        )
+        return
+    try:
+        _handle_supporthog_interactivity(
+            payload,
+            claim.event.provider_account_id,
+            is_retry=claim.event.attempts > 1,
+            allow_retry=claim.allow_retry,
+        )
+        complete_inbound_event(claim)
+    except TransientInboundError:
+        _retry_inbound_claim(claim, error_code="transient", error="interactivity work needs another attempt")
+    except Exception as exc:
+        logger.exception("supporthog_interactivity_handler_failed", inbound_event_id=inbound_event_id, error=str(exc))
+        _retry_inbound_claim(claim, error_code="handler_failed", error=str(exc)[:INBOUND_ERROR_MAX_LENGTH])
+
+
+@shared_task(
+    name="products.conversations.backend.tasks.process_supporthog_interactivity",
+    ignore_result=True,
+    max_retries=3,
+    default_retry_delay=5,
+)
+@skip_team_scope_audit
+def process_supporthog_interactivity(
+    payload: dict[str, Any] | None = None,
+    slack_team_id: str = "",
+    inbound_event_id: str | None = None,
+) -> None:
+    """Handle a button click from the opt-in "open a ticket?" confirmation prompt."""
+    if inbound_event_id:
+        _process_interactivity_from_receipt(inbound_event_id)
+        return
+    if not payload:
+        return
+    celery_retries = int(getattr(cast(Any, process_supporthog_interactivity).request, "retries", 0) or 0)
+    try:
+        _handle_supporthog_interactivity(
+            payload,
+            slack_team_id,
+            is_retry=celery_retries > 0,
+            allow_retry=True,
+        )
+    except TransientInboundError as exc:
+        try:
+            raise cast(Any, process_supporthog_interactivity).retry() from exc
+        except MaxRetriesExceededError:
+            _handle_supporthog_interactivity(payload, slack_team_id, is_retry=True, allow_retry=False)
+
+
+@shared_task(
+    name="products.conversations.backend.tasks.sweep_inbound_events",
+    ignore_result=True,
+)
+@skip_team_scope_audit
+def sweep_inbound_events() -> None:
+    """Re-drive due Slack receipts and expire payloads. Celery is only a wake-up hint."""
+    now = timezone.now()
+    due_rows = due_inbound_event_ids(limit=INBOUND_SWEEP_BATCH_SIZE, now=now)
+    dispatched = 0
+    for inbound_event_id, source in due_rows:
+        try:
+            if source == ConversationInboundEventSource.SLACK_EVENTS:
+                cast(Any, process_supporthog_event).delay(inbound_event_id=str(inbound_event_id))
+            elif source == ConversationInboundEventSource.SLACK_INTERACTIVITY:
+                cast(Any, process_supporthog_interactivity).delay(inbound_event_id=str(inbound_event_id))
+            dispatched += 1
+        except Exception:
+            logger.exception("inbound_sweep_dispatch_failed", inbound_event_id=str(inbound_event_id), source=source)
+
+    payload_gc_count = cleanup_inbound_payloads(now)
+    tombstone_delete_count = delete_inbound_tombstones(now)
+    oldest_ready_age_seconds = record_inbound_queue_metrics(now)
+    pending_count = (
+        ConversationInboundEvent.objects.unscoped().filter(status=ConversationInboundEvent.Status.PENDING).count()
+    )
+    processing_count = (
+        ConversationInboundEvent.objects.unscoped().filter(status=ConversationInboundEvent.Status.PROCESSING).count()
+    )
+    emit_inbound_sweep_event(
+        pending_count=pending_count,
+        processing_count=processing_count,
+        dispatched_count=dispatched,
+        payload_gc_count=payload_gc_count,
+        tombstone_delete_count=tombstone_delete_count,
+        oldest_ready_age_seconds=oldest_ready_age_seconds,
+    )
+    if dispatched or payload_gc_count or tombstone_delete_count:
+        logger.info(
+            "sweep_inbound_events_completed",
+            dispatched=dispatched,
+            payload_gc_count=payload_gc_count,
+            tombstone_delete_count=tombstone_delete_count,
+        )
 
 
 @shared_task(

--- a/products/conversations/backend/tasks/slack.py
+++ b/products/conversations/backend/tasks/slack.py
@@ -148,6 +148,8 @@ def _process_event_from_receipt(inbound_event_id: str) -> None:
     try:
         _handle_supporthog_event(event, team, claim.event.provider_account_id)
         complete_inbound_event(claim)
+    except TransientInboundError:
+        _retry_inbound_claim(claim, error_code="transient", error="slack event work needs another attempt")
     except Exception as exc:
         logger.exception(
             "supporthog_event_handler_failed",

--- a/products/conversations/backend/tasks/slack.py
+++ b/products/conversations/backend/tasks/slack.py
@@ -29,6 +29,7 @@ from products.conversations.backend.models.inbound_event import INBOUND_ERROR_MA
 from products.conversations.backend.models.ticket import Ticket
 from products.conversations.backend.services.attachments import CONVERSATIONS_MAX_IMAGE_BYTES
 from products.conversations.backend.services.inbound_events import (
+    INBOUND_LEASE_SECONDS,
     INBOUND_SWEEP_BATCH_SIZE,
     InboundClaim,
     TransientInboundError,
@@ -138,7 +139,7 @@ def _process_event_from_receipt(inbound_event_id: str) -> None:
         receipt_team_id=claim.event.team_id,
     )
     if not config:
-        fail_inbound_event(claim, error_code="no_team", error="slack workspace is not connected")
+        _retry_inbound_claim(claim, error_code="no_team", error="slack workspace is not connected")
         return
     team = config.team
     if not (team.conversations_settings or {}).get("slack_enabled"):
@@ -160,6 +161,8 @@ def _process_event_from_receipt(inbound_event_id: str) -> None:
 @shared_task(
     name="products.conversations.backend.tasks.process_supporthog_event_receipt",
     ignore_result=True,
+    soft_time_limit=INBOUND_LEASE_SECONDS - 30,
+    time_limit=INBOUND_LEASE_SECONDS - 15,
 )
 @skip_team_scope_audit
 def process_supporthog_event_receipt(inbound_event_id: str) -> None:
@@ -276,20 +279,20 @@ def _handle_supporthog_interactivity(
     is_retry: bool,
     allow_retry: bool,
     receipt_team_id: int | None = None,
-) -> None:
+) -> bool:
     """Handle a button click from the opt-in "open a ticket?" confirmation prompt."""
     config = _slack_config_for_workspace(slack_team_id, receipt_team_id=receipt_team_id)
     if not config:
         logger.warning("supporthog_interactivity_no_team", slack_team_id=slack_team_id)
-        return
+        return receipt_team_id is None
 
     team = config.team
     support_settings = team.conversations_settings or {}
     if not support_settings.get("slack_enabled"):
-        return
+        return True
 
     if payload.get("type") != "block_actions":
-        return
+        return True
 
     # The prompt message to delete: where the button was clicked.
     container = payload.get("container") or {}
@@ -324,7 +327,7 @@ def _handle_supporthog_interactivity(
             if clicker:
                 suppress_nudge(team.pk, prompt_channel, clicker, NUDGE_DISMISS_TTL)
             capture_nudge_event(team, "support nudge dismissed", click_properties)
-            return
+            return True
         if action_id == TICKET_CONFIRM_ACTION_OPEN:
             ticket = None
             if source_channel and source_message_ts:
@@ -373,7 +376,8 @@ def _handle_supporthog_interactivity(
                 emoji = get_safe_ticket_emoji(support_settings)
                 text = f":warning: Couldn't open a ticket — react with :{emoji}: or @mention us to try again."
             final_update_ok = _update_supporthog_prompt(team, prompt_channel, prompt_ts, text)
-            if not final_update_ok and prompt_channel and prompt_ts:
+            prompt_can_be_updated = bool(prompt_channel and prompt_ts)
+            if not final_update_ok and prompt_can_be_updated:
                 # The progress placeholder must never be the prompt's last word — if the
                 # final update fails transiently, retry the task (creation is idempotent,
                 # the re-run re-attempts just this update). Once retries are exhausted,
@@ -390,7 +394,8 @@ def _handle_supporthog_interactivity(
                     "ticket_id": str(ticket.id) if ticket else None,
                 },
             )
-            return
+            return ticket is not None and (final_update_ok or not prompt_can_be_updated)
+    return True
 
 
 def _process_interactivity_from_receipt(inbound_event_id: str) -> None:
@@ -403,15 +408,29 @@ def _process_interactivity_from_receipt(inbound_event_id: str) -> None:
             claim, error_code="poison_payload", error="inbound interactivity payload is missing or not an object"
         )
         return
+    config = _slack_config_for_workspace(
+        claim.event.provider_account_id,
+        receipt_team_id=claim.event.team_id,
+    )
+    if not config:
+        _retry_inbound_claim(claim, error_code="no_team", error="slack workspace is not connected")
+        return
     try:
-        _handle_supporthog_interactivity(
+        resolved = _handle_supporthog_interactivity(
             payload,
             claim.event.provider_account_id,
             is_retry=claim.event.attempts > 1,
             allow_retry=claim.allow_retry,
             receipt_team_id=claim.event.team_id,
         )
-        complete_inbound_event(claim)
+        if resolved:
+            complete_inbound_event(claim)
+        else:
+            fail_inbound_event(
+                claim,
+                error_code="interactivity_failed",
+                error="Slack interactivity could not be completed",
+            )
     except TransientInboundError:
         _retry_inbound_claim(claim, error_code="transient", error="interactivity work needs another attempt")
     except Exception as exc:
@@ -422,6 +441,8 @@ def _process_interactivity_from_receipt(inbound_event_id: str) -> None:
 @shared_task(
     name="products.conversations.backend.tasks.process_supporthog_interactivity_receipt",
     ignore_result=True,
+    soft_time_limit=INBOUND_LEASE_SECONDS - 30,
+    time_limit=INBOUND_LEASE_SECONDS - 15,
 )
 @skip_team_scope_audit
 def process_supporthog_interactivity_receipt(inbound_event_id: str) -> None:
@@ -482,20 +503,14 @@ def sweep_inbound_events() -> None:
 
     payload_gc_count = cleanup_inbound_payloads(now)
     tombstone_delete_count = delete_inbound_tombstones(now)
-    oldest_ready_age_seconds = record_inbound_queue_metrics(now)
-    pending_count = (
-        ConversationInboundEvent.objects.unscoped().filter(status=ConversationInboundEvent.Status.PENDING).count()
-    )
-    processing_count = (
-        ConversationInboundEvent.objects.unscoped().filter(status=ConversationInboundEvent.Status.PROCESSING).count()
-    )
+    queue_metrics = record_inbound_queue_metrics(now)
     emit_inbound_sweep_event(
-        pending_count=pending_count,
-        processing_count=processing_count,
+        pending_count=queue_metrics.pending_count,
+        processing_count=queue_metrics.processing_count,
         dispatched_count=dispatched,
         payload_gc_count=payload_gc_count,
         tombstone_delete_count=tombstone_delete_count,
-        oldest_ready_age_seconds=oldest_ready_age_seconds,
+        oldest_ready_age_seconds=queue_metrics.oldest_ready_age_seconds,
     )
     if dispatched or payload_gc_count or tombstone_delete_count:
         logger.info(

--- a/products/conversations/backend/tests/test_inbound_event_processing.py
+++ b/products/conversations/backend/tests/test_inbound_event_processing.py
@@ -5,10 +5,13 @@ from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, patch
 
 from django.core.cache import cache
+from django.db import IntegrityError
 from django.test import SimpleTestCase
 from django.utils import timezone
 
 from prometheus_client import REGISTRY
+
+from posthog.models.team import Team
 
 from products.conversations.backend.models import (
     ConversationInboundEvent,
@@ -17,12 +20,15 @@ from products.conversations.backend.models import (
 )
 from products.conversations.backend.models.inbound_event import INBOUND_PAYLOAD_TTL, INBOUND_TOMBSTONE_TTL
 from products.conversations.backend.services.inbound_events import (
+    accept_inbound_event,
     claim_inbound_event,
     complete_inbound_event,
+    persist_inbound_event,
+    schedule_inbound_retry,
     slack_events_source_id,
     slack_interactivity_source_id,
 )
-from products.conversations.backend.tasks.slack import process_supporthog_event, sweep_inbound_events
+from products.conversations.backend.tasks.slack import process_supporthog_event_receipt, sweep_inbound_events
 
 
 class TestInboundEventSourceId(SimpleTestCase):
@@ -85,14 +91,14 @@ class TestInboundEventProcessing(BaseTest):
             "products.conversations.backend.services.inbound_events.retry_delay_seconds",
             return_value=5,
         ):
-            process_supporthog_event(inbound_event_id=str(row.id))
+            process_supporthog_event_receipt(inbound_event_id=str(row.id))
         row.refresh_from_db()
         assert row.status == ConversationInboundEvent.Status.PENDING
         assert row.attempts == 1
 
         row.due_at = timezone.now()
         row.save(update_fields=["due_at", "updated_at"])
-        process_supporthog_event(inbound_event_id=str(row.id))
+        process_supporthog_event_receipt(inbound_event_id=str(row.id))
         row.refresh_from_db()
         assert row.status == ConversationInboundEvent.Status.PROCESSED
         assert mock_handle.call_count == 2
@@ -118,11 +124,52 @@ class TestInboundEventProcessing(BaseTest):
         second.event.refresh_from_db()
         assert second.event.status == ConversationInboundEvent.Status.PROCESSED
 
+    def test_complete_after_scheduled_retry_is_ignored(self) -> None:
+        row = self._create_pending()
+        claim = claim_inbound_event(str(row.id))
+        assert claim is not None
+        assert schedule_inbound_retry(claim, error_code="handler_failed", error="timeout") is not None
+        assert complete_inbound_event(claim) is False
+        row.refresh_from_db()
+        assert row.status == ConversationInboundEvent.Status.PENDING
+
+    def test_persist_check_violation_is_not_treated_as_duplicate(self) -> None:
+        with self.assertRaises(IntegrityError):
+            persist_inbound_event(
+                team=self.team,
+                source=ConversationInboundEventSource.SLACK_EVENTS,
+                source_id="",
+                provider_account_id="T123",
+                payload={"type": "event_callback"},
+                provider_retry_num=None,
+                provider_retry_reason="",
+            )
+
+    def test_accept_does_not_wake_before_due(self) -> None:
+        self._create_pending()
+        ConversationInboundEvent.objects.unscoped().filter(source_id="Ev1").update(
+            due_at=timezone.now() + timedelta(minutes=5),
+            updated_at=timezone.now(),
+        )
+        wake = MagicMock()
+        with self.captureOnCommitCallbacks(execute=True):
+            accept_inbound_event(
+                team=self.team,
+                source=ConversationInboundEventSource.SLACK_EVENTS,
+                source_id="Ev1",
+                provider_account_id="T123",
+                payload={"type": "event_callback", "event": {"type": "message"}},
+                provider_retry_num=2,
+                provider_retry_reason="http_timeout",
+                wake=wake,
+            )
+        wake.assert_not_called()
+
     @patch("products.conversations.backend.tasks.slack.handle_support_message")
     def test_duplicate_claim_of_processed_row_is_noop(self, mock_handle: MagicMock) -> None:
         row = self._create_pending()
-        process_supporthog_event(inbound_event_id=str(row.id))
-        process_supporthog_event(inbound_event_id=str(row.id))
+        process_supporthog_event_receipt(inbound_event_id=str(row.id))
+        process_supporthog_event_receipt(inbound_event_id=str(row.id))
         row.refresh_from_db()
         assert row.status == ConversationInboundEvent.Status.PROCESSED
         mock_handle.assert_called_once()
@@ -131,21 +178,60 @@ class TestInboundEventProcessing(BaseTest):
     def test_processing_survives_redis_loss(self, mock_handle: MagicMock) -> None:
         row = self._create_pending()
         with patch.object(cache, "add", side_effect=ConnectionError("redis down")):
-            process_supporthog_event(inbound_event_id=str(row.id))
+            process_supporthog_event_receipt(inbound_event_id=str(row.id))
         row.refresh_from_db()
         assert row.status == ConversationInboundEvent.Status.PROCESSED
         mock_handle.assert_called_once()
 
     @patch("products.conversations.backend.tasks.slack.handle_support_message")
+    def test_receipt_uses_workspace_config_from_child_environment(self, mock_handle: MagicMock) -> None:
+        TeamConversationsSlackConfig.objects.filter(team=self.team).update(slack_team_id=None)
+        child_team = Team.objects.create(
+            organization=self.organization,
+            project=self.project,
+            parent_team=self.team,
+            name="Child environment",
+            conversations_settings={"slack_enabled": True},
+        )
+        TeamConversationsSlackConfig.objects.update_or_create(
+            team=child_team,
+            defaults={"slack_team_id": "T123", "slack_bot_token": "xoxb-child"},
+        )
+        row = self._create_pending()
+
+        process_supporthog_event_receipt(inbound_event_id=str(row.id))
+
+        row.refresh_from_db()
+        assert row.status == ConversationInboundEvent.Status.PROCESSED
+        mock_handle.assert_called_once_with(row.payload["event"], child_team, "T123")
+
+    @patch("products.conversations.backend.tasks.slack.handle_support_message")
+    def test_receipt_is_not_processed_after_workspace_moves_to_another_team(self, mock_handle: MagicMock) -> None:
+        row = self._create_pending()
+        TeamConversationsSlackConfig.objects.filter(team=self.team).update(slack_team_id=None)
+        other_team = Team.objects.create_with_data(organization=self.organization, initiating_user=self.user)
+        TeamConversationsSlackConfig.objects.update_or_create(
+            team=other_team,
+            defaults={"slack_team_id": "T123", "slack_bot_token": "xoxb-other"},
+        )
+
+        process_supporthog_event_receipt(inbound_event_id=str(row.id))
+
+        row.refresh_from_db()
+        assert row.status == ConversationInboundEvent.Status.FAILED
+        assert row.last_error_code == "no_team"
+        mock_handle.assert_not_called()
+
+    @patch("products.conversations.backend.tasks.slack.handle_support_message")
     def test_poison_payload_is_terminal(self, mock_handle: MagicMock) -> None:
         row = self._create_pending(payload=["not", "an", "object"])
-        process_supporthog_event(inbound_event_id=str(row.id))
+        process_supporthog_event_receipt(inbound_event_id=str(row.id))
         row.refresh_from_db()
         assert row.status == ConversationInboundEvent.Status.FAILED
         assert row.last_error_code == "poison_payload"
         mock_handle.assert_not_called()
 
-    @patch("products.conversations.backend.tasks.slack.process_supporthog_event")
+    @patch("products.conversations.backend.tasks.slack.process_supporthog_event_receipt")
     def test_sweeper_redrives_due_work_and_cleans_payloads(self, mock_process: MagicMock) -> None:
         due = self._create_pending(source_id="Ev-due")
         future = self._create_pending(source_id="Ev-later")
@@ -180,15 +266,16 @@ class TestInboundEventProcessing(BaseTest):
         sweep_inbound_events()
         assert not ConversationInboundEvent.objects.unscoped().filter(id=row.id).exists()
 
-    @patch("products.conversations.backend.tasks.slack.process_supporthog_event")
-    def test_sweeper_sets_oldest_ready_age_gauge(self, mock_process: MagicMock) -> None:
+    @patch("products.conversations.backend.tasks.slack.process_supporthog_event_receipt")
+    def test_sweeper_measures_expired_lease_age_from_lease_expiry(self, mock_process: MagicMock) -> None:
         with freeze_time("2026-09-10 12:00:00"):
             self._create_pending(source_id="Ev-old-ready")
             ConversationInboundEvent.objects.unscoped().filter(source_id="Ev-old-ready").update(
-                due_at=timezone.now() - timedelta(minutes=3),
+                status=ConversationInboundEvent.Status.PROCESSING,
+                due_at=timezone.now() - timedelta(days=1),
+                lease_expires_at=timezone.now() - timedelta(minutes=3),
                 updated_at=timezone.now(),
             )
             sweep_inbound_events()
         age = REGISTRY.get_sample_value("posthog_conversations_inbound_oldest_ready_age_seconds")
-        assert age is not None
-        assert age >= 180
+        assert age == 180

--- a/products/conversations/backend/tests/test_inbound_event_processing.py
+++ b/products/conversations/backend/tests/test_inbound_event_processing.py
@@ -1,10 +1,10 @@
+import json
 from datetime import timedelta
 
 from freezegun import freeze_time
 from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, patch
 
-from django.core.cache import cache
 from django.db import IntegrityError
 from django.test import SimpleTestCase
 from django.utils import timezone
@@ -20,6 +20,8 @@ from products.conversations.backend.models import (
 )
 from products.conversations.backend.models.inbound_event import INBOUND_PAYLOAD_TTL, INBOUND_TOMBSTONE_TTL
 from products.conversations.backend.services.inbound_events import (
+    INBOUND_LEASE_SECONDS,
+    INBOUND_MAX_ATTEMPTS,
     accept_inbound_event,
     claim_inbound_event,
     complete_inbound_event,
@@ -28,7 +30,12 @@ from products.conversations.backend.services.inbound_events import (
     slack_events_source_id,
     slack_interactivity_source_id,
 )
-from products.conversations.backend.tasks.slack import process_supporthog_event_receipt, sweep_inbound_events
+from products.conversations.backend.slack import TICKET_CONFIRM_ACTION_OPEN
+from products.conversations.backend.tasks.slack import (
+    process_supporthog_event_receipt,
+    process_supporthog_interactivity_receipt,
+    sweep_inbound_events,
+)
 
 
 class TestInboundEventSourceId(SimpleTestCase):
@@ -60,6 +67,14 @@ class TestInboundEventSourceId(SimpleTestCase):
         )
 
 
+class TestInboundEventTaskLimits(SimpleTestCase):
+    def test_receipt_tasks_time_out_before_the_lease_expires(self) -> None:
+        for task in (process_supporthog_event_receipt, process_supporthog_interactivity_receipt):
+            assert task.soft_time_limit is not None
+            assert task.time_limit is not None
+            assert task.soft_time_limit < task.time_limit < INBOUND_LEASE_SECONDS
+
+
 class TestInboundEventProcessing(BaseTest):
     def setUp(self) -> None:
         super().setUp()
@@ -71,11 +86,17 @@ class TestInboundEventProcessing(BaseTest):
             defaults={"slack_team_id": "T123", "slack_bot_token": "xoxb-test"},
         )
 
-    def _create_pending(self, *, source_id: str = "Ev1", **kwargs: object) -> ConversationInboundEvent:
+    def _create_pending(
+        self,
+        *,
+        source: str = ConversationInboundEventSource.SLACK_EVENTS,
+        source_id: str = "Ev1",
+        **kwargs: object,
+    ) -> ConversationInboundEvent:
         payload = kwargs.pop("payload", {"type": "event_callback", "event": {"type": "message", "channel": "C1"}})
         return ConversationInboundEvent.objects.for_team(self.team.id).create(
             team=self.team,
-            source=ConversationInboundEventSource.SLACK_EVENTS,
+            source=source,
             source_id=source_id,
             provider_account_id="T123",
             payload=payload,
@@ -133,6 +154,20 @@ class TestInboundEventProcessing(BaseTest):
         row.refresh_from_db()
         assert row.status == ConversationInboundEvent.Status.PENDING
 
+    def test_expired_receipt_is_failed_after_max_attempts(self) -> None:
+        row = self._create_pending(
+            status=ConversationInboundEvent.Status.PROCESSING,
+            attempts=INBOUND_MAX_ATTEMPTS,
+            lease_expires_at=timezone.now() - timedelta(seconds=1),
+        )
+
+        assert claim_inbound_event(str(row.id)) is None
+
+        row.refresh_from_db()
+        assert row.status == ConversationInboundEvent.Status.FAILED
+        assert row.last_error_code == "max_attempts"
+        assert row.terminal_at is not None
+
     def test_persist_check_violation_is_not_treated_as_duplicate(self) -> None:
         with self.assertRaises(IntegrityError):
             persist_inbound_event(
@@ -175,15 +210,6 @@ class TestInboundEventProcessing(BaseTest):
         mock_handle.assert_called_once()
 
     @patch("products.conversations.backend.tasks.slack.handle_support_message")
-    def test_processing_survives_redis_loss(self, mock_handle: MagicMock) -> None:
-        row = self._create_pending()
-        with patch.object(cache, "add", side_effect=ConnectionError("redis down")):
-            process_supporthog_event_receipt(inbound_event_id=str(row.id))
-        row.refresh_from_db()
-        assert row.status == ConversationInboundEvent.Status.PROCESSED
-        mock_handle.assert_called_once()
-
-    @patch("products.conversations.backend.tasks.slack.handle_support_message")
     def test_receipt_uses_workspace_config_from_child_environment(self, mock_handle: MagicMock) -> None:
         TeamConversationsSlackConfig.objects.filter(team=self.team).update(slack_team_id=None)
         child_team = Team.objects.create(
@@ -218,9 +244,36 @@ class TestInboundEventProcessing(BaseTest):
         process_supporthog_event_receipt(inbound_event_id=str(row.id))
 
         row.refresh_from_db()
-        assert row.status == ConversationInboundEvent.Status.FAILED
+        assert row.status == ConversationInboundEvent.Status.PENDING
         assert row.last_error_code == "no_team"
         mock_handle.assert_not_called()
+
+    @patch("products.conversations.backend.tasks.slack._update_supporthog_prompt", return_value=True)
+    @patch("products.conversations.backend.tasks.slack.create_ticket_from_confirmation", return_value=None)
+    def test_exhausted_interactivity_is_failed(self, mock_create: MagicMock, mock_update: MagicMock) -> None:
+        row = self._create_pending(
+            source=ConversationInboundEventSource.SLACK_INTERACTIVITY,
+            attempts=INBOUND_MAX_ATTEMPTS - 1,
+            payload={
+                "type": "block_actions",
+                "team": {"id": "T123"},
+                "container": {"channel_id": "C1", "message_ts": "1.0"},
+                "actions": [
+                    {
+                        "action_id": TICKET_CONFIRM_ACTION_OPEN,
+                        "value": json.dumps({"channel": "C1", "message_ts": "1.0"}),
+                    }
+                ],
+            },
+        )
+
+        process_supporthog_interactivity_receipt(inbound_event_id=str(row.id))
+
+        row.refresh_from_db()
+        assert row.status == ConversationInboundEvent.Status.FAILED
+        assert row.last_error_code == "interactivity_failed"
+        mock_create.assert_called_once()
+        mock_update.assert_called_once()
 
     @patch("products.conversations.backend.tasks.slack.handle_support_message")
     def test_poison_payload_is_terminal(self, mock_handle: MagicMock) -> None:

--- a/products/conversations/backend/tests/test_inbound_event_processing.py
+++ b/products/conversations/backend/tests/test_inbound_event_processing.py
@@ -100,7 +100,7 @@ class TestInboundEventProcessing(BaseTest):
             source_id=source_id,
             provider_account_id="T123",
             payload=payload,
-            **kwargs,  # type: ignore[arg-type]
+            **kwargs,
         )
 
     @patch("products.conversations.backend.tasks.slack.handle_support_message")
@@ -229,7 +229,11 @@ class TestInboundEventProcessing(BaseTest):
 
         row.refresh_from_db()
         assert row.status == ConversationInboundEvent.Status.PROCESSED
-        mock_handle.assert_called_once_with(row.payload["event"], child_team, "T123")
+        mock_handle.assert_called_once_with(
+            {"type": "message", "channel": "C1"},
+            child_team,
+            "T123",
+        )
 
     @patch("products.conversations.backend.tasks.slack.handle_support_message")
     def test_receipt_is_not_processed_after_workspace_moves_to_another_team(self, mock_handle: MagicMock) -> None:

--- a/products/conversations/backend/tests/test_inbound_event_processing.py
+++ b/products/conversations/backend/tests/test_inbound_event_processing.py
@@ -1,0 +1,194 @@
+from datetime import timedelta
+
+from freezegun import freeze_time
+from posthog.test.base import BaseTest
+from unittest.mock import MagicMock, patch
+
+from django.core.cache import cache
+from django.test import SimpleTestCase
+from django.utils import timezone
+
+from prometheus_client import REGISTRY
+
+from products.conversations.backend.models import (
+    ConversationInboundEvent,
+    ConversationInboundEventSource,
+    TeamConversationsSlackConfig,
+)
+from products.conversations.backend.models.inbound_event import INBOUND_PAYLOAD_TTL, INBOUND_TOMBSTONE_TTL
+from products.conversations.backend.services.inbound_events import (
+    claim_inbound_event,
+    complete_inbound_event,
+    slack_events_source_id,
+    slack_interactivity_source_id,
+)
+from products.conversations.backend.tasks.slack import process_supporthog_event, sweep_inbound_events
+
+
+class TestInboundEventSourceId(SimpleTestCase):
+    def test_events_prefer_slack_event_id(self) -> None:
+        # Two retries of the same Events API callback must collapse to one receipt.
+        assert slack_events_source_id(event_id="Ev123", signed_body=b'{"x":1}') == "Ev123"
+
+    def test_events_hash_body_when_event_id_missing(self) -> None:
+        # Missing event_id must not collide across different callbacks.
+        first = slack_events_source_id(event_id=None, signed_body=b'{"a":1}')
+        second = slack_events_source_id(event_id=None, signed_body=b'{"a":2}')
+        assert first != second
+        assert len(first) == 64
+
+    def test_interactivity_uses_trigger_and_container(self) -> None:
+        payload = {
+            "trigger_id": "trig.abc",
+            "actions": [{"action_id": "open_ticket"}],
+            "container": {"type": "message", "message_ts": "1.2", "channel_id": "C1", "thread_ts": "1.1"},
+        }
+        assert slack_interactivity_source_id(payload=payload, signed_body=b"ignored") == (
+            "trig.abc:open_ticket:message:1.2:C1:1.1"
+        )
+
+    def test_interactivity_hashes_signed_body_without_trigger_id(self) -> None:
+        payload = {"actions": [{"action_id": "open_ticket"}]}
+        assert slack_interactivity_source_id(payload=payload, signed_body=b"form-a") != slack_interactivity_source_id(
+            payload=payload, signed_body=b"form-b"
+        )
+
+
+class TestInboundEventProcessing(BaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.team.conversations_enabled = True
+        self.team.conversations_settings = {"slack_enabled": True}
+        self.team.save()
+        TeamConversationsSlackConfig.objects.update_or_create(
+            team=self.team,
+            defaults={"slack_team_id": "T123", "slack_bot_token": "xoxb-test"},
+        )
+
+    def _create_pending(self, *, source_id: str = "Ev1", **kwargs: object) -> ConversationInboundEvent:
+        payload = kwargs.pop("payload", {"type": "event_callback", "event": {"type": "message", "channel": "C1"}})
+        return ConversationInboundEvent.objects.for_team(self.team.id).create(
+            team=self.team,
+            source=ConversationInboundEventSource.SLACK_EVENTS,
+            source_id=source_id,
+            provider_account_id="T123",
+            payload=payload,
+            **kwargs,  # type: ignore[arg-type]
+        )
+
+    @patch("products.conversations.backend.tasks.slack.handle_support_message")
+    def test_provider_retry_after_worker_failure(self, mock_handle: MagicMock) -> None:
+        row = self._create_pending()
+        mock_handle.side_effect = [RuntimeError("slack timeout"), None]
+
+        with patch(
+            "products.conversations.backend.services.inbound_events.retry_delay_seconds",
+            return_value=5,
+        ):
+            process_supporthog_event(inbound_event_id=str(row.id))
+        row.refresh_from_db()
+        assert row.status == ConversationInboundEvent.Status.PENDING
+        assert row.attempts == 1
+
+        row.due_at = timezone.now()
+        row.save(update_fields=["due_at", "updated_at"])
+        process_supporthog_event(inbound_event_id=str(row.id))
+        row.refresh_from_db()
+        assert row.status == ConversationInboundEvent.Status.PROCESSED
+        assert mock_handle.call_count == 2
+
+    def test_expired_lease_fencing_ignores_stale_complete(self) -> None:
+        row = self._create_pending()
+        first = claim_inbound_event(str(row.id))
+        assert first is not None
+
+        ConversationInboundEvent.objects.unscoped().filter(id=row.id).update(
+            lease_expires_at=timezone.now() - timedelta(seconds=1),
+            updated_at=timezone.now(),
+        )
+        second = claim_inbound_event(str(row.id))
+        assert second is not None
+        assert second.event.fencing_token != first.event.fencing_token
+        assert second.expired_reclaim is True
+
+        assert complete_inbound_event(first) is False
+        second.event.refresh_from_db()
+        assert second.event.status == ConversationInboundEvent.Status.PROCESSING
+        assert complete_inbound_event(second) is True
+        second.event.refresh_from_db()
+        assert second.event.status == ConversationInboundEvent.Status.PROCESSED
+
+    @patch("products.conversations.backend.tasks.slack.handle_support_message")
+    def test_duplicate_claim_of_processed_row_is_noop(self, mock_handle: MagicMock) -> None:
+        row = self._create_pending()
+        process_supporthog_event(inbound_event_id=str(row.id))
+        process_supporthog_event(inbound_event_id=str(row.id))
+        row.refresh_from_db()
+        assert row.status == ConversationInboundEvent.Status.PROCESSED
+        mock_handle.assert_called_once()
+
+    @patch("products.conversations.backend.tasks.slack.handle_support_message")
+    def test_processing_survives_redis_loss(self, mock_handle: MagicMock) -> None:
+        row = self._create_pending()
+        with patch.object(cache, "add", side_effect=ConnectionError("redis down")):
+            process_supporthog_event(inbound_event_id=str(row.id))
+        row.refresh_from_db()
+        assert row.status == ConversationInboundEvent.Status.PROCESSED
+        mock_handle.assert_called_once()
+
+    @patch("products.conversations.backend.tasks.slack.handle_support_message")
+    def test_poison_payload_is_terminal(self, mock_handle: MagicMock) -> None:
+        row = self._create_pending(payload=["not", "an", "object"])
+        process_supporthog_event(inbound_event_id=str(row.id))
+        row.refresh_from_db()
+        assert row.status == ConversationInboundEvent.Status.FAILED
+        assert row.last_error_code == "poison_payload"
+        mock_handle.assert_not_called()
+
+    @patch("products.conversations.backend.tasks.slack.process_supporthog_event")
+    def test_sweeper_redrives_due_work_and_cleans_payloads(self, mock_process: MagicMock) -> None:
+        due = self._create_pending(source_id="Ev-due")
+        future = self._create_pending(source_id="Ev-later")
+        ConversationInboundEvent.objects.unscoped().filter(id=future.id).update(
+            due_at=timezone.now() + timedelta(hours=1),
+            updated_at=timezone.now(),
+        )
+        terminal = self._create_pending(
+            source_id="Ev-old",
+            status=ConversationInboundEvent.Status.PROCESSED,
+            terminal_at=timezone.now() - INBOUND_PAYLOAD_TTL - timedelta(minutes=1),
+            payload={"event": {"type": "message"}},
+        )
+
+        with patch("products.conversations.backend.services.inbound_events.ph_scoped_capture") as mock_capture:
+            mock_capture.return_value.__enter__.return_value = MagicMock()
+            sweep_inbound_events()
+
+        mock_process.delay.assert_called_once_with(inbound_event_id=str(due.id))
+        terminal.refresh_from_db()
+        assert terminal.payload is None
+        future.refresh_from_db()
+        assert future.status == ConversationInboundEvent.Status.PENDING
+
+    def test_sweeper_deletes_expired_tombstones(self) -> None:
+        row = self._create_pending(
+            source_id="Ev-tombstone",
+            status=ConversationInboundEvent.Status.FAILED,
+            terminal_at=timezone.now() - INBOUND_TOMBSTONE_TTL - timedelta(minutes=1),
+            payload=None,
+        )
+        sweep_inbound_events()
+        assert not ConversationInboundEvent.objects.unscoped().filter(id=row.id).exists()
+
+    @patch("products.conversations.backend.tasks.slack.process_supporthog_event")
+    def test_sweeper_sets_oldest_ready_age_gauge(self, mock_process: MagicMock) -> None:
+        with freeze_time("2026-09-10 12:00:00"):
+            self._create_pending(source_id="Ev-old-ready")
+            ConversationInboundEvent.objects.unscoped().filter(source_id="Ev-old-ready").update(
+                due_at=timezone.now() - timedelta(minutes=3),
+                updated_at=timezone.now(),
+            )
+            sweep_inbound_events()
+        age = REGISTRY.get_sample_value("posthog_conversations_inbound_oldest_ready_age_seconds")
+        assert age is not None
+        assert age >= 180

--- a/products/conversations/backend/tests/test_inbound_event_processing.py
+++ b/products/conversations/backend/tests/test_inbound_event_processing.py
@@ -1,4 +1,6 @@
 import json
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import timedelta
 
 from freezegun import freeze_time
@@ -9,8 +11,9 @@ from django.db import IntegrityError
 from django.test import SimpleTestCase
 from django.utils import timezone
 
-from prometheus_client import REGISTRY
+from prometheus_client import REGISTRY, CollectorRegistry
 
+from posthog.metrics import pushed_metrics_registry
 from posthog.models.team import Team
 
 from products.conversations.backend.models import (
@@ -36,6 +39,21 @@ from products.conversations.backend.tasks.slack import (
     process_supporthog_interactivity_receipt,
     sweep_inbound_events,
 )
+
+
+@contextmanager
+def capture_pushed_registries() -> Iterator[list[CollectorRegistry]]:
+    """Collect the registries the sweep pushes its inbound queue gauges to."""
+    captured: list[CollectorRegistry] = []
+
+    @contextmanager
+    def wrapper(job_name: str) -> Iterator[CollectorRegistry]:
+        with pushed_metrics_registry(job_name) as registry:
+            captured.append(registry)
+            yield registry
+
+    with patch("products.conversations.backend.services.inbound_events.pushed_metrics_registry", wrapper):
+        yield captured
 
 
 class TestInboundEventSourceId(SimpleTestCase):
@@ -333,6 +351,10 @@ class TestInboundEventProcessing(BaseTest):
                 lease_expires_at=timezone.now() - timedelta(minutes=3),
                 updated_at=timezone.now(),
             )
-            sweep_inbound_events()
-        age = REGISTRY.get_sample_value("posthog_conversations_inbound_oldest_ready_age_seconds")
+            with capture_pushed_registries() as registries:
+                sweep_inbound_events()
+        age = registries[0].get_sample_value("posthog_conversations_inbound_oldest_ready_age_seconds")
         assert age == 180
+        # The gauge is a whole-table snapshot, so it must stay out of the process-global
+        # registry — otherwise every worker pod that swept exports its own stale copy.
+        assert REGISTRY.get_sample_value("posthog_conversations_inbound_oldest_ready_age_seconds") is None

--- a/products/conversations/backend/tests/test_task_registration.py
+++ b/products/conversations/backend/tests/test_task_registration.py
@@ -7,6 +7,7 @@ from posthog.celery import app
 EXPECTED_TASK_NAMES = {
     "products.conversations.backend.tasks.process_supporthog_event",
     "products.conversations.backend.tasks.process_supporthog_interactivity",
+    "products.conversations.backend.tasks.sweep_inbound_events",
     "products.conversations.backend.tasks.post_reply_to_slack",
     "products.conversations.backend.tasks.send_email_reply",
     "products.conversations.backend.tasks.flush_pending_email_replies",

--- a/products/conversations/backend/tests/test_task_registration.py
+++ b/products/conversations/backend/tests/test_task_registration.py
@@ -6,7 +6,9 @@ from posthog.celery import app
 # a submodule import would leave queued messages and Beat entries unresolved.
 EXPECTED_TASK_NAMES = {
     "products.conversations.backend.tasks.process_supporthog_event",
+    "products.conversations.backend.tasks.process_supporthog_event_receipt",
     "products.conversations.backend.tasks.process_supporthog_interactivity",
+    "products.conversations.backend.tasks.process_supporthog_interactivity_receipt",
     "products.conversations.backend.tasks.sweep_inbound_events",
     "products.conversations.backend.tasks.post_reply_to_slack",
     "products.conversations.backend.tasks.send_email_reply",


### PR DESCRIPTION
## Problem

Slack retries of a SupportHog callback used to be discarded.
A timeout after Slack's first POST permanently dropped the message.

S0 [#97306](https://github.com/PostHog/posthog/pull/97306) added the empty receipt table.
This PR writes receipts into it and acknowledges Slack only after that commit.

`X-Slack-Retry-Num` was treated as a drop signal.
Redis SETNX was the only dedupe, so a Redis outage could suppress work.
Events API proxy failure returned 2xx, so Slack never retried.

## Changes

- A Slack retry of a timed-out SupportHog callback is processed instead of discarded.
- A 2xx means owning-region Postgres committed the receipt, not that a worker ran.
- Duplicate callbacks collapse on `(team, source, source_id)`.
- Retry headers are metadata. Owning-region proxy failure returns 502.
- Workers claim with a fencing token. A stale complete is ignored.
- Celery is an `on_commit` wake-up. Beat runs `sweep_inbound_events` every minute.
- Redis is not the dedupe. Losing it does not drop or suppress a callback.

Mechanical: Beat registration, Prometheus gauges, one sanitized ClickHouse sweep event, and the internal reliability doc.
Nothing in the product UI looks different.

> [!NOTE]
> Task signatures still accept the old payload args so in-flight Celery messages survive the deploy.
> New calls pass `inbound_event_id`.

Before:

```mermaid
flowchart LR
    slack[Slack] --> ep[Events or interactivity]
    ep --> drop{Retry header?}
    drop -->|yes| discard[Discard]
    drop -->|no| celery[Celery delay]
    celery --> redis[Redis SETNX]
    celery --> worker[Worker]
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class slack,ep phRed;
    class drop phYellow;
    class discard,celery,redis,worker phGray;
```

After:

```mermaid
flowchart LR
    slack[Slack] --> ep[Events or interactivity]
    ep --> pg[(Postgres receipt)]
    pg --> ack[2xx]
    pg --> hint[on_commit Celery]
    pg --> sweep[Minute sweeper]
    hint --> worker[Leased worker]
    sweep --> worker
    worker --> pg
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class slack,ep phRed;
    class ack,hint phYellow;
    class pg,sweep,worker phGray;
```

## How did you test this code?

Ran locally:

- `products/conversations/backend/tests/test_inbound_event_processing.py`
- `products/conversations/backend/api/tests/test_slack_endpoints.py` (`TestSupportSlackEventsAPI`, `TestSupportSlackInteractivityAPI`)
- Earlier in the same change: `test_task_registration.py` and `test_slack_message_routing.py`

New tests catch:

- Retry headers persist instead of dropping the callback
- Duplicate Events API posts collapse to one receipt
- Broker failure after commit still returns 2xx
- Oversized payloads tombstone and still ack
- Events API proxy failure returns 502
- Worker failure leaves the row pending for a later claim
- Expired-lease fencing ignores a stale complete
- Poison payloads go terminal
- Processing survives Redis loss
- The sweeper re-drives due work, nulls old payloads, and deletes tombstones