### PR TITLE
chore(user): extract notification settings validation

### DIFF
--- a/posthog/api/notification_settings.py
+++ b/posthog/api/notification_settings.py
@@ -1,0 +1,158 @@
+import re
+from collections.abc import Mapping
+from typing import Any, cast
+
+from rest_framework import serializers
+
+from posthog.models import User
+from posthog.models.organization_notification_lock import GovernedSetting, notification_locks_for_users
+from posthog.models.user import NOTIFICATION_DEFAULTS, Notifications
+
+from products.notifications.backend.facade.api import NotificationType
+
+_VALID_NOTIFICATION_TYPE_VALUES: frozenset[str] = frozenset(t.value for t in NotificationType)
+MAX_PIPELINE_NOTIFICATIONS = 1000
+_PIPELINE_ID_PATTERN = re.compile(r"^(?:hog_function|batch_export|plugin_config):[0-9a-zA-Z-]{1,128}$")
+
+
+def _reject_locked_notification_settings(user: User, incoming: Notifications, current: Mapping[str, Any]) -> None:
+    """Stop a member changing a setting their organization enforces.
+
+    The settings page disables these controls, but the disabling has to be enforced here too, or
+    the rule is only a suggestion to anyone using the API directly. Only a changed value is
+    refused: the page submits the whole map on every save, so an untouched governed setting has
+    to pass through.
+
+    Deliberately not scoped to one organization: a value the member stores is the one every
+    organization that has no rule of its own falls back to, so any single rule freezes it.
+    """
+    locks = notification_locks_for_users([user.id]).get(user.id, {})
+    if not locks:
+        return
+
+    for key, value in incoming.items():
+        if isinstance(value, dict):
+            stored: dict = current.get(key) or {}
+            blocked = [
+                scope_id
+                for scope_id, scoped_value in value.items()
+                if GovernedSetting(setting=key, scope_id=str(scope_id)) in locks
+                and stored.get(scope_id) != scoped_value
+            ]
+            if blocked:
+                raise serializers.ValidationError(
+                    f"{key} is set by your organization for {', '.join(sorted(blocked))} and cannot be changed here",
+                    code="permission_denied",
+                )
+        elif GovernedSetting(setting=key, scope_id="") in locks and current.get(key) != value:
+            raise serializers.ValidationError(
+                f"{key} is set by your organization and cannot be changed here",
+                code="permission_denied",
+            )
+
+
+def _validate_pipeline_notifications(incoming: dict, merged: dict) -> None:
+    for pipeline_id in incoming:
+        if not isinstance(pipeline_id, str) or not _PIPELINE_ID_PATTERN.match(pipeline_id):
+            raise serializers.ValidationError(
+                f"Invalid pipeline id: {pipeline_id!r}",
+                code="invalid_input",
+            )
+    if len(merged) > MAX_PIPELINE_NOTIFICATIONS:
+        raise serializers.ValidationError(
+            f"pipeline_notifications_disabled cannot have more than {MAX_PIPELINE_NOTIFICATIONS} entries",
+            code="invalid_input",
+        )
+
+
+def validate_notification_settings(instance: User, notification_settings: Notifications) -> Notifications:
+    current_settings = {
+        **NOTIFICATION_DEFAULTS,
+        **(instance.partial_notification_settings or {}),
+    }
+
+    _reject_locked_notification_settings(instance, notification_settings, current_settings)
+
+    dict_notification_keys = (
+        "project_weekly_digest_disabled",
+        "error_tracking_weekly_digest_project_enabled",
+        "web_analytics_weekly_digest_project_enabled",
+        "organization_member_join_email_disabled",
+        "pipeline_notifications_disabled",
+    )
+
+    for key, value in notification_settings.items():
+        if key not in Notifications.__annotations__:
+            raise serializers.ValidationError(
+                f"Key {key} is not valid as a key for notification settings",
+                code="invalid_input",
+            )
+
+        expected_type = Notifications.__annotations__[key]
+
+        if key in dict_notification_keys:
+            if not isinstance(value, dict):
+                raise serializers.ValidationError(
+                    f"{key} must be a dictionary mapping IDs to boolean values",
+                    code="invalid_input",
+                )
+            for _, disabled in value.items():
+                if not isinstance(disabled, bool):
+                    raise serializers.ValidationError(
+                        f"Notification setting values must be boolean, got {type(disabled)} instead",
+                        code="invalid_input",
+                    )
+            merged = {**current_settings.get(key, {}), **value}
+            if key == "pipeline_notifications_disabled":
+                _validate_pipeline_notifications(value, merged)
+            current_settings[key] = merged
+        elif key == "realtime_notifications_disabled":
+            if not isinstance(value, dict):
+                raise serializers.ValidationError(
+                    "realtime_notifications_disabled must be a dict",
+                    code="invalid_input",
+                )
+            for type_key, team_map in value.items():
+                if type_key not in _VALID_NOTIFICATION_TYPE_VALUES:
+                    raise serializers.ValidationError(
+                        f"Unknown notification type {type_key}",
+                        code="invalid_input",
+                    )
+                if not isinstance(team_map, dict):
+                    raise serializers.ValidationError(
+                        f"Per-type value for {type_key} must be a dict of team_id to bool",
+                        code="invalid_input",
+                    )
+                for _team_id, disabled in team_map.items():
+                    if not isinstance(disabled, bool):
+                        raise serializers.ValidationError(
+                            f"Disabled flag for {type_key} must be boolean, got {type(disabled)}",
+                            code="invalid_input",
+                        )
+            existing = current_settings.get("realtime_notifications_disabled", {}) or {}
+            realtime_merged: dict[str, dict[str, bool]] = {**existing}
+            for type_key, team_map in value.items():
+                realtime_merged[type_key] = {**(existing.get(type_key, {}) or {}), **team_map}
+            current_settings["realtime_notifications_disabled"] = realtime_merged
+        elif key == "data_pipeline_error_threshold":
+            if not isinstance(value, (int, float)):
+                raise serializers.ValidationError(
+                    f"data_pipeline_error_threshold must be a number, got {type(value)} instead",
+                    code="invalid_input",
+                )
+            if value < 0.0 or value > 1.0:
+                raise serializers.ValidationError(
+                    f"data_pipeline_error_threshold must be between 0.0 and 1.0, got {value}",
+                    code="invalid_input",
+                )
+            current_settings[key] = float(value)
+        else:
+            # For non-dict settings, validate type directly
+            if not isinstance(value, expected_type):
+                raise serializers.ValidationError(
+                    f"{value} is not a valid type for notification settings, should be {expected_type}",
+                    code="invalid_input",
+                )
+            current_settings[key] = value
+
+    return cast(Notifications, current_settings)

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -2448,7 +2448,7 @@ class TestUserAPI(APIBaseTest):
             self.assertEqual(response.status_code, status.HTTP_200_OK, f"key {good_key!r} was rejected")
 
     def test_pipeline_notifications_caps_total_entries(self):
-        from posthog.api.user import MAX_PIPELINE_NOTIFICATIONS
+        from posthog.api.notification_settings import MAX_PIPELINE_NOTIFICATIONS
 
         too_many = {f"hog_function:fake-{i}": True for i in range(MAX_PIPELINE_NOTIFICATIONS + 1)}
         response = self.client.patch(

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -6,7 +6,6 @@ import secrets
 import urllib.parse
 from base64 import b32encode
 from binascii import unhexlify
-from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta
 from typing import Any, Optional, cast
 
@@ -48,6 +47,7 @@ from two_factor.utils import default_device
 from posthog.schema import UserUIConfiguration
 
 from posthog.api.email_verification import email_verification_code_verifier
+from posthog.api.notification_settings import validate_notification_settings
 from posthog.api.oauth.toolbar_service import (
     ToolbarOAuthError,
     ToolbarOAuthState,
@@ -109,15 +109,9 @@ from posthog.models.oauth import OAuthGrant, find_oauth_refresh_token, has_live_
 from posthog.models.onboarding_delegation import cancel_pending_delegation, clear_delegation_state
 from posthog.models.organization import Organization, OrganizationMembership
 from posthog.models.organization_domain import OrganizationDomain
-from posthog.models.organization_notification_lock import GovernedSetting, notification_locks_for_users
+from posthog.models.organization_notification_lock import notification_locks_for_users
 from posthog.models.personal_api_key import PersonalAPIKey
-from posthog.models.user import (
-    NOTIFICATION_DEFAULTS,
-    ROLE_CHOICES,
-    Notifications,
-    OnboardingSkippedReason,
-    ShortcutPosition,
-)
+from posthog.models.user import ROLE_CHOICES, Notifications, OnboardingSkippedReason, ShortcutPosition
 from posthog.models.webauthn_credential import WebauthnCredential
 from posthog.permissions import APIScopePermission, TimeSensitiveActionPermission, UserNoOrgMembershipDeletePermission
 from posthog.rate_limit import (
@@ -151,69 +145,14 @@ from products.access_control.backend.facade.user_access_control import UserAcces
 from products.dashboards.backend.models.dashboard import Dashboard
 from products.notifications.backend.facade.api import NotificationType
 
-_VALID_NOTIFICATION_TYPE_VALUES: frozenset[str] = frozenset(t.value for t in NotificationType)
-
 REDIRECT_TO_SITE_COUNTER = Counter("posthog_redirect_to_site", "Redirect to site")
 REDIRECT_TO_SITE_FAILED_COUNTER = Counter("posthog_redirect_to_site_failed", "Redirect to site failed")
 
 NUM_2FA_BACKUP_CODES = 10
 
-MAX_PIPELINE_NOTIFICATIONS = 1000
-_PIPELINE_ID_PATTERN = re.compile(r"^(?:hog_function|batch_export|plugin_config):[0-9a-zA-Z-]{1,128}$")
-
 # `product_intro_seen` is exempt from the re-auth gate, so it gets a ceiling of its own. Only a new key
 # is refused at the ceiling, so an intro the user already dismissed still reopens and closes.
 MAX_PRODUCT_INTROS_SEEN = 100
-
-
-def _reject_locked_notification_settings(user: User, incoming: Notifications, current: Mapping[str, Any]) -> None:
-    """Stop a member changing a setting their organization enforces.
-
-    The settings page disables these controls, but the disabling has to be enforced here too, or
-    the rule is only a suggestion to anyone using the API directly. Only a changed value is
-    refused: the page submits the whole map on every save, so an untouched governed setting has
-    to pass through.
-
-    Deliberately not scoped to one organization: a value the member stores is the one every
-    organization that has no rule of its own falls back to, so any single rule freezes it.
-    """
-    locks = notification_locks_for_users([user.id]).get(user.id, {})
-    if not locks:
-        return
-
-    for key, value in incoming.items():
-        if isinstance(value, dict):
-            stored: dict = current.get(key) or {}
-            blocked = [
-                scope_id
-                for scope_id, scoped_value in value.items()
-                if GovernedSetting(setting=key, scope_id=str(scope_id)) in locks
-                and stored.get(scope_id) != scoped_value
-            ]
-            if blocked:
-                raise serializers.ValidationError(
-                    f"{key} is set by your organization for {', '.join(sorted(blocked))} and cannot be changed here",
-                    code="permission_denied",
-                )
-        elif GovernedSetting(setting=key, scope_id="") in locks and current.get(key) != value:
-            raise serializers.ValidationError(
-                f"{key} is set by your organization and cannot be changed here",
-                code="permission_denied",
-            )
-
-
-def _validate_pipeline_notifications(incoming: dict, merged: dict) -> None:
-    for pipeline_id in incoming:
-        if not isinstance(pipeline_id, str) or not _PIPELINE_ID_PATTERN.match(pipeline_id):
-            raise serializers.ValidationError(
-                f"Invalid pipeline id: {pipeline_id!r}",
-                code="invalid_input",
-            )
-    if len(merged) > MAX_PIPELINE_NOTIFICATIONS:
-        raise serializers.ValidationError(
-            f"pipeline_notifications_disabled cannot have more than {MAX_PIPELINE_NOTIFICATIONS} entries",
-            code="invalid_input",
-        )
 
 
 logger = structlog.get_logger(__name__)
@@ -679,97 +618,7 @@ class UserSerializer(serializers.ModelSerializer):
         raise serializers.ValidationError(f"Object with id={value} does not exist.", code="does_not_exist")
 
     def validate_notification_settings(self, notification_settings: Notifications) -> Notifications:
-        instance = cast(User, self.instance)
-        current_settings = {
-            **NOTIFICATION_DEFAULTS,
-            **(instance.partial_notification_settings or {}),
-        }
-
-        _reject_locked_notification_settings(instance, notification_settings, current_settings)
-
-        _dict_notification_keys = (
-            "project_weekly_digest_disabled",
-            "error_tracking_weekly_digest_project_enabled",
-            "web_analytics_weekly_digest_project_enabled",
-            "organization_member_join_email_disabled",
-            "pipeline_notifications_disabled",
-        )
-
-        for key, value in notification_settings.items():
-            if key not in Notifications.__annotations__:
-                raise serializers.ValidationError(
-                    f"Key {key} is not valid as a key for notification settings",
-                    code="invalid_input",
-                )
-
-            expected_type = Notifications.__annotations__[key]
-
-            if key in _dict_notification_keys:
-                if not isinstance(value, dict):
-                    raise serializers.ValidationError(
-                        f"{key} must be a dictionary mapping IDs to boolean values",
-                        code="invalid_input",
-                    )
-                for _, disabled in value.items():
-                    if not isinstance(disabled, bool):
-                        raise serializers.ValidationError(
-                            f"Notification setting values must be boolean, got {type(disabled)} instead",
-                            code="invalid_input",
-                        )
-                merged = {**current_settings.get(key, {}), **value}
-                if key == "pipeline_notifications_disabled":
-                    _validate_pipeline_notifications(value, merged)
-                current_settings[key] = merged
-            elif key == "realtime_notifications_disabled":
-                if not isinstance(value, dict):
-                    raise serializers.ValidationError(
-                        "realtime_notifications_disabled must be a dict",
-                        code="invalid_input",
-                    )
-                for type_key, team_map in value.items():
-                    if type_key not in _VALID_NOTIFICATION_TYPE_VALUES:
-                        raise serializers.ValidationError(
-                            f"Unknown notification type {type_key}",
-                            code="invalid_input",
-                        )
-                    if not isinstance(team_map, dict):
-                        raise serializers.ValidationError(
-                            f"Per-type value for {type_key} must be a dict of team_id to bool",
-                            code="invalid_input",
-                        )
-                    for _team_id, disabled in team_map.items():
-                        if not isinstance(disabled, bool):
-                            raise serializers.ValidationError(
-                                f"Disabled flag for {type_key} must be boolean, got {type(disabled)}",
-                                code="invalid_input",
-                            )
-                existing = current_settings.get("realtime_notifications_disabled", {}) or {}
-                realtime_merged: dict[str, dict[str, bool]] = {**existing}
-                for type_key, team_map in value.items():
-                    realtime_merged[type_key] = {**(existing.get(type_key, {}) or {}), **team_map}
-                current_settings["realtime_notifications_disabled"] = realtime_merged
-            elif key == "data_pipeline_error_threshold":
-                if not isinstance(value, (int, float)):
-                    raise serializers.ValidationError(
-                        f"data_pipeline_error_threshold must be a number, got {type(value)} instead",
-                        code="invalid_input",
-                    )
-                if value < 0.0 or value > 1.0:
-                    raise serializers.ValidationError(
-                        f"data_pipeline_error_threshold must be between 0.0 and 1.0, got {value}",
-                        code="invalid_input",
-                    )
-                current_settings[key] = float(value)
-            else:
-                # For non-dict settings, validate type directly
-                if not isinstance(value, expected_type):
-                    raise serializers.ValidationError(
-                        f"{value} is not a valid type for notification settings, should be {expected_type}",
-                        code="invalid_input",
-                    )
-                current_settings[key] = value
-
-        return cast(Notifications, current_settings)
+        return validate_notification_settings(cast(User, self.instance), notification_settings)
 
     def validate_ui_configuration(self, value: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:
         if value is None:


### PR DESCRIPTION
## Problem

Maintainers need a smaller user serializer so they can change notification settings without navigating unrelated API code.

## Changes

- The notification-settings validator and its helpers now live in a focused API module.
- The user serializer now delegates validation to that module.
- This is a mechanical refactor with no user-visible change.

## How did you test this code?

- `uv run hogli test posthog/api/test/test_user.py`
- Ruff and the API-module Semgrep scan pass.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This refactor does not change documented behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- The `splitting-oversized-modules` and `writing-pr-descriptions` skills guided the refactor and this description.
- The open PR and issue searches found no duplicate.
- The committed files contain no external customer, support, or operational data.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0C0LU050GN/p1789038803871019?thread_ts=1789038803.871019&cid=C0C0LU050GN)*