### PR TITLE
fix(error-tracking): drop a remote url whose credential cannot be located

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3491,6 +3491,7 @@ dependencies = [
  "tower 0.4.13",
  "tracing",
  "tracing-subscriber",
+ "url",
  "uuid",
  "zip 4.6.1",
  "zstd",

--- a/rust/cymbal/Cargo.toml
+++ b/rust/cymbal/Cargo.toml
@@ -28,6 +28,7 @@ hogvm = { path = "../common/hogvm" }
 thiserror = { workspace = true }
 sqlx = { workspace = true }
 serde_json = { workspace = true }
+url = { workspace = true }
 serde = { workspace = true }
 sourcemap = "9.0.0"
 symbolic = { version = "12.12", features = ["sourcemapcache", "debuginfo", "symcache", "demangle"] }

--- a/rust/cymbal/src/core/types/frames/releases.rs
+++ b/rust/cymbal/src/core/types/frames/releases.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha512};
 use sqlx::Executor;
+use url::Url;
 use uuid::Uuid;
 
 use crate::symbolication::symbol_store::saving::truncate_ref;
@@ -202,7 +203,7 @@ fn sanitize_remote_url(url: &str) -> Option<String> {
         return None;
     }
 
-    let Some(scheme_end) = trimmed.find("://") else {
+    if !trimmed.contains("://") {
         // SSH carries no password, so the `git` in `git@host:owner/repo.git` is a fixed
         // username. Any other userinfo is not an SSH login and may be a token.
         let (authority, path) = trimmed.split_once(':').unwrap_or((trimmed, ""));
@@ -212,31 +213,32 @@ fn sanitize_remote_url(url: &str) -> Option<String> {
         } else {
             Some(trimmed.to_string())
         };
-    };
+    }
 
-    let authority_start = scheme_end + 3;
-    let authority_end = trimmed[authority_start..]
-        .find('/')
-        .map_or(trimmed.len(), |index| authority_start + index);
-    let authority = &trimmed[authority_start..authority_end];
-    let path = &trimmed[authority_end..];
+    // Userinfo must percent-encode `/`, so `https://user:secret/@host/o/r.git` is malformed and
+    // no scan can find where its authority ends. A parser that rejects it fails closed.
+    let Ok(mut parsed) = Url::parse(trimmed) else {
+        return if trimmed.contains('@') {
+            None
+        } else {
+            Some(trimmed.to_string())
+        };
+    };
 
     // `https://host/${TOKEN}@host/o/r.git` is a CI script interpolating one segment too late.
     // The authority parses clean, so userinfo stripping never sees the token.
-    if path_holds_credential(path) {
+    if path_holds_credential(parsed.path()) {
         return None;
     }
 
-    let Some(credentials_end) = authority.rfind('@') else {
+    // Returning the input untouched keeps the parser from reshaping a URL holding no credential.
+    if parsed.username().is_empty() && parsed.password().is_none() {
         return Some(trimmed.to_string());
-    };
+    }
 
-    Some(format!(
-        "{}{}{}",
-        &trimmed[..authority_start],
-        &authority[credentials_end + 1..],
-        path
-    ))
+    parsed.set_username("").ok()?;
+    parsed.set_password(None).ok()?;
+    Some(parsed.to_string())
 }
 
 /// An `@` opening a segment is an npm scope (`/@scope/package`), not a credential.
@@ -384,7 +386,7 @@ mod tests {
     #[test]
     fn event_remote_urls_drop_credentials_query_and_fragment() {
         // `None` means the URL cannot be cleaned, so the key is dropped from the event.
-        let cases: [(&str, Option<&str>); 10] = [
+        let cases: [(&str, Option<&str>); 12] = [
             (
                 "https://user:password@github.com/example/repo.git?token=query#access_token=fragment",
                 Some("https://github.com/example/repo.git"),
@@ -412,6 +414,10 @@ mod tests {
             ("git@github.com:ghs_tokenvalue@example/repo.git", None),
             // SSH has no password slot, so a non-`git` userinfo is not a login.
             ("ghs_tokenvalue@github.com:example/repo.git", None),
+            // An unencoded `/` in the password moves the `@` to the head of a path segment,
+            // where it would otherwise read as a scope.
+            ("https://user:secret/@github.com/example/repo.git", None),
+            ("https://user:sec/ret@github.com/example/repo.git", None),
             ("https://user:ghp_tokenvalue?x@github.com/example/repo.git", None),
             (
                 "https://github.com/example/@scope/package.git",

--- a/rust/cymbal/src/core/types/frames/releases.rs
+++ b/rust/cymbal/src/core/types/frames/releases.rs
@@ -203,9 +203,11 @@ fn sanitize_remote_url(url: &str) -> Option<String> {
     }
 
     let Some(scheme_end) = trimmed.find("://") else {
-        // In `git@host:owner/repo.git` the leading `git` is a fixed SSH username, not a secret.
-        let path = trimmed.split_once(':').map_or("", |(_, path)| path);
-        return if path_holds_credential(path) {
+        // SSH carries no password, so the `git` in `git@host:owner/repo.git` is a fixed
+        // username. Any other userinfo is not an SSH login and may be a token.
+        let (authority, path) = trimmed.split_once(':').unwrap_or((trimmed, ""));
+        let user = authority.split_once('@').map_or("", |(user, _)| user);
+        return if (!user.is_empty() && user != "git") || path_holds_credential(path) {
             None
         } else {
             Some(trimmed.to_string())
@@ -382,7 +384,7 @@ mod tests {
     #[test]
     fn event_remote_urls_drop_credentials_query_and_fragment() {
         // `None` means the URL cannot be cleaned, so the key is dropped from the event.
-        let cases: [(&str, Option<&str>); 9] = [
+        let cases: [(&str, Option<&str>); 10] = [
             (
                 "https://user:password@github.com/example/repo.git?token=query#access_token=fragment",
                 Some("https://github.com/example/repo.git"),
@@ -408,6 +410,8 @@ mod tests {
                 None,
             ),
             ("git@github.com:ghs_tokenvalue@example/repo.git", None),
+            // SSH has no password slot, so a non-`git` userinfo is not a login.
+            ("ghs_tokenvalue@github.com:example/repo.git", None),
             ("https://user:ghp_tokenvalue?x@github.com/example/repo.git", None),
             (
                 "https://github.com/example/@scope/package.git",

--- a/rust/cymbal/src/core/types/frames/releases.rs
+++ b/rust/cymbal/src/core/types/frames/releases.rs
@@ -165,32 +165,85 @@ fn truncate_chars(value: &mut String, max_chars: usize) {
 
 fn sanitize_metadata_for_event(metadata: &Value) -> Value {
     let mut sanitized = metadata.clone();
-    if let Some(Value::String(remote_url)) = sanitized.pointer_mut("/git/remote_url") {
-        *remote_url = sanitize_remote_url(remote_url);
+    let Some(Value::String(remote_url)) = sanitized.pointer("/git/remote_url") else {
+        return sanitized;
+    };
+
+    match sanitize_remote_url(remote_url) {
+        Some(cleaned) => {
+            if let Some(Value::String(target)) = sanitized.pointer_mut("/git/remote_url") {
+                *target = cleaned;
+            }
+        }
+        // Dropping only the URL keeps branch, commit and repo name on the event.
+        None => {
+            if let Some(git) = sanitized.pointer_mut("/git").and_then(Value::as_object_mut) {
+                git.remove("remote_url");
+            }
+        }
     }
     sanitized
 }
 
-fn sanitize_remote_url(url: &str) -> String {
-    let sanitized_end = url.find(['?', '#']).unwrap_or(url.len());
-    let Some(scheme_end) = url[..sanitized_end].find("://") else {
-        return url[..sanitized_end].to_string();
-    };
-    let authority_start = scheme_end + 3;
-    let authority_end = url[authority_start..sanitized_end]
-        .find('/')
-        .map_or(sanitized_end, |index| authority_start + index);
-    let authority = &url[authority_start..authority_end];
-    let Some(credentials_end) = authority.rfind('@') else {
-        return url[..sanitized_end].to_string();
+/// Removes the userinfo component, the query, and the fragment from a git remote URL.
+///
+/// Returns `None` when a credential sits where no parser can isolate it, so the caller drops
+/// the URL rather than store a secret.
+fn sanitize_remote_url(url: &str) -> Option<String> {
+    // `?token=` and `#access_token=` both carry secrets, and a git remote needs neither.
+    let trimmed = match url.find(['?', '#']) {
+        Some(index) => &url[..index],
+        None => url,
     };
 
-    format!(
+    // `https://user:token?x@host/o/r.git` loses its `@` to the trim, and what remains is the
+    // credential. Nothing tells that from a query that legitimately holds an `@`.
+    if url.contains('@') && !trimmed.contains('@') {
+        return None;
+    }
+
+    let Some(scheme_end) = trimmed.find("://") else {
+        // In `git@host:owner/repo.git` the leading `git` is a fixed SSH username, not a secret.
+        let path = trimmed.split_once(':').map_or("", |(_, path)| path);
+        return if path_holds_credential(path) {
+            None
+        } else {
+            Some(trimmed.to_string())
+        };
+    };
+
+    let authority_start = scheme_end + 3;
+    let authority_end = trimmed[authority_start..]
+        .find('/')
+        .map_or(trimmed.len(), |index| authority_start + index);
+    let authority = &trimmed[authority_start..authority_end];
+    let path = &trimmed[authority_end..];
+
+    // `https://host/${TOKEN}@host/o/r.git` is a CI script interpolating one segment too late.
+    // The authority parses clean, so userinfo stripping never sees the token.
+    if path_holds_credential(path) {
+        return None;
+    }
+
+    let Some(credentials_end) = authority.rfind('@') else {
+        return Some(trimmed.to_string());
+    };
+
+    Some(format!(
         "{}{}{}",
-        &url[..authority_start],
+        &trimmed[..authority_start],
         &authority[credentials_end + 1..],
-        &url[authority_end..sanitized_end]
-    )
+        path
+    ))
+}
+
+/// An `@` opening a segment is an npm scope (`/@scope/package`), not a credential.
+fn path_holds_credential(path: &str) -> bool {
+    path.split('/').any(|segment| {
+        segment
+            .split_once('@')
+            .is_some_and(|(before, _)| !before.is_empty())
+    })
 }
 
 /// Reconstruct the release `hash_id` the CLI wrote for a mobile build, from the app metadata the
@@ -328,35 +381,57 @@ mod tests {
 
     #[test]
     fn event_remote_urls_drop_credentials_query_and_fragment() {
-        let cases = [
+        // `None` means the URL cannot be cleaned, so the key is dropped from the event.
+        let cases: [(&str, Option<&str>); 9] = [
             (
                 "https://user:password@github.com/example/repo.git?token=query#access_token=fragment",
-                "https://github.com/example/repo.git",
+                Some("https://github.com/example/repo.git"),
             ),
             (
                 "https://github.com/example/repo.git#access_token=fragment",
-                "https://github.com/example/repo.git",
+                Some("https://github.com/example/repo.git"),
             ),
             (
                 "https://github.com/example/repo.git",
-                "https://github.com/example/repo.git",
+                Some("https://github.com/example/repo.git"),
             ),
             (
                 "git@github.com:example/repo.git",
-                "git@github.com:example/repo.git",
+                Some("git@github.com:example/repo.git"),
             ),
             (
                 "git@github.com:example/repo.git?token=query#access_token=fragment",
-                "git@github.com:example/repo.git",
+                Some("git@github.com:example/repo.git"),
+            ),
+            (
+                "https://github.com/ghs_tokenvalue@github.com/example/repo.git",
+                None,
+            ),
+            ("git@github.com:ghs_tokenvalue@example/repo.git", None),
+            ("https://user:ghp_tokenvalue?x@github.com/example/repo.git", None),
+            (
+                "https://github.com/example/@scope/package.git",
+                Some("https://github.com/example/@scope/package.git"),
             ),
         ];
 
         for (remote_url, expected) in cases {
             let info = serde_json::to_value(
-                record(Some(json!({"git": {"remote_url": remote_url}}))).to_info(),
+                record(Some(
+                    json!({"git": {"remote_url": remote_url, "branch": "main"}}),
+                ))
+                .to_info(),
             )
             .unwrap();
-            assert_eq!(info["metadata"]["git"]["remote_url"], expected);
+            let git = &info["metadata"]["git"];
+            match expected {
+                Some(value) => assert_eq!(git["remote_url"], value, "case: {remote_url}"),
+                None => assert!(
+                    git.get("remote_url").is_none(),
+                    "case: {remote_url} should have been dropped, got {git:?}"
+                ),
+            }
+            assert_eq!(git["branch"], "main", "case: {remote_url}");
         }
     }
 


### PR DESCRIPTION
NO LONG LIVED CREDENTIALS ARE LEAKED

But our last fix https://github.com/PostHog/posthog/pull/95925 left an edge case and `ghs` tokens are being leaked for old CLI versions still

This fixes it