### PR TITLE
fix(replay-vision): link Slack alerts to observations

### DIFF
--- a/products/replay_vision/backend/alert_destinations.py
+++ b/products/replay_vision/backend/alert_destinations.py
@@ -128,8 +128,8 @@ EVENT_KIND_CONFIG: dict[EventKind, EventKindSpec] = {
         display_kind="match",
         header="🔔 {event.properties.matched_count} new matching observations for '{event.properties.alert_name}'",
         details=(("Matches", "{event.properties.summary}"),),
-        primary_action_url=_OBSERVATIONS_URL,
-        primary_action_label="View observations",
+        primary_action_url="{project.url}/replay-vision/observations/{event.properties.observation_ids[1]}",
+        primary_action_label="View observation",
         webhook_body={
             "id": "{event.uuid}",
             "type": "replay_vision_alert.match",

--- a/products/replay_vision/backend/tests/test_alert_destinations.py
+++ b/products/replay_vision/backend/tests/test_alert_destinations.py
@@ -1,0 +1,9 @@
+from products.alerts.backend.destination_configs import slack_blocks
+from products.replay_vision.backend.alert_destinations import EVENT_KIND_CONFIG
+
+
+def test_match_action_links_to_the_first_observation() -> None:
+    action = slack_blocks(EVENT_KIND_CONFIG["match"], ())[-1]["elements"][0]
+
+    assert action["url"] == "{project.url}/replay-vision/observations/{event.properties.observation_ids[1]}"
+    assert action["text"]["text"] == "View observation"


### PR DESCRIPTION
## Problem

Replay Vision match notifications send their Slack button to the scanner observation list. The recipient then has to find the observation that caused the notification.

## Changes

- Point the match notification action at the first triggering observation from observation_ids.
- Rename the button from View observations to View observation.
- Add a focused test of the generated Slack action.

Hog arrays are one-indexed, so observation_ids[1] selects the first match.

This intentionally changes only the source configuration. Existing destinations persist their generated Slack blocks and must be recreated or updated separately through the supported destination configuration flow.

## How did you test this code?

- Targeted Replay Vision destination test: 1 passed.
- Ruff format and lint checks on both changed files.
- Mypy on the changed production module.
- git diff --check.

Not run: delivery through a real Slack workspace.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No user-facing documentation describes this Slack button.

## 🤖 Agent context

**Autonomy:** Human-driven, agent-assisted

- Implemented with Codex after a user report.
- Skills invoked: investigate, task, pr, and simplify.
- Two fresh simplify reviews reduced the final production diff to two replacements and found no material issue.
- Open PR search found no duplicate. PR #98198 also touches match notifications but restores prose in their summary; this PR fixes the action target.
- No customer data or identifiers are included in this change or description.