### PR TITLE
feat(cdp): count consumer loop errors per queue

### DIFF
--- a/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
@@ -14,7 +14,7 @@ import {
     CyclotronV2DequeuedJob,
     CyclotronV2JobInit,
 } from './types'
-import { CyclotronV2Worker } from './worker'
+import { CyclotronV2Worker, sleep } from './worker'
 import { CyclotronV2RateLimitedWorker } from './worker-rate-limited'
 
 const DB_URL = 'postgres://posthog:posthog@localhost:5432/test_cyclotron_node'
@@ -172,6 +172,12 @@ async function gaugeValueForQueue(queue: string): Promise<number | null> {
 }
 
 // Absent until the queue's first churning dequeue, so a missing line reads as 0.
+async function loopErrorCountForQueue(queue: string): Promise<number> {
+    const metric = await register.getSingleMetricAsString('cdp_cyclotron_v2_consumer_loop_errors_total')
+    const line = metric.split('\n').find((l) => l.includes(`queue="${queue}"`))
+    return line ? Number(line.trim().split(' ').pop()) : 0
+}
+
 async function churnCountForQueue(queue: string): Promise<number> {
     const metric = await register.getSingleMetricAsString('cdp_cyclotron_v2_high_transition_dequeues')
     const line = metric.split('\n').find((l) => l.includes(`queue="${queue}"`))
@@ -1021,6 +1027,50 @@ describe('Cyclotron V2', () => {
             const jobs = await dequeueOneBatch(worker)
             expect(jobs).toHaveLength(2)
             expect(await countByStatus('running')).toBe(2)
+        })
+
+        // The loop swallows errors and retries, so a queue whose batches all throw looks
+        // exactly like an idle queue. The counter is the only externally visible signal.
+        it.each([
+            ['the plain worker', 'loop-errors-plain', (): CyclotronV2Worker => createWorker('loop-errors-plain')],
+            [
+                'the rate-limited worker',
+                'loop-errors-limited',
+                (): CyclotronV2Worker =>
+                    new CyclotronV2RateLimitedWorker(
+                        {
+                            pool: { dbUrl: DB_URL },
+                            queueName: 'loop-errors-limited',
+                            batchMaxSize: 100,
+                            pollDelayMs: 10,
+                        },
+                        () => Promise.resolve(undefined)
+                    ),
+            ],
+        ])('counts a consumer loop error in %s', async (_name, queue, makeWorker) => {
+            await manager.createJob({ teamId: 1, queueName: queue })
+            const before = await loopErrorCountForQueue(queue)
+            const worker = makeWorker()
+
+            let threw = false
+            await new Promise<void>((resolve) => {
+                void worker.connect(async (batch) => {
+                    if (batch.length > 0 && !threw) {
+                        threw = true
+                        resolve()
+                        return Promise.reject(new Error('processing failed'))
+                    }
+                })
+            })
+            // The throw resolves the promise before the loop's catch runs; give the
+            // catch a moment to record it before stopping the loop.
+            const deadline = Date.now() + 2_000
+            while ((await loopErrorCountForQueue(queue)) - before < 1 && Date.now() < deadline) {
+                await sleep(25)
+            }
+            await worker.stopConsuming()
+
+            expect((await loopErrorCountForQueue(queue)) - before).toBe(1)
         })
 
         // Both dequeue paths bump transition_count for the whole batch in one UPDATE, so an

--- a/nodejs/src/cdp/services/cyclotron-v2/worker-rate-limited.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/worker-rate-limited.ts
@@ -2,7 +2,7 @@ import { logger } from '~/common/utils/logger'
 
 import { CyclotronV2BatchLimit, CyclotronV2WorkerConfig } from './types'
 import { CyclotronV2DequeuedJob } from './types'
-import { CyclotronV2Worker, sleep } from './worker'
+import { CyclotronV2Worker, consumerLoopErrorsCounter, sleep } from './worker'
 
 /**
  * Variant of CyclotronV2Worker that consults a per-poll rate-limit hook before
@@ -69,6 +69,7 @@ export class CyclotronV2RateLimitedWorker extends CyclotronV2Worker {
                 const jobs = rows.map((row) => this.wrapJob(row))
                 await processBatch(jobs)
             } catch (err) {
+                consumerLoopErrorsCounter.labels({ queue: this.queueName }).inc()
                 logger.error('CyclotronV2RateLimitedWorker consumer loop error', { error: String(err) })
                 await sleep(this.pollDelayMs)
             }

--- a/nodejs/src/cdp/services/cyclotron-v2/worker.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/worker.ts
@@ -48,7 +48,7 @@ const highTransitionDequeuesCounter = new Counter({
 // subclass, which has its own loop and catch.
 export const consumerLoopErrorsCounter = new Counter({
     name: 'cdp_cyclotron_v2_consumer_loop_errors_total',
-    help: 'Consumer loop iterations that threw, per queue. Sustained nonzero means the queue is not being consumed.',
+    help: 'Consumer loop iterations that threw, per queue. A sustained positive rate can indicate the queue is not being consumed.',
     labelNames: ['queue'] as const,
 })
 

--- a/nodejs/src/cdp/services/cyclotron-v2/worker.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/worker.ts
@@ -43,6 +43,15 @@ const highTransitionDequeuesCounter = new Counter({
     labelNames: ['queue'] as const,
 })
 
+// The loop swallows the error and retries, so without this counter a queue whose every
+// dequeue throws looks exactly like an idle queue. Exported for the rate-limited
+// subclass, which has its own loop and catch.
+export const consumerLoopErrorsCounter = new Counter({
+    name: 'cdp_cyclotron_v2_consumer_loop_errors_total',
+    help: 'Consumer loop iterations that threw, per queue. Sustained nonzero means the queue is not being consumed.',
+    labelNames: ['queue'] as const,
+})
+
 export function sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms))
 }
@@ -218,6 +227,7 @@ export class CyclotronV2Worker {
     protected lastPollTime = new Date()
     private consumerLoopPromise: Promise<void> | null = null
 
+    protected readonly queueName: string
     protected readonly batchMaxSize: number
     protected readonly pollDelayMs: number
     private readonly heartbeatTimeoutMs: number
@@ -230,6 +240,7 @@ export class CyclotronV2Worker {
             max: config.pool.maxConnections ?? 10,
             idleTimeoutMillis: config.pool.idleTimeoutMs ?? 30000,
         })
+        this.queueName = config.queueName
         this.batchMaxSize = config.batchMaxSize ?? 100
         this.pollDelayMs = config.pollDelayMs ?? 50
         this.heartbeatTimeoutMs = config.heartbeatTimeoutMs ?? 30000
@@ -266,6 +277,7 @@ export class CyclotronV2Worker {
                 const jobs = rows.map((row) => this.wrapJob(row))
                 await processBatch(jobs)
             } catch (err) {
+                consumerLoopErrorsCounter.labels({ queue: this.queueName }).inc()
                 logger.error('CyclotronV2Worker consumer loop error', { error: String(err) })
                 await sleep(this.pollDelayMs)
             }


### PR DESCRIPTION
## Problem

When every dequeue on a queue throws, the queue looks idle from the outside.

**Example:** during the email queue incident, one bad job row made every batch dequeue fail. The worker's loop caught each error, wrote a log line, slept, and tried again - forever. No metric moved, no alert fired, and the queue stood still for 32 hours until a human read the logs.

## Changes

- Both consumer loops (plain and rate-limited) count every caught error into `cdp_cyclotron_v2_consumer_loop_errors_total{queue}`.
- The log line stays; the counter is what an alert can watch. A sustained rate means "this queue is not being consumed" - within minutes, with the exception text one click away in the logs.
- No behavior change: the loop still swallows the error and retries exactly as before.
- The vmalert rule (sustained nonzero for ~10 min) comes as a PostHog/charts follow-up once this metric ships, together with the rule for #98270's queue-age gauge.

## How did you test this code?

Run locally against the dev stack: for each worker type, a batch handler that throws bumps the counter by exactly one, and healthy iterations do not. That is the regression nothing else catches: the counter silently not incrementing, which would leave the future alert permanently green.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code as detection follow-up to the email queue incident, companion to #98270 (oldest-ready-job age). Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions.
