### PR TITLE
feat(slack_app): show when a Slack model pin overrides task defaults

### DIFF
--- a/products/slack_app/backend/facade/api.py
+++ b/products/slack_app/backend/facade/api.py
@@ -18,7 +18,16 @@ from posthog.models.integration import Integration
 
 from products.slack_app.backend.models import SlackChannel
 from products.slack_app.backend.services.slack_auth import invalidate_auth_state
+from products.slack_app.backend.services.slack_settings import SlackModelPin, slack_model_pins_for_user
 from products.slack_app.backend.services.slack_user_info import invalidate_workspace_bot_user_id
+
+__all__ = [
+    "SlackModelPin",
+    "invalidate_slack_integration_auth_state",
+    "slack_artifact_delivery_state_updates",
+    "slack_channel_is_approved",
+    "slack_model_pins_for_user",
+]
 
 _SLACK_CANVAS_FILE_ADAPTER_SCOPES = frozenset({"canvases:write", "files:write"})
 

--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -639,6 +639,23 @@ def _active_model_blocks(
         {"type": "section", "text": {"type": "mrkdwn", "text": headline}},
         {"type": "context", "elements": [{"type": "mrkdwn", "text": f"Source: {source_label}"}]},
     ]
+    if not effective.is_empty and run_defaults.applies:
+        shadowed = "your PostHog default" if run_defaults.source == "user" else "the project default"
+        blocks.append(
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": (
+                            f"This overrides {shadowed} "
+                            f"({describe_run_model(run_defaults.model, run_defaults.reasoning_effort)}). "
+                            'Use "Reset to default" below to switch back to it.'
+                        ),
+                    }
+                ],
+            }
+        )
     if run_defaults.settings_url:
         blocks.append(
             {

--- a/products/slack_app/backend/services/slack_settings.py
+++ b/products/slack_app/backend/services/slack_settings.py
@@ -26,11 +26,16 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from django.db.models import Q
+
+from posthog.dataclasses import frozen
+
 from products.slack_app.backend.models import UntaggedFollowupMode
 from products.slack_app.backend.services.model_catalogue import filter_unsupported_effort
 
 if TYPE_CHECKING:
     from posthog.models.integration import Integration
+    from posthog.models.user import User
 
 
 @dataclass(frozen=True)
@@ -74,13 +79,20 @@ def resolve_ai_preferences(integration: Integration, slack_user_id: str | None) 
         .values("ai_preferences")
         .first()
     )
+    return _stored_preferences(row["ai_preferences"] if row else None)
+
+
+def _stored_preferences(raw: Any) -> AIPreferences:
+    """Parse a stored `ai_preferences` JSON value into the resolved triple.
+
+    `validate_ai_preferences` enforces that `runtime_adapter` and `model` are
+    set together, so a value missing either half was never explicitly
+    configured and contributes nothing.
+    """
     # Pulled into a local dict so mypy can give it a definite type — the
     # JSONField reads back as `Any | None`.
-    prefs: dict[str, Any] = (row["ai_preferences"] if row else None) or {}
+    prefs: dict[str, Any] = raw or {}
 
-    # `validate_ai_preferences` enforces that `runtime_adapter` and `model` are
-    # set together, so a row missing either half was never explicitly
-    # configured and contributes nothing.
     runtime_adapter = prefs.get("runtime_adapter") or None
     model = prefs.get("model") or None
     if not runtime_adapter or not model:
@@ -95,6 +107,84 @@ def resolve_ai_preferences(integration: Integration, slack_user_id: str | None) 
         model=model,
         reasoning_effort=reasoning_effort,
     )
+
+
+@frozen
+class SlackModelPin:
+    """A personal Slack settings row that pins a model for one workspace.
+
+    For runs started from that workspace, the pin shadows whatever the central
+    tasks defaults say — that is the fact callers surface to the user.
+    """
+
+    slack_workspace_id: str
+    slack_workspace_name: str | None
+    runtime_adapter: str
+    model: str
+    reasoning_effort: str | None
+
+
+def slack_model_pins_for_user(team_id: int, user: User) -> list[SlackModelPin]:
+    """Model pins this PostHog user holds in Slack workspaces connected to `team_id`.
+
+    The user's Slack identities are found the same two ways the inbound event
+    resolver maps them back: an explicit account link first, then a profile-cache
+    email match. So a pin reported here is one a mention of theirs would actually
+    resolve against. DB-only and best-effort — no Slack API calls, and an
+    identity we can't map simply contributes nothing.
+    """
+    from posthog.models.integration import Integration
+    from posthog.models.user_integration import UserIntegration
+
+    from products.slack_app.backend.models import SlackSettings, SlackUserProfileCache
+
+    integrations = [i for i in Integration.objects.filter(team_id=team_id, kind="slack") if i.integration_id]
+    if not integrations:
+        return []
+    by_workspace = {i.integration_id: i for i in integrations}
+
+    identities: set[tuple[str, str]] = set()
+    links = UserIntegration.objects.filter(kind=UserIntegration.IntegrationKind.SLACK, user_id=user.id).values_list(
+        "integration_id", "config"
+    )
+    for slack_user_id, config in links:
+        workspace = (config or {}).get("slack_team_id")
+        if isinstance(workspace, str) and workspace in by_workspace:
+            identities.add((workspace, slack_user_id))
+
+    if user.email:
+        cached = SlackUserProfileCache.objects.filter(
+            integration__in=integrations, email__iexact=user.email
+        ).values_list("integration__integration_id", "slack_user_id")
+        identities.update((workspace, slack_user_id) for workspace, slack_user_id in cached if workspace)
+
+    if not identities:
+        return []
+
+    pair_filter = Q()
+    for workspace, slack_user_id in identities:
+        pair_filter |= Q(slack_workspace_id=workspace, slack_user_id=slack_user_id)
+
+    pins = []
+    for settings_row in SlackSettings.objects.filter(pair_filter):
+        stored = _stored_preferences(settings_row.ai_preferences)
+        if stored.runtime_adapter is None or stored.model is None:
+            continue
+        workspace_integration = by_workspace[settings_row.slack_workspace_id]
+        # Straight off the stored OAuth response rather than `Integration.display_name`,
+        # which raises on instances without Slack app credentials configured.
+        team_config = workspace_integration.config.get("team") or {}
+        workspace_name = team_config.get("name") if isinstance(team_config, dict) else None
+        pins.append(
+            SlackModelPin(
+                slack_workspace_id=settings_row.slack_workspace_id,
+                slack_workspace_name=workspace_name,
+                runtime_adapter=stored.runtime_adapter,
+                model=stored.model,
+                reasoning_effort=stored.reasoning_effort,
+            )
+        )
+    return sorted(pins, key=lambda pin: pin.slack_workspace_id)
 
 
 def resolve_untagged_followup_mode(integration: Integration, slack_user_id: str | None) -> UntaggedFollowupMode:
@@ -177,8 +267,10 @@ def validate_ai_preferences(
 
 __all__ = [
     "AIPreferences",
+    "SlackModelPin",
     "build_ai_preferences_payload",
     "resolve_ai_preferences",
     "resolve_untagged_followup_mode",
+    "slack_model_pins_for_user",
     "validate_ai_preferences",
 ]

--- a/products/slack_app/backend/tests/services/test_slack_app_home.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home.py
@@ -58,6 +58,7 @@ from products.slack_app.backend.services.slack_app_home import (
     PreferenceSource,
     ProjectChoice,
     ProjectState,
+    RunDefaultsState,
     StatsState,
     TaskItem,
     TasksState,
@@ -438,6 +439,41 @@ class TestRenderHomeView:
         # Friendly label rather than raw model id; source attribution visible.
         assert "Claude Opus 4.7" in text_blob
         assert "Your personal override" in _all_text(view)
+
+    @pytest.mark.parametrize(
+        "source,expected",
+        [
+            pytest.param("user", "This overrides your PostHog default", id="user-default"),
+            pytest.param("team", "This overrides the project default", id="team-default"),
+        ],
+    )
+    def test_pin_names_the_shadowed_posthog_default(self, source, expected):
+        view = render_home_view(
+            effective=AIPreferences(runtime_adapter="claude", model="claude-opus-4-7", reasoning_effort="high"),
+            user_row=_make_row(runtime_adapter="claude", model="claude-opus-4-7", reasoning_effort="high"),
+            is_admin=False,
+            run_defaults=RunDefaultsState(model="gpt-5.5", runtime_adapter="codex", source=source),
+        )
+        assert expected in _all_text(view)
+
+    def test_no_shadow_callout_without_a_pin_or_without_a_default(self):
+        # Default applies but nothing pinned: the default is what runs, nothing shadowed.
+        view = render_home_view(
+            effective=AIPreferences(),
+            user_row=None,
+            is_admin=False,
+            run_defaults=RunDefaultsState(model="gpt-5.5", runtime_adapter="codex", source="user"),
+        )
+        assert "This overrides" not in _all_text(view)
+
+        # Pin without any central default underneath: nothing to name either.
+        view = render_home_view(
+            effective=AIPreferences(runtime_adapter="claude", model="claude-opus-4-7"),
+            user_row=_make_row(runtime_adapter="claude", model="claude-opus-4-7"),
+            is_admin=False,
+            run_defaults=RunDefaultsState(),
+        )
+        assert "This overrides" not in _all_text(view)
 
     def test_every_control_the_tab_renders_is_routable(self):
         # The interactivity endpoint claims region ownership and dispatches off

--- a/products/slack_app/backend/tests/services/test_slack_settings.py
+++ b/products/slack_app/backend/tests/services/test_slack_settings.py
@@ -7,12 +7,16 @@ from django.core.exceptions import ValidationError
 from posthog.models.integration import Integration
 from posthog.models.organization import Organization
 from posthog.models.team.team import Team
+from posthog.models.user import User
+from posthog.models.user_integration import UserIntegration
 
-from products.slack_app.backend.models import SlackSettings, UntaggedFollowupMode
+from products.slack_app.backend.models import SlackSettings, SlackUserProfileCache, UntaggedFollowupMode
 from products.slack_app.backend.services.slack_settings import (
     AIPreferences,
+    SlackModelPin,
     resolve_ai_preferences,
     resolve_untagged_followup_mode,
+    slack_model_pins_for_user,
     validate_ai_preferences,
 )
 
@@ -314,3 +318,82 @@ class TestValidateAIPreferences:
     def test_effort_unsupported_by_model_rejected(self):
         with pytest.raises(ValidationError, match="not supported"):
             validate_ai_preferences("claude", "claude-sonnet-4-6", "xhigh")
+
+
+class TestSlackModelPinsForUser:
+    PIN = {"runtime_adapter": "claude", "model": "claude-opus-4-7", "reasoning_effort": "high"}
+
+    @pytest.fixture
+    def user(self, db):
+        return User.objects.create_user("pin-owner@example.com", None, "Pin")
+
+    def _link(self, user, slack_user_id="U001", slack_team_id="T_WS"):
+        UserIntegration.objects.create(
+            user=user,
+            kind=UserIntegration.IntegrationKind.SLACK,
+            integration_id=slack_user_id,
+            config={"slack_team_id": slack_team_id},
+        )
+
+    def _pin_row(self, integration, slack_user_id: str | None = "U001", ai_preferences: Any = "use-pin"):
+        SlackSettings.objects.create(
+            default_integration=integration,
+            slack_workspace_id=integration.integration_id,
+            slack_user_id=slack_user_id,
+            ai_preferences=self.PIN if ai_preferences == "use-pin" else ai_preferences,
+        )
+
+    def test_pin_found_via_explicit_account_link(self, slack_setup, user):
+        integration = slack_setup
+        integration.config = {"team": {"id": "T_WS", "name": "Acme"}}
+        integration.save()
+        self._link(user)
+        self._pin_row(integration)
+
+        assert slack_model_pins_for_user(integration.team_id, user) == [
+            SlackModelPin(
+                slack_workspace_id="T_WS",
+                slack_workspace_name="Acme",
+                runtime_adapter="claude",
+                model="claude-opus-4-7",
+                reasoning_effort="high",
+            )
+        ]
+
+    def test_pin_found_via_profile_cache_email_match(self, slack_setup, user):
+        integration = slack_setup
+        SlackUserProfileCache.objects.create(
+            integration=integration,
+            slack_user_id="U001",
+            email="PIN-OWNER@example.com",
+        )
+        self._pin_row(integration)
+
+        pins = slack_model_pins_for_user(integration.team_id, user)
+        assert [pin.model for pin in pins] == ["claude-opus-4-7"]
+        assert pins[0].slack_workspace_name is None
+
+    @pytest.mark.parametrize(
+        "ai_preferences",
+        [
+            pytest.param(None, id="no-preferences-at-all"),
+            pytest.param({"reasoning_effort": "high"}, id="half-set-row-is-not-a-pin"),
+        ],
+    )
+    def test_row_without_the_atomic_pair_reports_nothing(self, slack_setup, user, ai_preferences):
+        integration = slack_setup
+        self._link(user)
+        self._pin_row(integration, ai_preferences=ai_preferences)
+
+        assert slack_model_pins_for_user(integration.team_id, user) == []
+
+    def test_workspace_row_and_other_identities_do_not_leak(self, slack_setup, user):
+        integration = slack_setup
+        self._link(user)
+        # Workspace-wide default row, another Slack user's pin, and a
+        # different-workspace pin: none belong to this user's identity here.
+        self._pin_row(integration, slack_user_id=None)
+        self._pin_row(integration, slack_user_id="U_OTHER")
+        self._link(user, slack_user_id="U9", slack_team_id="T_ELSEWHERE")
+
+        assert slack_model_pins_for_user(integration.team_id, user) == []

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -4613,6 +4613,24 @@ class TasksTeamConfigResponseSerializer(serializers.Serializer):
     )
 
 
+class TasksSlackModelPinSerializer(serializers.Serializer):
+    """A model the requesting user pinned in a connected Slack workspace.
+
+    Runs started from that workspace use the pin instead of the defaults stored here,
+    so the config endpoints report it to explain why a Slack run may not follow them.
+    """
+
+    slack_workspace_id = serializers.CharField(help_text="Slack workspace (team) id the pin applies to.")
+    slack_workspace_name = serializers.CharField(
+        allow_null=True, help_text="Display name of the Slack workspace, when known."
+    )
+    runtime_adapter = serializers.CharField(help_text="Runtime adapter the pin selects.")
+    model = serializers.CharField(help_text="Model identifier the pin selects.")
+    reasoning_effort = serializers.CharField(
+        allow_null=True, help_text="Reasoning effort the pin selects, or null when unset."
+    )
+
+
 @extend_schema_serializer(many=False)
 class TasksUserConfigResponseSerializer(serializers.Serializer):
     """The requesting user's per-project tasks configuration."""
@@ -4622,4 +4640,12 @@ class TasksUserConfigResponseSerializer(serializers.Serializer):
     )
     resolved_ai_run_defaults = TasksResolvedAIRunDefaultsSerializer(
         help_text="The defaults a new run will use when no explicit runtime selection is sent."
+    )
+    slack_model_pins = TasksSlackModelPinSerializer(
+        many=True,
+        help_text=(
+            "Models the requesting user pinned in connected Slack workspaces. A pin overrides the "
+            "defaults above for runs started from that workspace. Clear it from the Slack App Home "
+            "tab to have Slack runs follow these defaults."
+        ),
     )

--- a/products/tasks/backend/presentation/views/config_api.py
+++ b/products/tasks/backend/presentation/views/config_api.py
@@ -1,8 +1,9 @@
 from dataclasses import asdict
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from django.core.exceptions import ValidationError as DjangoValidationError
 
+import structlog
 from drf_spectacular.utils import extend_schema
 from rest_framework import viewsets
 from rest_framework.authentication import SessionAuthentication
@@ -24,12 +25,34 @@ from products.tasks.backend.presentation.serializers import (
     TasksUserConfigResponseSerializer,
 )
 
+if TYPE_CHECKING:
+    from products.slack_app.backend.facade.api import SlackModelPin
+
+logger = structlog.get_logger(__name__)
+
 _AUTH_CLASSES = [SessionAuthentication, PersonalAPIKeyAuthentication, OAuthAccessTokenAuthentication]
 
 
 def _user_id(request: Request) -> int:
     """The requesting user's id; `IsAuthenticated` guarantees a real user on these views."""
     return cast(User, request.user).id
+
+
+def _slack_model_pins(team_id: int, request: Request) -> "list[SlackModelPin]":
+    """The caller's Slack model pins in workspaces connected to this project.
+
+    Informational only: a failed lookup logs and yields an empty list rather than
+    failing the config read or write it decorates.
+    """
+    from products.slack_app.backend.facade.api import (  # noqa: PLC0415 — keeps slack_app deps off the tasks import path
+        slack_model_pins_for_user,
+    )
+
+    try:
+        return list(slack_model_pins_for_user(team_id, cast(User, request.user)))
+    except Exception:
+        logger.exception("tasks_config_slack_model_pins_lookup_failed", team_id=team_id)
+        return []
 
 
 def _validated_triple(request: Request) -> dict:
@@ -103,7 +126,11 @@ class TasksUserConfigViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         )
         return Response(
             TasksUserConfigResponseSerializer(
-                {"ai_run_preferences": preferences, "resolved_ai_run_defaults": asdict(resolved)}
+                {
+                    "ai_run_preferences": preferences,
+                    "resolved_ai_run_defaults": asdict(resolved),
+                    "slack_model_pins": _slack_model_pins(self.team_id, request),
+                }
             ).data
         )
 

--- a/products/tasks/backend/tests/test_ai_run_defaults.py
+++ b/products/tasks/backend/tests/test_ai_run_defaults.py
@@ -10,6 +10,7 @@ from posthog.models.organization import OrganizationMembership
 from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
 from posthog.models.utils import generate_random_token_personal
 
+from products.slack_app.backend.models import SlackSettings, SlackUserProfileCache
 from products.tasks.backend.facade import api as facade
 from products.tasks.backend.logic.services.ai_run_defaults import (
     get_team_ai_run_preferences,
@@ -420,6 +421,25 @@ class TestTasksConfigAPI(APIBaseTest):
         assert self.client.get(f"/api/projects/{self.team.id}/tasks/config/").status_code == 200
         assert self.client.post(f"/api/projects/{self.team.id}/tasks/config/", TEAM_TRIPLE).status_code == 403
         assert self.client.post(f"/api/projects/{self.team.id}/tasks/@me/config/", USER_TRIPLE).status_code == 200
+
+    def test_me_config_reports_slack_model_pins(self):
+        response = self.client.get(f"/api/projects/{self.team.id}/tasks/@me/config/")
+        assert response.json()["slack_model_pins"] == []
+
+        integration = Integration.objects.create(
+            team=self.team, kind="slack", integration_id="T_PIN", config={"team": {"id": "T_PIN", "name": "Acme"}}
+        )
+        SlackUserProfileCache.objects.create(integration=integration, slack_user_id="U42", email=self.user.email)
+        SlackSettings.objects.create(
+            slack_workspace_id="T_PIN",
+            slack_user_id="U42",
+            ai_preferences=TEAM_TRIPLE,
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/tasks/@me/config/")
+        assert response.json()["slack_model_pins"] == [
+            {"slack_workspace_id": "T_PIN", "slack_workspace_name": "Acme", **TEAM_TRIPLE}
+        ]
 
     def test_me_config_is_scoped_to_the_requesting_user(self):
         other = User.objects.create_and_join(self.organization, "other@posthog.com", None)

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -4455,6 +4455,31 @@ export interface TasksResolvedAIRunDefaultsApi {
 }
 
 /**
+ * A model the requesting user pinned in a connected Slack workspace.
+ *
+ * Runs started from that workspace use the pin instead of the defaults stored here,
+ * so the config endpoints report it to explain why a Slack run may not follow them.
+ */
+export interface TasksSlackModelPinApi {
+    /** Slack workspace (team) id the pin applies to. */
+    slack_workspace_id: string
+    /**
+     * Display name of the Slack workspace, when known.
+     * @nullable
+     */
+    slack_workspace_name: string | null
+    /** Runtime adapter the pin selects. */
+    runtime_adapter: string
+    /** Model identifier the pin selects. */
+    model: string
+    /**
+     * Reasoning effort the pin selects, or null when unset.
+     * @nullable
+     */
+    reasoning_effort: string | null
+}
+
+/**
  * The requesting user's per-project tasks configuration.
  */
 export interface TasksUserConfigResponseApi {
@@ -4462,6 +4487,8 @@ export interface TasksUserConfigResponseApi {
     ai_run_preferences: TasksAIRunPreferencesApi
     /** The defaults a new run will use when no explicit runtime selection is sent. */
     resolved_ai_run_defaults: TasksResolvedAIRunDefaultsApi
+    /** Models the requesting user pinned in connected Slack workspaces. A pin overrides the defaults above for runs started from that workspace. Clear it from the Slack App Home tab to have Slack runs follow these defaults. */
+    slack_model_pins: TasksSlackModelPinApi[]
 }
 
 /**

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -518,7 +518,9 @@ tools:
             Set the caller's per-project default AI run preferences (runtime adapter, model, reasoning effort). They
             override the project default wholesale. `runtime_adapter` and `model` must be set together; send all three
             fields as null to clear and inherit the project default. Returns the stored preferences plus the resolved
-            defaults a new run will use. Use tasks-models-retrieve to list valid model identifiers.
+            defaults a new run will use. When `slack_model_pins` is non-empty, tell the user: a model they pinned in
+            Slack overrides these defaults for runs started from that workspace, and clearing it from the Slack App
+            Home tab makes Slack runs follow these defaults. Use tasks-models-retrieve to list valid model identifiers.
         feature_flag: tasks
     tasks-me-config-list:
         operation: tasks_me_config_list
@@ -533,7 +535,8 @@ tools:
         description: >
             Get the caller's per-project default AI run preferences, plus the resolved defaults a new run will use when
             no explicit runtime selection is sent (the caller's preference wins over the project default; `source` says
-            which level supplied it).
+            which level supplied it). `slack_model_pins` lists models the caller pinned in connected Slack workspaces;
+            a pin overrides these defaults for runs started from that workspace.
         feature_flag: tasks
     tasks-models-retrieve:
         operation: tasks_models_retrieve

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -519,8 +519,8 @@ tools:
             override the project default wholesale. `runtime_adapter` and `model` must be set together; send all three
             fields as null to clear and inherit the project default. Returns the stored preferences plus the resolved
             defaults a new run will use. When `slack_model_pins` is non-empty, tell the user: a model they pinned in
-            Slack overrides these defaults for runs started from that workspace, and clearing it from the Slack App
-            Home tab makes Slack runs follow these defaults. Use tasks-models-retrieve to list valid model identifiers.
+            Slack overrides these defaults for runs started from that workspace, and clearing it from the Slack App Home
+            tab makes Slack runs follow these defaults. Use tasks-models-retrieve to list valid model identifiers.
         feature_flag: tasks
     tasks-me-config-list:
         operation: tasks_me_config_list
@@ -535,8 +535,8 @@ tools:
         description: >
             Get the caller's per-project default AI run preferences, plus the resolved defaults a new run will use when
             no explicit runtime selection is sent (the caller's preference wins over the project default; `source` says
-            which level supplied it). `slack_model_pins` lists models the caller pinned in connected Slack workspaces;
-            a pin overrides these defaults for runs started from that workspace.
+            which level supplied it). `slack_model_pins` lists models the caller pinned in connected Slack workspaces; a
+            pin overrides these defaults for runs started from that workspace.
         feature_flag: tasks
     tasks-models-retrieve:
         operation: tasks_models_retrieve

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -11216,7 +11216,7 @@
         "feature_flag": "tasks"
     },
     "tasks-me-config-create": {
-        "description": "Set the caller's per-project default AI run preferences (runtime adapter, model, reasoning effort). They override the project default wholesale. `runtime_adapter` and `model` must be set together; send all three fields as null to clear and inherit the project default. Returns the stored preferences plus the resolved defaults a new run will use. Use tasks-models-retrieve to list valid model identifiers.",
+        "description": "Set the caller's per-project default AI run preferences (runtime adapter, model, reasoning effort). They override the project default wholesale. `runtime_adapter` and `model` must be set together; send all three fields as null to clear and inherit the project default. Returns the stored preferences plus the resolved defaults a new run will use. When `slack_model_pins` is non-empty, tell the user: a model they pinned in Slack overrides these defaults for runs started from that workspace, and clearing it from the Slack App Home tab makes Slack runs follow these defaults. Use tasks-models-retrieve to list valid model identifiers.",
         "category": "Tasks",
         "feature": "tasks",
         "summary": "Set my task run defaults",
@@ -11231,7 +11231,7 @@
         "feature_flag": "tasks"
     },
     "tasks-me-config-list": {
-        "description": "Get the caller's per-project default AI run preferences, plus the resolved defaults a new run will use when no explicit runtime selection is sent (the caller's preference wins over the project default; `source` says which level supplied it).",
+        "description": "Get the caller's per-project default AI run preferences, plus the resolved defaults a new run will use when no explicit runtime selection is sent (the caller's preference wins over the project default; `source` says which level supplied it). `slack_model_pins` lists models the caller pinned in connected Slack workspaces; a pin overrides these defaults for runs started from that workspace.",
         "category": "Tasks",
         "feature": "tasks",
         "summary": "Get my task run defaults",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -11861,7 +11861,7 @@
         "feature_flag": "tasks"
     },
     "tasks-me-config-create": {
-        "description": "Set the caller's per-project default AI run preferences (runtime adapter, model, reasoning effort). They override the project default wholesale. `runtime_adapter` and `model` must be set together; send all three fields as null to clear and inherit the project default. Returns the stored preferences plus the resolved defaults a new run will use. Use tasks-models-retrieve to list valid model identifiers.",
+        "description": "Set the caller's per-project default AI run preferences (runtime adapter, model, reasoning effort). They override the project default wholesale. `runtime_adapter` and `model` must be set together; send all three fields as null to clear and inherit the project default. Returns the stored preferences plus the resolved defaults a new run will use. When `slack_model_pins` is non-empty, tell the user: a model they pinned in Slack overrides these defaults for runs started from that workspace, and clearing it from the Slack App Home tab makes Slack runs follow these defaults. Use tasks-models-retrieve to list valid model identifiers.",
         "category": "Tasks",
         "feature": "tasks",
         "summary": "Set my task run defaults",
@@ -11876,7 +11876,7 @@
         "feature_flag": "tasks"
     },
     "tasks-me-config-list": {
-        "description": "Get the caller's per-project default AI run preferences, plus the resolved defaults a new run will use when no explicit runtime selection is sent (the caller's preference wins over the project default; `source` says which level supplied it).",
+        "description": "Get the caller's per-project default AI run preferences, plus the resolved defaults a new run will use when no explicit runtime selection is sent (the caller's preference wins over the project default; `source` says which level supplied it). `slack_model_pins` lists models the caller pinned in connected Slack workspaces; a pin overrides these defaults for runs started from that workspace.",
         "category": "Tasks",
         "feature": "tasks",
         "summary": "Get my task run defaults",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -87906,6 +87906,31 @@ export namespace Schemas {
     }
 
     /**
+     * A model the requesting user pinned in a connected Slack workspace.
+     *
+     * Runs started from that workspace use the pin instead of the defaults stored here,
+     * so the config endpoints report it to explain why a Slack run may not follow them.
+     */
+    export interface TasksSlackModelPin {
+      /** Slack workspace (team) id the pin applies to. */
+      slack_workspace_id: string;
+      /**
+         * Display name of the Slack workspace, when known.
+         * @nullable
+         */
+      slack_workspace_name: string | null;
+      /** Runtime adapter the pin selects. */
+      runtime_adapter: string;
+      /** Model identifier the pin selects. */
+      model: string;
+      /**
+         * Reasoning effort the pin selects, or null when unset.
+         * @nullable
+         */
+      reasoning_effort: string | null;
+    }
+
+    /**
      * Team-level tasks configuration.
      */
     export interface TasksTeamConfigResponse {
@@ -87921,6 +87946,8 @@ export namespace Schemas {
       ai_run_preferences: TasksAIRunPreferences;
       /** The defaults a new run will use when no explicit runtime selection is sent. */
       resolved_ai_run_defaults: TasksResolvedAIRunDefaults;
+      /** Models the requesting user pinned in connected Slack workspaces. A pin overrides the defaults above for runs started from that workspace. Clear it from the Slack App Home tab to have Slack runs follow these defaults. */
+      slack_model_pins: TasksSlackModelPin[];
     }
 
     export interface TeachingCanvas {


### PR DESCRIPTION
## Problem

- A user who sets their default model in PostHog (task settings or the MCP config tools) can still see Slack mentions run a different model: a model they pinned in Slack earlier silently wins, and neither surface admits the other exists.
- Slack-run resolution reads the personal Slack settings row above the project and user defaults, so the pin shadows every later default change.

## Changes

- After setting or reading their task run defaults, the caller now learns about Slack pins that still override them: the tasks `@me/config` endpoint returns `slack_model_pins`, and the `tasks-me-config-*` MCP tool descriptions tell agents to relay it, with the fix (clear the pin from the Slack App Home tab).
- The App Home AI model card now names what a pin overrides ("This overrides your PostHog default (…)") next to the existing "Reset to default" button. This is the only user-visible surface; it renders in Slack, so no web UI screenshots apply.
- The lookup (`slack_model_pins_for_user`, in slack_app behind its facade) maps the caller to Slack identities the same way inbound events do: explicit account link first, then profile-cache email match. It is DB-only and fail-open, so a lookup failure never breaks the config endpoints.
- Mechanical: regenerated OpenAPI and MCP artifacts (`api.schemas.ts`, tool definitions).

## How did you test this code?

- `TestSlackModelPinsForUser` (5 cases): catches identity-mapping regressions (link and email paths), and workspace rows, half-set rows, or other users' pins being misreported as personal pins.
- `test_me_config_reports_slack_model_pins`: catches the endpoint dropping the field or the serializer losing pin fields, end to end through HTTP.
- Two renderer cases in `TestRenderHomeView`: catch the callout disappearing, or appearing when nothing is shadowed.
- Repo-wide mypy and `hogli ci:preflight --strict` ran clean locally. Not run: the full CI matrix.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (Fable 5) from a conversation about why a Slack-pinned model makes MCP-set defaults look ignored; exposing Slack settings for writes over MCP was considered and rejected in favor of making the shadow visible at both surfaces.
- Skills invoked: /writing-dataclasses, /improving-drf-endpoints, /writing-user-facing-copy, /writing-tests, /writing-pr-descriptions.
- No duplicate: `gh pr list --state open --search "slack model pin"` found no open PR covering this.
