### PR TITLE
chore(ci): attach git metadata to outage builds

### DIFF
--- a/.depot/workflows/actions-outage-image-build.yml
+++ b/.depot/workflows/actions-outage-image-build.yml
@@ -42,8 +42,12 @@ jobs:
 
             # The Dockerfile pulls node, python and debian from Docker Hub. Depot forwards the
             # credentials from this sandbox to the remote builder, so logging in here keeps those
-            # base image pulls off the anonymous per-IP rate limit.
+            # base image pulls off the anonymous per-IP rate limit. The images are public, so a
+            # missing secret or a failed login falls back to anonymous pulls and does not stop
+            # the outage build.
             - name: Login to Docker Hub
+              if: ${{ vars.DOCKERHUB_USER != '' && secrets.DOCKERHUB_TOKEN != '' }}
+              continue-on-error: true
               uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
               with:
                   username: ${{ vars.DOCKERHUB_USER }}

--- a/.depot/workflows/actions-outage-image-build.yml
+++ b/.depot/workflows/actions-outage-image-build.yml
@@ -40,6 +40,15 @@ jobs:
               id: aws-ecr
               uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
 
+            # The Dockerfile pulls node, python and debian from Docker Hub. Depot forwards the
+            # credentials from this sandbox to the remote builder, so logging in here keeps those
+            # base image pulls off the anonymous per-IP rate limit.
+            - name: Login to Docker Hub
+              uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+              with:
+                  username: ${{ vars.DOCKERHUB_USER }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+
             - name: Build and push
               id: build
               uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
@@ -47,7 +56,16 @@ jobs:
                   context: .
                   tags: ${{ steps.aws-ecr.outputs.registry }}/posthog-cloud-prs:${{ github.sha }}
                   platforms: linux/amd64,linux/arm64
-                  build-args: COMMIT_HASH=${{ github.sha }}
+                  # The GITHUB_* args become the git metadata on the error tracking release the
+                  # sourcemap upload stage creates. That stage builds in a container with no .git
+                  # directory, so the workflow has to hand them in (see Dockerfile).
+                  build-args: |
+                      COMMIT_HASH=${{ github.sha }}
+                      GITHUB_ACTIONS=true
+                      GITHUB_SHA=${{ github.sha }}
+                      GITHUB_REF_NAME=${{ github.ref_name }}
+                      GITHUB_REPOSITORY=${{ github.repository }}
+                      GITHUB_SERVER_URL=${{ github.server_url }}
                   push: true
                   # Without the upload the Dockerfile keeps the .map files in the image.
                   secrets: |


### PR DESCRIPTION
## Problem

Anyone triaging an exception from an image built during a GitHub Actions outage cannot get from the error tracking release back to the commit it was built from.

- [add image build for a github actions outage](https://github.com/PostHog/posthog/pull/91881) shipped the break-glass build, but it forwards only `COMMIT_HASH`.
- The sourcemap upload stage builds in a container with no `.git` directory. The CLI reads git metadata from five `GITHUB_*` variables instead.
- Without them the CLI still creates the release, because `--release-name` and `--release-version` are enough, and drops the metadata silently.
- The same build pulls node, python and debian from Docker Hub with no login, so those pulls sit on the anonymous per-IP rate limit.

## Changes

- An outage-built release now carries its branch, commit and repository, so a reviewer can reach the code from the exception.
- The build logs in to Docker Hub before pulling base images, using credentials already in the Depot store.
- The login is best-effort. A missing secret or a failed login falls back to anonymous pulls, so it cannot stop an outage build.
- Both changes are workflow wiring. The normal master build path is untouched.

## How did you test this code?

Not run: the workflow itself. It needs a real GitHub Actions outage or a manual Depot dispatch, and it pushes an image to ECR.

- The CLI reads exactly these five variables: [git.rs](https://github.com/PostHog/posthog/blob/1bad58dfdd9293c9f6b482ae1810d725d2b663fb/cli/src/utils/git.rs#L57-L64).
- Depot forwards the sandbox's Docker credentials to the remote builder for `FROM` pulls, per [Depot's private registry guide](https://depot.dev/docs/container-builds/how-to-guides/private-registries).
- `bin/hogli lint:workflows` reports no findings on this file, and the YAML parses.
- Unverified: whether Depot CI populates `github.ref_name` and `github.server_url`. `GITHUB_ACTIONS` is confirmed. The CLI treats an empty value as absent, so the build behaves as it does today if they are missing.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 5). Skills invoked: `/code-review`, `/simplify`, `/writing-code-comments`, `/writing-pr-descriptions`.
- Follow-up to a review of PR 91881, which raised four findings. Two ship here.
- Two were dropped after checking the sources. `buildx-fallback: false` is already the default in the pinned action, so setting it would be a no-op. The mutable `posthog-cloud-prs` tag in the step summary needs a runbook decision rather than a code change.
- Greptile flagged the first version's mandatory login. The login now uses the same `if:` guard and `continue-on-error` as the Docker Hub steps in `.depot/workflows/ci-backend.yml`.
- No duplicate: a search of open PRs for this workflow found nothing.
- Public artifact: every fact here comes from this repository or public Depot documentation.

https://claude.ai/code/session_01Szqb4LuwPQJnLcfwxNSVtb

