### PR TITLE
perf(signals): add suggested_reviewers to the reports list

### DIFF
--- a/products/signals/backend/serializers.py
+++ b/products/signals/backend/serializers.py
@@ -609,6 +609,37 @@ class ReportChartSerializer(serializers.Serializer):
     )
 
 
+class SignalSuggestedReviewerCommitSerializer(serializers.Serializer):
+    """One commit cited as evidence for why a reviewer is relevant."""
+
+    sha = serializers.CharField(help_text="Commit SHA.")
+    url = serializers.CharField(help_text="Link to the commit.")
+    reason = serializers.CharField(help_text="Why this commit makes the reviewer relevant.")
+
+
+class SignalSuggestedReviewerSerializer(serializers.Serializer):
+    """Read side of a `suggested_reviewers` artefact entry. The stored identity resolves to a
+    current org member at read time, so `user` stays right even when the reviewer linked their
+    GitHub account after the report was generated."""
+
+    github_login = serializers.CharField(
+        required=False, allow_null=True, help_text="GitHub login the reviewer was stored under, or null."
+    )
+    user_uuid = serializers.UUIDField(
+        required=False, allow_null=True, help_text="PostHog user UUID the reviewer was stored under, when present."
+    )
+    github_name = serializers.CharField(
+        required=False, allow_null=True, help_text="Human-readable display name captured with the entry, or null."
+    )
+    relevant_commits = SignalSuggestedReviewerCommitSerializer(
+        many=True, required=False, help_text="Commits cited as evidence for the reviewer."
+    )
+    user = _UserSerializer(
+        allow_null=True,
+        help_text="Resolved current org member, or null when no member matches the stored identity.",
+    )
+
+
 class SignalReportSerializer(serializers.ModelSerializer):
     artefact_count = serializers.IntegerField(read_only=True)
     charts = ReportChartSerializer(
@@ -660,6 +691,13 @@ class SignalReportSerializer(serializers.ModelSerializer):
         ),
     )
     is_suggested_reviewer = serializers.BooleanField(read_only=True, default=False)
+    suggested_reviewers = serializers.SerializerMethodField(
+        help_text=(
+            "Reviewers suggested for this report, from the latest suggested-reviewers artefact (empty "
+            "when none). Each carries the resolved current org member. Lets list cards show reviewer "
+            "avatars without a per-card artefact fetch."
+        ),
+    )
     source_products = serializers.SerializerMethodField(
         help_text="Distinct source products contributing signals to this report (from ClickHouse).",
     )
@@ -719,6 +757,7 @@ class SignalReportSerializer(serializers.ModelSerializer):
             "dismissal_note",
             "repo_slug",
             "is_suggested_reviewer",
+            "suggested_reviewers",
             "source_products",
             "scout_name",
             "implementation_pr_url",
@@ -848,6 +887,35 @@ class SignalReportSerializer(serializers.ModelSerializer):
             return None
         value = data.get("repository")
         return value if isinstance(value, str) and value else None
+
+    @extend_schema_field(SignalSuggestedReviewerSerializer(many=True))
+    def get_suggested_reviewers(self, obj: SignalReport) -> list[dict]:
+        prefetched = getattr(obj, "prefetched_suggested_reviewers_artefacts", None)
+        if prefetched is not None:
+            art = prefetched[0] if prefetched else None
+        else:
+            art = (
+                obj.artefacts.filter(type=SignalReportArtefact.ArtefactType.SUGGESTED_REVIEWERS)
+                .order_by("-created_at")
+                .first()
+            )
+        if art is None:
+            return []
+        try:
+            parsed = json.loads(art.content)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return []
+        if not isinstance(parsed, list):
+            return []
+        # None outside the reports list (e.g. detail), where the helper resolves per report instead.
+        login_map = cast(Mapping[str, User] | None, self.context.get("signals_github_login_to_user_map"))
+        uuid_map = cast(Mapping[str, User] | None, self.context.get("signals_reviewer_user_uuid_map"))
+        return enrich_reviewer_dicts_with_org_members(
+            obj.team_id,
+            parsed,
+            login_to_user=login_map,
+            uuid_to_user=uuid_map,
+        )
 
     def get_source_products(self, obj: SignalReport) -> list[str]:
         source_products_map: dict[str, list[str]] | None = self.context.get("source_products_map")

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -675,6 +675,47 @@ class TestSignalReportListAPI(APIBaseTest):
         row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
         assert row["is_suggested_reviewer"] is False
 
+    def test_list_surfaces_suggested_reviewers_with_resolved_user(self):
+        UserSocialAuth.objects.create(
+            user=self.user,
+            provider="github",
+            uid="github-test-list-reviewers",
+            extra_data={"login": "suggestedgh"},
+        )
+        report = self._create_report()
+        SignalReportArtefact.objects.create(
+            team=self.team,
+            report=report,
+            type=SignalReportArtefact.ArtefactType.SUGGESTED_REVIEWERS,
+            content=json.dumps(
+                [
+                    {
+                        "github_login": "suggestedgh",
+                        "relevant_commits": [
+                            {"sha": "abc123", "url": "https://gh/c/abc123", "reason": "owns the area"}
+                        ],
+                    }
+                ]
+            ),
+        )
+
+        response = self.client.get(self._list_url())
+        assert response.status_code == status.HTTP_200_OK
+        row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
+        reviewers = row["suggested_reviewers"]
+        assert len(reviewers) == 1
+        assert reviewers[0]["github_login"] == "suggestedgh"
+        assert reviewers[0]["relevant_commits"][0]["sha"] == "abc123"
+        assert reviewers[0]["user"]["id"] == self.user.id
+
+    def test_list_suggested_reviewers_empty_without_artefact(self):
+        report = self._create_report()
+
+        response = self.client.get(self._list_url())
+        assert response.status_code == status.HTTP_200_OK
+        row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
+        assert row["suggested_reviewers"] == []
+
     # --- implementation_pr_url ---
 
     def _create_implementation_task_with_run(

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -1573,6 +1573,13 @@ class SignalReportViewSet(
                 ).order_by("-created_at")[:1],
                 to_attr="prefetched_repo_selection_artefacts",
             ),
+            Prefetch(
+                "artefacts",
+                queryset=SignalReportArtefact.objects.filter(
+                    type=SignalReportArtefact.ArtefactType.SUGGESTED_REVIEWERS
+                ).order_by("-created_at")[:1],
+                to_attr="prefetched_suggested_reviewers_artefacts",
+            ),
         )
 
     def _annotate_is_suggested_reviewer(self, queryset):
@@ -2096,6 +2103,20 @@ class SignalReportViewSet(
         # actions carry, for the serializer's refund_ineligibility_reason field.
         with tracer.start_as_current_span("signals.reports.list.fetch_billable_pr_runs"):
             first_billable_pr_run_at_map = first_billable_pr_run_at_by_report(report_ids)
+
+        # Resolve every suggested reviewer on the page in two grouped queries, so the serializer's
+        # suggested_reviewers field enriches from these maps instead of one lookup per card.
+        with tracer.start_as_current_span("signals.reports.list.resolve_reviewers"):
+            page_reviewer_artefacts = [
+                art for r in reports for art in (getattr(r, "prefetched_suggested_reviewers_artefacts", None) or [])
+            ]
+            reviewer_logins = normalized_github_logins_from_suggested_reviewer_artefacts(page_reviewer_artefacts)
+            reviewer_login_map = (
+                resolve_org_github_login_to_users(self.team.id, reviewer_logins) if reviewer_logins else {}
+            )
+            reviewer_uuids = normalized_user_uuids_from_suggested_reviewer_artefacts(page_reviewer_artefacts)
+            reviewer_uuid_map = resolve_org_users_by_uuid(self.team.id, reviewer_uuids) if reviewer_uuids else {}
+
         context = {
             **self.get_serializer_context(),
             "source_products_map": {rid: meta.source_products for rid, meta in signal_meta_map.items()},
@@ -2104,6 +2125,8 @@ class SignalReportViewSet(
             "implementation_pr_state_map": {rid: pr.state for rid, pr in implementation_pr_by_report.items()},
             "implementation_pr_merged_ids": {rid for rid, pr in implementation_pr_by_report.items() if pr.merged},
             "first_billable_pr_run_at_map": first_billable_pr_run_at_map,
+            "signals_github_login_to_user_map": reviewer_login_map,
+            "signals_reviewer_user_uuid_map": reviewer_uuid_map,
         }
         serializer = self.get_serializer(reports, many=True, context=context)
 

--- a/products/signals/frontend/generated/api.schemas.ts
+++ b/products/signals/frontend/generated/api.schemas.ts
@@ -104,6 +104,53 @@ export interface ReportChartApi {
     size?: SizeEnumApi | null
 }
 
+/**
+ * One commit cited as evidence for why a reviewer is relevant.
+ */
+export interface SignalSuggestedReviewerCommitApi {
+    /** Commit SHA. */
+    sha: string
+    /** Link to the commit. */
+    url: string
+    /** Why this commit makes the reviewer relevant. */
+    reason: string
+}
+
+export interface _UserApi {
+    readonly id: number
+    readonly uuid: string
+    readonly first_name: string
+    readonly last_name: string
+    readonly email: string
+}
+
+/**
+ * Read side of a `suggested_reviewers` artefact entry. The stored identity resolves to a
+ * current org member at read time, so `user` stays right even when the reviewer linked their
+ * GitHub account after the report was generated.
+ */
+export interface SignalSuggestedReviewerApi {
+    /**
+     * GitHub login the reviewer was stored under, or null.
+     * @nullable
+     */
+    github_login?: string | null
+    /**
+     * PostHog user UUID the reviewer was stored under, when present.
+     * @nullable
+     */
+    user_uuid?: string | null
+    /**
+     * Human-readable display name captured with the entry, or null.
+     * @nullable
+     */
+    github_name?: string | null
+    /** Commits cited as evidence for the reviewer. */
+    relevant_commits?: SignalSuggestedReviewerCommitApi[]
+    /** Resolved current org member, or null when no member matches the stored identity. */
+    user: _UserApi | null
+}
+
 export type SignalReportAssignmentPrStateEnumApi =
     (typeof SignalReportAssignmentPrStateEnumApi)[keyof typeof SignalReportAssignmentPrStateEnumApi]
 
@@ -133,14 +180,6 @@ export const SignalActorKindEnumApi = {
     Agent: 'agent',
     System: 'system',
 } as const
-
-export interface _UserApi {
-    readonly id: number
-    readonly uuid: string
-    readonly first_name: string
-    readonly last_name: string
-    readonly email: string
-}
 
 export interface SignalReportAssigneeApi {
     kind: SignalActorKindEnumApi
@@ -287,6 +326,8 @@ export interface SignalReportApi {
      */
     readonly repo_slug: string | null
     readonly is_suggested_reviewer: boolean
+    /** Reviewers suggested for this report, from the latest suggested-reviewers artefact (empty when none). Each carries the resolved current org member. Lets list cards show reviewer avatars without a per-card artefact fetch. */
+    readonly suggested_reviewers: readonly SignalSuggestedReviewerApi[]
     /** Distinct source products contributing signals to this report (from ClickHouse). */
     readonly source_products: readonly string[]
     /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -58594,6 +58594,45 @@ export namespace Schemas {
       Suppressed: 'suppressed',
     } as const;
 
+    /**
+     * One commit cited as evidence for why a reviewer is relevant.
+     */
+    export interface SignalSuggestedReviewerCommit {
+      /** Commit SHA. */
+      sha: string;
+      /** Link to the commit. */
+      url: string;
+      /** Why this commit makes the reviewer relevant. */
+      reason: string;
+    }
+
+    /**
+     * Read side of a `suggested_reviewers` artefact entry. The stored identity resolves to a
+     * current org member at read time, so `user` stays right even when the reviewer linked their
+     * GitHub account after the report was generated.
+     */
+    export interface SignalSuggestedReviewer {
+      /**
+         * GitHub login the reviewer was stored under, or null.
+         * @nullable
+         */
+      github_login?: string | null;
+      /**
+         * PostHog user UUID the reviewer was stored under, when present.
+         * @nullable
+         */
+      user_uuid?: string | null;
+      /**
+         * Human-readable display name captured with the entry, or null.
+         * @nullable
+         */
+      github_name?: string | null;
+      /** Commits cited as evidence for the reviewer. */
+      relevant_commits?: SignalSuggestedReviewerCommit[];
+      /** Resolved current org member, or null when no member matches the stored identity. */
+      user: _User | null;
+    }
+
     export type SignalReportAssignmentPrStateEnum = typeof SignalReportAssignmentPrStateEnum[keyof typeof SignalReportAssignmentPrStateEnum];
 
 
@@ -58760,6 +58799,8 @@ export namespace Schemas {
          */
       readonly repo_slug: string | null;
       readonly is_suggested_reviewer: boolean;
+      /** Reviewers suggested for this report, from the latest suggested-reviewers artefact (empty when none). Each carries the resolved current org member. Lets list cards show reviewer avatars without a per-card artefact fetch. */
+      readonly suggested_reviewers: readonly SignalSuggestedReviewer[];
       /** Distinct source products contributing signals to this report (from ClickHouse). */
       readonly source_products: readonly string[];
       /**


### PR DESCRIPTION
## Problem

Opening the Self-driving inbox fires one `artefacts/` request per report card, only to read two things: the target repository and the suggested reviewers. On a full inbox that is dozens of extra requests and megabytes of payload on every open.

The repository half already landed: `repo_slug` is on the list from #96350. The reviewer half is still missing, so the card keeps fetching each report's full artefacts to draw its reviewer avatars.

This PR adds the reviewer half. It is the backend enabler; the desktop card stops fetching in a follow-up.

## Changes

- The reports list now returns `suggested_reviewers` for each report: the latest suggested-reviewers artefact, enriched with the resolved current org member (so avatars work even when the reviewer linked GitHub after the report was generated).
- The whole page resolves in two grouped queries, not one lookup per card: a `[:1]` prefetch of the suggested-reviewers artefact, plus page-level github-login and user-uuid maps built once and passed in serializer context. This mirrors the existing `repo_slug` lift exactly.
- `suggested_reviewers` is empty on reports with no reviewer artefact.
- No user-visible change ships in this PR on its own. It adds a field; the inbox only stops its per-card fetch once the desktop follow-up reads this field.

## How did you test this code?

Two API tests added to `TestSignalReportListAPI`, both guarding the new field on the list response:

- `test_list_surfaces_suggested_reviewers_with_resolved_user` — a reviewer stored by github login resolves to the org member, and `reason` passes through. Catches a regression that drops the field from the serializer, fails to wire the page-level maps, or breaks the prefetch.
- `test_list_suggested_reviewers_empty_without_artefact` — a report with no artefact returns `[]`, not null or an error.

Not run locally: the database-backed pytest suite and the OpenAPI type regeneration, because this sandbox has no database. CI runs both; the `tests-posthog[bot]` regenerates the generated types on the branch.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus). Skills invoked: `/improving-drf-endpoints` (serializer field typing, `@extend_schema_field`, `help_text`), `/writing-tests` (the two cases above), `/writing-pr-descriptions`, `/writing-code-comments`.

Design note: the enriched reviewer shape reuses the detail path's `enrich_reviewer_dicts_with_org_members` helper and its existing `signals_github_login_to_user_map` / `signals_reviewer_user_uuid_map` context keys, rather than a new code path. The getter falls back to per-report resolution when those maps are absent (detail view), so the field is correct everywhere and only cheap on the list.

- No duplicate: `gh pr list` search for suggested_reviewers on the reports list found nothing open.
- Public artifact: no customer or session material in the code, tests, or this description. The test reviewer identities are invented.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
