### PR TITLE
chore(customer-analytics): seed account notes as markdown notebooks

### DIFF
--- a/products/customer_analytics/backend/management/commands/seed_customer_analytics_accounts.py
+++ b/products/customer_analytics/backend/management/commands/seed_customer_analytics_accounts.py
@@ -34,6 +34,7 @@ from products.customer_analytics.backend.models.account import Account, AccountP
 from products.customer_analytics.backend.models.relationship import AccountRelationshipDefinition
 from products.customer_analytics.backend.models.team_customer_analytics_config import TeamCustomerAnalyticsConfig
 from products.notebooks.backend.facade import api as notebooks
+from products.notebooks.backend.facade.content import build_markdown_notebook_content
 
 ACCOUNT_GROUP_TYPE_INDEX = 0
 
@@ -233,14 +234,10 @@ class Command(BaseCommand):
                     team.id,
                     account.id,
                     title=f"{account.name} — {title}",
-                    content=_paragraph_doc(body),
+                    content=build_markdown_notebook_content(body),
                     text_content=body,
                     created_by_id=author.id if author else None,
                     last_modified_by_id=author.id if author else None,
                 )
                 created += 1
         self.stdout.write(f"Created {created} note(s) across up to {len(selected)} account(s).")
-
-
-def _paragraph_doc(text: str) -> dict[str, Any]:
-    return {"type": "doc", "content": [{"type": "paragraph", "content": [{"type": "text", "text": text}]}]}

--- a/products/customer_analytics/backend/management/commands/test/test_seed_customer_analytics_accounts.py
+++ b/products/customer_analytics/backend/management/commands/test/test_seed_customer_analytics_accounts.py
@@ -13,6 +13,7 @@ from posthog.persons_seed import insert_seed_group
 from products.customer_analytics.backend.models.account import Account
 from products.customer_analytics.backend.models.relationship import AccountRelationship
 from products.customer_analytics.backend.models.team_customer_analytics_config import TeamCustomerAnalyticsConfig
+from products.notebooks.backend.facade.content import is_markdown_notebook_content
 from products.notebooks.backend.models import Notebook, ResourceNotebook
 
 pytestmark = pytest.mark.persons_db_direct
@@ -79,6 +80,7 @@ class TestSeedCustomerAnalyticsAccounts(BaseTest):
         notebooks = Notebook.objects.filter(resources__account__team_id=self.team.pk)
         assert notebooks.count() == 4
         assert all(notebook.visibility == Notebook.Visibility.INTERNAL for notebook in notebooks)
+        assert all(is_markdown_notebook_content(notebook.content) for notebook in notebooks)
         accounts_with_notes = set(
             ResourceNotebook.objects.filter(account__team_id=self.team.pk).values_list("account_id", flat=True)
         )


### PR DESCRIPTION
## Problem

- A developer testing an agent against seeded accounts hits a rejection the real product no longer produces. The notebook cell tools refuse the seeded notes.
- The seed command wrote a legacy rich-text paragraph document. The cell tools accept one shape: a doc holding a single `ph-markdown-notebook` node.

## Changes

- Seeded notes open in the markdown editor and take cells, so they behave like a note the product creates.
- The local `_paragraph_doc` helper goes, replaced by the shared `build_markdown_notebook_content`.

## How did you test this code?

- `test_seeds_accounts_users_and_notes` gained one assertion: every seeded note is a markdown notebook. Nothing else in the suite reads the stored shape, so a return to a rich-text document would otherwise pass.
- Ran locally: that test file, and `uv run mypy --cache-fine-grained .` repo-wide.
- Not checked: the command was not run against a real project, and no seeded note was opened in a browser.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This is a local development seed command.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Opus 5 in PostHog Desktop, after a report that one agent could not append to a notebook another agent had written.
- Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- Follows [#98159](https://github.com/PostHog/posthog/pull/98159), which fixed the same class of bug in the anomaly investigation writer. A sweep of every notebook write path found three more legacy writers; each lands as its own PR. This is the smallest of the three and the only one that touches no production path.
- No duplicate: `gh pr list --state open --search "seed_customer_analytics"` found nothing covering this.
- Public artifact: the diff and this description carry no material from the session. The seed note templates are unchanged.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
