### PR TITLE
fix(desktop): clear stale local task spinner

### DIFF
--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -2258,6 +2258,7 @@ export class SessionService {
     }
 
     this.d.store.setSession(session);
+    this.updatePromptStateFromEvents(taskRunId, session.events);
     this.subscribeToChannel(taskRunId);
 
     try {

--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -2253,6 +2253,7 @@ export class SessionService {
       session.editingQueuedId = previous.editingQueuedId;
       session.isPromptPending = previous.isPromptPending;
       session.promptStartedAt = previous.promptStartedAt;
+      session.currentPromptId = previous.currentPromptId;
       session.pausedDurationMs = previous.pausedDurationMs;
     }
 

--- a/products/desktop/packages/core/src/sessions/sessionServiceRecovery.test.ts
+++ b/products/desktop/packages/core/src/sessions/sessionServiceRecovery.test.ts
@@ -1,4 +1,4 @@
-import type { AgentSession } from "@posthog/shared";
+import type { AgentSession, StoredLogEntry } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -44,10 +44,17 @@ function createHarness({ spyConnect = true } = {}) {
     getSessions: () => sessions,
     getSessionByTaskId: (taskId: string) =>
       Object.values(sessions).find((s) => s.taskId === taskId),
+    setSession: (session: AgentSession) => {
+      sessions[session.taskRunId] = session;
+    },
     removeSession: vi.fn(),
     setTaskStarting: vi.fn(),
     clearTaskStarting: vi.fn(),
-    updateSession: vi.fn(),
+    updateSession: vi.fn(
+      (taskRunId: string, updates: Partial<AgentSession>) => {
+        Object.assign(sessions[taskRunId], updates);
+      },
+    ),
   };
   const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
   const deps = {
@@ -64,11 +71,17 @@ function createHarness({ spyConnect = true } = {}) {
     trpc: {
       agent: {
         cancel: { mutate: vi.fn().mockResolvedValue(undefined) },
+        reconnect: { mutate: vi.fn().mockResolvedValue({}) },
+        onSessionEvent: { subscribe: () => ({ unsubscribe: vi.fn() }) },
+        onPermissionRequest: { subscribe: () => ({ unsubscribe: vi.fn() }) },
         onSessionIdleKilled: {
           subscribe: () => ({ unsubscribe: vi.fn() }),
         },
       },
+      workspace: { verify: { query: vi.fn().mockResolvedValue({ exists: true }) } },
     },
+    settings: {},
+    track: vi.fn(),
   } as unknown as SessionServiceDeps;
 
   const service = new SessionService(deps);
@@ -196,5 +209,60 @@ describe("SessionService run-less local task recovery", () => {
     reconcile(service, task);
 
     expect(connectToTask).toHaveBeenCalledWith({ task, repoPath: "/repo" });
+  });
+
+  it("clears stale pending state when the reconnected log contains a completed turn", async () => {
+    const { service, sessions } = createHarness({ spyConnect: false });
+    const task = makeTask();
+    sessions["run-task-1"] = {
+      ...makeSession(task.id),
+      isPromptPending: true,
+      promptStartedAt: 1,
+      currentPromptId: 1,
+    };
+    const rawEntries: StoredLogEntry[] = [
+      {
+        type: "notification",
+        timestamp: new Date(1).toISOString(),
+        notification: {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "session/prompt",
+          params: { prompt: [{ type: "text", text: "Ship the fix" }] },
+        },
+      },
+      {
+        type: "notification",
+        timestamp: new Date(2).toISOString(),
+        notification: {
+          jsonrpc: "2.0",
+          id: 1,
+          result: { stopReason: "end_turn" },
+        },
+      },
+    ];
+
+    await (
+      service as unknown as {
+        reconnectToLocalSession: (
+          taskId: string,
+          taskRunId: string,
+          taskTitle: string,
+          logUrl: string | undefined,
+          repoPath: string,
+          auth: { apiHost: string; projectId: number },
+          prefetchedLogs: { rawEntries: StoredLogEntry[] },
+        ) => Promise<boolean>;
+      }
+    ).reconnectToLocalSession(task.id, "run-task-1", task.title, undefined, "/repo", {
+      apiHost: "https://example.com",
+      projectId: 1,
+    }, { rawEntries });
+
+    expect(sessions["run-task-1"]).toMatchObject({
+      isPromptPending: false,
+      promptStartedAt: null,
+      currentPromptId: null,
+    });
   });
 });

--- a/products/desktop/packages/core/src/sessions/sessionServiceRecovery.test.ts
+++ b/products/desktop/packages/core/src/sessions/sessionServiceRecovery.test.ts
@@ -78,7 +78,9 @@ function createHarness({ spyConnect = true } = {}) {
           subscribe: () => ({ unsubscribe: vi.fn() }),
         },
       },
-      workspace: { verify: { query: vi.fn().mockResolvedValue({ exists: true }) } },
+      workspace: {
+        verify: { query: vi.fn().mockResolvedValue({ exists: true }) },
+      },
     },
     settings: {},
     track: vi.fn(),
@@ -225,7 +227,6 @@ describe("SessionService run-less local task recovery", () => {
         type: "notification",
         timestamp: new Date(1).toISOString(),
         notification: {
-          jsonrpc: "2.0",
           id: 1,
           method: "session/prompt",
           params: { prompt: [{ type: "text", text: "Ship the fix" }] },
@@ -235,7 +236,6 @@ describe("SessionService run-less local task recovery", () => {
         type: "notification",
         timestamp: new Date(2).toISOString(),
         notification: {
-          jsonrpc: "2.0",
           id: 1,
           result: { stopReason: "end_turn" },
         },
@@ -254,10 +254,18 @@ describe("SessionService run-less local task recovery", () => {
           prefetchedLogs: { rawEntries: StoredLogEntry[] },
         ) => Promise<boolean>;
       }
-    ).reconnectToLocalSession(task.id, "run-task-1", task.title, undefined, "/repo", {
-      apiHost: "https://example.com",
-      projectId: 1,
-    }, { rawEntries });
+    ).reconnectToLocalSession(
+      task.id,
+      "run-task-1",
+      task.title,
+      undefined,
+      "/repo",
+      {
+        apiHost: "https://example.com",
+        projectId: 1,
+      },
+      { rawEntries },
+    );
 
     expect(sessions["run-task-1"]).toMatchObject({
       isPromptPending: false,

--- a/products/desktop/packages/core/src/sidebar/buildSidebarData.test.ts
+++ b/products/desktop/packages/core/src/sidebar/buildSidebarData.test.ts
@@ -167,12 +167,20 @@ describe("deriveTaskRunState", () => {
       false,
     ],
     [
-      "a local agent streams output",
+      "a local agent has a current prompt",
       "in_progress",
       "local",
       undefined,
-      { taskRunId: "run-1", isPromptPending: true },
+      { taskRunId: "run-1", isPromptPending: true, currentPromptId: 1 },
       true,
+    ],
+    [
+      "a reconnected local session has no current prompt",
+      "in_progress",
+      "local",
+      undefined,
+      { taskRunId: "run-1", isPromptPending: true, currentPromptId: null },
+      false,
     ],
     [
       "an old local session streams output",

--- a/products/desktop/packages/core/src/sidebar/buildSidebarData.ts
+++ b/products/desktop/packages/core/src/sidebar/buildSidebarData.ts
@@ -122,6 +122,7 @@ export function filterVisibleTasks(
 export interface TaskSession {
   taskRunId: string;
   isPromptPending?: boolean;
+  currentPromptId?: number | null;
   pendingPermissions?: { size: number };
   cloudStatus?: TaskRunStatus;
   cloudOutput?: { pr_url?: unknown } | null;
@@ -147,7 +148,7 @@ export function computeSidebarSessionSignature(
     const isAgentIdle = session.agentIdleForRunId === session.taskRunId;
     signature += `${session.taskId}:${session.taskRunId ?? ""}:${
       session.isPromptPending ? 1 : 0
-    }:${session.pendingPermissions?.size ?? 0}:${
+    }:${session.currentPromptId ?? ""}:${session.pendingPermissions?.size ?? 0}:${
       session.cloudStatus ?? ""
     }:${prUrl}:${isAgentIdle ? 1 : 0};`;
   }
@@ -234,23 +235,25 @@ export function deriveTaskRunState(
   const taskRunStatus = resolveEffectiveCloudStatus(task, session) ?? undefined;
   const isAgentIdle =
     sessionRunsLatestRun && session?.agentIdleForRunId === latestRunId;
-  const isPromptPending =
+  const hasLivePrompt =
     sessionRunsLatestRun &&
     session?.isPromptPending === true &&
-    !isTerminalStatus(taskRunStatus);
+    !isTerminalStatus(taskRunStatus) &&
+    (task.latest_run?.environment === "cloud" ||
+      (session?.currentPromptId !== null &&
+        session?.currentPromptId !== undefined));
   const isCloudRunStarting =
     taskRunStatus === "not_started" || taskRunStatus === "queued";
   const isCloudRunWorking =
     taskRunStatus === "in_progress" &&
-    (isPromptPending ||
-      (task.latest_run?.mode === "background" && !isAgentIdle));
+    (hasLivePrompt || (task.latest_run?.mode === "background" && !isAgentIdle));
   const isActiveCloudRun =
     task.latest_run?.environment === "cloud" &&
     (isCloudRunStarting || isCloudRunWorking);
 
   return {
     id: task.id,
-    isGenerating: isPromptPending || isActiveCloudRun,
+    isGenerating: hasLivePrompt || isActiveCloudRun,
     needsPermission:
       sessionRunsLatestRun && (session?.pendingPermissions?.size ?? 0) > 0,
     taskRunId: task.latest_run?.id ?? undefined,

--- a/products/desktop/packages/ui/src/features/archive/useTaskArchive.tsx
+++ b/products/desktop/packages/ui/src/features/archive/useTaskArchive.tsx
@@ -52,18 +52,17 @@ export function useTaskArchive(
     currentPromptId,
     cloudStatus,
     agentIdleForRunId,
-  } =
-    useSessionSelector(
-      taskId,
-      (session) => ({
-        taskRunId: session?.taskRunId,
-        isPromptPending: session?.isPromptPending ?? false,
-        currentPromptId: session?.currentPromptId,
-        cloudStatus: session?.cloudStatus ?? null,
-        agentIdleForRunId: session?.agentIdleForRunId,
-      }),
-      shallow,
-    );
+  } = useSessionSelector(
+    taskId,
+    (session) => ({
+      taskRunId: session?.taskRunId,
+      isPromptPending: session?.isPromptPending ?? false,
+      currentPromptId: session?.currentPromptId,
+      cloudStatus: session?.cloudStatus ?? null,
+      agentIdleForRunId: session?.agentIdleForRunId,
+    }),
+    shallow,
+  );
   const piSessionController = useService<PiSessionController>(
     PI_SESSION_CONTROLLER,
   );

--- a/products/desktop/packages/ui/src/features/archive/useTaskArchive.tsx
+++ b/products/desktop/packages/ui/src/features/archive/useTaskArchive.tsx
@@ -46,12 +46,19 @@ export function useTaskArchive(
   },
 ): TaskArchive {
   const taskId = task?.id;
-  const { taskRunId, isPromptPending, cloudStatus, agentIdleForRunId } =
+  const {
+    taskRunId,
+    isPromptPending,
+    currentPromptId,
+    cloudStatus,
+    agentIdleForRunId,
+  } =
     useSessionSelector(
       taskId,
       (session) => ({
         taskRunId: session?.taskRunId,
         isPromptPending: session?.isPromptPending ?? false,
+        currentPromptId: session?.currentPromptId,
         cloudStatus: session?.cloudStatus ?? null,
         agentIdleForRunId: session?.agentIdleForRunId,
       }),
@@ -71,6 +78,7 @@ export function useTaskArchive(
           ? {
               taskRunId,
               isPromptPending,
+              currentPromptId,
               cloudStatus: cloudStatus ?? undefined,
               agentIdleForRunId,
             }

--- a/products/desktop/packages/ui/src/features/sidebar/components/TaskListView.stories.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/TaskListView.stories.tsx
@@ -11,6 +11,7 @@ const createTask = (
   title: string,
   lastActivityAt: number,
   isPinned: boolean,
+  overrides: Partial<TaskData> = {},
 ): TaskData => ({
   id,
   title,
@@ -26,6 +27,7 @@ const createTask = (
   cloudPrUrl: null,
   branchName: null,
   linkedBranch: null,
+  ...overrides,
 });
 
 const pinnedTasks = [
@@ -42,6 +44,53 @@ const flatTasks = [
   createTask("task-1", "Add keyboard shortcuts", 1_730_000_000_000, false),
   createTask("task-2", "Improve dashboard loading", 1_720_000_000_000, false),
   createTask("task-3", "Update empty states", 1_710_000_000_000, false),
+];
+
+const taskStates = [
+  createTask("working", "Build the dashboard view", 1_750_000_000_000, false, {
+    isGenerating: true,
+    taskRunStatus: "in_progress",
+    taskRunEnvironment: "local",
+  }),
+  createTask(
+    "permission",
+    "Allow access to the project folder",
+    1_750_000_000_000,
+    false,
+    {
+      needsPermission: true,
+      taskRunStatus: "in_progress",
+      taskRunEnvironment: "local",
+    },
+  ),
+  createTask("unread", "Review the agent update", 1_750_000_000_000, false, {
+    isUnread: true,
+    taskRunStatus: "in_progress",
+    taskRunEnvironment: "local",
+  }),
+  createTask(
+    "suspended",
+    "Prepare the release notes",
+    1_750_000_000_000,
+    false,
+    {
+      isSuspended: true,
+      taskRunStatus: "in_progress",
+      taskRunEnvironment: "local",
+    },
+  ),
+  createTask("completed", "Check the signup funnel", 1_750_000_000_000, false, {
+    taskRunStatus: "completed",
+    taskRunEnvironment: "cloud",
+  }),
+  createTask(
+    "failed",
+    "Update the project settings",
+    1_750_000_000_000,
+    false,
+    { taskRunStatus: "failed", taskRunEnvironment: "cloud" },
+  ),
+  createTask("quiet", "Explore session recordings", 1_750_000_000_000, false),
 ];
 
 function StatefulTaskList(args: React.ComponentProps<typeof TaskListView>) {
@@ -125,4 +174,13 @@ export const Default: Story = {};
 
 export const Archiving: Story = {
   render: (args) => <ArchivingTaskList {...args} />,
+};
+
+export const TaskStates: Story = {
+  render: (args) => <TaskListView {...args} />,
+  args: {
+    pinnedTasks: [],
+    flatTasks: taskStates,
+    activeTaskId: null,
+  },
 };


### PR DESCRIPTION
## Problem

Desktop users can see old local and worktree tasks as working after a session reconnects.

## Changes

- The sidebar shows a local task as working only when its current prompt is known.
- Reconnect clears stale prompt state from a completed transcript.
- Archiving a live local task asks for confirmation.
- The Task states Storybook scene shows the supported sidebar task states.

## How did you test this code?

- Ran the focused recovery test, Desktop typecheck, and formatter.
- Not rerun after this history-only split: Storybook capture.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The Storybook scene documents the visual task states.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Slack app used the Desktop, testing, and PR-description guidance. The Visual Review workflow moved to [the separate visual-regression PR](https://github.com/PostHog/posthog/pull/98824).

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1789030561058609?thread_ts=1789030561.058609&cid=C0ACRAMJUAG)*