### PR TITLE
feat(experiments): classify byte-capped canary direct scans as uncheckable

### DIFF
--- a/products/experiments/backend/temporal/canary_logic.py
+++ b/products/experiments/backend/temporal/canary_logic.py
@@ -21,7 +21,7 @@ The bug class this guards (multi-node ClickHouse read-your-writes, see
 Runbook:
 
 - Outcomes land in Prometheus via the pushgateway (job ``experiment_precompute_canary``):
-  ``experiment_precompute_canary_outcomes{outcome=pass|divergence|path_flip|error|skipped}``,
+  ``experiment_precompute_canary_outcomes{outcome=pass|divergence|path_flip|uncheckable|error|skipped}``,
   ``experiment_precompute_canary_max_deviation{check=stability|correctness}``, and
   ``experiment_precompute_canary_last_run_timestamp``. Suggested alerts:
   ``outcomes{outcome="divergence"} > 0`` (experiment results unstable between refreshes or cache content
@@ -51,6 +51,7 @@ from prometheus_client import Gauge
 from posthog.schema import ExperimentQuery, PrecomputationMode
 
 from posthog.clickhouse.query_tagging import tags_context
+from posthog.errors import CHQueryErrorTooManyBytes
 from posthog.metrics import pushed_metrics_registry
 from posthog.models.scoping import team_scope
 
@@ -71,6 +72,7 @@ from products.experiments.backend.temporal.models import (
     OUTCOME_PASS,
     OUTCOME_PATH_FLIP,
     OUTCOME_SKIPPED,
+    OUTCOME_UNCHECKABLE,
     CanaryMetricResult,
     CanaryMetricTarget,
     CanaryOutcome,
@@ -276,11 +278,13 @@ def _stability_violated(metric_type: str, run_a: CanaryRunSnapshot, run_b: Canar
 
 
 def evaluate_canary_runs(
-    metric_type: str, run_a: CanaryRunSnapshot, run_b: CanaryRunSnapshot, run_c: CanaryRunSnapshot
+    metric_type: str, run_a: CanaryRunSnapshot, run_b: CanaryRunSnapshot, run_c: CanaryRunSnapshot | None
 ) -> CanaryVerdict:
-    """Compare the three runs: A↔B is the stability check, B↔C the correctness check (B is adjacent in
-    time to C, minimizing live-ingestion drift)."""
-    runs = (run_a, run_b, run_c)
+    """Compare the runs: A↔B is the stability check, B↔C the correctness check (B is adjacent in
+    time to C, minimizing live-ingestion drift). run_c is None when the direct scan cannot execute
+    under the per-query byte cap: stability is still checked, and a clean pair verdicts as
+    uncheckable rather than pass because correctness stays unverified."""
+    runs = tuple(run for run in (run_a, run_b, run_c) if run is not None)
     if any(not run.variants for run in runs):
         return CanaryVerdict(outcome=OUTCOME_SKIPPED, detail="empty results (no exposures yet)")
 
@@ -304,8 +308,21 @@ def evaluate_canary_runs(
         )
 
     stability_deviation = _max_deviation(run_a, run_b)
+    stability_broken = _stability_violated(metric_type, run_a, run_b)
+
+    if run_c is None:
+        return CanaryVerdict(
+            outcome=OUTCOME_DIVERGENCE if stability_broken else OUTCOME_UNCHECKABLE,
+            stability_deviation=stability_deviation,
+            detail=(
+                "deviation beyond tolerance"
+                if stability_broken
+                else "direct scan exceeds the byte cap; correctness not checked"
+            ),
+        )
+
     correctness_deviation = _max_deviation(run_b, run_c, min_sum_delta=MIN_CORRECTNESS_SUM_DELTA)
-    diverged = _stability_violated(metric_type, run_a, run_b) or correctness_deviation > LOOSE_TOLERANCE
+    diverged = stability_broken or correctness_deviation > LOOSE_TOLERANCE
 
     return CanaryVerdict(
         outcome=OUTCOME_DIVERGENCE if diverged else OUTCOME_PASS,
@@ -354,12 +371,26 @@ def _execute_canary_run(
     )
 
 
+def _log_canary_run_failed(target: CanaryMetricTarget, label: str, query_id: str) -> None:
+    logger.warning(
+        "experiment_precompute_canary_run_failed",
+        team_id=target.team_id,
+        experiment_id=target.experiment_id,
+        metric_uuid=target.metric_uuid,
+        run_label=label,
+        query_id=query_id,
+        exc_info=True,
+    )
+
+
 def run_metric_canary_sync(target: CanaryMetricTarget) -> CanaryMetricResult:
     """Run one metric three times (precomputed, precomputed, direct) and compare.
 
     Deterministic dead ends (experiment/metric gone, unparseable definition) return a skipped result.
     Query failures raise so Temporal retries the whole triple — the comparisons require runs adjacent in
-    time, so retrying a single run against stale siblings would skew the pair.
+    time, so retrying a single run against stale siblings would skew the pair. One exception: the direct
+    scan hitting the per-query byte cap is deterministic for the data window, so it yields an uncheckable
+    verdict instead of burning another full scan per retry.
     """
     close_old_connections()
 
@@ -391,23 +422,31 @@ def run_metric_canary_sync(target: CanaryMetricTarget) -> CanaryMetricResult:
 
         canary_id = uuid.uuid4().hex[:12]
         runs: list[CanaryRunSnapshot] = []
+        direct_scan_uncheckable = False
         for label, mode in _CANARY_RUNS:
             query_id = f"experiment-canary-{canary_id}-{label}"
             try:
                 runs.append(_execute_canary_run(experiment, metric, mode, label, query_id))
-            except Exception:
-                logger.warning(
-                    "experiment_precompute_canary_run_failed",
+            except CHQueryErrorTooManyBytes:
+                if label != "c":
+                    # A forced-precomputed run that falls back to the direct scan can hit the cap too;
+                    # that failure is what a user's read would see, so it stays an error.
+                    _log_canary_run_failed(target, label, query_id)
+                    raise
+                direct_scan_uncheckable = True
+                logger.info(
+                    "experiment_precompute_canary_direct_scan_uncheckable",
                     team_id=target.team_id,
                     experiment_id=target.experiment_id,
                     metric_uuid=target.metric_uuid,
-                    run_label=label,
                     query_id=query_id,
-                    exc_info=True,
                 )
+            except Exception:
+                _log_canary_run_failed(target, label, query_id)
                 raise
 
-        verdict = evaluate_canary_runs(metric_type, *runs)
+        run_c = None if direct_scan_uncheckable else runs[2]
+        verdict = evaluate_canary_runs(metric_type, runs[0], runs[1], run_c)
         result = CanaryMetricResult(
             target=target,
             outcome=verdict.outcome,

--- a/products/experiments/backend/temporal/models.py
+++ b/products/experiments/backend/temporal/models.py
@@ -4,17 +4,22 @@ from typing import Final, Literal
 # Shared by the workflow definition, the schedule, and the management command.
 CANARY_WORKFLOW_NAME = "experiment-precompute-canary"
 
-CanaryOutcome = Literal["pass", "divergence", "path_flip", "error", "skipped"]
+CanaryOutcome = Literal["pass", "divergence", "path_flip", "uncheckable", "error", "skipped"]
 
 OUTCOME_PASS: Final = "pass"
 OUTCOME_DIVERGENCE: Final = "divergence"
 OUTCOME_PATH_FLIP: Final = "path_flip"
+# The direct-scan ground truth cannot execute under the per-query byte cap, so correctness is
+# unverifiable for this metric. Stability was still checked. Kept separate from "error" so the
+# error gauge only counts unexpected failures.
+OUTCOME_UNCHECKABLE: Final = "uncheckable"
 OUTCOME_ERROR: Final = "error"
 OUTCOME_SKIPPED: Final = "skipped"
 ALL_OUTCOMES: tuple[CanaryOutcome, ...] = (
     OUTCOME_PASS,
     OUTCOME_DIVERGENCE,
     OUTCOME_PATH_FLIP,
+    OUTCOME_UNCHECKABLE,
     OUTCOME_ERROR,
     OUTCOME_SKIPPED,
 )

--- a/products/experiments/backend/temporal/test_canary_logic.py
+++ b/products/experiments/backend/temporal/test_canary_logic.py
@@ -12,6 +12,7 @@ import requests
 from parameterized import parameterized
 
 from posthog.clickhouse.query_tagging import get_query_tags
+from posthog.errors import CHQueryErrorTooManyBytes
 
 from products.experiments.backend.models.experiment import Experiment, ExperimentSavedMetric, ExperimentToSavedMetric
 from products.experiments.backend.models.team_experiments_config import TeamExperimentsConfig
@@ -28,6 +29,7 @@ from products.experiments.backend.temporal.models import (
     OUTCOME_PASS,
     OUTCOME_PATH_FLIP,
     OUTCOME_SKIPPED,
+    OUTCOME_UNCHECKABLE,
     CanaryMetricResult,
     CanaryMetricTarget,
     CanaryOutcome,
@@ -171,6 +173,17 @@ class TestEvaluateCanaryRuns:
     def test_outcomes(self, _name, metric_type, a, b, c, expected):
         verdict = evaluate_canary_runs(metric_type, _snapshot("a", a), _snapshot("b", b), _snapshot("c", c))
         assert verdict.outcome == expected
+
+    @parameterized.expand(
+        [
+            ("stable_pair_is_uncheckable", _BASE, OUTCOME_UNCHECKABLE),
+            ("unstable_pair_still_diverges", {"control": (1005.0, 10000), "test": (1100.0, 10000)}, OUTCOME_DIVERGENCE),
+        ]
+    )
+    def test_missing_direct_run(self, _name, b_variants, expected):
+        verdict = evaluate_canary_runs("funnel", _snapshot("a", _BASE), _snapshot("b", b_variants), None)
+        assert verdict.outcome == expected
+        assert verdict.correctness_deviation is None
 
     def test_path_flip_is_not_divergence(self):
         diverged = {"control": (1300.0, 12000), "test": (1100.0, 10000)}
@@ -450,6 +463,30 @@ class TestRunMetricCanary(BaseTest):
             side_effect=RuntimeError("clickhouse timeout"),
         ):
             with pytest.raises(RuntimeError):
+                run_metric_canary_sync(self._target(experiment, metric["uuid"]))
+
+    def test_direct_scan_byte_cap_is_uncheckable_not_error(self):
+        metric = _funnel_metric()
+        experiment = self._experiment([metric])
+        side_effects = [
+            _snapshot("a", _BASE),
+            _snapshot("b", _BASE),
+            CHQueryErrorTooManyBytes("byte cap", code=307),
+        ]
+        with patch("products.experiments.backend.temporal.canary_logic._execute_canary_run", side_effect=side_effects):
+            result = run_metric_canary_sync(self._target(experiment, metric["uuid"]))
+
+        assert result.outcome == OUTCOME_UNCHECKABLE
+        assert len(result.runs) == 2
+
+    def test_precomputed_run_byte_cap_still_raises(self):
+        metric = _funnel_metric()
+        experiment = self._experiment([metric])
+        with patch(
+            "products.experiments.backend.temporal.canary_logic._execute_canary_run",
+            side_effect=CHQueryErrorTooManyBytes("byte cap", code=307),
+        ):
+            with pytest.raises(CHQueryErrorTooManyBytes):
                 run_metric_canary_sync(self._target(experiment, metric["uuid"]))
 
 


### PR DESCRIPTION
## Problem

The canary checks each sampled metric by running it three times: twice through the precomputed path (runs a and b), once as a direct events scan (run c). The direct scan is the ground truth for correctness.

One heavy team's direct scans always blow the 5 TiB per-query read cap. Every night this shows up as canary errors, and the Temporal retry burns a second 5 TiB scan for nothing. The failure is deterministic, so this repeats forever and makes the error count too noisy to alert on.

## Changes

- When run c hits the byte cap, the metric now gets a new outcome, `uncheckable`, instead of `error`. No retry.
- Runs a and b are still compared. If they disagree, the metric still reports `divergence`.
- A byte cap on run a or b still raises. That case means a precomputed read fell back to a direct scan and died, which is what a real user would hit, so it stays loud.

Why not `skipped`: skipped means there was nothing to check. Uncheckable means we cannot verify correctness at this team's data volume. That gap is worth seeing on the dashboard, since heavy teams are exactly where precompute matters most.

The Prometheus gauge and the Slack summary pick up the new outcome automatically. A new info log (`experiment_precompute_canary_direct_scan_uncheckable`) has the per-metric trail.

## How did you test this code?

New cases in test_canary_logic.py: a c-leg byte cap gives `uncheckable`, an unstable a/b pair still gives `divergence`, and an a-leg byte cap still raises.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: internal monitoring job.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code in Juraj's session, after a Metabase system.query_log drill-down showed 4 days of canary failures were all byte-cap 307s. Skills invoked: /wt, /querying-production-databases-via-metabase, /writing-tests, /writing-code-comments, /writing-pr-descriptions. No customer names in this PR; team-level figures come from internal query logs.