### PR TITLE
fix(posthog_ai): keep a text-only tool query off the insight card

### DIFF
--- a/products/posthog_ai/frontend/components/tool/widgets/extractors.test.ts
+++ b/products/posthog_ai/frontend/components/tool/widgets/extractors.test.ts
@@ -79,6 +79,17 @@ describe('mcp tool adapter extractors', () => {
             { content: [null, { type: 'image', data: 'unused', mimeType: 'image/png' }] },
             { content: [{ type: 'text', text: 'No insight found' }] },
             { structuredContent: savedInsight, isError: true },
+            // The MCP server writes `query` into its TOON response as raw pretty-printed JSON. TOON is
+            // line based, so the decoder reads the value as the literal string `{` and drops the keys
+            // after it. That string used to reach `<Query>`, which JSON-parsed it and failed.
+            {
+                content: [
+                    {
+                        type: 'text',
+                        text: 'short_id: abc12345\nname: Signups\nquery: {\n  "kind": "TrendsQuery"\n}\ndeleted: false',
+                    },
+                ],
+            },
         ])('returns null for missing, malformed, or failed insight output: %j', (rawOutput) => {
             expect(extractVisualizationArtifact(toolMessage(rawOutput))).toBeNull()
         })

--- a/products/posthog_ai/frontend/components/tool/widgets/extractors.ts
+++ b/products/posthog_ai/frontend/components/tool/widgets/extractors.ts
@@ -75,7 +75,10 @@ export function extractVisualizationArtifact(message: ToolCallMessage): Visualiz
         return null
     }
 
-    const query = output.query
+    // Must be a record, not just truthy: the widget hands this straight to `<Query>`, which JSON-parses
+    // a string query and replaces the whole card with a parse error when that fails. A tool output whose
+    // query survived the wire as text is unrenderable here — fall back to the generic card.
+    const query = asRecord(output.query)
     if (!query) {
         return null
     }


### PR DESCRIPTION
## Problem

An `insight-create` call in a PostHog AI thread can render a red box reading `Error parsing JSON: Expected property name or '}' in JSON at position 1` where the insight should be.

`extractVisualizationArtifact` accepted any truthy `query` from a tool output, including a string, and handed it to the visualization widget. The widget passes it to `<Query>`, which JSON-parses a string query and renders the parse error in place of the card.

A string gets there today because the MCP server writes `query` into its TOON response as raw pretty-printed JSON (`services/mcp/src/lib/response.ts`). TOON is line based, so the decoder reads that value as the literal string `{` and drops every key after it. `extractQueryResult`, the sibling extractor, already guards against this with `asRecord`; the visualization one did not.

## Changes

- A tool result whose query did not survive the wire as an object now shows the normal collapsed tool card instead of a red parse error.
- `extractVisualizationArtifact` requires a record, matching the guard `extractQueryResult` already applies.

This is the guard, not the transport fix. #97494 is the structural change: it moves widget data onto app metadata so widgets stop reading the model-facing text at all. That PR does not touch this line, so the guard is still worth having after it lands, and it fixes the visible error for threads served by today's transport.

## How did you test this code?

Extended the existing `it.each` malformed-output block in `extractors.test.ts` with the real server shape — a TOON body carrying inline JSON under `query`. It catches a regression no existing case catches: the file's current TOON case uses a well-formed TOON object, which the server never emits. Without the guard that case returns an artifact whose `query` is the string `"{"`; with it, null.

Ran `extractors.test.ts` locally (36 tests). Lint and format are clean.

No browser QA was run.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude) from a screenshot of the error in a live thread. The exact V8 message was reproduced end to end by running the server's `formatResponse` and the frontend's TOON decode over a real insight payload, which showed the decoded `query` as `"{"` and `JSON.parse("{")` producing the reported text.

Skills invoked: none of the repo skills are loaded in this environment; the PR template and the repo's testing and PR-description guidance were read from the repo directly.

Duplicate search: `gh pr list --state open --search` found #97494, which reworks the same area from the transport side. This PR is deliberately narrow and does not overlap its diff.

The originating report is a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1789040133811759?thread_ts=1789040133.811759&cid=C0ACRAMJUAG). Nothing from it is quoted or carried into the diff; the test fixture is invented.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1789040133811759?thread_ts=1789040133.811759&cid=C0ACRAMJUAG)*
