### PR TITLE
fix(desktop): keep a streamed message whole across server diagnostics

### DIFF
--- a/products/desktop/packages/agent/src/session-log-writer.test.ts
+++ b/products/desktop/packages/agent/src/session-log-writer.test.ts
@@ -254,6 +254,43 @@ describe("SessionLogWriter", () => {
       },
     );
 
+    // The double-prefixed form is what extNotification puts on the wire.
+    it.each(["_posthog/console", "__posthog/usage_update"])(
+      "keeps a streamed message whole across an interleaved %s",
+      async (method) => {
+        const sessionId = "s1";
+        logWriter.register(sessionId, { taskId: "t1", runId: sessionId });
+
+        logWriter.appendRawLine(
+          sessionId,
+          makeSessionUpdate("agent_message_chunk", {
+            content: { type: "text", text: "dashboards still" },
+          }),
+        );
+        logWriter.appendRawLine(
+          sessionId,
+          JSON.stringify({ jsonrpc: "2.0", method, params: {} }),
+        );
+        logWriter.appendRawLine(
+          sessionId,
+          makeSessionUpdate("agent_message_chunk", {
+            content: { type: "text", text: " use that field filter" },
+          }),
+        );
+        logWriter.appendRawLine(
+          sessionId,
+          makeSessionUpdate("tool_call", { toolCallId: "tc1" }),
+        );
+
+        await logWriter.flush(sessionId);
+
+        // A split here would reach the Slack relay as only the second half.
+        expect(logWriter.getAgentResponseParts(sessionId)).toEqual([
+          "dashboards still use that field filter",
+        ]);
+      },
+    );
+
     it("stamps the coalesced entry with the covered chunk id range", async () => {
       const sessionId = "s1";
       logWriter.register(sessionId, { taskId: "t1", runId: sessionId });

--- a/products/desktop/packages/agent/src/session-log-writer.ts
+++ b/products/desktop/packages/agent/src/session-log-writer.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs";
 import fsp from "node:fs/promises";
 import path from "node:path";
-import { serializeError } from "@posthog/shared";
+import {
+  isTranscriptNeutralNotificationMethod,
+  serializeError,
+} from "@posthog/shared";
 import type { PostHogAPIClient } from "./posthog-api";
 import type { StoredNotification } from "./types";
 import { isEmptyContentBlock } from "./utils/acp-content";
@@ -240,7 +243,11 @@ export class SessionLogWriter {
       if (this.isDirectAgentMessage(message) && session.chunkBuffer) {
         supersededChunks = session.chunkBuffer;
         session.chunkBuffer = undefined;
-      } else {
+      } else if (
+        !isTranscriptNeutralNotificationMethod(
+          message.method as string | undefined,
+        )
+      ) {
         this.emitCoalescedMessage(sessionId, session);
       }
 

--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -38,6 +38,7 @@ import {
   isJsonRpcResponse,
   isPersistedOptionSupported,
   isRateLimitError,
+  isTranscriptNeutralNotificationMethod,
   isTransientUpstreamError,
   isTurnEndedWithoutResponseError,
   leadingSlashCommand,
@@ -1494,6 +1495,14 @@ function isSessionPromptEvent(event: AcpMessage): boolean {
   );
 }
 
+/** Matches SessionLogWriter, which keeps one chunk buffer across these. */
+function isTranscriptNeutralEvent(event: AcpMessage): boolean {
+  return (
+    isJsonRpcNotification(event.message) &&
+    isTranscriptNeutralNotificationMethod(event.message.method)
+  );
+}
+
 function finishAgentMessageChunkRun(position: AgentMessagePosition): void {
   if (!position.chunkRunActive) return;
   position.messageIndex += 1;
@@ -1512,6 +1521,7 @@ function discardChunksSupersededByHydratedMessages(
   };
   for (const event of hydratedTurn.events) {
     if (isSessionPromptEvent(event)) continue;
+    if (isTranscriptNeutralEvent(event)) continue;
     const updateKind = agentMessageUpdateKind(event);
     if (updateKind === "ignored") continue;
     if (updateKind === "chunk") {
@@ -1548,6 +1558,9 @@ function discardChunksSupersededByHydratedMessages(
     let keep = true;
     if (isSessionPromptEvent(event)) {
       discardChunkRun = false;
+    } else if (isTranscriptNeutralEvent(event)) {
+      // The writer's chunk buffer stays open across these, so the live
+      // position must not advance either.
     } else {
       const updateKind = agentMessageUpdateKind(event);
       if (updateKind === "chunk") {

--- a/products/desktop/packages/core/src/sessions/sessionServiceHydration.test.ts
+++ b/products/desktop/packages/core/src/sessions/sessionServiceHydration.test.ts
@@ -82,6 +82,18 @@ function turnComplete(ts: number): AcpMessage {
   };
 }
 
+function consoleLog(ts: number): AcpMessage {
+  return {
+    type: "acp_message",
+    ts,
+    message: {
+      jsonrpc: "2.0",
+      method: "_posthog/console",
+      params: { level: "debug", message: "diagnostic" },
+    },
+  };
+}
+
 function storedEntry(event: AcpMessage): StoredLogEntry {
   return {
     type: "notification",
@@ -106,6 +118,31 @@ describe("resume hydration reconciliation", () => {
         [
           { ...firstResponse, ts: 21 },
           { ...firstCompletion, ts: 31 },
+        ],
+        hydratedEvents,
+      ),
+    ).toEqual([]);
+  });
+
+  it("discards both halves of a chunk run split by a server-internal notification", () => {
+    // The writer keeps one chunk buffer across a diagnostic, so the durable
+    // log holds one message where the live tail holds two chunk runs.
+    const diagnostic = consoleLog(20);
+    const completion = turnComplete(40);
+    const hydratedEvents = [
+      prompt(1, "ask", 10),
+      diagnostic,
+      agentMessage("dashboards still use that filter", 30),
+      completion,
+    ];
+
+    expect(
+      reconcileLiveEventsWithHydratedEvents(
+        [
+          agentMessageChunk("dashboards still", 21),
+          { ...diagnostic, ts: 22 },
+          agentMessageChunk(" use that filter", 23),
+          { ...completion, ts: 41 },
         ],
         hydratedEvents,
       ),

--- a/products/desktop/packages/shared/src/index.ts
+++ b/products/desktop/packages/shared/src/index.ts
@@ -373,6 +373,7 @@ export {
   readMcpToolName,
   readParentToolCallId,
 } from "./tool-meta";
+export { isTranscriptNeutralNotificationMethod } from "./transcript-neutral-notifications";
 export { TypedEventEmitter } from "./typed-event-emitter";
 export { isSafeExternalUrl, isSafePostHogUrl } from "./url";
 export { getCloudUrlFromRegion } from "./urls";

--- a/products/desktop/packages/shared/src/transcript-neutral-notifications.ts
+++ b/products/desktop/packages/shared/src/transcript-neutral-notifications.ts
@@ -1,0 +1,31 @@
+/**
+ * Notifications the agent server emits about itself rather than about the
+ * conversation. They arrive at arbitrary moments, including between two
+ * chunks of a message the model is still streaming, so no consumer that
+ * groups chunks into messages may treat one as a message boundary. The
+ * session log writer and hydration reconciliation share this predicate;
+ * if they disagree, a resumed transcript duplicates part of the answer.
+ *
+ * `_posthog/progress` is deliberately absent: the client renders it as a
+ * card in the transcript, so it is a visible boundary.
+ */
+const TRANSCRIPT_NEUTRAL_NOTIFICATION_METHODS = [
+  "_posthog/console",
+  "_posthog/mode_change",
+  "_posthog/status",
+  "_posthog/task_notification",
+  "_posthog/usage_update",
+  "_posthog/resources_used",
+  "_posthog/rtk_savings",
+  "_posthog/codex_goal",
+];
+
+/** Accepts the double-prefixed `__posthog/…` form extNotification puts on the wire. */
+export function isTranscriptNeutralNotificationMethod(
+  method: string | undefined,
+): boolean {
+  if (!method) return false;
+  return TRANSCRIPT_NEUTRAL_NOTIFICATION_METHODS.some(
+    (neutral) => method === neutral || method === `_${neutral}`,
+  );
+}


### PR DESCRIPTION
## Problem

Someone who asks the agent a question in Slack can get a reply that starts mid-sentence, missing the opening half of the answer.

- The session log writer coalesces streamed `agent_message_chunk` events and closes the buffered message when any non-chunk notification arrives.
- The agent server's own `_posthog/console` and telemetry notifications arrive at arbitrary moments, including between two chunks the model is still streaming.
- One answer then becomes two assistant parts, and the relay posts only the last one ([`_pick_relay_text`](https://github.com/PostHog/posthog/blob/347c3d6f4128874614c124e924c5679242bbcedf/products/tasks/backend/facade/api.py#L4524-L4533)).

Origin: [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1789028068977459). A debug log about PR attribution landed between two chunks of one answer, 1.2 seconds apart.

## Changes

- A Slack reply now carries the whole answer, not only the text after the last diagnostic notification.
- The server's own diagnostics (`_posthog/console`, `usage_update`, `status`, `mode_change`, `task_notification`, `resources_used`, `rtk_savings`, `codex_goal`) pass through the log writer without closing a streamed message.
- `_posthog/progress` stays a boundary: the client renders it as a card in the transcript, so the split is visible anyway.
- ACP `session/update` events keep their boundary meaning, so a tool call still ends a part.
- Hydration reconciliation counts message positions with the same predicate, so a resumed desktop transcript does not duplicate the tail of the answer. The predicate lives in `@posthog/shared`, imported by both the writer and `sessionService`.
- Nothing looks different in the app. The visible effect is in Slack replies.

## How did you test this code?

- Added a parameterized case in `session-log-writer.test.ts`: an interleaved `_posthog/console` or double-prefixed `__posthog/usage_update` (the form `extNotification` puts on the wire) leaves one part rather than two. It catches the split that no existing test covered, and it fails against the previous behavior.
- Added a reconcile case in `sessionServiceHydration.test.ts`: a live chunk run split by a diagnostic fully reconciles against the durable log's single message. It fails without the `sessionService` change (verified by reverting the predicate).
- Not run: the Slack delivery path end to end, which needs a live workspace and a sandbox run.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) diagnosed the report and wrote the fix. Skills invoked: `/writing-pr-descriptions`.

The report named the `slack-app-markdown` flag. Reading the run's session log ruled that out: the two fragments were already separate `agent_message` events before any Slack code ran. The alternative fix, joining the trailing parts in `_pick_relay_text`, was rejected because the parts list carries no record of which boundaries were real tool calls.


