### PR TITLE
docs(signals): document the per-scout Slack destination in authoring-scouts

### DIFF
--- a/products/signals/skills/authoring-scouts/SKILL.md
+++ b/products/signals/skills/authoring-scouts/SKILL.md
@@ -141,8 +141,9 @@ For an **existing scout**, tune with `posthog:scout-config-update` (find the `id
   A dry run (`emit: false`) never holds the grant, so a scout can be previewed without it changing anything.
   Applies from the scout's next run.
 - `output_destinations` — defaults to none.
+  When adding Slack to an existing scout, first read `output_destinations`, then send the full object with every key preserved. Updates replace the object, so sending only `slack` removes an existing `webhook` pointer.
   Set `slack` to deliver every report the scout emits to Slack as well as the inbox: an `integration_id` for the workspace, plus either a `channel` (`channel_id|#channel-name`) or up to five `users` to DM (`member_id|@display-name`), never both.
-  `thread_reports: true` posts a channel report as a short lead message with the rest split into replies at the summary's section labels, so a long report isn't clipped; it doesn't change how findings post.
+  `thread_reports: true` posts a report as a short lead message with the rest split into replies at the summary's section labels, so a long report isn't clipped; it doesn't change how findings post.
   Slack delivery is a firehose of that one scout's output — no priority filter, no reviewer routing — so it suits a scout whose bar is already tight rather than a chatty one you're still calibrating.
   A Slack-delivered scout is also exempt from the ignored-reports auto-pause, since consumption there isn't measurable.
 - `tags` — free-form labels grouping the fleet, e.g. `["revenue", "on-call"]`. Up to 10 per scout, normalized to lowercase kebab-case (`On Call` → `on-call`) and deduped.

--- a/products/signals/skills/authoring-scouts/SKILL.md
+++ b/products/signals/skills/authoring-scouts/SKILL.md
@@ -6,14 +6,14 @@ description: >
   canonical scout (narrow its scope, retune thresholds, add disqualifiers), tweak a
   scout's schedule or dry-run posture, write a new scout for a surface the fleet
   doesn't cover, build a measurement scout that records structured output (an
-  LLM-judge scoring a sample on a schedule), or steer a scout without editing it by
-  leaving it a note. Covers the scout SKILL.md
-  anatomy, the report contract, the structured-output channel, Slack delivery, the
-  dedupe + scratchpad-memory conventions, scout notes, the per-team skills-store path
-  vs the canonical in-repo path, and the test loop. Trigger on
+  LLM-judge scoring a sample on a schedule — a custom metric no query can compute),
+  or steer a scout without editing it by leaving it a note. Covers the scout SKILL.md
+  anatomy, the report contract, the structured-output channel, the dedupe +
+  scratchpad-memory conventions, scout notes, the per-team skills-store path vs the
+  canonical in-repo path, and the test loop. Trigger on
   "write/edit/customize a signals scout", "new scout for X", "tune my scout schedule",
   "make a scout that watches <event>", "score/judge/measure X with a scout",
-  "structured output from a scout", "send a scout's output to Slack",
+  "structured output from a scout", "scout output to Slack",
   "leave a note for / give feedback to a scout".
 metadata:
   owner_team: signals
@@ -27,8 +27,7 @@ This skill helps you and your agent **adapt those canonical scouts to a specific
 
 A scout's output is the **report channel**: it lists `emit_report` / `edit_report` in its frontmatter `allowed_tools` and authors or edits full inbox reports 1:1 directly.
 The canonical fleet runs this way, and **every new scout should too** — always include the `allowed_tools` opt-in when authoring one.
-Where that output *lands* is a separate, per-scout config decision: a report goes to the Signals inbox, and the same report can be delivered to a Slack channel or DM at the same time (see `output_destinations` under Run posture).
-The inbox is the default, not the only destination — don't rule a scout out of a job because the user wants the result in Slack.
+Where that output *lands* is a separate, per-scout config decision: the report goes to the Signals inbox, and the same report can be delivered to a Slack channel or DM at the same time (`output_destinations` under Run posture) — so don't rule a scout out of a job because the user wants the result in Slack.
 (A historical signal-emitting channel — weak `emit-signal` findings a pipeline consolidated — still exists in the harness for scouts that never opted in, but it is deprecated: don't author new scouts on it, and opt an old one in rather than extending it.)
 
 A scout is an `LLMSkill` that holds a `SignalScoutConfig`.
@@ -143,10 +142,9 @@ For an **existing scout**, tune with `posthog:scout-config-update` (find the `id
   Applies from the scout's next run.
 - `output_destinations` — defaults to none.
   Set `slack` to deliver every report the scout emits to Slack as well as the inbox: an `integration_id` for the workspace, plus either a `channel` (`channel_id|#channel-name`) or up to five `users` to DM (`member_id|@display-name`), never both.
-  `thread_reports: true` posts a channel report as a short lead message with the rest split into replies at the summary's section labels, which keeps a long report from being clipped — it does not change how findings post.
-  This is a firehose of that one scout's output: it carries no priority filter and no reviewer routing, so pair it with a scout whose bar is already tight rather than using it to triage a chatty one.
-  A Slack-delivered scout is exempt from the ignored-reports auto-pause, since consumption in Slack isn't measurable — which also means an uncalibrated one won't be switched off for you.
-  Reach for it when the user asks for a recurring update *in a channel or a DM* — a scout that stays quiet unless something clears its bar, with dedupe and memory across runs, is a better fit for that job than a subscription that fires every day regardless.
+  `thread_reports: true` posts a channel report as a short lead message with the rest split into replies at the summary's section labels, so a long report isn't clipped; it doesn't change how findings post.
+  Slack delivery is a firehose of that one scout's output — no priority filter, no reviewer routing — so it suits a scout whose bar is already tight rather than a chatty one you're still calibrating.
+  A Slack-delivered scout is also exempt from the ignored-reports auto-pause, since consumption there isn't measurable.
 - `tags` — free-form labels grouping the fleet, e.g. `["revenue", "on-call"]`. Up to 10 per scout, normalized to lowercase kebab-case (`On Call` → `on-call`) and deduped.
   Set them at create time: a scout that lands already grouped saves a follow-up edit, and the desktop app's scout list filters on them.
   Prefer a tag that already exists on the fleet (`-config-list` shows every scout's tags) over minting a near-duplicate — `revenue` and `revenue-analytics` fragment the same group.

--- a/products/signals/skills/authoring-scouts/SKILL.md
+++ b/products/signals/skills/authoring-scouts/SKILL.md
@@ -2,18 +2,19 @@
 name: authoring-scouts
 description: >
   How to author, edit, and adapt PostHog Signals scouts — the scheduled agents that
-  scan a project and write reports into the Signals inbox. Use to customize a
+  scan a project and file what they find. Use to customize a
   canonical scout (narrow its scope, retune thresholds, add disqualifiers), tweak a
   scout's schedule or dry-run posture, write a new scout for a surface the fleet
   doesn't cover, build a measurement scout that records structured output (an
-  LLM-judge scoring a sample on a schedule — a custom metric no query can compute),
-  or steer a scout without editing it by leaving it a note. Covers the scout SKILL.md
-  anatomy, the report contract, the structured-output channel, the dedupe +
-  scratchpad-memory conventions, scout notes, the per-team skills-store path vs the
-  canonical in-repo path, and the test loop. Trigger on
+  LLM-judge scoring a sample on a schedule), or steer a scout without editing it by
+  leaving it a note. Covers the scout SKILL.md
+  anatomy, the report contract, the structured-output channel, Slack delivery, the
+  dedupe + scratchpad-memory conventions, scout notes, the per-team skills-store path
+  vs the canonical in-repo path, and the test loop. Trigger on
   "write/edit/customize a signals scout", "new scout for X", "tune my scout schedule",
   "make a scout that watches <event>", "score/judge/measure X with a scout",
-  "structured output from a scout", "leave a note for / give feedback to a scout".
+  "structured output from a scout", "send a scout's output to Slack",
+  "leave a note for / give feedback to a scout".
 metadata:
   owner_team: signals
 ---
@@ -26,6 +27,8 @@ This skill helps you and your agent **adapt those canonical scouts to a specific
 
 A scout's output is the **report channel**: it lists `emit_report` / `edit_report` in its frontmatter `allowed_tools` and authors or edits full inbox reports 1:1 directly.
 The canonical fleet runs this way, and **every new scout should too** — always include the `allowed_tools` opt-in when authoring one.
+Where that output *lands* is a separate, per-scout config decision: a report goes to the Signals inbox, and the same report can be delivered to a Slack channel or DM at the same time (see `output_destinations` under Run posture).
+The inbox is the default, not the only destination — don't rule a scout out of a job because the user wants the result in Slack.
 (A historical signal-emitting channel — weak `emit-signal` findings a pipeline consolidated — still exists in the harness for scouts that never opted in, but it is deprecated: don't author new scouts on it, and opt an old one in rather than extending it.)
 
 A scout is an `LLMSkill` that holds a `SignalScoutConfig`.
@@ -138,6 +141,12 @@ For an **existing scout**, tune with `posthog:scout-config-update` (find the `id
   A granted scout is told in its run prompt which objects it may change, and is asked to name every change in its close-out. The grant is an upper bound: the acting user's own permissions still apply to each object, and the scout reports a refused write rather than retrying it.
   A dry run (`emit: false`) never holds the grant, so a scout can be previewed without it changing anything.
   Applies from the scout's next run.
+- `output_destinations` — defaults to none.
+  Set `slack` to deliver every report the scout emits to Slack as well as the inbox: an `integration_id` for the workspace, plus either a `channel` (`channel_id|#channel-name`) or up to five `users` to DM (`member_id|@display-name`), never both.
+  `thread_reports: true` posts a channel report as a short lead message with the rest split into replies at the summary's section labels, which keeps a long report from being clipped — it does not change how findings post.
+  This is a firehose of that one scout's output: it carries no priority filter and no reviewer routing, so pair it with a scout whose bar is already tight rather than using it to triage a chatty one.
+  A Slack-delivered scout is exempt from the ignored-reports auto-pause, since consumption in Slack isn't measurable — which also means an uncalibrated one won't be switched off for you.
+  Reach for it when the user asks for a recurring update *in a channel or a DM* — a scout that stays quiet unless something clears its bar, with dedupe and memory across runs, is a better fit for that job than a subscription that fires every day regardless.
 - `tags` — free-form labels grouping the fleet, e.g. `["revenue", "on-call"]`. Up to 10 per scout, normalized to lowercase kebab-case (`On Call` → `on-call`) and deduped.
   Set them at create time: a scout that lands already grouped saves a follow-up edit, and the desktop app's scout list filters on them.
   Prefer a tag that already exists on the fleet (`-config-list` shows every scout's tags) over minting a near-duplicate — `revenue` and `revenue-analytics` fragment the same group.

--- a/products/signals/skills/authoring-scouts/SKILL.md
+++ b/products/signals/skills/authoring-scouts/SKILL.md
@@ -27,7 +27,7 @@ This skill helps you and your agent **adapt those canonical scouts to a specific
 
 A scout's output is the **report channel**: it lists `emit_report` / `edit_report` in its frontmatter `allowed_tools` and authors or edits full inbox reports 1:1 directly.
 The canonical fleet runs this way, and **every new scout should too** — always include the `allowed_tools` opt-in when authoring one.
-Where that output *lands* is a separate, per-scout config decision: the report goes to the Signals inbox, and the same report can be delivered to a Slack channel or DM at the same time (`output_destinations` under Run posture) — so don't rule a scout out of a job because the user wants the result in Slack.
+Where that output _lands_ is a separate, per-scout config decision: the report goes to the Signals inbox, and the same report can be delivered to a Slack channel or DM at the same time (`output_destinations` under Run posture) — so don't rule a scout out of a job because the user wants the result in Slack.
 (A historical signal-emitting channel — weak `emit-signal` findings a pipeline consolidated — still exists in the harness for scouts that never opted in, but it is deprecated: don't author new scouts on it, and opt an old one in rather than extending it.)
 
 A scout is an `LLMSkill` that holds a `SignalScoutConfig`.


### PR DESCRIPTION
## Problem

An agent asked to set up a recurring daily update in a Slack channel considered a scout, then eliminated it — its stated reason was that scouts write to the Signals inbox and cannot post to Slack. That is wrong: `SignalScoutConfig.output_destinations.slack` sends a scout's output to a channel or a DM, and a large share of the scouts on our own project already use it.

The `authoring-scouts` skill is where an agent goes to answer that question, and it supported the wrong conclusion. Its opening paragraph frames a scout's output as the inbox, and its "Run posture (config)" list documents every config field an author can tune *except* `output_destinations`. So the capability was invisible exactly where the decision gets made, and the scout lost the job to a mechanism with no cross-run memory or dedupe.

Refs #74379 — the reviewer-routed inbox notification genuinely does not fire for scout-authored reports, which makes this area easy to get wrong in the other direction too.

## Changes

- Adds an `output_destinations` bullet to "Run posture (config)", in the same shape as its neighbours: `integration_id` plus either a `channel` or up to five DM `users`, what `thread_reports` does to a long report, that it is a firehose with no priority filter or reviewer routing, and that a Slack-delivered scout is exempt from the ignored-reports auto-pause.
- States near the top that where a report *lands* is a separate per-scout config decision, with an explicit instruction not to rule a scout out of a job because the user wants the result in Slack.
- Description: "write reports into the Signals inbox" becomes "file what they find", so the routing blurb no longer asserts the inbox is the only destination, and "scout output to Slack" joins the trigger phrases. Both are worded to stay inside the 1024-character frontmatter limit, which the linter enforces.

Documentation only — no behaviour change.

## How did you test this code?

`python products/posthog_ai/scripts/build_skills.py --lint` (`hogli lint:skills`) passes, exit 0. It rejected the description twice on length first, which is why the frontmatter wording is as terse as it is. Every statement in the new bullet was checked against the `scout-config-create` input schema and the [Slack section of the scouts docs](https://posthog.com/docs/self-driving/scouts#sending-a-scouts-output-to-slack) rather than written from memory.

No automated test covers skill prose beyond the linter, and no manual scout run was performed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The public docs already carry the Slack section; a separate PR against posthog.com adds a pointer to it from the "How a scout works" table, which is the other place this reads as inbox-only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raised from a Slack thread: a teammate spotted the wrong claim in an agent's reasoning and asked for the cause. Diagnosis was that both the skill and the docs table present a scout's three filing methods (report, signal, structured record) as the full picture of where output goes, so the separate destination config never enters the frame.

A second commit is a `/simplify` pass over the first: the same guidance, stated once instead of twice, and an unrelated description clause the first commit had deleted for character budget is restored.

No duplicate: `gh pr list --state open --search "authoring-scouts"` and an issue search for scout/Slack docs found nothing covering this file. Two open drafts on posthog.com (#18912, #18944) propose documenting per-scout Slack delivery, but the section they add already landed on master, so they are superseded rather than duplicated by this work.

Public artifact: nothing here carries non-public material — the diff is guidance prose, and the numbers that motivated it stayed in the thread.

Tools: PostHog Slack app (Claude Opus 5) with the PostHog MCP for the scout config schema and docs search. No repo skills were invoked.


---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1789029619162229?thread_ts=1789029619.162229&cid=C09SK2PAGKF)*

