### PR TITLE
fix(posthog_ai): append a replayed run history in one log update

### DIFF
--- a/products/posthog_ai/frontend/logics/runStreamLogic.test.ts
+++ b/products/posthog_ai/frontend/logics/runStreamLogic.test.ts
@@ -1,3 +1,4 @@
+import { getContext } from 'kea'
 import { expectLogic } from 'kea-test-utils'
 import posthog from 'posthog-js'
 
@@ -341,6 +342,45 @@ describe('runStreamLogic', () => {
             }).toFinishAllListeners()
 
             expect(logic.values.currentRunStatus).toEqual('completed')
+        })
+    })
+
+    describe('ingestAcpFrames', () => {
+        it('appends a replayed history in one log update, and still runs each frame side effect', async () => {
+            const frames: StoredLogEntry[] = [
+                notification('_posthog/run_started', {}),
+                sessionUpdate({ sessionUpdate: 'agent_message', messageId: 'm1', content: { text: 'Hello' } }),
+                sessionUpdate({ sessionUpdate: 'tool_call', toolCallId: 't1', status: 'in_progress' }),
+                sessionUpdate({ sessionUpdate: 'tool_call_update', toolCallId: 't1', status: 'completed' }),
+                notification('_posthog/turn_complete', {}),
+            ]
+
+            // The thread projection is memoized on `log` identity, so counting how often the log changes
+            // counts how often the whole history re-folds. One append per frame makes that quadratic and
+            // freezes the tab while a long conversation opens.
+            let logUpdates = 0
+            let lastLog = logic.values.log
+            const unsubscribe = getContext().store.subscribe(() => {
+                if (logic.values.log !== lastLog) {
+                    lastLog = logic.values.log
+                    logUpdates += 1
+                }
+            })
+            try {
+                await expectLogic(logic, () => {
+                    logic.actions.ingestAcpFrames(frames, 'replay')
+                }).toFinishAllListeners()
+            } finally {
+                unsubscribe()
+            }
+
+            expect(logUpdates).toEqual(1)
+            expect(logic.values.log.entries).toHaveLength(frames.length)
+            // The batch folds and side-effects exactly like per-frame ingestion.
+            expect(logic.values.runStarted).toEqual(true)
+            expect(logic.values.turnComplete).toEqual(true)
+            expect(logic.values.threadItems.find((item) => item.type === 'assistant_message')?.text).toEqual('Hello')
+            expect(logic.values.toolInvocations.get('t1')?.status).toEqual('completed')
         })
     })
 

--- a/products/posthog_ai/frontend/logics/runStreamLogic.ts
+++ b/products/posthog_ai/frontend/logics/runStreamLogic.ts
@@ -1614,6 +1614,13 @@ export interface runStreamLogicActions {
         entry: StoredLogEntry
         source: FrameSource
     }
+    ingestAcpFrames: (
+        entries: StoredLogEntry[],
+        source?: FrameSource
+    ) => {
+        entries: StoredLogEntry[]
+        source: FrameSource
+    }
     ingestPermissionRequest: (
         record: PermissionRequestRecord,
         replayedFromHistory?: boolean
@@ -1889,6 +1896,14 @@ export const runStreamLogic = kea<runStreamLogicType>([
          * per-frame key. The resume cursor (`cache.lastEventId`) is stamped by the SSE reader, not here.
          */
         ingestAcpFrame: (entry: StoredLogEntry, source: FrameSource = 'live') => ({ entry, source }),
+        /**
+         * Bulk frame ingestion for the bootstrap history replay. Runs the same per-frame side effects
+         * as `ingestAcpFrame`, but appends the whole batch to the log in one `appendEntries` dispatch:
+         * the thread projection is memoized on log identity, so a per-frame append re-folds the entire
+         * log once per frame, which is quadratic over a long history and locks the tab up while a big
+         * conversation opens. Live frames keep using `ingestAcpFrame` — they arrive one at a time.
+         */
+        ingestAcpFrames: (entries: StoredLogEntry[], source: FrameSource = 'live') => ({ entries, source }),
         /** Append frames to the ordered log (the single source of truth). */
         appendEntries: (entries: StoredEntry[]) => ({ entries }),
         replaceLog: (log: RunLog) => ({ log }),
@@ -2582,9 +2597,7 @@ export const runStreamLogic = kea<runStreamLogicType>([
                 const replayEntries = replayResult
                 breakpoint()
                 if (values.log.entries.length === 0) {
-                    normalizeHistory(replayEntries, runId, isResumeRun(replayRun)).forEach((entry) =>
-                        actions.ingestAcpFrame(entry, 'replay')
-                    )
+                    actions.ingestAcpFrames(normalizeHistory(replayEntries, runId, isResumeRun(replayRun)), 'replay')
                 }
 
                 if (isTerminalRunStatus(replayRun.status ?? null)) {
@@ -2667,21 +2680,16 @@ export const runStreamLogic = kea<runStreamLogicType>([
                 // Replace the partial snapshot synchronously; ancestor lifecycle frames must not make
                 // a successor that is still provisioning appear started or finished.
                 actions.replaceLog(emptyRunLog())
-                let reachedSuccessor = false
-                history.forEach((entry) => {
-                    if (!reachedSuccessor && entry.source_run_id === runId) {
-                        actions.appendResumeBoundary()
-                        actions.prepareResumeRun()
-                        actions.permissionRunChanged()
-                        reachedSuccessor = true
-                    }
-                    actions.ingestAcpFrame(entry, 'replay')
-                })
-                if (!reachedSuccessor) {
-                    actions.appendResumeBoundary()
-                    actions.prepareResumeRun()
-                    actions.permissionRunChanged()
-                }
+                // The boundary splits the batch: it must be inserted before the successor's first
+                // frame (and after everything when the snapshot has none), and `appendResumeBoundary`
+                // reads the log, so the ancestor frames have to be appended before it runs.
+                const successorIndex = history.findIndex((entry) => entry.source_run_id === runId)
+                const boundaryAt = successorIndex === -1 ? history.length : successorIndex
+                actions.ingestAcpFrames(history.slice(0, boundaryAt), 'replay')
+                actions.appendResumeBoundary()
+                actions.prepareResumeRun()
+                actions.permissionRunChanged()
+                actions.ingestAcpFrames(history.slice(boundaryAt), 'replay')
                 const successorItems = foldLogToThread(
                     history
                         .filter((entry) => entry.source_run_id === runId)
@@ -2692,7 +2700,7 @@ export const runStreamLogic = kea<runStreamLogicType>([
                     actions.pushHumanMessage(retainedMessage)
                 }
             } else {
-                history.forEach((entry) => actions.ingestAcpFrame(entry, 'replay'))
+                actions.ingestAcpFrames(history, 'replay')
             }
 
             if (terminal) {
@@ -2718,7 +2726,7 @@ export const runStreamLogic = kea<runStreamLogicType>([
             const buffered = (cache.bufferedLiveFrames as StoredLogEntry[] | undefined) ?? []
             cache.bufferingLiveFrames = false
             cache.bufferedLiveFrames = undefined
-            dedupeBufferedAgainstHistory(buffered, history).forEach((entry) => actions.ingestAcpFrame(entry, 'live'))
+            actions.ingestAcpFrames(dedupeBufferedAgainstHistory(buffered, history), 'live')
             actions.bootstrapLogReady()
         },
         openSseForRun: ({ taskId, runId, startLatest }) => {
@@ -3497,6 +3505,27 @@ export const runStreamLogic = kea<runStreamLogicType>([
                 },
             ])
         },
+        ingestAcpFrames: ({ entries, source }) => {
+            if (entries.length === 0) {
+                return
+            }
+            // Collect this batch's appends instead of letting each frame dispatch its own, then append
+            // once — the projection folds the log a single time for the whole history rather than once
+            // per frame. `ingestAcpFrame` is dispatched synchronously here, so the per-frame side
+            // effects still run in wire order.
+            const batch: StoredEntry[] = []
+            cache.pendingLogEntries = batch
+            try {
+                for (const entry of entries) {
+                    actions.ingestAcpFrame(entry, source)
+                }
+            } finally {
+                cache.pendingLogEntries = undefined
+            }
+            if (batch.length > 0) {
+                actions.appendEntries(batch)
+            }
+        },
         ingestAcpFrame: ({ entry, source }) => {
             const notification = entry?.notification
             if (!notification) {
@@ -3539,7 +3568,15 @@ export const runStreamLogic = kea<runStreamLogicType>([
             // deduped (see `bootstrapRun`) and steady-state live frames resume exclusively, so the
             // side effects below run exactly once per frame without a per-frame key; the
             // run-started/permission/tool-completion guards enforce fire-once on their own.
-            actions.appendEntries([{ entry, source }])
+            // Inside an `ingestAcpFrames` batch the append is deferred to a single dispatch at the end
+            // of the batch; nothing below reads the log or the projection, so the side effects don't
+            // care that their own frame isn't in it yet.
+            const batch = cache.pendingLogEntries as StoredEntry[] | undefined
+            if (batch) {
+                batch.push({ entry, source })
+            } else {
+                actions.appendEntries([{ entry, source }])
+            }
 
             // Custom `_posthog/*` notification namespace emitted by the agent-server. Thread items
             // (errors, status, compaction, task notifications, progress, human turns) are derived by


### PR DESCRIPTION
## Problem

Opening a PostHog AI conversation with a long history locks the browser tab up. The thread is already virtualized, so it is not the DOM — it is how the persisted log is loaded.

Bootstrap replayed the run's `logs/` snapshot one Kea action per frame. Each append changed `log` identity, and the thread projection is memoized on that identity, so every frame re-folded the entire log and re-rendered the thread. The cost of opening a conversation grew with the square of its history. A run that resumes from an earlier run replays the whole resume chain, which makes it worse.

## Changes

- Opening a long conversation no longer freezes the tab: the history is appended once and the thread folds once, instead of once per frame.
- New `ingestAcpFrames` action runs the same per-frame side effects as `ingestAcpFrame`, but buffers the log appends and dispatches a single `appendEntries` for the batch.
- The three bootstrap replay paths (read-only snapshot, resume-chain snapshot, buffered live tail) call it. Live frames keep using `ingestAcpFrame` — they arrive one at a time.
- Mechanical: the resume-boundary path now splits the history at the successor's first frame and ingests the two halves, rather than dispatching the boundary inside a loop. The boundary lands in the same position, and `appendResumeBoundary` still reads a log that holds every earlier frame.

## How did you test this code?

Added one test in `runStreamLogic.test.ts`. It counts how often `log` identity changes while a replayed history is ingested, which is what drives the re-fold. It catches a regression to per-frame appends that no existing test catches: reverting the batching makes it report 5 updates for 5 frames instead of 1. It also asserts the batch folds and side-effects like per-frame ingestion (`runStarted`, `turnComplete`, the assistant message, the tool invocation status).

The resume-boundary restructure is covered by the existing "reconciles incomplete history with a persisted successor message" cases.

Ran `runStreamLogic.test.ts` locally (236 tests). Lint and format are clean. `typescript:check` reports no errors in the changed files; the failures it does report are pre-existing missing-`@posthog/quill` module errors from an unbuilt workspace in this sandbox.

No browser QA was run — the fix was not verified against a real long conversation in this environment.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude) from a report that the PostHog AI panel hung while loading a long chat. Investigation started from the reported symptom, traced the thread rendering path to rule out the virtualizer, then found the per-frame dispatch in the bootstrap replay.

Skills invoked: none of the repo skills are loaded in this environment; the PR template and the repo's testing and PR-description guidance were read from the repo directly.

Duplicate search: `gh pr list --state open --search` over runStreamLogic and thread-replay keywords found no open PR addressing the replay cost. The nearby open PR #97494 reworks how widgets read tool results and does not touch this path.

The originating report is a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1789040133811759?thread_ts=1789040133.811759&cid=C0ACRAMJUAG). Nothing from it is quoted or carried into the diff.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1789040133811759?thread_ts=1789040133.811759&cid=C0ACRAMJUAG)*
