### PR TITLE
feat(warehouse_sources): add ActiveCampaign deal activity and contact automation tables

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/COVERAGE_GAPS_APPENDIX.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/COVERAGE_GAPS_APPENDIX.md
@@ -38,7 +38,7 @@ Note: Source uses a static ENDPOINTS list (products/warehouse_sources/backend/te
 
 ## ActiveCampaign — gaps
 
-Today (16): `accounts`, `automations`, `campaigns`, `contacts`, `custom_fields`, `deal_groups`, `deal_stages`, `deals`, `ecom_customers`, `ecom_order_products`, `ecom_orders`, `email_activities`, `forms`, `lists`, `segments`, `tags`
+Today (18): `accounts`, `automations`, `campaigns`, `contact_automations`, `contacts`, `custom_fields`, `deal_activities`, `deal_groups`, `deal_stages`, `deals`, `ecom_customers`, `ecom_order_products`, `ecom_orders`, `email_activities`, `forms`, `lists`, `segments`, `tags`
 
 Diffed against: <https://developers.activecampaign.com/reference/overview>
 
@@ -46,14 +46,21 @@ Diffed against: <https://developers.activecampaign.com/reference/overview>
 - [x] `ecomOrders` — e-commerce revenue transactions; no commerce data is synced at all today (high)
 - [x] `ecomOrderProducts` — order line items needed for product-level revenue breakdowns (high)
 - [x] `ecomCustomers` — resolves the customer IDs carried on ecom orders (high)
-- [ ] `dealActivities (GET /deals/{id}/dealActivities)` — deal stage-transition and change history (high)
+- [x] `dealActivities (GET /dealActivities)` — deal stage-transition and change history (high)
 - [ ] `contactActivities (GET /activities)` — contact-level activity timeline across campaigns and automations (high)
 - [ ] `contactLists (list memberships)` — membership table joining synced contacts to synced lists (high)
-- [ ] `contactAutomations` — membership table joining synced contacts to synced automations, with entry/exit state (high)
+- [x] `contactAutomations` — membership table joining synced contacts to synced automations, with entry/exit state (high)
 - [ ] `accountContacts (account-contact association)` — membership table joining synced accounts to synced contacts (medium)
 - [ ] `users (and groups)` — lookup resolving owner IDs on deals, tasks and notes (medium)
 - [ ] `notes` — free-text CRM notes attached to contacts, deals and accounts (medium)
 - [ ] `tasks (with taskTypes / taskOutcomes)` — sales activity volume plus the lookup tables that decode task type and outcome (medium)
+
+Note: `contactActivities` and `contactLists` are left unticked on purpose. Neither has an
+account-wide collection route in API v3: `GET /activities` documents "A contact ID is required to
+access this endpoint. This endpoint does not support multiple contact IDs with a single call", and
+list memberships are only readable at `GET /contacts/{id}/contactLists`. Both would therefore cost
+one request per contact per sync, which does not finish on a real contact base. Revisit if
+ActiveCampaign adds a collection route.
 
 Note: deal_groups/deal_stages already cover the pipelines and stages lookups. The reference sidebar also exposes campaign messages, campaign link stats, scores, bounce logs, custom object records, conversations, SMS broadcast metrics and the separate e-commerce GraphQL API — all plausible but lower value than the 12 above.
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/active_campaign/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/active_campaign/settings.py
@@ -52,6 +52,12 @@ ACTIVE_CAMPAIGN_ENDPOINTS: dict[str, ActiveCampaignEndpointConfig] = {
         path="/dealGroups",
         data_selector="dealGroups",
     ),
+    "deal_activities": ActiveCampaignEndpointConfig(
+        name="deal_activities",
+        path="/dealActivities",
+        data_selector="dealActivities",
+        partition_key="cdate",
+    ),
     "campaigns": ActiveCampaignEndpointConfig(
         name="campaigns",
         path="/campaigns",
@@ -81,6 +87,15 @@ ACTIVE_CAMPAIGN_ENDPOINTS: dict[str, ActiveCampaignEndpointConfig] = {
         name="automations",
         path="/automations",
         data_selector="automations",
+    ),
+    "contact_automations": ActiveCampaignEndpointConfig(
+        name="contact_automations",
+        path="/contactAutomations",
+        data_selector="contactAutomations",
+        partition_key="adddate",
+        # `adddate` is the only documented sort on this collection that never changes
+        # once a row exists, so it keeps offset pages from shifting mid-sync.
+        extra_params={"orders[adddate]": "ASC"},
     ),
     "custom_fields": ActiveCampaignEndpointConfig(
         name="custom_fields",
@@ -118,4 +133,8 @@ ENDPOINTS = tuple(ACTIVE_CAMPAIGN_ENDPOINTS.keys())
 # (rather than being silently ignored), we ship every endpoint as full refresh per
 # the implementing-warehouse-sources guidance. Enable incremental per endpoint only
 # after confirming the server-side filter against the live API.
+# `contact_automations` documents `filters[adddate]` with comparison operators, but a
+# row keeps changing after it is added (status, remdate, lastdate all move when the
+# contact finishes the automation), so filtering on the entry date would freeze those
+# rows at their first-seen state.
 INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/active_campaign/tests/test_active_campaign.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/active_campaign/tests/test_active_campaign.py
@@ -194,7 +194,9 @@ class TestActiveCampaignSourceResumeBehavior:
         selector = ACTIVE_CAMPAIGN_ENDPOINTS[endpoint].data_selector
         return {selector: items, "meta": {"total": total}}
 
-    @pytest.mark.parametrize("endpoint", ["contacts", "deals", "lists", "campaigns"])
+    @pytest.mark.parametrize(
+        "endpoint", ["contacts", "deals", "lists", "campaigns", "deal_activities", "contact_automations"]
+    )
     def test_fresh_run_saves_offset_after_each_non_terminal_page(self, endpoint: str) -> None:
         manager = MagicMock(spec=ResumableSourceManager)
         manager.can_resume.return_value = False


### PR DESCRIPTION
## Problem

A team that syncs ActiveCampaign can query its deals and its automations, but nothing records how a deal moved through the pipeline or which contacts entered which automation. Deal stage history and automation membership are two of the four high-priority gaps the warehouse source coverage audit recorded for this source.

## Changes

- The ActiveCampaign table picker now offers two more tables: `deal_activities` and `contact_automations`.
- `deal_activities` carries the change history of each deal, including stage transitions and task and note events, from `GET /api/3/dealActivities`.
- `contact_automations` joins synced contacts to synced automations, with the run status and the entry and exit dates, from `GET /api/3/contactAutomations`.
- Both tables sync full refresh through the source's existing offset paginator, so no transport code changed.
- `contact_automations` requests `orders[adddate]=ASC`, the one documented sort on that collection that never moves after a row exists.
- Two endpoints from the audit list stay out. `GET /activities` states "A contact ID is required to access this endpoint. This endpoint does not support multiple contact IDs with a single call", and list memberships are only readable at `GET /contacts/{id}/contactLists`. Neither has an account-wide collection route in API v3, so either table would cost one request per contact per sync and would not finish on a real contact base.
- Mechanical: the coverage appendix ticks the two shipped endpoints and records why the other two stay open.

No UI code changed. The two tables appear as rows in the existing source table picker.

## How did you test this code?

Extended the existing parameterized end-to-end test in `test_active_campaign.py` to drive both new endpoints. It catches a wrong path or a wrong `data_selector`: a selector that does not match the response envelope yields no rows, the paginator stops after the first page, and the offset and saved-state assertions fail. That shape is worth guarding because a bad selector otherwise syncs an empty table with no error.

Ran the source's two test modules locally. Not run: anything against a live ActiveCampaign account, since the sandbox has no credentials. The endpoint paths, response envelopes, pagination and sort parameters come from the vendor reference at <https://developers.activecampaign.com/reference/overview>.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The posthog.com Supported tables section renders from `get_documented_tables()`, so both tables appear there with no doc edit.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude Code in a PostHog cloud task. Skills invoked: `/implementing-warehouse-sources`, `/writing-tests`, `/writing-pr-descriptions`.

The audit listed four endpoints. Each was checked against the vendor reference before any code was written, which is what removed two of them: the audit named `dealActivities` by its per-deal path, but the account-wide collection exists and is the cheaper shape, while the two membership tables have only per-contact routes. Incremental sync was considered for `contact_automations`, whose `filters[adddate]` accepts comparison operators, and rejected because a row keeps changing after the entry date; a settings comment records that.

No duplicate: `gh pr list --state open` searches for the source name and the endpoint names returned nothing, and the maintainer's open PRs hold no ActiveCampaign work.

Public artifact: the change draws only on the vendor's public API reference and this repository.
