### PR TITLE
feat(experiments): detect metric-events fallback in the precompute canary

### DIFF
--- a/products/experiments/backend/hogql_queries/experiment_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_query_runner.py
@@ -521,6 +521,17 @@ class ExperimentQueryRunner(QueryRunner):
             return self._retention_metric_events_precomputation_enabled()
         return False
 
+    @property
+    def metric_events_path(self) -> str:
+        """
+        Which source fed the metric-events side of the built query: "precomputed",
+        "direct_scan", or "not_applicable". Meaningful after _get_experiment_query()
+        has run. The exposures side is reported separately (response.is_precomputed).
+        """
+        if not self._metric_events_precompute_applicable():
+            return "not_applicable"
+        return "precomputed" if self._metric_events_precomputed else "direct_scan"
+
     def _get_experiment_query(self) -> ast.SelectQuery:
         """
         Returns the main experiment query.
@@ -644,10 +655,7 @@ class ExperimentQueryRunner(QueryRunner):
 
         # Tag after _get_experiment_query() which sets the precompute flags
         exposures_path = "precomputed" if self._is_precomputed else "direct_scan"
-        if not self._metric_events_precompute_applicable():
-            metric_events_path = "not_applicable"
-        else:
-            metric_events_path = "precomputed" if self._metric_events_precomputed else "direct_scan"
+        metric_events_path = self.metric_events_path
         tag_queries(
             experiment_exposures_path=exposures_path,
             experiment_metric_events_path=metric_events_path,

--- a/products/experiments/backend/temporal/canary_logic.py
+++ b/products/experiments/backend/temporal/canary_logic.py
@@ -285,8 +285,15 @@ def evaluate_canary_runs(
         return CanaryVerdict(outcome=OUTCOME_SKIPPED, detail="empty results (no exposures yet)")
 
     # Checked before the variant-set comparison: a flipped run compares live vs frozen data, so it can
-    # also explain a variant showing up in one run but not another.
-    flipped = [run.label for run in (run_a, run_b) if not run.is_precomputed]
+    # also explain a variant showing up in one run but not another. Both cache sides count: a run whose
+    # metric-events build fell back to scanning events would compare that scan against run c's scan,
+    # which passes trivially without testing the cache.
+    flipped = []
+    for run in (run_a, run_b):
+        if not run.is_precomputed:
+            flipped.append(f"{run.label} (exposures)")
+        elif run.metric_events_path == "direct_scan":
+            flipped.append(f"{run.label} (metric events)")
     if flipped:
         # A forced-precomputed run fell back to the direct scan (e.g. the lazy computation executor timed
         # out). Deviation is expected — not a divergence.
@@ -351,6 +358,7 @@ def _execute_canary_run(
             entry.key: CanaryVariantStats(sum=entry.sum, number_of_samples=entry.number_of_samples)
             for entry in stats_entries
         },
+        metric_events_path=runner.metric_events_path,
     )
 
 
@@ -439,6 +447,8 @@ def run_metric_canary_sync(target: CanaryMetricTarget) -> CanaryMetricResult:
 
 def _format_run_line(run: CanaryRunSnapshot) -> str:
     path = "precomputed" if run.is_precomputed else "direct"
+    if run.metric_events_path != "not_applicable":
+        path += f", metric events {run.metric_events_path}"
     variants = ", ".join(
         f"{key} {stats.sum:g}/{stats.number_of_samples}" for key, stats in sorted(run.variants.items())
     )

--- a/products/experiments/backend/temporal/canary_logic.py
+++ b/products/experiments/backend/temporal/canary_logic.py
@@ -292,7 +292,7 @@ def evaluate_canary_runs(
     for run in (run_a, run_b):
         if not run.is_precomputed:
             flipped.append(f"{run.label} (exposures)")
-        elif run.metric_events_path == "direct_scan":
+        if run.metric_events_path == "direct_scan":
             flipped.append(f"{run.label} (metric events)")
     if flipped:
         # A forced-precomputed run fell back to the direct scan (e.g. the lazy computation executor timed

--- a/products/experiments/backend/temporal/models.py
+++ b/products/experiments/backend/temporal/models.py
@@ -144,8 +144,11 @@ class CanaryRunSnapshot:
 
     label: str  # "a" | "b" (forced precomputed) | "c" (forced direct scan)
     query_id: str  # client_query_id, for system.query_log forensics
-    is_precomputed: bool
+    is_precomputed: bool  # exposures side
     variants: dict[str, CanaryVariantStats]
+    # "precomputed" | "direct_scan" | "not_applicable". Defaulted so snapshots
+    # recorded before this field existed still decode during Temporal replay.
+    metric_events_path: str = "not_applicable"
 
 
 @dataclasses.dataclass(frozen=False)

--- a/products/experiments/backend/temporal/models.py
+++ b/products/experiments/backend/temporal/models.py
@@ -1,6 +1,8 @@
 import dataclasses
 from typing import Final, Literal
 
+from posthog.dataclasses import frozen
+
 # Shared by the workflow definition, the schedule, and the management command.
 CANARY_WORKFLOW_NAME = "experiment-precompute-canary"
 
@@ -138,7 +140,7 @@ class CanaryVariantStats:
     number_of_samples: int
 
 
-@dataclasses.dataclass
+@frozen
 class CanaryRunSnapshot:
     """Per-variant aggregates from one execution of the metric query."""
 

--- a/products/experiments/backend/temporal/test_canary_logic.py
+++ b/products/experiments/backend/temporal/test_canary_logic.py
@@ -39,7 +39,12 @@ from products.experiments.backend.temporal.models import (
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
 
 
-def _snapshot(label: str, variants: dict[str, tuple[float, int]], is_precomputed: bool = True) -> CanaryRunSnapshot:
+def _snapshot(
+    label: str,
+    variants: dict[str, tuple[float, int]],
+    is_precomputed: bool = True,
+    metric_events_path: str = "not_applicable",
+) -> CanaryRunSnapshot:
     return CanaryRunSnapshot(
         label=label,
         query_id=f"experiment-canary-test-{label}",
@@ -47,6 +52,7 @@ def _snapshot(label: str, variants: dict[str, tuple[float, int]], is_precomputed
         variants={
             key: CanaryVariantStats(sum=sum_, number_of_samples=samples) for key, (sum_, samples) in variants.items()
         },
+        metric_events_path=metric_events_path,
     )
 
 
@@ -180,9 +186,22 @@ class TestEvaluateCanaryRuns:
         assert verdict.outcome == OUTCOME_PATH_FLIP
         assert "a" in (verdict.detail or "")
 
+    def test_metric_events_fallback_is_path_flip(self):
+        verdict = evaluate_canary_runs(
+            "mean",
+            _snapshot("a", _BASE, metric_events_path="direct_scan"),
+            _snapshot("b", _BASE, metric_events_path="precomputed"),
+            _snapshot("c", _BASE, metric_events_path="direct_scan"),
+        )
+        assert verdict.outcome == OUTCOME_PATH_FLIP
+        assert "a (metric events)" in (verdict.detail or "")
+
     def test_direct_run_not_precomputed_is_expected(self):
         verdict = evaluate_canary_runs(
-            "funnel", _snapshot("a", _BASE), _snapshot("b", _BASE), _snapshot("c", _BASE, is_precomputed=False)
+            "funnel",
+            _snapshot("a", _BASE, metric_events_path="precomputed"),
+            _snapshot("b", _BASE, metric_events_path="precomputed"),
+            _snapshot("c", _BASE, is_precomputed=False, metric_events_path="direct_scan"),
         )
         assert verdict.outcome == OUTCOME_PASS
 


### PR DESCRIPTION
## Problem

The precompute canary can report a pass without testing the metric-events cache. Its forced-precomputed runs only report whether the exposures cache was used. If the metric-events build fails or is slow, the run silently falls back to scanning events, and the correctness check compares direct scan against direct scan. That passes trivially and looks like cache coverage.

The canary already turns this situation into a `path_flip` outcome for the exposures cache. It cannot do the same for the metric-events cache because the run snapshot does not carry that information.

## Changes

- A forced-precomputed run whose metric-events side fell back to a direct scan now counts as `path_flip` instead of pass. The detail names which side flipped, e.g. "run(s) a (metric events) fell back to direct scan".
- The Slack divergence report and the structured log now show the metric-events path per run.
- Mechanical: the runner's inline path computation moved into a `metric_events_path` property, and `CanaryRunSnapshot` gained the field. The field has a default so snapshots recorded before this change still decode during Temporal replay.
- No user-facing change. This affects canary reporting only.

## How did you test this code?

- Extended the existing path-flip tests: a metric-events fallback on a forced-precomputed run now asserts `path_flip` (catches removing the new check), and run C staying on the direct scan still asserts pass (catches flagging the forced-direct run by mistake).
- Ran the canary logic and workflow tests and the mean preaggregation tests locally; all pass.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Internal monitoring behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code. Follow-up from the avg/min/max gate widening (#96149): production verification showed the canary cannot see whether the metric-events cache was actually exercised.
- Skills invoked: /wt, /writing-tests, /writing-code-comments, /writing-pr-descriptions.
- The snapshot field defaults to "not_applicable" so in-flight Temporal workflows decode old histories safely.
