### PR TITLE
test(canvas): verify cloud task user activation

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/freeform/canvasHostMessageRouter.test.ts
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/canvasHostMessageRouter.test.ts
@@ -21,11 +21,13 @@ describe("createCanvasHostMessageRouter", () => {
     },
   );
   it.each([
-    [false, false],
-    [true, true],
+    [false, false, "tasks.create"],
+    [true, true, "tasks.create"],
+    [false, false, "tasks.create_and_run"],
+    [true, true, "tasks.create_and_run"],
   ])(
-    "forwards action invocations only under a user gesture (activation: %s)",
-    async (hasActivation, forwarded) => {
+    "forwards action invocations only under a user gesture (activation: %s, forwarded: %s, verb: %s)",
+    async (hasActivation, forwarded, verb) => {
       const post = vi.fn();
       const onDataRequest = vi.fn().mockResolvedValue({ ok: true });
       const route = createCanvasHostMessageRouter({
@@ -40,12 +42,12 @@ describe("createCanvasHostMessageRouter", () => {
         type: "data-request",
         id: "request-1",
         method: "actionInvoke",
-        payload: { verb: "tasks.create", payload: { title: "t" } },
+        payload: { verb, payload: { title: "t" } },
       });
 
       if (forwarded) {
         expect(onDataRequest).toHaveBeenCalledWith("actionInvoke", {
-          verb: "tasks.create",
+          verb,
           payload: { title: "t" },
         });
       } else {


### PR DESCRIPTION
## Problem

The backend action in [#98194](https://github.com/PostHog/posthog/pull/98194) needs frontend coverage for its existing click protection.

**Why:** Frontend and backend changes need separate review and CI checks.

## Changes

- Check that the host rejects `tasks.create_and_run` without user activation and forwards it with activation.
- Keep runtime behavior and the visible interface unchanged. This layer contains only frontend tests.

## How did you test this code?

`pnpm --filter @posthog/ui test src/features/canvas/freeform/canvasHostMessageRouter.test.ts` checks both activation states.

Biome and `hogli ci:preflight --fix --against ea0bb46c5778d1df4cf77aeaeec4e641c26a6e0c` pass. No live cloud run was started.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No public contract or runtime behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used GitHub CLI and PostHog Desktop signed-commit and stack tools. Skills: `stacking-prs`, `writing-pr-descriptions`, and `writing-tests`.

The existing changes were split by file ownership. The combined code is unchanged. No private data was added.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
