### PR TITLE
feat(error-tracking): add a symbol set upload check endpoint

### DIFF
--- a/products/error_tracking/backend/facade/symbol_sets.py
+++ b/products/error_tracking/backend/facade/symbol_sets.py
@@ -108,5 +108,20 @@ def bulk_start_upload(
     )
 
 
+def bulk_check_upload(
+    team: Any,
+    *,
+    symbol_sets: list[dict],
+    force: bool,
+    skip_on_conflict: bool,
+) -> list[str]:
+    return _logic.bulk_check_upload(
+        team,
+        symbol_sets=symbol_sets,
+        force=force,
+        skip_on_conflict=skip_on_conflict,
+    )
+
+
 def bulk_finish_upload(team: Any, content_hashes: dict[str, str]) -> None:
     _logic.bulk_finish_upload(team, content_hashes)

--- a/products/error_tracking/backend/logic/symbol_sets.py
+++ b/products/error_tracking/backend/logic/symbol_sets.py
@@ -8,6 +8,7 @@ the CLI-facing upload contract and are surfaced verbatim by the views.
 
 import hashlib
 import datetime
+from collections import Counter
 from dataclasses import dataclass
 from typing import Any
 
@@ -168,24 +169,15 @@ def refresh_last_used(team: Team, chunk_ids: list[str]) -> None:
     ).update(last_used=now)
 
 
-@posthoganalytics.scoped()
-def bulk_create_symbol_sets(
-    new_symbol_sets: list[SymbolSetUpload],
-    team: Team,
-    force: bool = False,
-    skip_on_conflict: bool = False,
-) -> dict[str, dict[str, Any]]:
+def _validate_uploads(new_symbol_sets: list[SymbolSetUpload], team: Team) -> None:
     chunk_ids = [x.chunk_id for x in new_symbol_sets]
-
-    # Check for dupes
-    duplicates = [x for x in chunk_ids if chunk_ids.count(x) > 1]
+    duplicates = sorted(chunk_id for chunk_id, count in Counter(chunk_ids).items() if count > 1)
     if duplicates:
         raise ValidationError(
             code="invalid_chunk_ids",
             detail=f"Duplicate chunk IDs provided: {', '.join(duplicates)}",
         )
 
-    # Check we're using all valid release IDs
     release_ids = {ss.release_id for ss in new_symbol_sets if ss.release_id}
     fetched_releases = {str(r.id) for r in ErrorTrackingRelease.objects.all().filter(team=team, pk__in=release_ids)}
     for release_id in release_ids:
@@ -194,6 +186,110 @@ def bulk_create_symbol_sets(
                 code="invalid_release_id",
                 detail=f"Unknown release ID provided: {release_id}",
             )
+
+
+def _binds_release(existing: ErrorTrackingSymbolSet, upload: SymbolSetUpload) -> bool:
+    """Whether the upload binds a release to a symbol set that has none.
+
+    An orphan symbol set may join a release, but a bound one never moves between releases.
+    """
+    if not upload.release_id:
+        return False
+    if existing.release_id is None:
+        return True
+    if str(existing.release_id) != upload.release_id:
+        raise ValidationError(
+            code="release_id_mismatch",
+            detail=f"Symbol set {existing.ref} already has a release ID",
+        )
+    return False
+
+
+def _needs_upload(
+    existing: ErrorTrackingSymbolSet,
+    upload: SymbolSetUpload,
+    team_id: int,
+    force: bool,
+    skip_on_conflict: bool,
+) -> bool:
+    if upload.content_hash is None:
+        if existing.content_hash is not None:
+            # Old CLI (no content hash) trying to re-upload a symbol set
+            # that was already fully uploaded. We can't determine safety,
+            # so reject rather than silently overwrite production data.
+            raise ValidationError(
+                code="content_hash_required",
+                detail=f"Symbol set {existing.ref} already has content; provide a content_hash to update it.",
+            )
+        # Both sides have no hash: this is a pending upload being restarted.
+        return True
+    if existing.content_hash is None:
+        # Existing record has no hash (pending upload or uploaded by old CLI
+        # without hash support). Allow the new upload to supply one.
+        return True
+    if existing.content_hash == upload.content_hash:
+        return False
+    if force:
+        return True
+    if skip_on_conflict:
+        # Content has changed, but the caller explicitly asked to keep
+        # the already-uploaded symbol set.
+        logger.warning(
+            "symbol_set_content_changed_skipped",
+            ref=existing.ref,
+            team_id=team_id,
+        )
+        return False
+    raise ValidationError(
+        code="content_hash_mismatch",
+        detail=f"Symbol set {existing.ref} already exists with different content.",
+    )
+
+
+@posthoganalytics.scoped()
+def bulk_check_symbol_sets(
+    new_symbol_sets: list[SymbolSetUpload],
+    team: Team,
+    force: bool = False,
+    skip_on_conflict: bool = False,
+) -> list[str]:
+    """Return the chunk ids `bulk_create_symbol_sets` would act on, without creating rows or
+    issuing upload URLs. It raises the same validation errors, so a conflict fails the client
+    before it uploads anything. The other chunks are marked as still in use here, because the
+    client drops them from the upload and nothing else touches their rows.
+    """
+    _validate_uploads(new_symbol_sets, team)
+    chunk_ids = [x.chunk_id for x in new_symbol_sets]
+    existing_by_ref = {s.ref: s for s in ErrorTrackingSymbolSet.objects.filter(team=team, ref__in=chunk_ids)}
+
+    chunk_ids_to_upload: list[str] = []
+    unchanged_chunk_ids: list[str] = []
+    for upload in new_symbol_sets:
+        existing = existing_by_ref.get(upload.chunk_id)
+        if existing is None:
+            chunk_ids_to_upload.append(upload.chunk_id)
+            continue
+        binds_release = _binds_release(existing, upload)
+        needs_upload = _needs_upload(existing, upload, team.id, force, skip_on_conflict)
+        if binds_release or needs_upload:
+            chunk_ids_to_upload.append(upload.chunk_id)
+        else:
+            unchanged_chunk_ids.append(upload.chunk_id)
+
+    if unchanged_chunk_ids:
+        refresh_last_used(team, unchanged_chunk_ids)
+    return chunk_ids_to_upload
+
+
+@posthoganalytics.scoped()
+def bulk_create_symbol_sets(
+    new_symbol_sets: list[SymbolSetUpload],
+    team: Team,
+    force: bool = False,
+    skip_on_conflict: bool = False,
+) -> dict[str, dict[str, Any]]:
+    _validate_uploads(new_symbol_sets, team)
+    chunk_ids = [x.chunk_id for x in new_symbol_sets]
 
     id_url_map: dict[str, dict[str, Any]] = {}
     new_symbol_set_map = {x.chunk_id: x for x in new_symbol_sets}
@@ -205,6 +301,8 @@ def bulk_create_symbol_sets(
             "symbol_set_id": str(existing.id),
         }
         existing.storage_ptr = storage_ptr
+        # bulk_finish_upload stores the hash once the new file is confirmed in object storage.
+        existing.content_hash = None
 
     with transaction.atomic():
         existing_symbol_sets = list(ErrorTrackingSymbolSet.objects.filter(team=team, ref__in=chunk_ids))
@@ -238,60 +336,13 @@ def bulk_create_symbol_sets(
             upload = new_symbol_set_map[existing.ref]
             dirty = False
 
-            # Allow adding an "orphan" symbol set to a release, but not
-            # moving symbols sets between releases
-            if upload.release_id:
-                if existing.release_id is None:
-                    existing.release_id = upload.release_id
-                    dirty = True
-                elif str(existing.release_id) != upload.release_id:
-                    raise ValidationError(
-                        code="release_id_mismatch",
-                        detail=f"Symbol set {existing.ref} already has a release ID",
-                    )
+            if _binds_release(existing, upload):
+                existing.release_id = upload.release_id
+                dirty = True
 
-            if upload.content_hash is None:
-                if existing.content_hash is not None:
-                    # Old CLI (no content hash) trying to re-upload a symbol set
-                    # that was already fully uploaded. We can't determine safety,
-                    # so reject rather than silently overwrite production data.
-                    raise ValidationError(
-                        code="content_hash_required",
-                        detail=f"Symbol set {existing.ref} already has content; provide a content_hash to update it.",
-                    )
-                # Both sides have no hash: this is a pending upload being restarted.
-                # Issue a fresh presigned URL so the client can retry.
+            if _needs_upload(existing, upload, team.id, force, skip_on_conflict):
                 reissue_upload(existing)
                 dirty = True
-            elif existing.content_hash is None:
-                # Existing record has no hash (pending upload or uploaded by old CLI
-                # without hash support). Allow the new upload to supply one.
-                reissue_upload(existing)
-                dirty = True
-            elif existing.content_hash == upload.content_hash:
-                # Content is identical — no upload needed.
-                # (We may still update the release below if it changed.)
-                pass
-            elif force:
-                # force=True: content has changed and the caller explicitly
-                # requested an overwrite. Issue a new presigned URL and clear
-                # the old content hash so bulk_finish_upload stores the new one.
-                reissue_upload(existing)
-                existing.content_hash = None  # will be set by bulk_finish_upload
-                dirty = True
-            elif skip_on_conflict:
-                # Content has changed, but the caller explicitly asked to keep
-                # the already-uploaded symbol set.
-                logger.warning(
-                    "symbol_set_content_changed_skipped",
-                    ref=existing.ref,
-                    team_id=team.id,
-                )
-            else:
-                raise ValidationError(
-                    code="content_hash_mismatch",
-                    detail=f"Symbol set {existing.ref} already exists with different content.",
-                )
 
             if dirty:
                 to_update.append(existing)
@@ -458,6 +509,17 @@ def bulk_start_upload(
         force=force,
         skip_on_conflict=skip_on_conflict,
     )
+
+
+def bulk_check_upload(
+    team: Team,
+    *,
+    symbol_sets: list[dict],
+    force: bool,
+    skip_on_conflict: bool,
+) -> list[str]:
+    uploads = [SymbolSetUpload(**data) for data in symbol_sets]
+    return bulk_check_symbol_sets(uploads, team, force=force, skip_on_conflict=skip_on_conflict)
 
 
 def bulk_finish_upload(team: Team, content_hashes: dict[str, str]) -> None:

--- a/products/error_tracking/backend/logic/symbol_sets.py
+++ b/products/error_tracking/backend/logic/symbol_sets.py
@@ -25,6 +25,7 @@ from posthog.event_usage import groups
 from posthog.models.team.team import Team
 from posthog.models.utils import uuid7
 from posthog.storage import object_storage
+from posthog.uuidt import UUIDT
 
 from products.error_tracking.backend.models import ErrorTrackingRelease, ErrorTrackingStackFrame, ErrorTrackingSymbolSet
 
@@ -179,6 +180,15 @@ def _validate_uploads(new_symbol_sets: list[SymbolSetUpload], team: Team) -> Non
         )
 
     release_ids = {ss.release_id for ss in new_symbol_sets if ss.release_id}
+    # A release ID that is not a UUID makes the `pk__in` lookup below raise before it reaches the
+    # database, and that error leaves as a 500 instead of telling the client what to correct.
+    malformed = sorted(release_id for release_id in release_ids if not UUIDT.is_valid_uuid(release_id))
+    if malformed:
+        raise ValidationError(
+            code="invalid_release_id",
+            detail=f"Invalid release ID provided: {', '.join(malformed)}",
+        )
+
     fetched_releases = {str(r.id) for r in ErrorTrackingRelease.objects.all().filter(team=team, pk__in=release_ids)}
     for release_id in release_ids:
         if release_id not in fetched_releases:

--- a/products/error_tracking/backend/presentation/views/symbol_sets.py
+++ b/products/error_tracking/backend/presentation/views/symbol_sets.py
@@ -18,6 +18,8 @@ from products.error_tracking.backend.facade import (
 )
 from products.error_tracking.backend.presentation.pagination import paginate_via_facade
 
+BULK_CHECK_UPLOAD_MAX_SYMBOL_SETS = 1000
+
 
 class ErrorTrackingSymbolSetSerializer(DataclassSerializer):
     class Meta:
@@ -50,9 +52,14 @@ class ErrorTrackingSymbolSetBulkDeleteSerializer(serializers.Serializer):
 
 
 class ErrorTrackingSymbolSetBulkCheckUploadSerializer(serializers.Serializer):
-    symbol_sets = ErrorTrackingSymbolSetUploadSerializer(
+    # `max_length` reaches the ListSerializer through `many_init`, which the DRF stubs do not model.
+    symbol_sets = ErrorTrackingSymbolSetUploadSerializer(  # type: ignore[call-arg]
         many=True,
-        help_text="Symbol sets the client intends to upload, with per-symbol release IDs and content hashes.",
+        max_length=BULK_CHECK_UPLOAD_MAX_SYMBOL_SETS,
+        help_text=(
+            "Symbol sets the client intends to upload, with per-symbol release IDs and content hashes. "
+            f"Send at most {BULK_CHECK_UPLOAD_MAX_SYMBOL_SETS} per request."
+        ),
     )
     force = serializers.BooleanField(
         required=False,

--- a/products/error_tracking/backend/presentation/views/symbol_sets.py
+++ b/products/error_tracking/backend/presentation/views/symbol_sets.py
@@ -49,22 +49,10 @@ class ErrorTrackingSymbolSetBulkDeleteSerializer(serializers.Serializer):
     )
 
 
-class ErrorTrackingSymbolSetBulkStartUploadSerializer(serializers.Serializer):
-    chunk_ids = serializers.ListField(
-        child=serializers.CharField(),
-        required=False,
-        help_text="Legacy list of symbol set references to upload, all associated with `release_id`.",
-    )
-    release_id = serializers.CharField(
-        required=False,
-        allow_null=True,
-        default=None,
-        help_text="Optional error tracking release ID used with `chunk_ids`.",
-    )
+class ErrorTrackingSymbolSetBulkCheckUploadSerializer(serializers.Serializer):
     symbol_sets = ErrorTrackingSymbolSetUploadSerializer(
         many=True,
-        required=False,
-        help_text="Symbol sets to upload with per-symbol release IDs and content hashes.",
+        help_text="Symbol sets the client intends to upload, with per-symbol release IDs and content hashes.",
     )
     force = serializers.BooleanField(
         required=False,
@@ -84,6 +72,32 @@ class ErrorTrackingSymbolSetBulkStartUploadSerializer(serializers.Serializer):
                 detail="Use either force or skip_on_conflict, not both.",
             )
         return attrs
+
+
+class ErrorTrackingSymbolSetBulkCheckUploadResponseSerializer(serializers.Serializer):
+    chunk_ids_to_upload = serializers.ListField(
+        child=serializers.CharField(),
+        help_text="Chunk IDs to send to `bulk_start_upload`: the symbol set is missing, its upload never completed, its content differs, or it still needs the release bound. The other chunks are already uploaded with identical content and were marked as still in use.",
+    )
+
+
+class ErrorTrackingSymbolSetBulkStartUploadSerializer(ErrorTrackingSymbolSetBulkCheckUploadSerializer):
+    chunk_ids = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        help_text="Legacy list of symbol set references to upload, all associated with `release_id`.",
+    )
+    release_id = serializers.CharField(
+        required=False,
+        allow_null=True,
+        default=None,
+        help_text="Optional error tracking release ID used with `chunk_ids`.",
+    )
+    symbol_sets = ErrorTrackingSymbolSetUploadSerializer(
+        many=True,
+        required=False,
+        help_text="Symbol sets to upload with per-symbol release IDs and content hashes.",
+    )
 
 
 class ErrorTrackingSymbolSetPresignedPostSerializer(serializers.Serializer):
@@ -159,6 +173,7 @@ class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.GenericView
     throttle_classes = [SymbolSetUploadBurstRateThrottle, SymbolSetUploadSustainedRateThrottle]
     scope_object_read_actions = ["list", "retrieve", "download"]
     scope_object_write_actions = [
+        "bulk_check_upload",
         "bulk_start_upload",
         "bulk_finish_upload",
         "start_upload",
@@ -313,16 +328,57 @@ class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.GenericView
 
         return Response({"success": True}, status=status.HTTP_200_OK)
 
+    def _identify_upload_context(self, request: Request) -> None:
+        if request.user.pk:
+            posthoganalytics.identify_context(str(request.user.pk))
+        else:
+            posthoganalytics.identify_context(str(self.team.uuid))
+
+    @extend_schema(
+        request=ErrorTrackingSymbolSetBulkCheckUploadSerializer,
+        responses={200: ErrorTrackingSymbolSetBulkCheckUploadResponseSerializer},
+    )
+    @action(methods=["POST"], detail=False, parser_classes=[JSONParser])
+    def bulk_check_upload(self, request: Request, **kwargs) -> Response:
+        """Report which of the given symbol sets still need `bulk_start_upload`. Symbol sets already uploaded with identical content are omitted and marked as still in use."""
+        self._identify_upload_context(request)
+
+        check_serializer = ErrorTrackingSymbolSetBulkCheckUploadSerializer(data=request.data)
+        check_serializer.is_valid(raise_exception=True)
+        check_data = check_serializer.validated_data
+
+        force: bool = check_data["force"]
+        skip_on_conflict: bool = check_data["skip_on_conflict"]
+        symbol_sets = list(check_data["symbol_sets"])
+
+        chunk_ids_to_upload = symbol_sets_facade.bulk_check_upload(
+            self.team,
+            symbol_sets=symbol_sets,
+            force=force,
+            skip_on_conflict=skip_on_conflict,
+        )
+
+        posthoganalytics.capture(
+            "error_tracking_symbol_set_upload_checked",
+            properties={
+                "team_id": self.team.id,
+                "force": force,
+                "skip_on_conflict": skip_on_conflict,
+                "total_chunks": len(symbol_sets),
+                "chunks_skipped": len(symbol_sets) - len(chunk_ids_to_upload),
+            },
+            groups=groups(self.team.organization, self.team),
+        )
+
+        return Response({"chunk_ids_to_upload": chunk_ids_to_upload}, status=status.HTTP_200_OK)
+
     @extend_schema(
         request=ErrorTrackingSymbolSetBulkStartUploadSerializer,
         responses={201: ErrorTrackingSymbolSetBulkStartUploadResponseSerializer},
     )
     @action(methods=["POST"], detail=False, parser_classes=[JSONParser])
     def bulk_start_upload(self, request: Request, **kwargs) -> Response:
-        if request.user.pk:
-            posthoganalytics.identify_context(str(request.user.pk))
-        else:
-            posthoganalytics.identify_context(str(self.team.uuid))
+        self._identify_upload_context(request)
 
         upload_serializer = ErrorTrackingSymbolSetBulkStartUploadSerializer(data=request.data)
         upload_serializer.is_valid(raise_exception=True)
@@ -363,10 +419,7 @@ class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.GenericView
     @extend_schema(request=ErrorTrackingSymbolSetBulkFinishUploadSerializer)
     @action(methods=["POST"], detail=False, parser_classes=[JSONParser])
     def bulk_finish_upload(self, request: Request, **kwargs) -> Response:
-        if request.user.pk:
-            posthoganalytics.identify_context(str(request.user.pk))
-        else:
-            posthoganalytics.identify_context(str(self.team.uuid))
+        self._identify_upload_context(request)
         content_hashes = request.data.get("content_hashes", {})
         if content_hashes is None:
             return Response({"detail": "content_hashes are required"}, status=status.HTTP_400_BAD_REQUEST)

--- a/products/error_tracking/backend/presentation/views/symbol_sets.py
+++ b/products/error_tracking/backend/presentation/views/symbol_sets.py
@@ -377,7 +377,10 @@ class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.GenericView
             groups=groups(self.team.organization, self.team),
         )
 
-        return Response({"chunk_ids_to_upload": chunk_ids_to_upload}, status=status.HTTP_200_OK)
+        response = ErrorTrackingSymbolSetBulkCheckUploadResponseSerializer(
+            instance={"chunk_ids_to_upload": chunk_ids_to_upload}
+        )
+        return Response(response.data, status=status.HTTP_200_OK)
 
     @extend_schema(
         request=ErrorTrackingSymbolSetBulkStartUploadSerializer,

--- a/products/error_tracking/backend/tests/api/test_error_tracking_api.py
+++ b/products/error_tracking/backend/tests/api/test_error_tracking_api.py
@@ -37,6 +37,10 @@ from products.error_tracking.backend.models import (
     ErrorTrackingSymbolSet,
 )
 from products.error_tracking.backend.presentation.views.issues import ErrorTrackingIssueAssignRequestSerializer
+from products.error_tracking.backend.presentation.views.symbol_sets import (
+    BULK_CHECK_UPLOAD_MAX_SYMBOL_SETS,
+    ErrorTrackingSymbolSetBulkCheckUploadSerializer,
+)
 
 TEST_BUCKET = "test_storage_bucket-TestErrorTracking"
 
@@ -60,6 +64,23 @@ class TestErrorTrackingIssueAssignRequestSerializer(SimpleTestCase):
 
         assert not serializer.is_valid()
         assert "id" in serializer.errors["assignee"]
+
+
+class TestErrorTrackingSymbolSetBulkCheckUploadSerializer(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("at_limit", BULK_CHECK_UPLOAD_MAX_SYMBOL_SETS, True),
+            ("over_limit", BULK_CHECK_UPLOAD_MAX_SYMBOL_SETS + 1, False),
+        ]
+    )
+    def test_caps_the_symbol_sets_per_request(self, _name: str, count: int, expected_valid: bool) -> None:
+        serializer = ErrorTrackingSymbolSetBulkCheckUploadSerializer(
+            data={"symbol_sets": [{"chunk_id": f"chunk-{i}", "content_hash": "hash"} for i in range(count)]}
+        )
+
+        assert serializer.is_valid() == expected_valid
+        if not expected_valid:
+            assert "symbol_sets" in serializer.errors
 
 
 class TestErrorTracking(APIBaseTest):

--- a/products/error_tracking/backend/tests/api/test_error_tracking_api.py
+++ b/products/error_tracking/backend/tests/api/test_error_tracking_api.py
@@ -1610,6 +1610,125 @@ class TestErrorTracking(APIBaseTest):
         symbol_set.refresh_from_db()
         assert symbol_set.release_id == first_release.id
 
+    @parameterized.expand(
+        [
+            # (name, existing row (None = missing), upload names the release, request flags, expected to upload)
+            ("missing", None, False, {}, True),
+            ("unchanged", {"content_hash": "hash", "bound": False}, False, {}, False),
+            ("pending", {"content_hash": None, "bound": False}, False, {}, True),
+            ("changed_with_force", {"content_hash": "other", "bound": False}, False, {"force": True}, True),
+            (
+                "changed_with_skip_on_conflict",
+                {"content_hash": "other", "bound": False},
+                False,
+                {"skip_on_conflict": True},
+                False,
+            ),
+            ("unchanged_needing_release_bound", {"content_hash": "hash", "bound": False}, True, {}, True),
+            ("unchanged_with_release_bound", {"content_hash": "hash", "bound": True}, True, {}, False),
+        ]
+    )
+    @patch("products.error_tracking.backend.presentation.views.symbol_sets.posthoganalytics.capture")
+    def test_bulk_check_upload_reports_chunks_bulk_start_upload_needs(
+        self,
+        _name: str,
+        existing: dict | None,
+        upload_names_release: bool,
+        request_flags: dict[str, bool],
+        expected_to_upload: bool,
+        patched_capture: Mock,
+    ) -> None:
+        chunk_id = str(uuid7())
+        release = ErrorTrackingRelease.objects.create(
+            team=self.team,
+            hash_id="check-release",
+            version="1.0.0",
+            project="test",
+        )
+        if existing is not None:
+            ErrorTrackingSymbolSet.objects.create(
+                team=self.team,
+                ref=chunk_id,
+                storage_ptr="existing",
+                content_hash=existing["content_hash"],
+                release=release if existing["bound"] else None,
+            )
+        upload: dict[str, str | None] = {"chunk_id": chunk_id, "content_hash": "hash"}
+        if upload_names_release:
+            upload["release_id"] = str(release.id)
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/error_tracking/symbol_sets/bulk_check_upload",
+            data={"symbol_sets": [upload], **request_flags},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {"chunk_ids_to_upload": [chunk_id] if expected_to_upload else []}
+
+        symbol_set = ErrorTrackingSymbolSet.objects.filter(ref=chunk_id).first()
+        if existing is None:
+            assert symbol_set is None
+        else:
+            assert symbol_set is not None
+            assert symbol_set.storage_ptr == "existing"
+            assert symbol_set.content_hash == existing["content_hash"]
+            assert symbol_set.release_id == (release.id if existing["bound"] else None)
+            assert (symbol_set.last_used is not None) == (not expected_to_upload)
+
+        assert patched_capture.call_args.args[0] == "error_tracking_symbol_set_upload_checked"
+        assert patched_capture.call_args.kwargs["properties"]["chunks_skipped"] == (0 if expected_to_upload else 1)
+
+    @parameterized.expand(
+        [
+            # (name, uploaded content hash, upload names another release, chunk id repeated, expected code)
+            ("content_mismatch", "other", False, False, "content_hash_mismatch"),
+            ("release_mismatch", "hash", True, False, "release_id_mismatch"),
+            ("duplicate_chunk_ids", "hash", False, True, "invalid_chunk_ids"),
+        ]
+    )
+    def test_bulk_check_upload_rejects_conflicts_before_any_upload(
+        self,
+        _name: str,
+        upload_content_hash: str,
+        upload_names_other_release: bool,
+        chunk_id_repeated: bool,
+        expected_code: str,
+    ) -> None:
+        chunk_id = str(uuid7())
+        bound_release = ErrorTrackingRelease.objects.create(
+            team=self.team,
+            hash_id="bound-release",
+            version="1.0.0",
+            project="test",
+        )
+        other_release = ErrorTrackingRelease.objects.create(
+            team=self.team,
+            hash_id="other-release",
+            version="1.0.1",
+            project="test",
+        )
+        ErrorTrackingSymbolSet.objects.create(
+            team=self.team,
+            ref=chunk_id,
+            storage_ptr="existing",
+            content_hash="hash",
+            release=bound_release,
+        )
+        upload = {"chunk_id": chunk_id, "content_hash": upload_content_hash}
+        if upload_names_other_release:
+            upload["release_id"] = str(other_release.id)
+        symbol_sets = [upload, upload] if chunk_id_repeated else [upload]
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/error_tracking/symbol_sets/bulk_check_upload",
+            data={"symbol_sets": symbol_sets},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["code"] == expected_code
+
     @patch("posthog.storage.object_storage.head_object")
     def test_can_finish_bulk_symbol_set_upload(self, patched_object_storage) -> None:
         symbol_set_one = ErrorTrackingSymbolSet.objects.create(

--- a/products/error_tracking/backend/tests/api/test_error_tracking_api.py
+++ b/products/error_tracking/backend/tests/api/test_error_tracking_api.py
@@ -1428,17 +1428,25 @@ class TestErrorTracking(APIBaseTest):
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    def test_bulk_start_upload_rejects_unknown_release(self) -> None:
+    @parameterized.expand(
+        [
+            # (name, endpoint, release ID the client sends)
+            ("start_upload_unknown", "bulk_start_upload", "01920000-0000-7000-8000-000000000000"),
+            ("start_upload_malformed", "bulk_start_upload", "not-a-uuid"),
+            ("check_upload_unknown", "bulk_check_upload", "01920000-0000-7000-8000-000000000000"),
+            ("check_upload_malformed", "bulk_check_upload", "not-a-uuid"),
+        ]
+    )
+    def test_bulk_upload_rejects_bad_release(self, _name: str, endpoint: str, release_id: str) -> None:
         chunk_id = str(uuid7())
-        missing_release_id = str(uuid7())
 
         response = self.client.post(
-            f"/api/environments/{self.team.id}/error_tracking/symbol_sets/bulk_start_upload",
+            f"/api/environments/{self.team.id}/error_tracking/symbol_sets/{endpoint}",
             data={
                 "symbol_sets": [
                     {
                         "chunk_id": chunk_id,
-                        "release_id": missing_release_id,
+                        "release_id": release_id,
                         "content_hash": "hash",
                     }
                 ]
@@ -1447,6 +1455,7 @@ class TestErrorTracking(APIBaseTest):
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["code"] == "invalid_release_id"
         assert not ErrorTrackingSymbolSet.objects.filter(ref=chunk_id).exists()
 
     def test_bulk_start_upload_allows_no_release(self) -> None:

--- a/products/error_tracking/frontend/generated/api.schemas.ts
+++ b/products/error_tracking/frontend/generated/api.schemas.ts
@@ -2134,21 +2134,6 @@ export interface ErrorTrackingSymbolSetFinishUploadApi {
     content_hash: string
 }
 
-export interface ErrorTrackingSymbolSetBulkDeleteApi {
-    /** Symbol set IDs to delete. */
-    ids: string[]
-}
-
-/**
- * Map of symbol set ID to uploaded content hash.
- */
-export type ErrorTrackingSymbolSetBulkFinishUploadApiContentHashes = { [key: string]: string }
-
-export interface ErrorTrackingSymbolSetBulkFinishUploadApi {
-    /** Map of symbol set ID to uploaded content hash. */
-    content_hashes: ErrorTrackingSymbolSetBulkFinishUploadApiContentHashes
-}
-
 export interface ErrorTrackingSymbolSetUploadApi {
     /** Symbol set reference to upload. */
     chunk_id: string
@@ -2164,7 +2149,42 @@ export interface ErrorTrackingSymbolSetUploadApi {
     content_hash?: string | null
 }
 
+export interface ErrorTrackingSymbolSetBulkCheckUploadApi {
+    /** Symbol sets the client intends to upload, with per-symbol release IDs and content hashes. */
+    symbol_sets: ErrorTrackingSymbolSetUploadApi[]
+    /** Whether to overwrite uploaded symbol sets whose content hash changed. */
+    force?: boolean
+    /** Whether to skip uploaded symbol sets whose content hash changed instead of failing. */
+    skip_on_conflict?: boolean
+}
+
+export interface ErrorTrackingSymbolSetBulkCheckUploadResponseApi {
+    /** Chunk IDs to send to `bulk_start_upload`: the symbol set is missing, its upload never completed, its content differs, or it still needs the release bound. The other chunks are already uploaded with identical content and were marked as still in use. */
+    chunk_ids_to_upload: string[]
+}
+
+export interface ErrorTrackingSymbolSetBulkDeleteApi {
+    /** Symbol set IDs to delete. */
+    ids: string[]
+}
+
+/**
+ * Map of symbol set ID to uploaded content hash.
+ */
+export type ErrorTrackingSymbolSetBulkFinishUploadApiContentHashes = { [key: string]: string }
+
+export interface ErrorTrackingSymbolSetBulkFinishUploadApi {
+    /** Map of symbol set ID to uploaded content hash. */
+    content_hashes: ErrorTrackingSymbolSetBulkFinishUploadApiContentHashes
+}
+
 export interface ErrorTrackingSymbolSetBulkStartUploadApi {
+    /** Symbol sets to upload with per-symbol release IDs and content hashes. */
+    symbol_sets?: ErrorTrackingSymbolSetUploadApi[]
+    /** Whether to overwrite uploaded symbol sets whose content hash changed. */
+    force?: boolean
+    /** Whether to skip uploaded symbol sets whose content hash changed instead of failing. */
+    skip_on_conflict?: boolean
     /** Legacy list of symbol set references to upload, all associated with `release_id`. */
     chunk_ids?: string[]
     /**
@@ -2172,12 +2192,6 @@ export interface ErrorTrackingSymbolSetBulkStartUploadApi {
      * @nullable
      */
     release_id?: string | null
-    /** Symbol sets to upload with per-symbol release IDs and content hashes. */
-    symbol_sets?: ErrorTrackingSymbolSetUploadApi[]
-    /** Whether to overwrite uploaded symbol sets whose content hash changed. */
-    force?: boolean
-    /** Whether to skip uploaded symbol sets whose content hash changed instead of failing. */
-    skip_on_conflict?: boolean
 }
 
 /**

--- a/products/error_tracking/frontend/generated/api.schemas.ts
+++ b/products/error_tracking/frontend/generated/api.schemas.ts
@@ -2150,7 +2150,7 @@ export interface ErrorTrackingSymbolSetUploadApi {
 }
 
 export interface ErrorTrackingSymbolSetBulkCheckUploadApi {
-    /** Symbol sets the client intends to upload, with per-symbol release IDs and content hashes. */
+    /** Symbol sets the client intends to upload, with per-symbol release IDs and content hashes. Send at most 1000 per request. */
     symbol_sets: ErrorTrackingSymbolSetUploadApi[]
     /** Whether to overwrite uploaded symbol sets whose content hash changed. */
     force?: boolean

--- a/products/error_tracking/frontend/generated/api.ts
+++ b/products/error_tracking/frontend/generated/api.ts
@@ -72,6 +72,8 @@ import type {
     ErrorTrackingSuppressionRuleUpdateRequestApi,
     ErrorTrackingSuppressionRulesListParams,
     ErrorTrackingSymbolSetApi,
+    ErrorTrackingSymbolSetBulkCheckUploadApi,
+    ErrorTrackingSymbolSetBulkCheckUploadResponseApi,
     ErrorTrackingSymbolSetBulkDeleteApi,
     ErrorTrackingSymbolSetBulkFinishUploadApi,
     ErrorTrackingSymbolSetBulkStartUploadApi,
@@ -1933,6 +1935,29 @@ export const errorTrackingSymbolSetsFinishUploadUpdate = async (
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(errorTrackingSymbolSetFinishUploadApi),
     })
+}
+
+export const getErrorTrackingSymbolSetsBulkCheckUploadCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/error_tracking/symbol_sets/bulk_check_upload/`
+}
+
+/**
+ * Report which of the given symbol sets still need `bulk_start_upload`. Symbol sets already uploaded with identical content are omitted and marked as still in use.
+ */
+export const errorTrackingSymbolSetsBulkCheckUploadCreate = async (
+    projectId: string,
+    errorTrackingSymbolSetBulkCheckUploadApi: ErrorTrackingSymbolSetBulkCheckUploadApi,
+    options?: RequestInit
+): Promise<ErrorTrackingSymbolSetBulkCheckUploadResponseApi> => {
+    return apiMutator<ErrorTrackingSymbolSetBulkCheckUploadResponseApi>(
+        getErrorTrackingSymbolSetsBulkCheckUploadCreateUrl(projectId),
+        {
+            ...options,
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', ...options?.headers },
+            body: JSON.stringify(errorTrackingSymbolSetBulkCheckUploadApi),
+        }
+    )
 }
 
 export const getErrorTrackingSymbolSetsBulkDeleteCreateUrl = (projectId: string) => {

--- a/products/error_tracking/frontend/generated/api.zod.ts
+++ b/products/error_tracking/frontend/generated/api.zod.ts
@@ -1331,7 +1331,9 @@ export const ErrorTrackingSymbolSetsBulkCheckUploadCreateBody = /* @__PURE__ */ 
                     .describe('Optional hash of the symbol set content, used to skip unchanged uploads.'),
             })
         )
-        .describe('Symbol sets the client intends to upload, with per-symbol release IDs and content hashes.'),
+        .describe(
+            'Symbol sets the client intends to upload, with per-symbol release IDs and content hashes. Send at most 1000 per request.'
+        ),
     force: zod
         .boolean()
         .default(errorTrackingSymbolSetsBulkCheckUploadCreateBodyForceDefault)

--- a/products/error_tracking/frontend/generated/api.zod.ts
+++ b/products/error_tracking/frontend/generated/api.zod.ts
@@ -1310,6 +1310,38 @@ export const ErrorTrackingSymbolSetsFinishUploadUpdateBody = /* @__PURE__ */ zod
     content_hash: zod.string().describe('Hash of the uploaded symbol set content.'),
 })
 
+/**
+ * Report which of the given symbol sets still need `bulk_start_upload`. Symbol sets already uploaded with identical content are omitted and marked as still in use.
+ */
+export const errorTrackingSymbolSetsBulkCheckUploadCreateBodyForceDefault = false
+export const errorTrackingSymbolSetsBulkCheckUploadCreateBodySkipOnConflictDefault = false
+
+export const ErrorTrackingSymbolSetsBulkCheckUploadCreateBody = /* @__PURE__ */ zod.object({
+    symbol_sets: zod
+        .array(
+            zod.object({
+                chunk_id: zod.string().describe('Symbol set reference to upload.'),
+                release_id: zod
+                    .string()
+                    .nullish()
+                    .describe('Optional error tracking release ID associated with this symbol set.'),
+                content_hash: zod
+                    .string()
+                    .nullish()
+                    .describe('Optional hash of the symbol set content, used to skip unchanged uploads.'),
+            })
+        )
+        .describe('Symbol sets the client intends to upload, with per-symbol release IDs and content hashes.'),
+    force: zod
+        .boolean()
+        .default(errorTrackingSymbolSetsBulkCheckUploadCreateBodyForceDefault)
+        .describe('Whether to overwrite uploaded symbol sets whose content hash changed.'),
+    skip_on_conflict: zod
+        .boolean()
+        .default(errorTrackingSymbolSetsBulkCheckUploadCreateBodySkipOnConflictDefault)
+        .describe('Whether to skip uploaded symbol sets whose content hash changed instead of failing.'),
+})
+
 export const ErrorTrackingSymbolSetsBulkDeleteCreateBody = /* @__PURE__ */ zod.object({
     ids: zod.array(zod.uuid()).describe('Symbol set IDs to delete.'),
 })
@@ -1322,11 +1354,6 @@ export const errorTrackingSymbolSetsBulkStartUploadCreateBodyForceDefault = fals
 export const errorTrackingSymbolSetsBulkStartUploadCreateBodySkipOnConflictDefault = false
 
 export const ErrorTrackingSymbolSetsBulkStartUploadCreateBody = /* @__PURE__ */ zod.object({
-    chunk_ids: zod
-        .array(zod.string())
-        .optional()
-        .describe('Legacy list of symbol set references to upload, all associated with `release_id`.'),
-    release_id: zod.string().nullish().describe('Optional error tracking release ID used with `chunk_ids`.'),
     symbol_sets: zod
         .array(
             zod.object({
@@ -1351,4 +1378,9 @@ export const ErrorTrackingSymbolSetsBulkStartUploadCreateBody = /* @__PURE__ */ 
         .boolean()
         .default(errorTrackingSymbolSetsBulkStartUploadCreateBodySkipOnConflictDefault)
         .describe('Whether to skip uploaded symbol sets whose content hash changed instead of failing.'),
+    chunk_ids: zod
+        .array(zod.string())
+        .optional()
+        .describe('Legacy list of symbol set references to upload, all associated with `release_id`.'),
+    release_id: zod.string().nullish().describe('Optional error tracking release ID used with `chunk_ids`.'),
 })

--- a/products/error_tracking/mcp/tools.yaml
+++ b/products/error_tracking/mcp/tools.yaml
@@ -576,6 +576,9 @@ tools:
             tightly scoped to the exact errors you want gone. Prefer raising `sampling_rate` to dampen volume over
             widening the match. Confirm with the user before changing a rule's filters in a way that could match more
             than one distinct error.
+    error-tracking-symbol-sets-bulk-check-upload-create:
+        operation: error_tracking_symbol_sets_bulk_check_upload_create
+        enabled: false
     error-tracking-symbol-sets-bulk-delete-create:
         operation: error_tracking_symbol_sets_bulk_delete_create
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -33731,21 +33731,6 @@ export namespace Schemas {
       release: ErrorTrackingRelease | null;
     }
 
-    export interface ErrorTrackingSymbolSetBulkDelete {
-      /** Symbol set IDs to delete. */
-      ids: string[];
-    }
-
-    /**
-     * Map of symbol set ID to uploaded content hash.
-     */
-    export type ErrorTrackingSymbolSetBulkFinishUploadContentHashes = {[key: string]: string};
-
-    export interface ErrorTrackingSymbolSetBulkFinishUpload {
-      /** Map of symbol set ID to uploaded content hash. */
-      content_hashes: ErrorTrackingSymbolSetBulkFinishUploadContentHashes;
-    }
-
     export interface ErrorTrackingSymbolSetUpload {
       /** Symbol set reference to upload. */
       chunk_id: string;
@@ -33761,7 +33746,42 @@ export namespace Schemas {
       content_hash?: string | null;
     }
 
+    export interface ErrorTrackingSymbolSetBulkCheckUpload {
+      /** Symbol sets the client intends to upload, with per-symbol release IDs and content hashes. */
+      symbol_sets: ErrorTrackingSymbolSetUpload[];
+      /** Whether to overwrite uploaded symbol sets whose content hash changed. */
+      force?: boolean;
+      /** Whether to skip uploaded symbol sets whose content hash changed instead of failing. */
+      skip_on_conflict?: boolean;
+    }
+
+    export interface ErrorTrackingSymbolSetBulkCheckUploadResponse {
+      /** Chunk IDs to send to `bulk_start_upload`: the symbol set is missing, its upload never completed, its content differs, or it still needs the release bound. The other chunks are already uploaded with identical content and were marked as still in use. */
+      chunk_ids_to_upload: string[];
+    }
+
+    export interface ErrorTrackingSymbolSetBulkDelete {
+      /** Symbol set IDs to delete. */
+      ids: string[];
+    }
+
+    /**
+     * Map of symbol set ID to uploaded content hash.
+     */
+    export type ErrorTrackingSymbolSetBulkFinishUploadContentHashes = {[key: string]: string};
+
+    export interface ErrorTrackingSymbolSetBulkFinishUpload {
+      /** Map of symbol set ID to uploaded content hash. */
+      content_hashes: ErrorTrackingSymbolSetBulkFinishUploadContentHashes;
+    }
+
     export interface ErrorTrackingSymbolSetBulkStartUpload {
+      /** Symbol sets to upload with per-symbol release IDs and content hashes. */
+      symbol_sets?: ErrorTrackingSymbolSetUpload[];
+      /** Whether to overwrite uploaded symbol sets whose content hash changed. */
+      force?: boolean;
+      /** Whether to skip uploaded symbol sets whose content hash changed instead of failing. */
+      skip_on_conflict?: boolean;
       /** Legacy list of symbol set references to upload, all associated with `release_id`. */
       chunk_ids?: string[];
       /**
@@ -33769,12 +33789,6 @@ export namespace Schemas {
          * @nullable
          */
       release_id?: string | null;
-      /** Symbol sets to upload with per-symbol release IDs and content hashes. */
-      symbol_sets?: ErrorTrackingSymbolSetUpload[];
-      /** Whether to overwrite uploaded symbol sets whose content hash changed. */
-      force?: boolean;
-      /** Whether to skip uploaded symbol sets whose content hash changed instead of failing. */
-      skip_on_conflict?: boolean;
     }
 
     /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -33747,7 +33747,7 @@ export namespace Schemas {
     }
 
     export interface ErrorTrackingSymbolSetBulkCheckUpload {
-      /** Symbol sets the client intends to upload, with per-symbol release IDs and content hashes. */
+      /** Symbol sets the client intends to upload, with per-symbol release IDs and content hashes. Send at most 1000 per request. */
       symbol_sets: ErrorTrackingSymbolSetUpload[];
       /** Whether to overwrite uploaded symbol sets whose content hash changed. */
       force?: boolean;


### PR DESCRIPTION
## Problem

A CLI upload of a build with 3600 chunks makes 144 API calls, even when the server already holds every chunk. `bulk_start_upload` creates rows and issues presigned URLs, so the CLI keeps its batches at 50 chunks.

## Changes

- A client can now ask which of its chunks the server still needs, with one request per 1000 chunks.
- The new endpoint is `bulk_check_upload`. It takes chunk ids and content hashes and returns the chunk ids that `bulk_start_upload` still needs.
- The check creates no rows and issues no URLs.
- The check marks the unchanged chunks as still in use, so retention does not delete them.
- The check raises the same conflict errors as `bulk_start_upload`, so a conflict fails before any upload.
- `bulk_start_upload` keeps its full logic, which covers concurrent uploads.
- Mechanical: both endpoints share the per-chunk decision helpers, and the generated types are regenerated.

The CLI side is #98154.

## How did you test this code?

- Ten new parameterized cases cover each decision of the check, the refresh of `last_used` for unchanged chunks, and the three conflict codes.
- The CLI PR holds the end-to-end measurement.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Only the CLI calls the endpoint.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code with Claude Fable 5.1. Skills invoked: /improving-drf-endpoints, /writing-tests, /writing-code-comments, /writing-user-facing-copy, /writing-pr-descriptions, /asd-ste100. The check reports a chunk that only needs its release bound as a chunk to upload, so `bulk_start_upload` keeps that write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015aB7hMSfqghiJRCpHienaF

