### PR TITLE
feat(alerts): probe postgres before the delivery handoff

### DIFF
--- a/docs/internal/alerts-product-temporal.md
+++ b/docs/internal/alerts-product-temporal.md
@@ -35,13 +35,48 @@ docker exec posthog-temporal-admin-tools-1 \
 The empty `--input '{}'` becomes the empty `AlertsProductInputs`.
 Watch the evaluation run and its delivery child in the Temporal UI at <http://localhost:8081>.
 
-Both workflows accept an empty `AlertsProductInputs` dataclass and run an empty activity with no I/O.
-Each activity has a 10-second start-to-close timeout, a 30-second schedule-to-close timeout, and at most three attempts.
+Both workflows accept an empty `AlertsProductInputs` dataclass.
+Evaluation runs a Postgres connectivity probe; delivery runs an empty activity with no I/O.
+Each activity has a 10-second start-to-close timeout and a 30-second schedule-to-close timeout.
+Evaluation has one attempt; delivery retains at most three attempts.
 Evaluation starts one delivery child on the delivery queue and waits for confirmation that it started, without waiting for completion.
 The child ID includes the evaluation run ID, so repeated runs of the same evaluation workflow ID start different children.
 `ParentClosePolicy.ABANDON` lets delivery continue after evaluation closes.
 Delivery has a one-minute execution timeout for the noop.
 Real notification delivery guarantees remain undecided.
+
+## Postgres connectivity probe
+
+Each evaluation activity issues one explicit `SELECT 1` and checks for `(1,)` through Django's `default` main writer connection.
+It inherits runtime credentials and connection/pooler settings without overrides, new aliases, or a separate pool.
+It does not use replicas, persons services, or application tables.
+One probe per tick means one intended activity attempt, not exactly-once SQL execution.
+Connection setup and transaction control can issue additional statements.
+
+The probe uses `execute_with_timeout(1000, database="default")` for a one-second transaction-local statement timeout.
+The transaction commits on success and rolls back on failure, so the timeout does not persist on pooled connections.
+Connection acquisition, SQL, and force-close cleanup run in the same executor thread, outside the default thread-sensitive executor.
+`close_db_connections` closes initialized connections without a cleanup health-check query after failure.
+
+Django `OperationalError` and `InterfaceError` become a sanitized `AlertsProductPostgresProbeFailure` activity failure.
+Evaluation starts delivery after that failure or an activity start-to-close/schedule-to-close timeout.
+Cancellation and unrelated errors propagate without starting delivery.
+This handoff requires the parent and its worker to remain available; termination before child startup is not covered.
+
+A successful evaluation workflow does not prove that the database probe succeeded.
+Activity success/failure logs and attempt duration remain separate from delivery outcomes; #97445 owns lifecycle telemetry.
+Activity duration includes executor wait, connection setup, transaction work, and cleanup, not just SQL execution.
+On activity timeout, the replay-safe workflow log records an unknown database outcome and continuation to delivery, without a completed query duration.
+A late activity completion does not replace that timeout observation.
+
+The SQL timeout does not cover connection acquisition or pooler waiting.
+Temporal's activity bounds limit the workflow's wait, but timeout or cancellation cannot kill a running database thread or guarantee SQL has stopped.
+Cleanup runs when that thread finishes; this probe does not change connection defaults or add a watchdog.
+
+Before production rollout, deployment owners must verify the runtime database identity and main writer route in dev using the deployment's credentials.
+Verify a successful probe, statement timeout and transaction reset through the configured pooler, and delivery continuation after failure or timeout.
+`SELECT 1` alone does not verify the intended database identity, application grants, schema, or write readiness.
+These tests do not replace deployment verification.
 
 This registration does not create schedules or deploy workers.
 Schedule registration will set the evaluation workflow's 50-second execution timeout separately.

--- a/products/alerts/backend/temporal/postgres.py
+++ b/products/alerts/backend/temporal/postgres.py
@@ -1,0 +1,11 @@
+from posthog.models.utils import execute_with_timeout
+from posthog.temporal.common.utils import close_db_connections
+
+
+# Force-close in the database thread to avoid a cleanup health-check query after failure.
+@close_db_connections
+def check_postgres_connection() -> None:
+    with execute_with_timeout(1000, database="default") as cursor:
+        cursor.execute("SELECT 1")
+        if cursor.fetchone() != (1,):
+            raise ValueError("Unexpected Postgres probe result")

--- a/products/alerts/backend/temporal/workflows.py
+++ b/products/alerts/backend/temporal/workflows.py
@@ -2,12 +2,21 @@ import datetime as dt
 
 from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
+from temporalio.exceptions import ActivityError, ApplicationError, TimeoutError, TimeoutType
 
 from posthog.dataclasses import frozen
 from posthog.temporal.common.base import PostHogWorkflow
 
 with workflow.unsafe.imports_passed_through():
     from django.conf import settings
+    from django.db import InterfaceError, OperationalError
+
+    from asgiref.sync import sync_to_async
+
+    from products.alerts.backend.temporal.postgres import check_postgres_connection
+
+
+POSTGRES_PROBE_FAILURE = "AlertsProductPostgresProbeFailure"
 
 
 @frozen
@@ -17,7 +26,10 @@ class AlertsProductInputs:
 
 @activity.defn
 async def alerts_product_check_due_activity() -> None:
-    pass
+    try:
+        await sync_to_async(check_postgres_connection, thread_sensitive=False)()
+    except (OperationalError, InterfaceError):
+        raise ApplicationError("Postgres connectivity probe failed", type=POSTGRES_PROBE_FAILURE) from None
 
 
 @activity.defn
@@ -45,12 +57,23 @@ class AlertsProductCheckDueWorkflow(PostHogWorkflow):
 
     @workflow.run
     async def run(self, inputs: AlertsProductInputs) -> None:
-        await workflow.execute_activity(
-            alerts_product_check_due_activity,
-            start_to_close_timeout=dt.timedelta(seconds=10),
-            schedule_to_close_timeout=dt.timedelta(seconds=30),
-            retry_policy=RetryPolicy(maximum_attempts=3),
-        )
+        try:
+            await workflow.execute_activity(
+                alerts_product_check_due_activity,
+                start_to_close_timeout=dt.timedelta(seconds=10),
+                schedule_to_close_timeout=dt.timedelta(seconds=30),
+                retry_policy=RetryPolicy(maximum_attempts=1),
+            )
+        except ActivityError as error:
+            if isinstance(error.cause, ApplicationError) and error.cause.type == POSTGRES_PROBE_FAILURE:
+                pass
+            elif isinstance(error.cause, TimeoutError) and error.cause.type in (
+                TimeoutType.START_TO_CLOSE,
+                TimeoutType.SCHEDULE_TO_CLOSE,
+            ):
+                workflow.logger.warning("Postgres probe timed out; database outcome unknown; delivery is continuing")
+            else:
+                raise
         # Delivery must outlive the tick, so wait for start confirmation without awaiting the handle.
         await workflow.start_child_workflow(
             AlertsProductDeliverWorkflow.run,

--- a/products/alerts/backend/tests/test_temporal_postgres.py
+++ b/products/alerts/backend/tests/test_temporal_postgres.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from django.db import InterfaceError, OperationalError, ProgrammingError, connections
+from django.test import override_settings
+
+from temporalio.api.failure.v1 import Failure
+from temporalio.converter import DefaultFailureConverter, DefaultPayloadConverter
+from temporalio.exceptions import ApplicationError, CancelledError
+from temporalio.testing import ActivityEnvironment
+
+from products.alerts.backend.temporal import postgres
+from products.alerts.backend.temporal.workflows import POSTGRES_PROBE_FAILURE, alerts_product_check_due_activity
+
+if TYPE_CHECKING:
+    from pytest_django.fixtures import Settings
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        None,
+        OperationalError("sensitive connection details"),
+        InterfaceError("sensitive connection details"),
+        ProgrammingError("unrelated error"),
+        CancelledError(),
+        asyncio.CancelledError(),
+    ],
+)
+async def test_probe_uses_database_thread_and_sanitizes_only_expected_errors(
+    error: BaseException | None, settings: Settings
+) -> None:
+    settings.TEST = False
+    threads: list[int] = []
+    cursor = MagicMock()
+    cursor.fetchone.return_value = (1,)
+    cursor.execute.side_effect = error
+    connection = MagicMock()
+    connection.close.side_effect = lambda: threads.append(threading.get_ident())
+
+    @contextmanager
+    def execute_with_timeout(timeout: int, database: str) -> Iterator[MagicMock]:
+        assert timeout == 1000
+        assert database == "default"
+        threads.append(threading.get_ident())
+        try:
+            yield cursor
+        finally:
+            threads.append(threading.get_ident())
+
+    with (
+        patch.object(postgres, "execute_with_timeout", execute_with_timeout),
+        patch("django.db.connections.all", return_value=[connection]),
+    ):
+        environment = ActivityEnvironment()
+        if error is None:
+            await environment.run(alerts_product_check_due_activity)
+            cursor.fetchone.assert_called_once_with()
+        elif isinstance(error, (OperationalError, InterfaceError)):
+            with pytest.raises(ApplicationError) as caught:
+                await environment.run(alerts_product_check_due_activity)
+            assert caught.value.type == POSTGRES_PROBE_FAILURE
+            failure = Failure()
+            DefaultFailureConverter().to_failure(caught.value, DefaultPayloadConverter(), failure)
+            assert not failure.HasField("cause")
+            assert "sensitive" not in str(failure)
+        else:
+            with pytest.raises(type(error)) as caught_unrelated:
+                await environment.run(alerts_product_check_due_activity)
+            assert caught_unrelated.value is error
+
+    cursor.execute.assert_called_once_with("SELECT 1")
+    assert len(threads) == 4
+    assert len(set(threads)) == 1
+    assert threads[0] != threading.get_ident()
+    assert connection.close.call_count == 2
+    connection.close_if_unusable_or_obsolete.assert_not_called()
+
+
+async def test_probe_cancellation_and_concurrent_activity_cleanup(settings: Settings) -> None:
+    settings.TEST = False
+    entered = asyncio.Event()
+    release = threading.Event()
+    cleaned_up = threading.Event()
+    loop = asyncio.get_running_loop()
+    cursor = MagicMock()
+    cursor.fetchone.return_value = (1,)
+    connection = MagicMock()
+    cleanup_threads: list[int] = []
+
+    def close() -> None:
+        cleanup_threads.append(threading.get_ident())
+        if cleanup_threads.count(cleanup_threads[0]) == 2:
+            cleaned_up.set()
+
+    connection.close.side_effect = close
+
+    @contextmanager
+    def execute_with_timeout(timeout: int, database: str) -> Iterator[MagicMock]:
+        if not entered.is_set():
+            loop.call_soon_threadsafe(entered.set)
+            assert release.wait(timeout=10)
+        yield cursor
+
+    with (
+        patch.object(postgres, "execute_with_timeout", execute_with_timeout),
+        patch("django.db.connections.all", return_value=[connection]),
+    ):
+        task = asyncio.create_task(ActivityEnvironment().run(alerts_product_check_due_activity))
+        try:
+            await asyncio.wait_for(entered.wait(), timeout=5)
+            await asyncio.wait_for(ActivityEnvironment().run(alerts_product_check_due_activity), timeout=5)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            assert not cleaned_up.is_set()
+        finally:
+            release.set()
+            assert await asyncio.to_thread(cleaned_up.wait, 5)
+    assert len(cleanup_threads) == 4
+    assert len(set(cleanup_threads)) == 2
+    assert threading.get_ident() not in cleanup_threads
+
+
+def test_probe_rejects_unexpected_result() -> None:
+    with patch.object(postgres, "execute_with_timeout") as execute:
+        execute.return_value.__enter__.return_value.fetchone.return_value = (0,)
+        with pytest.raises(ValueError, match="Unexpected Postgres probe result"):
+            postgres.check_postgres_connection()
+
+
+@pytest.mark.django_db(transaction=True, databases=["default"], available_apps=[])
+def test_probe_statement_timeout_rolls_back_and_closes_without_leaking() -> None:
+    connection = connections["default"]
+    with connection.cursor() as cursor:
+        cursor.execute("SHOW statement_timeout")
+        original_timeout = cursor.fetchone()
+    statements: list[str] = []
+    close_states: list[tuple[bool, bool]] = []
+    original_close = connection.close
+
+    def close() -> None:
+        close_states.append((connection.in_atomic_block, connection.needs_rollback))
+        if len(close_states) == 2:
+            with connection.cursor() as cursor:
+                cursor.execute("SHOW statement_timeout")
+                assert cursor.fetchone() == original_timeout
+                cursor.execute("SELECT 2")
+                assert cursor.fetchone() == (2,)
+        original_close()
+
+    def slow_probe(
+        execute: Callable[[str, object, bool, dict[str, object]], object],
+        sql: str,
+        params: object,
+        many: bool,
+        context: dict[str, object],
+    ) -> object:
+        statements.append(sql)
+        if sql == "SELECT 1":
+            assert connection.in_atomic_block
+            with connection.cursor() as timeout_cursor:
+                timeout_cursor.execute("SHOW statement_timeout")
+                assert timeout_cursor.fetchone() == ("1s",)
+            return execute("SELECT pg_sleep(2)", None, False, context)
+        return execute(sql, params, many, context)
+
+    with (
+        override_settings(TEST=False),
+        patch.object(connection, "close", close),
+        patch.object(connection, "rollback", wraps=connection.rollback) as rollback,
+    ):
+        with connection.execute_wrapper(slow_probe):
+            with pytest.raises(OperationalError) as caught:
+                postgres.check_postgres_connection()
+            assert getattr(caught.value.__cause__, "sqlstate", None) == "57014"
+        rollback.assert_called_once_with()
+        assert connection.connection is None
+        assert close_states == [(False, False), (False, False)]
+        assert statements.count("SELECT 1") == 1
+        with connection.cursor() as cursor:
+            cursor.execute("SHOW statement_timeout")
+            assert cursor.fetchone() == original_timeout
+            cursor.execute("SELECT 1")
+            assert cursor.fetchone() == (1,)
+        postgres.check_postgres_connection()
+        assert connection.connection is None

--- a/products/alerts/backend/tests/test_temporal_postgres.py
+++ b/products/alerts/backend/tests/test_temporal_postgres.py
@@ -178,10 +178,9 @@ def test_probe_statement_timeout_rolls_back_and_closes_without_leaking() -> None
         patch.object(connection, "close", close),
         patch.object(connection, "rollback", wraps=connection.rollback) as rollback,
     ):
-        with connection.execute_wrapper(slow_probe):
-            with pytest.raises(OperationalError) as caught:
-                postgres.check_postgres_connection()
-            assert getattr(caught.value.__cause__, "sqlstate", None) == "57014"
+        with connection.execute_wrapper(slow_probe), pytest.raises(OperationalError) as caught:
+            postgres.check_postgres_connection()
+        assert getattr(caught.value.__cause__, "sqlstate", None) == "57014"
         rollback.assert_called_once_with()
         assert connection.connection is None
         assert close_states == [(False, False), (False, False)]

--- a/products/alerts/backend/tests/test_temporal_workflows.py
+++ b/products/alerts/backend/tests/test_temporal_workflows.py
@@ -2,12 +2,14 @@ import uuid
 import asyncio
 import logging
 import datetime as dt
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterator
 from typing import Literal
 
 import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from django.conf import settings
+from django.db import OperationalError
 
 import pytest_asyncio
 from opentelemetry import trace
@@ -16,10 +18,17 @@ from temporalio import activity, workflow
 from temporalio.api.enums.v1 import EventType
 from temporalio.client import WorkflowExecutionStatus, WorkflowFailureError
 from temporalio.contrib.opentelemetry import OpenTelemetryPlugin
-from temporalio.exceptions import ApplicationError, TerminatedError
+from temporalio.exceptions import (
+    ActivityError,
+    ApplicationError,
+    CancelledError,
+    TerminatedError,
+    TimeoutError,
+    TimeoutType,
+)
 from temporalio.runtime import MetricBuffer, Runtime, TelemetryConfig
 from temporalio.testing import WorkflowEnvironment
-from temporalio.worker import UnsandboxedWorkflowRunner, Worker
+from temporalio.worker import Replayer, UnsandboxedWorkflowRunner, Worker
 
 from products.alerts.backend.facade.temporal import (
     DELIVERY_ACTIVITIES,
@@ -28,6 +37,7 @@ from products.alerts.backend.facade.temporal import (
     EVALUATION_WORKFLOWS,
     AlertsProductTelemetryInterceptor,
 )
+from products.alerts.backend.temporal import postgres
 from products.alerts.backend.temporal.workflows import AlertsProductCheckDueWorkflow, AlertsProductInputs
 
 
@@ -58,14 +68,27 @@ async def environment(
         yield env
 
 
+@pytest.fixture(autouse=True)
+def postgres_cursor() -> Iterator[MagicMock]:
+    with patch.object(postgres, "execute_with_timeout") as execute:
+        cursor = execute.return_value.__enter__.return_value
+        cursor.fetchone.return_value = (1,)
+        yield cursor
+
+
 @pytest.mark.asyncio
+@pytest.mark.parametrize("database_error", [False, True])
 async def test_each_tick_starts_independent_delivery(
     environment: WorkflowEnvironment,
     caplog: pytest.LogCaptureFixture,
     sdk_metrics: MetricBuffer,
     span_exporter: InMemorySpanExporter,
     activity_logs,
+    postgres_cursor: MagicMock,
+    database_error: bool,
 ) -> None:
+    if database_error:
+        postgres_cursor.execute.side_effect = OperationalError("sensitive connection details")
     caplog.set_level(logging.INFO, logger="temporalio.activity")
     caplog.set_level(logging.INFO, logger="temporalio.workflow")
     client = environment.client
@@ -97,6 +120,18 @@ async def test_each_tick_starts_independent_delivery(
             )
             assert await parent.result() is None
             history = await parent.fetch_history()
+            scheduled = [
+                event.activity_task_scheduled_event_attributes
+                for event in history.events
+                if event.event_type == EventType.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED
+            ]
+            assert len(scheduled) == 1
+            assert scheduled[0].retry_policy.maximum_attempts == 1
+            failures = [
+                event for event in history.events if event.event_type == EventType.EVENT_TYPE_ACTIVITY_TASK_FAILED
+            ]
+            assert len(failures) == int(database_error)
+            assert "sensitive" not in str(history)
             children = [
                 event.child_workflow_execution_started_event_attributes
                 for event in history.events
@@ -108,11 +143,13 @@ async def test_each_tick_starts_independent_delivery(
             assert parent.first_execution_run_id in child_id
             assert children[0].workflow_type.name == "alerts-product-deliver"
             child_ids.add(child_id)
-            child = await client.get_workflow_handle(child_id).describe()
-            assert child.task_queue == settings.ALERTS_PRODUCT_DELIVERY_TASK_QUEUE
-            assert child.status == WorkflowExecutionStatus.RUNNING
+            child_description = await client.get_workflow_handle(child_id).describe()
+            assert child_description.task_queue == settings.ALERTS_PRODUCT_DELIVERY_TASK_QUEUE
+            assert child_description.status == WorkflowExecutionStatus.RUNNING
 
     assert len(child_ids) == 2
+    assert postgres_cursor.execute.call_count == 2
+    assert "sensitive" not in caplog.text
     async with Worker(
         client,
         task_queue=settings.ALERTS_PRODUCT_DELIVERY_TASK_QUEUE,
@@ -122,7 +159,16 @@ async def test_each_tick_starts_independent_delivery(
         workflow_runner=UnsandboxedWorkflowRunner(),
     ):
         for child_id in child_ids:
-            assert await client.get_workflow_handle(child_id).result() is None
+            child = client.get_workflow_handle(child_id)
+            assert await child.result() is None
+            history = await child.fetch_history()
+            scheduled = [
+                event.activity_task_scheduled_event_attributes
+                for event in history.events
+                if event.event_type == EventType.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED
+            ]
+            assert len(scheduled) == 1
+            assert scheduled[0].retry_policy.maximum_attempts == 3
 
     updates = sdk_metrics.retrieve_updates()
     for metric_name in ("temporal_activity_schedule_to_start_latency", "temporal_activity_execution_latency"):
@@ -178,7 +224,10 @@ async def test_each_tick_starts_independent_delivery(
         assert entries[0]["attempt"] == entries[1]["attempt"]
         assert entries[1]["outcome"] == (
             "failure"
-            if attempt_span.name == "RunActivity:alerts_product_deliver_activity" and entries[1]["attempt"] == 1
+            if (
+                (attempt_span.name == "RunActivity:alerts_product_deliver_activity" and entries[1]["attempt"] == 1)
+                or (attempt_span.name == "RunActivity:alerts_product_check_due_activity" and database_error)
+            )
             else "success"
         )
     assert "sensitive" not in str(activity_logs)
@@ -231,3 +280,94 @@ async def test_delivery_survives_parent_closure(
         workflow_runner=UnsandboxedWorkflowRunner(),
     ):
         assert await child.result() is None
+
+
+@pytest.mark.parametrize("timeout_type", [TimeoutType.START_TO_CLOSE, TimeoutType.SCHEDULE_TO_CLOSE])
+async def test_probe_timeout_still_starts_independent_delivery(
+    environment: WorkflowEnvironment, caplog: pytest.LogCaptureFixture, timeout_type: TimeoutType
+) -> None:
+    caplog.set_level(logging.WARNING, logger="temporalio.workflow")
+
+    @activity.defn(name="alerts_product_check_due_activity")
+    async def blocked_probe() -> None:
+        await asyncio.Event().wait()
+
+    client = environment.client
+    async with Worker(
+        client,
+        task_queue=settings.ALERTS_PRODUCT_EVALUATION_TASK_QUEUE,
+        workflows=EVALUATION_WORKFLOWS,
+        activities=[blocked_probe] if timeout_type == TimeoutType.START_TO_CLOSE else [],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+    ):
+        parent = await client.start_workflow(
+            AlertsProductCheckDueWorkflow.run,
+            AlertsProductInputs(),
+            id=str(uuid.uuid4()),
+            task_queue=settings.ALERTS_PRODUCT_EVALUATION_TASK_QUEUE,
+            execution_timeout=dt.timedelta(seconds=50),
+        )
+        await parent.result()
+        history = await parent.fetch_history()
+        timeouts = [
+            event.activity_task_timed_out_event_attributes
+            for event in history.events
+            if event.event_type == EventType.EVENT_TYPE_ACTIVITY_TASK_TIMED_OUT
+        ]
+        assert len(timeouts) == 1
+        assert timeouts[0].failure.timeout_failure_info.timeout_type == int(timeout_type)
+        child = client.get_workflow_handle(f"alerts-product-deliver-{parent.first_execution_run_id}")
+        assert (await child.describe()).status == WorkflowExecutionStatus.RUNNING
+
+    observation = "Postgres probe timed out; database outcome unknown; delivery is continuing"
+    assert caplog.text.count(observation) == 1
+    await Replayer(workflows=EVALUATION_WORKFLOWS, workflow_runner=UnsandboxedWorkflowRunner()).replay_workflow(history)
+    assert caplog.text.count(observation) == 1
+    async with Worker(
+        client,
+        task_queue=settings.ALERTS_PRODUCT_DELIVERY_TASK_QUEUE,
+        workflows=DELIVERY_WORKFLOWS,
+        activities=DELIVERY_ACTIVITIES,
+        workflow_runner=UnsandboxedWorkflowRunner(),
+    ):
+        assert await child.result() is None
+
+
+@pytest.mark.parametrize(
+    "cause",
+    [
+        ApplicationError("Unrelated failure", type="OtherFailure"),
+        CancelledError(),
+        TimeoutError("Heartbeat timeout", type=TimeoutType.HEARTBEAT, last_heartbeat_details=[]),
+        TimeoutError("Schedule-to-start timeout", type=TimeoutType.SCHEDULE_TO_START, last_heartbeat_details=[]),
+    ],
+)
+async def test_probe_unrelated_activity_failures_do_not_start_delivery(cause: Exception) -> None:
+    error = ActivityError(
+        "Activity failed",
+        scheduled_event_id=1,
+        started_event_id=2,
+        identity="test-worker",
+        activity_type="alerts_product_check_due_activity",
+        activity_id="1",
+        retry_state=None,
+    )
+    error.__cause__ = cause
+    with (
+        patch.object(workflow, "execute_activity", AsyncMock(side_effect=error)),
+        patch.object(workflow, "start_child_workflow", AsyncMock()) as start_delivery,
+    ):
+        with pytest.raises(ActivityError) as caught:
+            await AlertsProductCheckDueWorkflow().run(AlertsProductInputs())
+        assert caught.value is error
+        start_delivery.assert_not_awaited()
+
+
+async def test_probe_workflow_cancellation_does_not_start_delivery() -> None:
+    with (
+        patch.object(workflow, "execute_activity", AsyncMock(side_effect=asyncio.CancelledError)),
+        patch.object(workflow, "start_child_workflow", AsyncMock()) as start_delivery,
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await AlertsProductCheckDueWorkflow().run(AlertsProductInputs())
+        start_delivery.assert_not_awaited()

--- a/products/alerts/backend/tests/test_temporal_workflows.py
+++ b/products/alerts/backend/tests/test_temporal_workflows.py
@@ -287,17 +287,19 @@ async def test_probe_timeout_still_starts_independent_delivery(
     environment: WorkflowEnvironment, caplog: pytest.LogCaptureFixture, timeout_type: TimeoutType
 ) -> None:
     caplog.set_level(logging.WARNING, logger="temporalio.workflow")
+    activity_started = asyncio.Event()
+    release_activity = asyncio.Event()
 
     @activity.defn(name="alerts_product_check_due_activity")
     async def blocked_probe() -> None:
-        await asyncio.Event().wait()
+        activity_started.set()
+        await release_activity.wait()
 
     client = environment.client
     async with Worker(
         client,
         task_queue=settings.ALERTS_PRODUCT_EVALUATION_TASK_QUEUE,
         workflows=EVALUATION_WORKFLOWS,
-        activities=[blocked_probe] if timeout_type == TimeoutType.START_TO_CLOSE else [],
         workflow_runner=UnsandboxedWorkflowRunner(),
     ):
         parent = await client.start_workflow(
@@ -307,7 +309,25 @@ async def test_probe_timeout_still_starts_independent_delivery(
             task_queue=settings.ALERTS_PRODUCT_EVALUATION_TASK_QUEUE,
             execution_timeout=dt.timedelta(seconds=50),
         )
-        await parent.result()
+        async with asyncio.timeout(10):
+            while not any(
+                event.event_type == EventType.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED
+                for event in (await parent.fetch_history()).events
+            ):
+                pass
+        if timeout_type == TimeoutType.SCHEDULE_TO_CLOSE:
+            # Separate the close deadlines instead of racing schedule-to-start at the same deadline.
+            await environment.sleep(25)
+        async with Worker(
+            client,
+            task_queue=settings.ALERTS_PRODUCT_EVALUATION_TASK_QUEUE,
+            activities=[blocked_probe],
+        ):
+            try:
+                await asyncio.wait_for(activity_started.wait(), timeout=5)
+                await parent.result()
+            finally:
+                release_activity.set()
         history = await parent.fetch_history()
         timeouts = [
             event.activity_task_timed_out_event_attributes

--- a/products/alerts/backend/tests/test_temporal_workflows.py
+++ b/products/alerts/backend/tests/test_temporal_workflows.py
@@ -127,10 +127,10 @@ async def test_each_tick_starts_independent_delivery(
             ]
             assert len(scheduled) == 1
             assert scheduled[0].retry_policy.maximum_attempts == 1
-            failures = [
-                event for event in history.events if event.event_type == EventType.EVENT_TYPE_ACTIVITY_TASK_FAILED
-            ]
-            assert len(failures) == int(database_error)
+            failure_count = sum(
+                event.event_type == EventType.EVENT_TYPE_ACTIVITY_TASK_FAILED for event in history.events
+            )
+            assert failure_count == int(database_error)
             assert "sensitive" not in str(history)
             children = [
                 event.child_workflow_execution_started_event_attributes
@@ -376,18 +376,18 @@ async def test_probe_unrelated_activity_failures_do_not_start_delivery(cause: Ex
     with (
         patch.object(workflow, "execute_activity", AsyncMock(side_effect=error)),
         patch.object(workflow, "start_child_workflow", AsyncMock()) as start_delivery,
+        pytest.raises(ActivityError) as caught,
     ):
-        with pytest.raises(ActivityError) as caught:
-            await AlertsProductCheckDueWorkflow().run(AlertsProductInputs())
-        assert caught.value is error
-        start_delivery.assert_not_awaited()
+        await AlertsProductCheckDueWorkflow().run(AlertsProductInputs())
+    assert caught.value is error
+    start_delivery.assert_not_awaited()
 
 
 async def test_probe_workflow_cancellation_does_not_start_delivery() -> None:
     with (
         patch.object(workflow, "execute_activity", AsyncMock(side_effect=asyncio.CancelledError)),
         patch.object(workflow, "start_child_workflow", AsyncMock()) as start_delivery,
+        pytest.raises(asyncio.CancelledError),
     ):
-        with pytest.raises(asyncio.CancelledError):
-            await AlertsProductCheckDueWorkflow().run(AlertsProductInputs())
-        start_delivery.assert_not_awaited()
+        await AlertsProductCheckDueWorkflow().run(AlertsProductInputs())
+    start_delivery.assert_not_awaited()


### PR DESCRIPTION
## Problem

The noop workers can exercise delivery, but operators cannot yet check their main PostgreSQL connection through an evaluation tick.

Closes #97446. Stacked on #98254, which supplies activity telemetry.

## Changes

- Evaluation checks the main database once, using the existing Django connection and a transaction-local SQL timeout.
- Delivery still starts after recognized database failures or activity timeouts; cancellation and unrelated errors propagate.
- Existing connection and pooler settings remain unchanged. A Temporal timeout does not stop an underlying database thread.
- Tests account for failed evaluation alongside successful delivery in the telemetry layer. No UI changes.

Before:
```mermaid
flowchart LR
    T[Tick] --> E[Evaluation noop] --> D[Delivery noop]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    class T phYellow;
    class E,D phBlue;
```

After:
```mermaid
flowchart LR
    T[Tick] --> P[Postgres probe]
    P -->|Success, expected DB failure or timeout| D[Delivery noop]
    P -->|Cancellation or unrelated error| X[Propagate]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    class T,X phYellow;
    class D phBlue;
    class P phRed;
```

## How did you test this code?

- Added coverage for database failure, cancellation, timeout rollback, connection cleanup, and delivery after activity timeouts.
- Recovered a timeout-test fix that separates competing deadlines. Full backend CI is requested to validate the combined stack.
- Local lint, formatting and staged type checks passed. Final full-suite and mypy results remain unverified.
- Not checked: deployed pooler behavior or live database connectivity. Patch coverage awaits CI.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated `docs/internal/alerts-product-temporal.md` with probe behavior, timeout limitations and verification steps.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi worker implemented the public issue; the supervising agent recovered its saved test fix after the worker runtime expired. Tools: repository reads, shell, Git and GitHub CLI. Skills include stacking-prs and writing-pr-descriptions.

The duplicate search found no open connectivity PR. This layer builds on #98254 without modifying its branch. No private infrastructure details or customer data are included.
