### PR TITLE
fix(error-tracking): limit the missing release banner to JS exceptions

### DIFF
--- a/frontend/src/lib/components/Errors/utils.test.ts
+++ b/frontend/src/lib/components/Errors/utils.test.ts
@@ -343,6 +343,8 @@ describe('Error Display', () => {
         ['two symbol sets uploaded without a release', {}, [UPLOADED_SET, UPLOADED_SET], true],
         ['a frame whose record did not load', {}, [UPLOADED_SET, undefined], false],
         ['a Node.js exception', { $lib: 'posthog-node' }, [UPLOADED_SET, UPLOADED_SET], true],
+        ['an edge runtime exception', { $lib: 'posthog-edge' }, [UPLOADED_SET, UPLOADED_SET], true],
+        ['a Segment Node.js exception', { $lib: 'analytics-node' }, [UPLOADED_SET, UPLOADED_SET], false],
         ['a Rust exception', { $lib: 'posthog-rs' }, [UPLOADED_SET, UPLOADED_SET], false],
         ['an exception from an unknown SDK', { $lib: undefined }, [UPLOADED_SET, UPLOADED_SET], false],
     ])('reports a release the SDK never sent for %s', (_name, properties, records, expected) => {
@@ -352,7 +354,7 @@ describe('Error Display', () => {
                 record ? [[`frame-${index}`, record as ErrorTrackingStackFrameRecord]] : []
             )
         )
-        const eventProperties = { $lib: 'posthog-js', ...properties } as ErrorEventProperties
+        const eventProperties = { $lib: 'web', ...properties } as ErrorEventProperties
         expect(isReleaseIdMissingFromSDK(eventProperties, frames, keyedRecords)).toBe(expected)
     })
 })

--- a/frontend/src/lib/components/Errors/utils.test.ts
+++ b/frontend/src/lib/components/Errors/utils.test.ts
@@ -342,6 +342,9 @@ describe('Error Display', () => {
         ['one of two symbol sets with a release', {}, [UPLOADED_SET, UPLOADED_SET_WITH_RELEASE], false],
         ['two symbol sets uploaded without a release', {}, [UPLOADED_SET, UPLOADED_SET], true],
         ['a frame whose record did not load', {}, [UPLOADED_SET, undefined], false],
+        ['a Node.js exception', { $lib: 'posthog-node' }, [UPLOADED_SET, UPLOADED_SET], true],
+        ['a Rust exception', { $lib: 'posthog-rs' }, [UPLOADED_SET, UPLOADED_SET], false],
+        ['an exception from an unknown SDK', { $lib: undefined }, [UPLOADED_SET, UPLOADED_SET], false],
     ])('reports a release the SDK never sent for %s', (_name, properties, records, expected) => {
         const frames = records.map((_, index) => ({ raw_id: `frame-${index}` }) as ErrorTrackingStackFrame)
         const keyedRecords = Object.fromEntries(
@@ -349,6 +352,7 @@ describe('Error Display', () => {
                 record ? [[`frame-${index}`, record as ErrorTrackingStackFrameRecord]] : []
             )
         )
-        expect(isReleaseIdMissingFromSDK(properties as ErrorEventProperties, frames, keyedRecords)).toBe(expected)
+        const eventProperties = { $lib: 'posthog-js', ...properties } as ErrorEventProperties
+        expect(isReleaseIdMissingFromSDK(eventProperties, frames, keyedRecords)).toBe(expected)
     })
 })

--- a/frontend/src/lib/components/Errors/utils.ts
+++ b/frontend/src/lib/components/Errors/utils.ts
@@ -264,6 +264,9 @@ export function getExceptionRelease(properties: ErrorEventProperties): ErrorTrac
     }
 }
 
+// Only the JavaScript SDKs (posthog-js and posthog-node) report `$release_id` on exceptions.
+const RUNTIMES_REPORTING_RELEASE_ID: ReadonlySet<ErrorTrackingRuntime> = new Set(['web', 'node'])
+
 // Uploaded symbol sets without a release leave the SDK's `$release_id` as the only source of a release.
 // A symbol set fetched by URL never carries one, so it cannot signal a missing `$release_id`.
 // A frame with no loaded record still could, so the answer stays unknown until every frame has one.
@@ -273,6 +276,9 @@ export function isReleaseIdMissingFromSDK(
     stackFrameRecords: Record<string, ErrorTrackingStackFrameRecord>
 ): boolean {
     if (!properties || properties['$release_id'] || getExceptionRelease(properties)) {
+        return false
+    }
+    if (!RUNTIMES_REPORTING_RELEASE_ID.has(getRuntimeFromLib(properties['$lib']))) {
         return false
     }
 

--- a/frontend/src/lib/components/Errors/utils.ts
+++ b/frontend/src/lib/components/Errors/utils.ts
@@ -264,8 +264,9 @@ export function getExceptionRelease(properties: ErrorEventProperties): ErrorTrac
     }
 }
 
-// Only the JavaScript SDKs (posthog-js and posthog-node) report `$release_id` on exceptions.
-const RUNTIMES_REPORTING_RELEASE_ID: ReadonlySet<ErrorTrackingRuntime> = new Set(['web', 'node'])
+// Only posthog-js (`web`) and posthog-node (`posthog-node`, `posthog-edge`) report `$release_id`.
+// Other libraries that share their runtime, such as analytics-node, never send it.
+const LIBS_REPORTING_RELEASE_ID: ReadonlySet<string> = new Set(['web', 'posthog-node', 'posthog-edge'])
 
 // Uploaded symbol sets without a release leave the SDK's `$release_id` as the only source of a release.
 // A symbol set fetched by URL never carries one, so it cannot signal a missing `$release_id`.
@@ -278,7 +279,7 @@ export function isReleaseIdMissingFromSDK(
     if (!properties || properties['$release_id'] || getExceptionRelease(properties)) {
         return false
     }
-    if (!RUNTIMES_REPORTING_RELEASE_ID.has(getRuntimeFromLib(properties['$lib']))) {
+    if (!LIBS_REPORTING_RELEASE_ID.has(String(properties['$lib'] ?? '').toLowerCase())) {
         return false
     }
 


### PR DESCRIPTION
## Problem

- Users who send exceptions from the Rust SDK see a banner on the stack trace tab that asks them to update their PostHog SDK to attach releases.
- No Rust SDK version reports `$release_id`, so the banner asks for an update that does not exist.
- The check behind the banner looked only at the uploaded symbol sets on the frames. It never looked at which SDK sent the event.

## Changes

- The banner and its modal now show only for exceptions from posthog-js or posthog-node.
- Exceptions from any other SDK, or with no `$lib` property, no longer get the banner.
- The helper `isReleaseIdMissingFromSDK` reads `$lib` and returns false unless it is `web`, `posthog-node`, or `posthog-edge`.
- The gate keys on `$lib` rather than the runtime, because analytics-node shares the node runtime and never sends `$release_id`.
- No screenshot: the banner looks the same as before. It only stops appearing for non-JS runtimes.

## How did you test this code?

- Five new rows in the existing parameterized Jest case for the helper. Node.js and edge exceptions still get the banner. A Segment analytics-node, a Rust, and an unknown SDK exception do not.
- Every existing row now sends `$lib: web`, the value posthog-js reports, because an event with no `$lib` gets no banner.
- Not run: the banner Storybook stories, because they render the component directly and the change is in the helper.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code with Claude Fable 5.1. Session: https://claude.ai/code/session_01M952XBTqsPW2G9eghPEbmx
- Skills invoked: /asd-ste100, /writing-tests, /writing-code-comments, /writing-pr-descriptions
- Duplicate check: an open PR search for "release banner" found no PR for this fix.
- Decision: the gate lives in the helper, so the kea selector and the stack trace tab stay unchanged.
- React Native gets no banner. In the posthog-js monorepo only the browser and node packages set `$release_id`.
- Greptile flagged that the node runtime also covers analytics-node and posthog-edge. The gate now keys on `$lib`, which keeps posthog-edge and drops analytics-node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M952XBTqsPW2G9eghPEbmx

