### PR TITLE
feat(cdp): measure how long the oldest ready job has been waiting

### DIFF
--- a/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
@@ -171,6 +171,12 @@ async function gaugeValueForQueue(queue: string): Promise<number | null> {
     return line ? Number(line.trim().split(' ').pop()) : null
 }
 
+async function ageValueForQueue(queue: string): Promise<number | null> {
+    const metric = await register.getSingleMetricAsString('cdp_cyclotron_v2_oldest_due_job_age_seconds')
+    const line = metric.split('\n').find((l) => l.includes(`queue="${queue}"`))
+    return line ? Number(line.trim().split(' ').pop()) : null
+}
+
 // Absent until the queue's first churning dequeue, so a missing line reads as 0.
 async function churnCountForQueue(queue: string): Promise<number> {
     const metric = await register.getSingleMetricAsString('cdp_cyclotron_v2_high_transition_dequeues')
@@ -2621,6 +2627,40 @@ describe('Cyclotron V2', () => {
 
             expect(result.depths.get('queue-a')).toBe(2)
             expect(result.depths.get('queue-b')).toBe(1)
+        })
+
+        it('measureQueueDepths reports how long the oldest ready job has waited', async () => {
+            await insertRawJob({
+                id: uuidv7(),
+                queue_name: 'queue-aging',
+                status: 'available',
+                scheduled: new Date(Date.now() - 120_000),
+            })
+            // A younger ready job must not lower the age, a future one must not count at all.
+            await insertRawJob({
+                id: uuidv7(),
+                queue_name: 'queue-aging',
+                status: 'available',
+                scheduled: new Date(Date.now() - 10_000),
+            })
+            await insertRawJob({
+                id: uuidv7(),
+                queue_name: 'queue-aging',
+                status: 'available',
+                scheduled: new Date(Date.now() + 3_600_000),
+            })
+
+            const janitor = createJanitor({ stallTimeoutMs: 60_000 })
+            await janitor.runOnce()
+            const age = await ageValueForQueue('queue-aging')
+            expect(age).toBeGreaterThanOrEqual(119)
+            expect(age).toBeLessThan(150)
+
+            // Zeroes when the queue drains, so an age alert cannot fire on an idle queue.
+            await assertPool.query(`DELETE FROM cyclotron_jobs WHERE queue_name = 'queue-aging'`)
+            await janitor.runOnce()
+            await janitor.stop()
+            expect(await ageValueForQueue('queue-aging')).toBe(0)
         })
 
         it('sweeps expired conversion watchers and keeps live ones', async () => {

--- a/nodejs/src/cdp/services/cyclotron-v2/janitor.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/janitor.ts
@@ -543,24 +543,36 @@ export class CyclotronV2Janitor {
         }
     }
 
+    /**
+     * Samples queue depth and head-of-line age. Runs ahead of the cleanup stages, so a failure here
+     * must not reject out of `runOnce` and take those stages with it. Reported to error tracking and
+     * swallowed, the same trade the conversion-watcher sweep makes. The gauges keep their last value
+     * on a failed sample, so error tracking is what makes a persistent one visible.
+     */
     async measureQueueDepths(): Promise<Map<string, number>> {
-        // EXTRACT(EPOCH ...) computes the age on the database's clock, so worker clock
-        // drift cannot make a queue look stuck or freshly drained.
-        const result = await this.pool.query<{ queue_name: string; count: string; oldest_age_seconds: string }>(
-            `SELECT queue_name, COUNT(*) as count,
-                    EXTRACT(EPOCH FROM (NOW() - MIN(scheduled))) as oldest_age_seconds
-             FROM cyclotron_jobs
-             WHERE status = 'available' AND scheduled <= NOW()
-             GROUP BY queue_name`
-        )
-
         const depths = new Map<string, number>()
-        for (const row of result.rows) {
-            const count = parseInt(row.count, 10)
-            depths.set(row.queue_name, count)
-            this.seenQueues.add(row.queue_name)
-            queueDepthGauge.labels({ queue: row.queue_name }).set(count)
-            oldestDueJobAgeGauge.labels({ queue: row.queue_name }).set(Math.max(0, Number(row.oldest_age_seconds)))
+        try {
+            // EXTRACT(EPOCH ...) computes the age on the database's clock, so worker clock
+            // drift cannot make a queue look stuck or freshly drained.
+            const result = await this.pool.query<{ queue_name: string; count: string; oldest_age_seconds: string }>(
+                `SELECT queue_name, COUNT(*) as count,
+                        EXTRACT(EPOCH FROM (NOW() - MIN(scheduled))) as oldest_age_seconds
+                 FROM cyclotron_jobs
+                 WHERE status = 'available' AND scheduled <= NOW()
+                 GROUP BY queue_name`
+            )
+
+            for (const row of result.rows) {
+                const count = parseInt(row.count, 10)
+                depths.set(row.queue_name, count)
+                this.seenQueues.add(row.queue_name)
+                queueDepthGauge.labels({ queue: row.queue_name }).set(count)
+                oldestDueJobAgeGauge.labels({ queue: row.queue_name }).set(Math.max(0, Number(row.oldest_age_seconds)))
+            }
+        } catch (err) {
+            logger.error('CyclotronV2Janitor queue depth sample failed', { error: String(err) })
+            captureException(err)
+            return depths
         }
 
         // GROUP BY returns no row for a queue that is empty. Without the write below,

--- a/nodejs/src/cdp/services/cyclotron-v2/janitor.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/janitor.ts
@@ -184,6 +184,13 @@ export class CyclotronV2Janitor {
         // expired watchers draining even while cyclotron cleanup is failing.
         await this.sweepExpiredConversionWatchers()
 
+        // Sample the gauges before the cleanup stages, not after. Those stages issue
+        // unguarded writes against cyclotron_jobs, and a failure there (a statement
+        // timeout, lock pressure) rejects out of runOnce. Sampled last, the gauges
+        // would then freeze at their previous value on exactly the ticks where the
+        // queue is in trouble, and an alert on them would read a stale healthy number.
+        const depths = await this.measureQueueDepths()
+
         const deletedCounts = await this.cleanupTerminalJobs()
         const deleted = Object.values(deletedCounts).reduce((a, b) => a + b, 0)
 
@@ -197,7 +204,6 @@ export class CyclotronV2Janitor {
             : await this.failPoisonPills()
 
         const stalled = await this.resetStalledJobs()
-        const depths = await this.measureQueueDepths()
 
         janitorRunCounter.inc()
 

--- a/nodejs/src/cdp/services/cyclotron-v2/janitor.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/janitor.ts
@@ -81,12 +81,16 @@ const queueDepthGauge = new Gauge({
     labelNames: ['queue'],
 })
 
-// Queue depth cannot separate a healthy burst from a stuck queue: a large backlog that
-// drains is fine, a small one that does not move is an outage. The age of the job at the
-// front of the line can: no healthy queue leaves a ready job waiting for minutes.
+// Head-of-line latency, per queue: how long the oldest due row has waited. It does not show
+// whether workers make progress. A throttled drain raises it while every send succeeds,
+// because the email worker gates sends behind a token bucket and leaves `scheduled`
+// unchanged while it waits. On the email queue it can also read a row that
+// `fairDequeueJobs` defers on purpose, because that path orders by priority and
+// `dequeue_seq` instead of `scheduled`. A stall alert must therefore pair a high age with a
+// zero `cdp_cyclotron_jobs_processed` rate for the same queue.
 const oldestDueJobAgeGauge = new Gauge({
     name: 'cdp_cyclotron_v2_oldest_due_job_age_seconds',
-    help: 'How long the oldest ready-to-run job has been waiting to be picked up, per queue.',
+    help: 'Head-of-line latency per queue: seconds the oldest due job has waited. Rises on a throttled drain too, so pair it with cdp_cyclotron_jobs_processed to detect a stall.',
     labelNames: ['queue'],
 })
 

--- a/nodejs/src/cdp/services/cyclotron-v2/janitor.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/janitor.ts
@@ -81,6 +81,15 @@ const queueDepthGauge = new Gauge({
     labelNames: ['queue'],
 })
 
+// Queue depth cannot separate a healthy burst from a stuck queue: a large backlog that
+// drains is fine, a small one that does not move is an outage. The age of the job at the
+// front of the line can: no healthy queue leaves a ready job waiting for minutes.
+const oldestDueJobAgeGauge = new Gauge({
+    name: 'cdp_cyclotron_v2_oldest_due_job_age_seconds',
+    help: 'How long the oldest ready-to-run job has been waiting to be picked up, per queue.',
+    labelNames: ['queue'],
+})
+
 interface PoisonRow {
     id: string
     team_id: number
@@ -525,8 +534,11 @@ export class CyclotronV2Janitor {
     }
 
     async measureQueueDepths(): Promise<Map<string, number>> {
-        const result = await this.pool.query<{ queue_name: string; count: string }>(
-            `SELECT queue_name, COUNT(*) as count
+        // EXTRACT(EPOCH ...) computes the age on the database's clock, so worker clock
+        // drift cannot make a queue look stuck or freshly drained.
+        const result = await this.pool.query<{ queue_name: string; count: string; oldest_age_seconds: string }>(
+            `SELECT queue_name, COUNT(*) as count,
+                    EXTRACT(EPOCH FROM (NOW() - MIN(scheduled))) as oldest_age_seconds
              FROM cyclotron_jobs
              WHERE status = 'available' AND scheduled <= NOW()
              GROUP BY queue_name`
@@ -538,6 +550,7 @@ export class CyclotronV2Janitor {
             depths.set(row.queue_name, count)
             this.seenQueues.add(row.queue_name)
             queueDepthGauge.labels({ queue: row.queue_name }).set(count)
+            oldestDueJobAgeGauge.labels({ queue: row.queue_name }).set(Math.max(0, Number(row.oldest_age_seconds)))
         }
 
         // GROUP BY returns no row for a queue that is empty. Without the write below,
@@ -548,6 +561,7 @@ export class CyclotronV2Janitor {
         for (const queue of this.seenQueues) {
             if (!depths.has(queue)) {
                 queueDepthGauge.labels({ queue }).set(0)
+                oldestDueJobAgeGauge.labels({ queue }).set(0)
             }
         }
 


### PR DESCRIPTION
## Problem

When the email queue stalled for 32 hours, no metric could see it. We watch queue depth, but depth says nothing about waiting time.

**Example:** 100,000 emails queued and draining fast - depth is huge, everything is fine. 5,000 emails queued and the worker dead - depth looks harmless, nothing sends. Same panel, opposite situations. This gauge adds the missing dimension: how long the job at the front of the line has been waiting.

## Changes

- The janitor now reports `cdp_cyclotron_v2_oldest_due_job_age_seconds` per queue, from the same query that already measures depth (one extra aggregate, no new scan).
- To be precise about what it is (review finding): a **head-of-line latency** signal, not a stall detector on its own. A rate-limited email drain legitimately ages the head while sends flow at full permitted speed, and the email queue dequeues in fairness order rather than by `scheduled`. The stall alert therefore pairs a high age with a zero `cdp_cyclotron_jobs_processed` rate for the same queue - that counter already exists. The rule is a PostHog/charts follow-up once this metric ships.
- The gauges are sampled at the start of the janitor tick, before the cleanup stages (review finding): sampled last, a cleanup failure would freeze them at a stale healthy value on exactly the ticks where the queue is in trouble.
- The age is computed on the database's clock, so worker clock drift cannot fake a stall.
- A drained queue reports 0, same pattern as the depth gauge, so an alert cannot fire on an idle queue.

## How did you test this code?

Run locally against the dev stack: a queue with ready jobs 120s, 10s old and one scheduled in the future reports ~120s (the oldest counts, the future one does not); after draining the queue the gauge drops to 0. This is the regression no existing test catches: the gauge silently not reporting, or reporting for a drained queue.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code as detection follow-up to the email queue incident (see #97618 / #97591): the outage was found by a human a day late because no metric measures whether a queue is moving. Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions. Companion PR adds a consumer-loop error counter; the vmalert rules for both come as a PostHog/charts PR after the metrics deploy.

