### PR TITLE
fix(endpoints): stop counting budget refusals as endpoint errors

### DIFF
--- a/products/endpoints/backend/logic/execution.py
+++ b/products/endpoints/backend/logic/execution.py
@@ -56,6 +56,7 @@ from posthog.clickhouse.query_tagging import (
 from posthog.errors import ExposedCHQueryError
 from posthog.event_usage import get_request_analytics_properties, report_user_action
 from posthog.exceptions import (
+    APIQueriesBudgetExceeded,
     ClickHouseAtCapacity,
     ClickHouseEstimatedQueryExecutionTimeTooLong,
     ClickHouseQueryMemoryLimitExceeded,
@@ -626,6 +627,10 @@ class EndpointExecutionService(PydanticModelMixin):
         except ConcurrencyLimitExceeded:
             ENDPOINT_CONCURRENCY_REJECTED_TOTAL.labels(team_id=str(self.team.pk)).inc()
             raise Throttled(detail="Too many concurrent requests. Please try again later.")
+        except APIQueriesBudgetExceeded:
+            # The platform refused this query on purpose, so it is not an endpoint fault. Leave the
+            # execution counter alone: the budget path counts its own refusals.
+            raise
         except tuple(_QUERY_PERFORMANCE_ERRORS) as e:
             execution_status = "query_performance"
             error_label = type(e).__name__

--- a/products/endpoints/backend/logic/execution.py
+++ b/products/endpoints/backend/logic/execution.py
@@ -123,9 +123,13 @@ _QUERY_PERFORMANCE_ERRORS: dict[type[Exception], tuple[str, str]] = {
     ),
 }
 
-# Cost guardrails + transient capacity: customer problems, not faults. Skipped from capture and
-# re-raised past the materialized/ducklake inline fallback.
-_QUERY_GUARDRAIL_ERRORS: tuple[type[Exception], ...] = (*_QUERY_PERFORMANCE_ERRORS, ClickHouseAtCapacity)
+# Cost guardrails, budget refusals and transient capacity: customer problems, not faults. Skipped
+# from capture and re-raised past the materialized/ducklake inline fallback.
+_QUERY_GUARDRAIL_ERRORS: tuple[type[Exception], ...] = (
+    *_QUERY_PERFORMANCE_ERRORS,
+    ClickHouseAtCapacity,
+    APIQueriesBudgetExceeded,
+)
 
 
 def _is_query_guardrail_error(error: BaseException) -> bool:
@@ -572,7 +576,9 @@ class EndpointExecutionService(PydanticModelMixin):
                         limit=limit,
                         offset=offset,
                     )
-                except ConcurrencyLimitExceeded:
+                except (ConcurrencyLimitExceeded, APIQueriesBudgetExceeded):
+                    # A refusal is not a broken table. The inline path meets the same limiter
+                    # with the same balance, so falling back cannot succeed.
                     raise
                 except Exception:
                     # Already logged/captured/signaled inside the materialized path. Re-run

--- a/products/endpoints/backend/tests/test_endpoint_execution.py
+++ b/products/endpoints/backend/tests/test_endpoint_execution.py
@@ -16,6 +16,7 @@ from posthog.schema import EventsNode, TrendsQuery
 from posthog.hogql.errors import ExposedHogQLError
 
 from posthog.errors import CHQueryErrorNoCommonType
+from posthog.exceptions import APIQueriesBudgetExceeded
 
 from products.data_modeling.backend.facade.models import DataModelingJob, DataWarehouseSavedQuery
 from products.endpoints.backend.logic.execution import EndpointExecutionService, _emit_endpoint_failure_signal
@@ -197,6 +198,30 @@ class TestEndpointExecution(ClickhouseTestMixin, APIBaseTest):
         self.assertNotIn("Query execution failed.", detail)
         if forbidden_detail:
             self.assertNotIn(forbidden_detail, detail)
+
+    def test_budget_refusal_does_not_count_as_an_endpoint_error(self):
+        endpoint = create_endpoint_with_version(
+            name="budget_refused",
+            team=self.team,
+            query={"kind": "HogQLQuery", "query": "SELECT count() FROM events"},
+            created_by=self.user,
+            is_active=True,
+        )
+
+        with (
+            mock.patch(
+                "products.endpoints.backend.logic.execution.process_query_model",
+                side_effect=APIQueriesBudgetExceeded(wait=120),
+            ),
+            mock.patch("products.endpoints.backend.logic.execution.ENDPOINT_EXECUTION_TOTAL") as mock_counter,
+            mock.patch("products.endpoints.backend.logic.execution._emit_endpoint_failure_signal"),
+        ):
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/", {}, format="json"
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+        mock_counter.labels.assert_not_called()
 
     def test_hogql_endpoint_executes_with_variable_override(self):
         endpoint = create_endpoint_with_version(

--- a/products/endpoints/backend/tests/test_endpoint_execution.py
+++ b/products/endpoints/backend/tests/test_endpoint_execution.py
@@ -214,7 +214,8 @@ class TestEndpointExecution(ClickhouseTestMixin, APIBaseTest):
                 side_effect=APIQueriesBudgetExceeded(wait=120),
             ),
             mock.patch("products.endpoints.backend.logic.execution.ENDPOINT_EXECUTION_TOTAL") as mock_counter,
-            mock.patch("products.endpoints.backend.logic.execution._emit_endpoint_failure_signal"),
+            mock.patch("products.endpoints.backend.logic.execution._emit_endpoint_failure_signal") as mock_signal,
+            mock.patch("products.endpoints.backend.logic.execution.capture_exception") as mock_capture,
         ):
             response = self.client.post(
                 f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/", {}, format="json"
@@ -222,6 +223,8 @@ class TestEndpointExecution(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
         mock_counter.labels.assert_not_called()
+        mock_signal.assert_not_called()
+        mock_capture.assert_not_called()
 
     def test_hogql_endpoint_executes_with_variable_override(self):
         endpoint = create_endpoint_with_version(


### PR DESCRIPTION
## Problem

An endpoint run that the hourly API read budget refuses returns 429 to the customer, which is the platform working as designed. Endpoints recorded it as a system fault anyway, so the refusals landed on the endpoint execution counter as `status="error"`, in error tracking, and on the per-endpoint failure signal.

That counter is what the system-error alert reads, so the alert pages the data modeling team every time a customer runs out of read budget. Nothing is broken when it fires.

## Changes

- A refused run no longer touches the execution counter, so the alert stops firing on it. The budget path already counts its own refusals.
- A refused run no longer reaches error tracking or the per-endpoint failure signal, which is how the cost guardrails next to it already behave.
- A materialized run refused by the budget stops retrying inline. The inline attempt meets the same balance, so it could only be refused a second time, and that second refusal was labeled `execution_type="inline"` on a request that started out materialized.
- Mechanical: `APIQueriesBudgetExceeded` joins the existing `_QUERY_GUARDRAIL_ERRORS` tuple and gets a re-raise ahead of the catch-all.

The customer sees no change. The response is the same 429 with the same `Retry-After`.

## How did you test this code?

One test, red before the fix on each of the three surfaces it covers: the counter, error tracking, and the failure signal.

```
products/endpoints/backend/tests/test_endpoint_execution.py::TestEndpointExecution::test_budget_refusal_does_not_count_as_an_endpoint_error
```

Full file green: 98 passed. Ruff and format clean.

## 🤖 Agent context

Found while investigating repeated `EndpointExecutionErrorRateCritical` pages on `execution_type=inline`. The refusals come from the hourly read budget added in #95375, which endpoints classified through its own `except` ladder rather than the shared `classify_query_error` other products use.

This PR only stops the alert. Whether endpoint traffic should be subject to a byte budget at all is a separate contract question and is not settled here.

Touches the same `except` ladder as #93691, so a textual conflict with that PR is expected.
