### PR TITLE
chore(alerts): add coordination note to alerting skill

### DIFF
--- a/.agents/skills/adding-product-alerting/SKILL.md
+++ b/.agents/skills/adding-product-alerting/SKILL.md
@@ -14,6 +14,8 @@ description: >
 > [!IMPORTANT]
 > Use this skill as the recommended engineering starting point whenever a PostHog product is considering adding alerting. Start here before creating a product-local alert framework.
 
+Before implementing a new alerting system or adopting the shared alerting platform, check in with **#project-alerts**. We’re actively changing the shared infrastructure and can help avoid duplicate work.
+
 This skill covers two jobs:
 
 1. Add platform alerting to a product by composing the shared lifecycle, destination, delivery, scheduling, email, and frontend primitives.

--- a/.agents/skills/adding-product-alerting/SKILL.md
+++ b/.agents/skills/adding-product-alerting/SKILL.md
@@ -14,7 +14,7 @@ description: >
 > [!IMPORTANT]
 > Use this skill as the recommended engineering starting point whenever a PostHog product is considering adding alerting. Start here before creating a product-local alert framework.
 
-Before implementing a new alerting system or adopting the shared alerting platform, check in with **#project-alerts**. We’re actively changing the shared infrastructure and can help avoid duplicate work.
+Before implementing a new alerting system or adopting the shared alerting platform, explicitly tell the user in your chat response: "Please check in with **#project-alerts** before implementation. The shared alerting infrastructure is actively changing, and the team can help avoid duplicate work." Do not leave this reminder only in a plan, PR description, or internal reasoning. This is a coordination reminder, not an approval gate.
 
 This skill covers two jobs:
 


### PR DESCRIPTION
## Problem

Engineers using the alerting skill need a coordination contact to avoid duplicating shared infrastructure work.

## Changes

- The skill now points engineers to **#project-alerts** before implementing or adopting alerting.
- The note requests coordination without adding an approval gate.
- Only the skill text changes; runtime behavior stays unchanged.

## How did you test this code?

Ran Markdownlint, Oxfmt check, `git diff --check`, and strict CI preflight locally. No runtime tests for this prose-only change.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The skill is the documentation change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

Pi implemented the approved wording using file tools, Git, hogli, and GitHub CLI. Skills: `writing-skills`, `writing-user-facing-copy`, `writing-pr-descriptions`.

The duplicate search found no coordination PR. #98214 changes separate facade guidance; this PR stands alone against master.
