### PR TITLE
fix(experiments): restrict bytes-per-read trend to fully precomputed reads

### DIFF
--- a/.agents/skills/analyzing-experiment-query-performance/SKILL.md
+++ b/.agents/skills/analyzing-experiment-query-performance/SKILL.md
@@ -136,12 +136,17 @@ Duration/bytes percentiles cover **successful** reads only (failed reads have tr
 Bucketed history behind the Trends tab. One param: `hours` (1–504, default 168).
 Returns zero-filled arrays aligned to `buckets` (hourly up to 48h, daily beyond):
 read counts (`total`, `precomputed`, `fallback`),
-latency and cost of the precomputed read path
-(`precomputed_p50_duration_ms`, `precomputed_p90_duration_ms`, `precomputed_avg_read_bytes`;
-successful precomputed reads only).
-The latency and bytes-per-read series should stay flat as the preaggregation tables grow —
-a sustained rise means precomputed reads are scanning more than their own jobs' rows,
-which breaks the core assumption that read cost tracks experiment size, not cache size.
+latency of the precomputed exposures path
+(`precomputed_p50_duration_ms`, `precomputed_p90_duration_ms`; successful reads only),
+and `fully_precomputed_avg_read_bytes` — average `read_bytes` of reads where **both** the
+exposures and metric-events sides came from the cache.
+The bytes series is restricted to fully precomputed reads because `read_bytes` covers the
+whole metric query: a direct events scan on the metric-events side swamps the cache read
+by orders of magnitude.
+The latency and bytes series should stay flat as the preaggregation tables grow —
+a sustained rise in the bytes series means cache reads are scanning more than their own
+jobs' rows, which breaks the core assumption that read cost tracks experiment size, not
+cache size.
 Also `builds.failed_by_code` and `builds.failed_read_bytes`.
 
 ### GET `/api/debug_ch_queries/cache_health/`

--- a/frontend/src/scenes/experiments/staff/PrecomputeTrends.tsx
+++ b/frontend/src/scenes/experiments/staff/PrecomputeTrends.tsx
@@ -56,7 +56,7 @@ export function PrecomputeTrends(): JSX.Element {
         : []
 
     const bytesPerReadSeries: Series[] = ts
-        ? [{ key: 'avg_bytes', label: 'Avg bytes read', data: ts.reads.precomputed_avg_read_bytes }]
+        ? [{ key: 'avg_bytes', label: 'Avg bytes read', data: ts.reads.fully_precomputed_avg_read_bytes }]
         : []
 
     // One stacked series per exit code, biggest offenders first so the legend leads with them.
@@ -129,7 +129,7 @@ export function PrecomputeTrends(): JSX.Element {
                             }}
                         />
                     </ChartCard>
-                    <ChartCard title="Bytes read per precomputed read (average; a rise means reads scan more than their own rows)">
+                    <ChartCard title="Bytes read per fully precomputed read (both sides from the cache; a rise means reads scan more than their own rows)">
                         <TimeSeriesLineChart
                             series={bytesPerReadSeries}
                             labels={ts.buckets}

--- a/frontend/src/scenes/experiments/staff/queryPerformanceLogic.ts
+++ b/frontend/src/scenes/experiments/staff/queryPerformanceLogic.ts
@@ -83,7 +83,9 @@ export interface PrecomputeTimeseriesResponse {
         // Successful precomputed-path reads only; 0 where a bucket has none
         precomputed_p50_duration_ms: number[]
         precomputed_p90_duration_ms: number[]
-        precomputed_avg_read_bytes: number[]
+        // Reads with both exposures and metric events precomputed; read_bytes on a partly
+        // precomputed read includes the metric-events events scan, which swamps the cache read
+        fully_precomputed_avg_read_bytes: number[]
     }
     builds: {
         failed_by_code: Record<string, number[]>

--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -1016,6 +1016,11 @@ class DebugCHQueries(viewsets.ViewSet):
         # Latency and bytes stats cover successful precomputed reads only, matching the
         # overview endpoint (failed reads have truncated durations). ifNotFinite guards the
         # empty buckets, where quantileIf/avgIf return nan and nan is not valid JSON.
+        # The bytes series requires the metric-events side to be precomputed too: read_bytes
+        # covers the whole metric query, so a direct events scan on the metric-events side
+        # (breakdowns, CUPED, ineligible metrics) swamps the cache read by orders of magnitude.
+        # Fully precomputed reads touch only the preaggregation tables, so their bytes directly
+        # measure whether cache reads prune to their own jobs' rows.
         # nosemgrep: clickhouse-fstring-param-audit - bucket_fn is one of two hardcoded function names
         reads_sql = f"""
             SELECT
@@ -1030,8 +1035,13 @@ class DebugCHQueries(viewsets.ViewSet):
                     quantileIf(0.9)(query_duration_ms, exposures_path = 'precomputed' AND exception_code = 0), 0
                 ) AS precomputed_p90_duration_ms,
                 ifNotFinite(
-                    avgIf(read_bytes, exposures_path = 'precomputed' AND exception_code = 0), 0
-                ) AS precomputed_avg_read_bytes
+                    avgIf(
+                        read_bytes,
+                        exposures_path = 'precomputed'
+                            AND metric_events_path = 'precomputed'
+                            AND exception_code = 0
+                    ), 0
+                ) AS fully_precomputed_avg_read_bytes
             FROM (
                 SELECT
                     event_time,
@@ -1042,6 +1052,7 @@ class DebugCHQueries(viewsets.ViewSet):
                         nullIf(toString(log_comment.experiment_exposures_path), ''),
                         ifNull(toString(log_comment.experiment_execution_path), '')
                     ) AS exposures_path,
+                    ifNull(toString(log_comment.experiment_metric_events_path), '') AS metric_events_path,
                     ifNull(toString(log_comment.experiment_precompute_skip_reason), '') AS skip_reason
                 FROM query_log_archive
                 WHERE
@@ -1085,7 +1096,7 @@ class DebugCHQueries(viewsets.ViewSet):
         fallback_reads = [0] * n
         precomputed_p50_duration_ms = [0] * n
         precomputed_p90_duration_ms = [0] * n
-        precomputed_avg_read_bytes = [0] * n
+        fully_precomputed_avg_read_bytes = [0] * n
         failed_build_read_bytes = [0] * n
         failed_builds_by_code: dict[str, list[int]] = {}
         for (
@@ -1105,7 +1116,7 @@ class DebugCHQueries(viewsets.ViewSet):
             fallback_reads[i] = bucket_fallback
             precomputed_p50_duration_ms[i] = round(bucket_p50)
             precomputed_p90_duration_ms[i] = round(bucket_p90)
-            precomputed_avg_read_bytes[i] = round(bucket_bytes)
+            fully_precomputed_avg_read_bytes[i] = round(bucket_bytes)
         for bucket, exception_code, bucket_builds, bucket_read_bytes in builds_response:
             i = index_by_bucket.get(bucket)
             if i is None or exception_code == 0:
@@ -1125,7 +1136,7 @@ class DebugCHQueries(viewsets.ViewSet):
                     "fallback": fallback_reads,
                     "precomputed_p50_duration_ms": precomputed_p50_duration_ms,
                     "precomputed_p90_duration_ms": precomputed_p90_duration_ms,
-                    "precomputed_avg_read_bytes": precomputed_avg_read_bytes,
+                    "fully_precomputed_avg_read_bytes": fully_precomputed_avg_read_bytes,
                 },
                 "builds": {
                     "failed_by_code": failed_builds_by_code,

--- a/posthog/api/test/test_debug_ch_queries.py
+++ b/posthog/api/test/test_debug_ch_queries.py
@@ -167,11 +167,15 @@ class TestDebugCHQuery(APIBaseTest):
         data = resp.json()
         i = data["buckets"].index(bucket)
         reads = data["reads"]
-        for series in ("precomputed_p50_duration_ms", "precomputed_p90_duration_ms", "precomputed_avg_read_bytes"):
+        for series in (
+            "precomputed_p50_duration_ms",
+            "precomputed_p90_duration_ms",
+            "fully_precomputed_avg_read_bytes",
+        ):
             self.assertEqual(len(reads[series]), len(data["buckets"]))
         self.assertEqual(reads["precomputed_p50_duration_ms"][i], 120)
         self.assertEqual(reads["precomputed_p90_duration_ms"][i], 450)
-        self.assertEqual(reads["precomputed_avg_read_bytes"][i], 2048)
+        self.assertEqual(reads["fully_precomputed_avg_read_bytes"][i], 2048)
         self.assertEqual(sum(reads["precomputed_p50_duration_ms"]), 120)
 
     @patch("posthog.api.debug_ch_queries.sync_execute", return_value=[])


### PR DESCRIPTION
## Problem

The "bytes read per precomputed read" chart on the staff Trends tab (from #96150) shows 0.5 to 66 GB per bucket in production. `read_bytes` covers the whole metric query, and the chart only required the exposures side to be precomputed. When the metric-events side falls back to a direct events scan (breakdowns, CUPED, ineligible metrics), those events-table bytes swamp the cache read, so the chart cannot detect cache reads scanning more than their own rows.

## Changes

- The bytes chart now covers only reads where both the exposures and metric-events sides came from the cache. Those queries touch only the preaggregation tables, so their bytes directly test cache pruning and should be small and flat.
- The response field is renamed to `fully_precomputed_avg_read_bytes` and the chart title says "fully precomputed". The endpoint is staff-only with no consumers outside this scene, so the rename is safe.
- The latency percentiles are unchanged.
- Mechanical: skill doc updated for the new field semantics.

## How did you test this code?

- Updated the existing bucket-alignment test to the renamed field. No new test: the change is a SQL filter condition a mocked test cannot see.
- Production evidence for the problem: `precomputed_avg_read_bytes` buckets ranged from 503 MB to 66 GB over the last 48h in US, which is events-scan volume, not cache-read volume.
- Not run: frontend typecheck (light worktree without `node_modules`); CI covers it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None (internal staff tooling; the skill doc is updated in this PR).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: /wt, /writing-code-comments, /writing-user-facing-copy, /writing-tests, /writing-pr-descriptions. Follow-up to #96150 after checking the deployed series against production data.
