### PR TITLE
feat(aio): report prompt fetches on labeled list calls

### DIFF
--- a/posthog/api/llm_prompt.py
+++ b/posthog/api/llm_prompt.py
@@ -191,7 +191,7 @@ class LLMPromptViewSet(
             prompt["config"] = prompt.get("config")
         return prompt
 
-    def _track_prompt_fetch(self, prompt: dict[str, Any]) -> None:
+    def _track_prompt_fetch(self, prompt: dict[str, Any], fetch_path: str = "by_name") -> None:
         # prompt_label + prompt_version together answer "what was the production label
         # actually serving at time X" from the event stream alone.
         properties = {
@@ -202,6 +202,7 @@ class LLMPromptViewSet(
             "prompt_is_latest": prompt["is_latest"],
             "prompt_first_version_created_at": prompt["first_version_created_at"],
             "prompt_has_config": prompt.get("config") is not None,
+            "prompt_fetch_path": fetch_path,
         }
         if not settings.TEST:
             try:
@@ -613,6 +614,18 @@ class LLMPromptViewSet(
         )
         return Response(status=status.HTTP_204_NO_CONTENT)
 
+    def _labeled_list_fetch_payload(self, prompt: LLMPrompt, label: str) -> dict[str, Any]:
+        first_version_created_at = getattr(prompt, "first_version_created_at", None) or prompt.created_at
+        return {
+            "id": str(prompt.id),
+            "name": prompt.name,
+            "version": prompt.version,
+            "label": label,
+            "is_latest": prompt.is_latest,
+            "first_version_created_at": first_version_created_at.isoformat().replace("+00:00", "Z"),
+            "config": prompt.config,
+        }
+
     def _get_prompt_labels_map(self, prompt_names: list[str]) -> dict[str, list[dict[str, Any]]]:
         labels_map: dict[str, list[dict[str, Any]]] = {}
         labels = (
@@ -635,6 +648,14 @@ class LLMPromptViewSet(
         context = self.get_serializer_context()
         context["prompt_labels_by_name"] = self._get_prompt_labels_map([prompt.name for prompt in prompts])
         serializer = LLMPromptListSerializer(prompts, many=True, context=context)
+
+        label = self._get_list_params(request).get("label")
+        if label:
+            # Each prompt served through a labeled list counts as one fetch, matching
+            # get_by_name, so usage counts survive a caller migrating from per-name
+            # calls. The unlabeled list backs the prompts UI page and stays untracked.
+            for prompt in prompts:
+                self._track_prompt_fetch(self._labeled_list_fetch_payload(prompt, label), fetch_path="list")
 
         if page is not None:
             return self.get_paginated_response(serializer.data)

--- a/posthog/api/llm_prompt.py
+++ b/posthog/api/llm_prompt.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Sequence
 from typing import Any, cast
 from uuid import UUID
 
@@ -14,7 +15,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import BaseSerializer
 
-from posthog.api.capture import capture_internal
+from posthog.api.capture import capture_batch_internal, capture_internal
 from posthog.api.llm_prompt_serializers import (
     ALLOWED_LIST_ORDERINGS,
     LLMPromptDuplicateSerializer,
@@ -191,10 +192,10 @@ class LLMPromptViewSet(
             prompt["config"] = prompt.get("config")
         return prompt
 
-    def _track_prompt_fetch(self, prompt: dict[str, Any], fetch_path: str = "by_name") -> None:
+    def _prompt_fetch_properties(self, prompt: dict[str, Any], fetch_path: str) -> dict[str, Any]:
         # prompt_label + prompt_version together answer "what was the production label
         # actually serving at time X" from the event stream alone.
-        properties = {
+        return {
             "prompt_id": prompt["id"],
             "prompt_name": prompt["name"],
             "prompt_version": prompt["version"],
@@ -204,6 +205,9 @@ class LLMPromptViewSet(
             "prompt_has_config": prompt.get("config") is not None,
             "prompt_fetch_path": fetch_path,
         }
+
+    def _track_prompt_fetch(self, prompt: dict[str, Any]) -> None:
+        properties = self._prompt_fetch_properties(prompt, fetch_path="by_name")
         if not settings.TEST:
             try:
                 capture_internal(
@@ -218,6 +222,34 @@ class LLMPromptViewSet(
                 capture_exception(err)
 
         report_team_action(self.team, "llma prompt fetched", properties)
+
+    def _track_labeled_list_fetches(self, prompts: Sequence[LLMPrompt], label: str) -> None:
+        # One batch call, not one capture_internal per prompt: capture_internal is a
+        # synchronous HTTP request, so per-prompt calls would multiply request latency
+        # by the page size.
+        properties_per_prompt = [
+            self._prompt_fetch_properties(self._labeled_list_fetch_payload(prompt, label), fetch_path="list")
+            for prompt in prompts
+        ]
+        if not settings.TEST and properties_per_prompt:
+            try:
+                capture_batch_internal(
+                    events=[
+                        {
+                            "event": PROMPT_FETCHED_EVENT,
+                            "distinct_id": str(self.team.uuid),
+                            "properties": properties,
+                        }
+                        for properties in properties_per_prompt
+                    ],
+                    token=self.team.api_token,
+                    event_source=PROMPT_FETCHED_EVENT_SOURCE,
+                )
+            except Exception as err:
+                capture_exception(err)
+
+        for properties in properties_per_prompt:
+            report_team_action(self.team, "llma prompt fetched", properties)
 
     def _get_list_params(self, request: Request) -> dict[str, Any]:
         serializer = LLMPromptListQuerySerializer(data=request.query_params)
@@ -654,8 +686,7 @@ class LLMPromptViewSet(
             # Each prompt served through a labeled list counts as one fetch, matching
             # get_by_name, so usage counts survive a caller migrating from per-name
             # calls. The unlabeled list backs the prompts UI page and stays untracked.
-            for prompt in prompts:
-                self._track_prompt_fetch(self._labeled_list_fetch_payload(prompt, label), fetch_path="list")
+            self._track_labeled_list_fetches(prompts, label)
 
         if page is not None:
             return self.get_paginated_response(serializer.data)

--- a/posthog/api/test/test_llm_prompt.py
+++ b/posthog/api/test/test_llm_prompt.py
@@ -1459,6 +1459,34 @@ class TestLLMPromptLabelsAPI(APIBaseTest):
         assert results[0]["latest_version"] == 2
         assert results[0]["prompt"] == "Prompt content"
 
+    @patch("posthog.api.llm_prompt.report_team_action")
+    def test_list_with_label_reports_one_fetch_per_returned_prompt(self, mock_report: Any) -> None:
+        self.create_prompt_version(name="prompt-a", version=1, is_latest=False)
+        self.create_prompt_version(name="prompt-a", version=2)
+        self.create_prompt_version(name="prompt-b", version=1)
+        assert self._set_label("prompt-a", "production", 1).status_code == status.HTTP_201_CREATED
+        assert self._set_label("prompt-b", "production", 1).status_code == status.HTTP_201_CREATED
+        mock_report.reset_mock()
+
+        response = self.client.get(f"/api/environments/{self.team.id}/llm_prompts/?label=production")
+
+        assert response.status_code == status.HTTP_200_OK
+        fetch_properties = [
+            call.args[2] for call in mock_report.call_args_list if call.args[1] == "llma prompt fetched"
+        ]
+        assert sorted(
+            (p["prompt_name"], p["prompt_version"], p["prompt_label"], p["prompt_is_latest"], p["prompt_fetch_path"])
+            for p in fetch_properties
+        ) == [
+            ("prompt-a", 1, "production", False, "list"),
+            ("prompt-b", 1, "production", True, "list"),
+        ]
+
+        # The unlabeled list backs the prompts UI page and must not count as fetches.
+        mock_report.reset_mock()
+        assert self.client.get(f"/api/environments/{self.team.id}/llm_prompts/").status_code == status.HTTP_200_OK
+        assert not any(call.args[1] == "llma prompt fetched" for call in mock_report.call_args_list)
+
     def test_archive_prompt_deletes_its_labels(self):
         self.create_prompt_version(version=1)
         assert self._set_label("my-prompt", "production", 1).status_code == status.HTTP_201_CREATED


### PR DESCRIPTION
## Problem

- #96137 lets apps load all prompts at a label in one list call. But `$llm_prompt_fetched` only fires on the per-name endpoint.
- A team that switches from per-name fetches to the list call would see its prompt usage counts drop to zero. The AI observability usage report counts these events directly.

Part of #95460. Keep the issue open until the SDK follow-up is done.

## Changes

- A labeled list call now reports one prompt fetch per returned prompt, with the same properties as a per-name fetch.
- The list without a label reports nothing. It backs the prompts UI page, and counting page views as fetches would inflate the usage report.
- All fetch events get a new `prompt_fetch_path` property (`by_name` or `list`) to tell the two paths apart.

No UI changes.

Follow-up: add a bulk fetch to posthog-python and posthog-js that loads all prompts at a label and fills the SDK cache.

## How did you test this code?

- New API test: a labeled list reports one fetch per returned prompt with correct properties, and a plain list reports none. Nothing covered fetch reporting before, on any route.
- Ran the full `posthog/api/test/test_llm_prompt.py` file and repo-wide mypy.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- Follow-up to #96137, planned there as the step before pointing SDK users at the list endpoint.
