### PR TITLE
feat(warehouse_sources): add Amplitude taxonomy tables

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/COVERAGE_GAPS_APPENDIX.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/COVERAGE_GAPS_APPENDIX.md
@@ -273,14 +273,14 @@ Note: Static schema list. The Amazon Ads docs site is a Redocly SPA; the real sp
 
 ## Amplitude — gaps
 
-Today (3): `annotations`, `cohorts`, `events`
+Today (7): `annotations`, `cohorts`, `event_categories`, `event_properties`, `event_types`, `events`, `user_properties`
 
 Diffed against: <https://amplitude.com/docs/apis>
 
-- [ ] `GET /api/2/taxonomy/event` — event type catalog - the lookup that names and describes the event stream already synced (high)
-- [ ] `GET /api/2/taxonomy/event-property` — event property definitions and types, needed to interpret the events table (high)
-- [ ] `GET /api/2/taxonomy/user-property` — user property catalog with types and descriptions (high)
-- [ ] `GET /api/2/taxonomy/category` — event category lookup resolving the category IDs on event types (medium)
+- [x] `GET /api/2/taxonomy/event` — event type catalog - the lookup that names and describes the event stream already synced (high)
+- [x] `GET /api/2/taxonomy/event-property` — event property definitions and types, needed to interpret the events table (high)
+- [x] `GET /api/2/taxonomy/user-property` — user property catalog with types and descriptions (high)
+- [x] `GET /api/2/taxonomy/category` — event category lookup resolving the category IDs on event types (medium)
 - [ ] `GET /api/2/taxonomy/group-property` — group property catalog for account-level analysis (medium)
 - [ ] `GET /api/2/release` — release markers to join against event timestamps, the sibling of the annotations table already synced (medium)
 - [ ] `GET /api/2/audit-logs/{ORG_ID}` — org-level change history for charts, cohorts and permissions (medium)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/amplitude/amplitude.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/amplitude/amplitude.py
@@ -288,7 +288,7 @@ def _get_fanout_rows(
     for parent in parents:
         if not isinstance(parent, dict):
             continue
-        parent_value = parent.get(fanout.field)
+        parent_value = parent.get(fanout.join_field)
         if not isinstance(parent_value, str) or not parent_value:
             continue
 
@@ -301,23 +301,23 @@ def _get_fanout_rows(
                 config.data_selector,
                 config.name,
                 logger,
-                params={fanout.field: parent_value},
+                params={fanout.join_field: parent_value},
             )
         except requests.HTTPError as e:
-            # Amplitude answers 400 "Not found" for a parent it no longer resolves — for example
-            # one deleted between listing the parents and querying it. Skip it rather than
-            # failing the whole catalog.
+            # Amplitude answers 400 "Not found" for an event type deleted between listing the
+            # parents and querying it. Skip that parent instead of failing the whole table.
             if e.response is not None and e.response.status_code == 400:
-                logger.warning(f"Amplitude {config.name}: skipping {fanout.field}={parent_value} (Amplitude returned 400)")
+                logger.warning(
+                    f"Amplitude {config.name}: skipping {fanout.join_field}={parent_value} (Amplitude returned 400)"
+                )
                 continue
             raise
 
         for row in rows:
             if not isinstance(row, dict):
                 continue
-            # Shared properties come back without the parent field, so stamp on the value we
-            # queried with — otherwise part of the primary key is null.
-            row[fanout.field] = parent_value
+            # Amplitude omits this on shared properties, so set it from the value we queried with.
+            row[fanout.join_field] = parent_value
             yield row
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/amplitude/amplitude.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/amplitude/amplitude.py
@@ -223,6 +223,33 @@ def _get_events_rows(
         resumable_source_manager.save_state(AmplitudeResumeConfig(window_start=cursor.isoformat()))
 
 
+def _fetch_list(
+    session: requests.Session,
+    host: str,
+    path: str,
+    headers: dict[str, str],
+    data_selector: str | None,
+    name: str,
+    logger: FilteringBoundLogger,
+    params: Optional[dict[str, str]] = None,
+) -> list[Any]:
+    url = f"{host}{path}"
+    if params:
+        url = f"{url}?{urlencode(params)}"
+
+    response = _get(session, url, headers)
+    if not response.ok:
+        logger.error(f"Amplitude {name} error: status={response.status_code}, body={response.text[:500]}")
+        response.raise_for_status()
+
+    body = response.json()
+    if data_selector is not None and isinstance(body, dict):
+        return body.get(data_selector, [])
+    if isinstance(body, list):
+        return body
+    return []
+
+
 def _get_list_rows(
     api_key: str,
     secret_key: str,
@@ -230,25 +257,68 @@ def _get_list_rows(
     config: AmplitudeEndpointConfig,
     logger: FilteringBoundLogger,
 ) -> Iterator[dict[str, Any]]:
+    session = make_tracked_session()
+    yield from _fetch_list(
+        session,
+        _host(region),
+        config.path,
+        _auth_headers(api_key, secret_key),
+        config.data_selector,
+        config.name,
+        logger,
+    )
+
+
+def _get_fanout_rows(
+    api_key: str,
+    secret_key: str,
+    region: str,
+    config: AmplitudeEndpointConfig,
+    logger: FilteringBoundLogger,
+) -> Iterator[dict[str, Any]]:
+    fanout = config.fanout
+    assert fanout is not None
+
     host = _host(region)
     headers = _auth_headers(api_key, secret_key)
     session = make_tracked_session()
 
-    url = f"{host}{config.path}"
-    response = _get(session, url, headers)
-    if not response.ok:
-        logger.error(f"Amplitude {config.name} error: status={response.status_code}, body={response.text[:500]}")
-        response.raise_for_status()
+    parents = _fetch_list(session, host, fanout.parent_path, headers, fanout.parent_data_selector, config.name, logger)
 
-    body = response.json()
-    if config.data_selector is not None and isinstance(body, dict):
-        items = body.get(config.data_selector, [])
-    elif isinstance(body, list):
-        items = body
-    else:
-        items = []
+    for parent in parents:
+        if not isinstance(parent, dict):
+            continue
+        parent_value = parent.get(fanout.field)
+        if not isinstance(parent_value, str) or not parent_value:
+            continue
 
-    yield from items
+        try:
+            rows = _fetch_list(
+                session,
+                host,
+                config.path,
+                headers,
+                config.data_selector,
+                config.name,
+                logger,
+                params={fanout.field: parent_value},
+            )
+        except requests.HTTPError as e:
+            # Amplitude answers 400 "Not found" for a parent it no longer resolves — for example
+            # one deleted between listing the parents and querying it. Skip it rather than
+            # failing the whole catalog.
+            if e.response is not None and e.response.status_code == 400:
+                logger.warning(f"Amplitude {config.name}: skipping {fanout.field}={parent_value} (Amplitude returned 400)")
+                continue
+            raise
+
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            # Shared properties come back without the parent field, so stamp on the value we
+            # queried with — otherwise part of the primary key is null.
+            row[fanout.field] = parent_value
+            yield row
 
 
 def _get_rows(
@@ -272,6 +342,8 @@ def _get_rows(
             should_use_incremental_field=should_use_incremental_field,
             db_incremental_field_last_value=db_incremental_field_last_value,
         )
+    elif config.fanout is not None:
+        yield from _get_fanout_rows(api_key, secret_key, region, config, logger)
     else:
         yield from _get_list_rows(api_key, secret_key, region, config, logger)
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/amplitude/api_inventory.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/amplitude/api_inventory.md
@@ -31,6 +31,35 @@ So `401`/`403` are permanent auth failures (wired into `get_non_retryable_errors
 - Grain: one annotation. Primary key: `id`. Sync mode: full refresh.
 - Dashboard REST API. Response wrapped in `{"data": [...]}`.
 
+### `event_types` — `/api/2/taxonomy/event`
+
+- Grain: one event type in the tracking plan. Primary key: `event_type`. Sync mode: full refresh.
+- Taxonomy API. Response wrapped in `{"success": true, "data": [...]}`.
+- Hidden events are omitted; deleted ones need `?showDeleted=true`, which we do not pass.
+
+### `event_properties` — `/api/2/taxonomy/event-property`
+
+- Grain: one property definition on one event type. Primary key: `["event_type", "event_property"]`.
+  Sync mode: full refresh.
+- Only lists properties for a single event type at a time, so the table is built by fanning out over
+  `/api/2/taxonomy/event` and querying `?event_type=<name>` per event type. Each child row is stamped
+  with the event type we queried, so the composite key is always populated.
+- A property name is only unique within its event type, which is why the key is composite.
+- Amplitude answers `400` with `"Not found"` for a parent it cannot resolve; those parents are skipped
+  with a warning rather than failing the whole table.
+
+### `user_properties` — `/api/2/taxonomy/user-property`
+
+- Grain: one user property definition. Primary key: `user_property`. Sync mode: full refresh.
+- Taxonomy API. Response wrapped in `{"success": true, "data": [...]}`.
+- Custom group properties appear with a `gp:` prefix.
+
+### `event_categories` — `/api/2/taxonomy/category`
+
+- Grain: one event category. Primary key: `id`. Sync mode: full refresh.
+- Taxonomy API. Response wrapped in `{"success": true, "data": [...]}`.
+- Resolves the `category` object carried on each event type.
+
 ## Incremental design (events)
 
 The Export API's only server-side filter is the `start`/`end` window on **server upload time**, so
@@ -40,10 +69,19 @@ the stored cursor (or a 30-day lookback on first sync) to `now - 2h`, saving the
 resumable state after each window. Re-fetched windows dedupe on `uuid` via merge semantics. Partitioning uses
 the stable `event_time` field.
 
+## Incremental design (taxonomy)
+
+No Taxonomy endpoint documents a timestamp filter, a cursor, or any pagination parameter — each "get all"
+call returns the complete array. So all four taxonomy tables are full refresh, and none advertise an
+incremental field.
+
 ## Unverified (no credentials to curl)
 
 - Exact wrapper keys for `cohorts` (`cohorts`) and `annotations` (`data`) come from the public docs, not a
-  live 200 response. `_get_list_rows` falls back to treating a bare-list body as the row list if the wrapper
+  live 200 response. `_fetch_list` falls back to treating a bare-list body as the row list if the wrapper
   key is absent.
+- Amplitude's Taxonomy docs show `event_type` sent to `/api/2/taxonomy/event-property` as a urlencoded
+  request body on a `GET`, while the single-property examples on the same page use a query string. We send
+  it as a query string.
 - The Export JSON field set (timestamp field names, `uuid` presence) is taken from Amplitude's documented
   export schema. Timestamp normalization tolerates both `%Y-%m-%d %H:%M:%S.%f` and `%Y-%m-%d %H:%M:%S`.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/amplitude/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/amplitude/canonical_descriptions.py
@@ -1,7 +1,8 @@
 """Canonical, documentation-sourced descriptions for Amplitude endpoints and columns.
 
 Sourced from the official Amplitude HTTP API reference (https://amplitude.com/docs/apis), covering the
-Export API (events) and the Dashboard REST APIs (cohorts, annotations). Keyed by the endpoint names in
+Export API (events), the Dashboard REST APIs (cohorts, annotations), and the Taxonomy API (event types,
+event properties, user properties, event categories). Keyed by the endpoint names in
 `settings.py` `AMPLITUDE_ENDPOINTS`, which match the `ExternalDataSchema.name` of a synced Amplitude
 table. Columns absent here fall back to LLM enrichment.
 """
@@ -61,6 +62,62 @@ CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
             "date": "Date the annotation is placed on.",
             "label": "Short label shown for the annotation.",
             "details": "Longer description of the annotation.",
+        },
+    },
+    "event_types": {
+        "description": "An event type in the project's tracking plan, naming and describing one kind of tracked event.",
+        "docs_url": "https://amplitude.com/docs/apis/analytics/taxonomy",
+        "columns": {
+            "event_type": "Name of the event as sent by your instrumentation — joins to `event_type` on the events table.",
+            "display_name": "Human-readable name shown for the event in the Amplitude UI.",
+            "description": "Description of what the event means, from the tracking plan.",
+            "category": "Event category the event belongs to, as an object carrying the category name.",
+            "is_active": "Whether the event is active in the tracking plan.",
+            "is_hidden_from_dropdowns": "Whether the event is hidden from event pickers in the Amplitude UI.",
+            "is_hidden_from_persona_results": "Whether the event is excluded from persona results.",
+            "is_hidden_from_pathfinder": "Whether the event is excluded from Pathfinder charts.",
+            "is_hidden_from_timeline": "Whether the event is excluded from the user timeline.",
+            "tags": "Tags applied to the event in the tracking plan.",
+            "owner": "User who owns the event definition.",
+        },
+    },
+    "event_properties": {
+        "description": "An event property definition from the tracking plan, describing one property carried by an event type.",
+        "docs_url": "https://amplitude.com/docs/apis/analytics/taxonomy",
+        "columns": {
+            "event_type": "Event type the property belongs to — joins to `event_type` on the event_types and events tables.",
+            "event_property": "Name of the property as it appears inside the event's `event_properties`.",
+            "description": "Description of what the property means, from the tracking plan.",
+            "type": "Declared value type of the property (for example string, number, boolean, enum).",
+            "regex": "Regular expression the property value must match, if one is set.",
+            "enum_values": "Allowed values when the property is declared as an enum.",
+            "is_array_type": "Whether the property holds an array of values.",
+            "is_required": "Whether the tracking plan requires the property on this event.",
+            "is_hidden": "Whether the property is hidden from pickers in the Amplitude UI.",
+            "classifications": "Data classification labels applied to the property.",
+        },
+    },
+    "user_properties": {
+        "description": "A user property definition from the tracking plan, describing one property carried on users.",
+        "docs_url": "https://amplitude.com/docs/apis/analytics/taxonomy",
+        "columns": {
+            "user_property": "Name of the property as it appears inside an event's `user_properties`. Custom group properties carry a `gp:` prefix.",
+            "description": "Description of what the property means, from the tracking plan.",
+            "type": "Declared value type of the property (for example string, number, boolean, enum).",
+            "regex": "Regular expression the property value must match, if one is set.",
+            "enum_values": "Allowed values when the property is declared as an enum.",
+            "is_array_type": "Whether the property holds an array of values.",
+            "is_hidden": "Whether the property is hidden from pickers in the Amplitude UI.",
+            "classifications": "Data classification labels applied to the property.",
+            "deleted": "Whether the property has been deleted from the tracking plan.",
+        },
+    },
+    "event_categories": {
+        "description": "An event category in the tracking plan, used to group event types.",
+        "docs_url": "https://amplitude.com/docs/apis/analytics/taxonomy",
+        "columns": {
+            "id": "Unique identifier for the category.",
+            "name": "Name of the category — matches the category name carried on event types.",
         },
     },
 }

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/amplitude/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/amplitude/settings.py
@@ -23,6 +23,21 @@ EVENTS_DEFAULT_LOOKBACK_DAYS = 30
 EVENTS_ENDPOINT = "events"
 COHORTS_ENDPOINT = "cohorts"
 ANNOTATIONS_ENDPOINT = "annotations"
+EVENT_TYPES_ENDPOINT = "event_types"
+EVENT_PROPERTIES_ENDPOINT = "event_properties"
+USER_PROPERTIES_ENDPOINT = "user_properties"
+EVENT_CATEGORIES_ENDPOINT = "event_categories"
+
+TAXONOMY_EVENT_PATH = "/api/2/taxonomy/event"
+
+
+@dataclass
+class AmplitudeFanoutConfig:
+    parent_path: str
+    parent_data_selector: str
+    # Field read off each parent row, sent to the child endpoint as a query param, and stamped
+    # back onto every child row so the composite primary key is always populated.
+    field: str
 
 
 @dataclass
@@ -40,6 +55,9 @@ class AmplitudeEndpointConfig:
     # Must be a STABLE datetime field (never `updated_at`/`last_seen`) so partitions don't
     # rewrite on every sync.
     partition_key: str | None = None
+    # Set when the endpoint only lists rows for one parent at a time, so the catalog is built
+    # by walking a parent endpoint and querying this one per parent row.
+    fanout: AmplitudeFanoutConfig | None = None
 
 
 AMPLITUDE_ENDPOINTS: dict[str, AmplitudeEndpointConfig] = {
@@ -72,6 +90,38 @@ AMPLITUDE_ENDPOINTS: dict[str, AmplitudeEndpointConfig] = {
     ANNOTATIONS_ENDPOINT: AmplitudeEndpointConfig(
         name=ANNOTATIONS_ENDPOINT,
         path="/api/2/annotations",
+        primary_keys=["id"],
+        data_selector="data",
+    ),
+    # Taxonomy API lookups. None of them expose a timestamp filter or a cursor, so they are
+    # full-refresh snapshots of the project's tracking plan.
+    EVENT_TYPES_ENDPOINT: AmplitudeEndpointConfig(
+        name=EVENT_TYPES_ENDPOINT,
+        path=TAXONOMY_EVENT_PATH,
+        primary_keys=["event_type"],
+        data_selector="data",
+    ),
+    EVENT_PROPERTIES_ENDPOINT: AmplitudeEndpointConfig(
+        name=EVENT_PROPERTIES_ENDPOINT,
+        path="/api/2/taxonomy/event-property",
+        # A property name is only unique within its event type, so the event type is part of the key.
+        primary_keys=["event_type", "event_property"],
+        data_selector="data",
+        fanout=AmplitudeFanoutConfig(
+            parent_path=TAXONOMY_EVENT_PATH,
+            parent_data_selector="data",
+            field="event_type",
+        ),
+    ),
+    USER_PROPERTIES_ENDPOINT: AmplitudeEndpointConfig(
+        name=USER_PROPERTIES_ENDPOINT,
+        path="/api/2/taxonomy/user-property",
+        primary_keys=["user_property"],
+        data_selector="data",
+    ),
+    EVENT_CATEGORIES_ENDPOINT: AmplitudeEndpointConfig(
+        name=EVENT_CATEGORIES_ENDPOINT,
+        path="/api/2/taxonomy/category",
         primary_keys=["id"],
         data_selector="data",
     ),

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/amplitude/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/amplitude/settings.py
@@ -1,4 +1,6 @@
-from dataclasses import dataclass, field
+from dataclasses import field
+
+from posthog.dataclasses import frozen
 
 from products.warehouse_sources.backend.types import IncrementalField, IncrementalFieldType
 
@@ -31,16 +33,15 @@ EVENT_CATEGORIES_ENDPOINT = "event_categories"
 TAXONOMY_EVENT_PATH = "/api/2/taxonomy/event"
 
 
-@dataclass
+@frozen
 class AmplitudeFanoutConfig:
     parent_path: str
     parent_data_selector: str
-    # Field read off each parent row, sent to the child endpoint as a query param, and stamped
-    # back onto every child row so the composite primary key is always populated.
-    field: str
+    # Stamped onto every child row, so the composite primary key is never half null.
+    join_field: str
 
 
-@dataclass
+@frozen
 class AmplitudeEndpointConfig:
     name: str
     path: str
@@ -55,8 +56,7 @@ class AmplitudeEndpointConfig:
     # Must be a STABLE datetime field (never `updated_at`/`last_seen`) so partitions don't
     # rewrite on every sync.
     partition_key: str | None = None
-    # Set when the endpoint only lists rows for one parent at a time, so the catalog is built
-    # by walking a parent endpoint and querying this one per parent row.
+    # Set when the endpoint only lists rows for one parent at a time.
     fanout: AmplitudeFanoutConfig | None = None
 
 
@@ -93,8 +93,7 @@ AMPLITUDE_ENDPOINTS: dict[str, AmplitudeEndpointConfig] = {
         primary_keys=["id"],
         data_selector="data",
     ),
-    # Taxonomy API lookups. None of them expose a timestamp filter or a cursor, so they are
-    # full-refresh snapshots of the project's tracking plan.
+    # Taxonomy API lookups. None expose a timestamp filter or a cursor, so all are full refresh.
     EVENT_TYPES_ENDPOINT: AmplitudeEndpointConfig(
         name=EVENT_TYPES_ENDPOINT,
         path=TAXONOMY_EVENT_PATH,
@@ -110,7 +109,7 @@ AMPLITUDE_ENDPOINTS: dict[str, AmplitudeEndpointConfig] = {
         fanout=AmplitudeFanoutConfig(
             parent_path=TAXONOMY_EVENT_PATH,
             parent_data_selector="data",
-            field="event_type",
+            join_field="event_type",
         ),
     ),
     USER_PROPERTIES_ENDPOINT: AmplitudeEndpointConfig(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/amplitude/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/amplitude/source.py
@@ -128,7 +128,7 @@ class AmplitudeSource(ResumableSource[AmplitudeSourceConfig, AmplitudeResumeConf
             caption=(
                 "Connect Amplitude with your project's **API key** and **secret key**, found in Amplitude under "
                 "**Settings → Organization settings → Projects**. These authenticate the Export API (raw events), "
-                "the Cohorts API, and the Annotations API.\n\n"
+                "the Cohorts API, the Annotations API, and the Taxonomy API (event and property definitions).\n\n"
                 "The events stream uses Amplitude's Export API, which enforces a ~2 hour data latency and only "
                 "syncs the last 30 days on the initial sync."
             ),

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/amplitude/tests/test_amplitude.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/amplitude/tests/test_amplitude.py
@@ -18,6 +18,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.amplitude.
     _auth_headers,
     _coerce_datetime,
     _get_events_rows,
+    _get_fanout_rows,
     _get_list_rows,
     _iter_export_window,
     _normalize_event,
@@ -29,6 +30,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.amplitude.
     AMPLITUDE_ENDPOINTS,
     ANNOTATIONS_ENDPOINT,
     COHORTS_ENDPOINT,
+    EVENT_PROPERTIES_ENDPOINT,
     EVENTS_ENDPOINT,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
@@ -340,6 +342,72 @@ class TestListRows:
             rows = list(_get_list_rows("key", "secret", "us", config, mock.MagicMock()))
 
         assert [row["id"] for row in rows] == [7]
+
+
+class TestFanoutRows:
+    config = AMPLITUDE_ENDPOINTS[EVENT_PROPERTIES_ENDPOINT]
+
+    def _run(self, responses: list[mock.MagicMock]) -> tuple[list[dict[str, Any]], list[str]]:
+        urls: list[str] = []
+
+        def get(url: str, **kwargs: Any) -> mock.MagicMock:
+            urls.append(url)
+            return responses[len(urls) - 1]
+
+        with mock.patch(f"{MODULE}.make_tracked_session") as make_session:
+            make_session.return_value.get.side_effect = get
+            rows = list(_get_fanout_rows("key", "secret", "us", self.config, mock.MagicMock()))
+
+        return rows, urls
+
+    def test_queries_each_event_type_and_stamps_it_onto_child_rows(self) -> None:
+        parents = _response(
+            status=200,
+            json_body={
+                "success": True,
+                "data": [
+                    {"event_type": "Play Song"},
+                    {"event_type": "Onboard Start"},
+                    # A parent with no usable name must not be queried, or we would stamp a null
+                    # into half of the composite primary key.
+                    {"category": {"name": "Attribution"}},
+                ],
+            },
+        )
+        # Amplitude omits `event_type` on shared properties, so the fan-out has to supply it.
+        song_props = _response(status=200, json_body={"success": True, "data": [{"event_property": "genre"}]})
+        onboard_props = _response(status=200, json_body={"success": True, "data": [{"event_property": "step"}]})
+
+        rows, urls = self._run([parents, song_props, onboard_props])
+
+        assert [(row["event_type"], row["event_property"]) for row in rows] == [
+            ("Play Song", "genre"),
+            ("Onboard Start", "step"),
+        ]
+        assert len(urls) == 3
+        assert urls[0].endswith("/api/2/taxonomy/event")
+        assert "/api/2/taxonomy/event-property?event_type=Play+Song" in urls[1]
+        assert "/api/2/taxonomy/event-property?event_type=Onboard+Start" in urls[2]
+
+    def test_400_on_one_event_type_skips_it_and_keeps_going(self) -> None:
+        parents = _response(
+            status=200, json_body={"data": [{"event_type": "Deleted Event"}, {"event_type": "Play Song"}]}
+        )
+        not_found = _response(status=400, text='{"success": false, "errors": [{"message": "Not found"}]}')
+        not_found.raise_for_status.side_effect = requests.HTTPError(response=not_found)
+        song_props = _response(status=200, json_body={"data": [{"event_property": "genre"}]})
+
+        rows, _urls = self._run([parents, not_found, song_props])
+
+        assert [row["event_type"] for row in rows] == ["Play Song"]
+
+    def test_other_http_errors_propagate(self) -> None:
+        parents = _response(status=200, json_body={"data": [{"event_type": "Play Song"}]})
+        forbidden = _response(status=403, text="Forbidden")
+        forbidden.raise_for_status.side_effect = requests.HTTPError(response=forbidden)
+
+        with pytest.raises(requests.HTTPError):
+            self._run([parents, forbidden])
 
 
 class TestAmplitudeSourceResponse:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/amplitude/tests/test_amplitude.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/amplitude/tests/test_amplitude.py
@@ -368,8 +368,7 @@ class TestFanoutRows:
                 "data": [
                     {"event_type": "Play Song"},
                     {"event_type": "Onboard Start"},
-                    # A parent with no usable name must not be queried, or we would stamp a null
-                    # into half of the composite primary key.
+                    # A parent with no usable name must not be queried.
                     {"category": {"name": "Attribution"}},
                 ],
             },

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/amplitude/tests/test_amplitude_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/amplitude/tests/test_amplitude_source.py
@@ -8,7 +8,11 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.amplitude.
     ANNOTATIONS_ENDPOINT,
     COHORTS_ENDPOINT,
     ENDPOINTS,
+    EVENT_CATEGORIES_ENDPOINT,
+    EVENT_PROPERTIES_ENDPOINT,
+    EVENT_TYPES_ENDPOINT,
     EVENTS_ENDPOINT,
+    USER_PROPERTIES_ENDPOINT,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.amplitude.source import AmplitudeSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
@@ -17,7 +21,14 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.generated_
     AmplitudeSourceConfig,
 )
 
-FULL_REFRESH_ENDPOINTS = [COHORTS_ENDPOINT, ANNOTATIONS_ENDPOINT]
+FULL_REFRESH_ENDPOINTS = [
+    COHORTS_ENDPOINT,
+    ANNOTATIONS_ENDPOINT,
+    EVENT_TYPES_ENDPOINT,
+    EVENT_PROPERTIES_ENDPOINT,
+    USER_PROPERTIES_ENDPOINT,
+    EVENT_CATEGORIES_ENDPOINT,
+]
 
 
 class TestAmplitudeSource:


### PR DESCRIPTION
## Problem

A team syncing Amplitude gets raw events but no way to read them. The `events` table carries bare `event_type` strings and opaque `event_properties` / `user_properties` blobs, with nothing that says what any of them mean.

Amplitude's Taxonomy API holds exactly that: the tracking plan, with descriptions, declared types, enum values and categories. The source never wired it up.

## Changes

- Amplitude users can now sync four lookup tables and join them to the events they already have: `event_types`, `event_properties`, `user_properties` and `event_categories`.
- `event_types` joins to `events.event_type` and carries the display name, description, category and tracking-plan flags.
- `event_properties` explains each property on an event: declared type, enum values, regex, whether it is required.
- All four are full refresh. No Taxonomy endpoint documents a timestamp filter, a cursor, or any pagination parameter, so there is nothing to sync incrementally against.
- `event_properties` fans out over `/api/2/taxonomy/event` and queries `/api/2/taxonomy/event-property?event_type=...` per event type. Amplitude only lists properties for one event type at a time, so the unfiltered call returns just the tracking plan's shared set, not the catalog a person needs.
- The fan-out stamps the queried event type onto every child row. Amplitude omits `event_type` on shared properties, and the composite primary key `(event_type, event_property)` must never be half null. A property name is only unique inside its event type, so the key has to be composite.
- The fan-out skips a parent that answers `400 Not found`, an event type deleted between listing and querying, and logs it rather than failing the whole table.
- Mechanical: `_get_list_rows` splits into a reusable `_fetch_list` that takes query params, the connect-form caption names the Taxonomy API, and `canonical_descriptions.py` plus `api_inventory.md` gain entries for the new tables.

No endpoints were skipped. All four exist on the API version this source calls, and each was checked against <https://amplitude.com/docs/apis/analytics/taxonomy> before building.

## How did you test this code?

The Amplitude source tests and the shared `sources/tests` suite pass locally, and `mypy --cache-fine-grained` reports no issues on the source package. Not run: anything against a live Amplitude project, because this sandbox holds no Amplitude credentials. Endpoint paths, wrapper keys and the `event_type` parameter semantics come from the vendor docs, not from a 200 response, which `api_inventory.md` records under "Unverified".

New tests all sit on the fan-out, which is the only new runtime logic:

- Querying each event type and stamping it onto child rows. Catches a regression where a shared property row lands with a null `event_type`, which makes the composite key non-unique and multiplies duplicates on every merge.
- Skipping a parent that returns 400 while the rest still sync. Catches one stale event type failing the whole table.
- Re-raising any other HTTP error, so a 403 is not swallowed as a missing parent.

The four new endpoints also join the existing parameterized `test_full_refresh_endpoints_do_not_advertise_incremental` case list, guarding against advertising incremental sync on an endpoint with no server-side filter.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The posthog.com Amplitude page renders its supported-tables list from `get_documented_tables()`, which this source already opts into. The four new tables and their column descriptions appear there with no docs-repo change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude Opus 5 in PostHog Desktop, working from the Amplitude entry in `COVERAGE_GAPS_APPENDIX.md`. Skills invoked: `/implementing-warehouse-sources`, `/writing-tests`, `/writing-pr-descriptions`.

No duplicate: `gh pr list --state open` found no open PR touching the Amplitude source or its taxonomy endpoints, including the maintainer's own open branches.

Decisions across the session: the audit listed the four endpoints without saying how to shape them. Each was confirmed against the vendor docs first. `event-property` turned out to be the only one that cannot be fetched as a flat list, which is what drove the fan-out and the composite key. The endpoint config gained a small `AmplitudeFanoutConfig` rather than a per-endpoint branch in the transport, matching how the rest of the source keeps endpoint behavior declarative in `settings.py`.

Public artifact: nothing in this PR draws on non-public material. Test fixtures use invented event names.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
