### PR TITLE
fix(replay): hide translator extension popup injected into recorded pages

### DIFF
--- a/common/replay-shared/src/rrweb-plugins/common-replayer-config.test.ts
+++ b/common/replay-shared/src/rrweb-plugins/common-replayer-config.test.ts
@@ -19,4 +19,12 @@ describe('COMMON_REPLAYER_CONFIG', () => {
         // PostHog renders canvas via CanvasReplayerPlugin instead, so this must stay off.
         expect(COMMON_REPLAYER_CONFIG.UNSAFE_replayCanvas).toBe(false)
     })
+
+    it.each([
+        ['body > div.translate-tooltip-mtz', 'translator extension popup'],
+        ['body > span.translate-button-mtz', 'translator extension button'],
+    ])('hides %s (%s) injected by a browser extension', (selector) => {
+        const rule = COMMON_REPLAYER_CONFIG.insertStyleRules?.find((r) => r.includes(selector))
+        expect(rule).toContain('display: none !important')
+    })
 })

--- a/common/replay-shared/src/rrweb-plugins/common-replayer-config.test.ts
+++ b/common/replay-shared/src/rrweb-plugins/common-replayer-config.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 import { COMMON_REPLAYER_CONFIG } from './index'
 
 // posthog-js/* ships ESM that the test transform can't load directly; these values are
@@ -20,11 +23,40 @@ describe('COMMON_REPLAYER_CONFIG', () => {
         expect(COMMON_REPLAYER_CONFIG.UNSAFE_replayCanvas).toBe(false)
     })
 
-    it.each([
-        ['body > div.translate-tooltip-mtz', 'translator extension popup'],
-        ['body > span.translate-button-mtz', 'translator extension button'],
-    ])('hides %s (%s) injected by a browser extension', (selector) => {
-        const rule = COMMON_REPLAYER_CONFIG.insertStyleRules?.find((r) => r.includes(selector))
-        expect(rule).toContain('display: none !important')
+    describe('extension popup rule', () => {
+        const parseShippedRule = (): CSSStyleRule => {
+            const css = COMMON_REPLAYER_CONFIG.insertStyleRules?.find((rule) => rule.includes('translate-tooltip-mtz'))
+            const style = document.createElement('style')
+            style.textContent = css ?? ''
+            document.head.appendChild(style)
+            const rules = [...(style.sheet?.cssRules ?? [])]
+            expect(rules).toHaveLength(1)
+            return rules[0] as CSSStyleRule
+        }
+
+        it('hides what it matches', () => {
+            expect(parseShippedRule().style.display).toBe('none')
+        })
+
+        it.each([
+            ['div', 'translate-tooltip-mtz blue sm-root translate hidden_translate', true],
+            ['span', 'translate-button-mtz hidden_translate blue', true],
+            ['div', 'app-content', false],
+        ])('page-level %s.%s hidden: %s', (tagName, className, expected) => {
+            const el = document.createElement(tagName)
+            el.className = className
+            document.body.appendChild(el)
+            expect(el.matches(parseShippedRule().selectorText)).toBe(expected)
+        })
+
+        it('leaves an identically named element inside the recorded page alone', () => {
+            // Matching below <body> could hide a customer's own content and blank the replay.
+            const app = document.createElement('div')
+            const nested = document.createElement('div')
+            nested.className = 'translate-tooltip-mtz'
+            app.appendChild(nested)
+            document.body.appendChild(app)
+            expect(nested.matches(parseShippedRule().selectorText)).toBe(false)
+        })
     })
 })

--- a/common/replay-shared/src/rrweb-plugins/index.ts
+++ b/common/replay-shared/src/rrweb-plugins/index.ts
@@ -66,11 +66,8 @@ export const CorsPlugin: ReplayPlugin & {
 const defaultStyleRules = `.ph-no-capture { background-image: ${PLACEHOLDER_SVG_DATA_IMAGE_URL}; }`
 const shopifyShorthandCSSFix =
     '@media (prefers-reduced-motion: no-preference) { .scroll-trigger:not(.scroll-trigger--offscreen).animate--slide-in { animation: var(--animation-slide-in) } }'
-// The Chrome extension "Translator, dictionary - accurate translate" (id bebmphofpgkhclocdbgomhnjcpelbenh)
-// prepends its language-picker popup to <body> on every page. The CSS that hides and positions it
-// lives in the extension's content-script stylesheet, which browsers keep out of document.styleSheets,
-// so the recorder cannot capture it. Without it the popup renders in normal flow as a full-height
-// list of languages and pushes the recorded page below the fold.
+// Language picker prepended to <body> by the "Translator, dictionary - accurate translate" extension.
+// Its hiding CSS is content-script-only, so unrecordable; without this the picker reflows the page.
 const translatorExtensionPopupFix =
     'body > div.translate-tooltip-mtz, body > span.translate-button-mtz { display: none !important; }'
 

--- a/common/replay-shared/src/rrweb-plugins/index.ts
+++ b/common/replay-shared/src/rrweb-plugins/index.ts
@@ -66,10 +66,17 @@ export const CorsPlugin: ReplayPlugin & {
 const defaultStyleRules = `.ph-no-capture { background-image: ${PLACEHOLDER_SVG_DATA_IMAGE_URL}; }`
 const shopifyShorthandCSSFix =
     '@media (prefers-reduced-motion: no-preference) { .scroll-trigger:not(.scroll-trigger--offscreen).animate--slide-in { animation: var(--animation-slide-in) } }'
+// The Chrome extension "Translator, dictionary - accurate translate" (id bebmphofpgkhclocdbgomhnjcpelbenh)
+// prepends its language-picker popup to <body> on every page. The CSS that hides and positions it
+// lives in the extension's content-script stylesheet, which browsers keep out of document.styleSheets,
+// so the recorder cannot capture it. Without it the popup renders in normal flow as a full-height
+// list of languages and pushes the recorded page below the fold.
+const translatorExtensionPopupFix =
+    'body > div.translate-tooltip-mtz, body > span.translate-button-mtz { display: none !important; }'
 
 export const COMMON_REPLAYER_CONFIG: Partial<playerConfig> = {
     triggerFocus: false,
-    insertStyleRules: [defaultStyleRules, shopifyShorthandCSSFix],
+    insertStyleRules: [defaultStyleRules, shopifyShorthandCSSFix, translatorExtensionPopupFix],
     // Keep the replay iframe scriptless. UNSAFE_replayCanvas makes rrweb add `allow-scripts`
     // to the sandbox, which combined with the required `allow-same-origin` lets untrusted
     // recorded content escape the sandbox into the app origin. Canvas is replayed via


### PR DESCRIPTION
## Problem
A replay that rendered as a bare list of language names with the rest of the page blank. The recording itself was fine. The viewer had the Chrome extension "Translator, dictionary - accurate translate" installed, which prepends its language-picker popup to <body> on every page. The CSS that hides and positions it lives in the extension's content-script stylesheet, which browsers keep out of document.styleSheets, so the recorder cannot capture it. In replay the popup lands in normal flow at full height and pushes the recorded page below the fold.

## Changes
- Add a rule to the shared insertStyleRules hiding body > div.translate-tooltip-mtz and body > span.translate-button-mtz, next to the existing Shopify rule.
- Parametrized test asserting both selectors are covered.

## How did you test this code?
- Unit test in common-replayer-config.test.ts.
- Replayed the reported recording through the rrweb Replayer in headless Chromium with the rule injected. The page renders correctly with the language list gone. Without the rule it reproduces the blank screen.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - No duplicate: when this PR fixes something believed to be live on master, no open PR already fixes it. A broken master attracts parallel agents, so search before opening — `gh pr list --state open --search "<keywords>" --limit 20`, which lists drafts too, and most agent PRs start as drafts. Say here which PR you found and why this one is still needed, or that the search found nothing.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Voice: the subject of every sentence is the change, never its author. No "I", "me" or "my" anywhere in the body. "I (actually Claude)" is worse than either half: it hands the assignee an account of work they did not do. Authorship is one stated fact in the Agent context section below.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Flow and topology changes: include separate before-and-after Mermaid `flowchart` blocks with PostHog colors. This includes CI wiring, pipelines, state machines, and request paths. Use `/writing-pr-descriptions` for the palette and role mapping.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Simplify before opening: if your agent has a behavior-preserving cleanup pass (Claude Code: `/simplify`), run it on a non-trivial diff before final tests and preflight, since it edits the tree. Skip it for small mechanical changes.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->
