### PR TITLE
fix(metrics): wait for the API before opening the preview gate

### DIFF
--- a/frontend/src/layout/scenes/components/FeaturePreviewSceneGate.test.tsx
+++ b/frontend/src/layout/scenes/components/FeaturePreviewSceneGate.test.tsx
@@ -27,6 +27,10 @@ jest.mock('scenes/sceneLogic', () => ({
     sceneLogic: { __mock: 'sceneLogic' },
 }))
 
+jest.mock('./featurePreviewGateLogic', () => ({
+    featurePreviewGateLogic: () => ({ __mock: 'featurePreviewGateLogic' }),
+}))
+
 jest.mock('scenes/scenes', () => ({
     sceneConfigurations: {
         CustomerAnalytics: { name: 'Customer analytics', description: 'Analytics for customers', iconType: 'default' },
@@ -100,6 +104,10 @@ function isSupportLogicRef(logic: unknown): boolean {
     return logic === supportLogic
 }
 
+function isFeaturePreviewGateLogicRef(logic: unknown): boolean {
+    return (logic as { __mock?: string } | null | undefined)?.__mock === 'featurePreviewGateLogic'
+}
+
 function setupMocks({
     earlyAccessFeatures = [],
     waitlistSurveysEnabled = false,
@@ -108,6 +116,7 @@ function setupMocks({
     featureFlags = {},
     cloud = true,
     isDebug = false,
+    serverAccessConfirmed = true,
 }: {
     earlyAccessFeatures?: Array<{
         flagKey: string
@@ -121,6 +130,7 @@ function setupMocks({
     featureFlags?: Record<string, boolean | string>
     cloud?: boolean
     isDebug?: boolean
+    serverAccessConfirmed?: boolean
 } = {}): void {
     mockedUseMountedLogic.mockReturnValue({})
 
@@ -136,6 +146,9 @@ function setupMocks({
         }
         if (isPreflightLogicRef(logic)) {
             return { preflight: { cloud, is_debug: isDebug } }
+        }
+        if (isFeaturePreviewGateLogicRef(logic)) {
+            return { confirmed: serverAccessConfirmed }
         }
         return {}
     })
@@ -173,6 +186,16 @@ describe('FeaturePreviewSceneGate', () => {
             render(<FeaturePreviewSceneGate config={BASE_CONFIG}>{CHILDREN}</FeaturePreviewSceneGate>)
 
             expect(screen.getByTestId('scene-content-rendered')).toBeInTheDocument()
+            expect(screen.queryByTestId('product-introduction')).not.toBeInTheDocument()
+        })
+
+        test('waits on the enabling state while the API has not caught up with the flag', () => {
+            setupMocks({ featureFlags: { [BASE_CONFIG.flag]: true }, serverAccessConfirmed: false })
+
+            render(<FeaturePreviewSceneGate config={BASE_CONFIG}>{CHILDREN}</FeaturePreviewSceneGate>)
+
+            expect(screen.getByTestId('feature-preview-enabling')).toBeInTheDocument()
+            expect(screen.queryByTestId('scene-content-rendered')).not.toBeInTheDocument()
             expect(screen.queryByTestId('product-introduction')).not.toBeInTheDocument()
         })
 

--- a/frontend/src/layout/scenes/components/FeaturePreviewSceneGate.tsx
+++ b/frontend/src/layout/scenes/components/FeaturePreviewSceneGate.tsx
@@ -7,6 +7,7 @@ import { LemonButton, LemonInput, LemonSwitch } from '@posthog/lemon-ui'
 import { EnrichedEarlyAccessFeature, featurePreviewsLogic } from 'lib/components/FeaturePreviews/featurePreviewsLogic'
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import { supportLogic } from 'lib/components/Support/supportLogic'
+import { Spinner } from 'lib/lemon-ui/Spinner'
 import {
     FEATURE_PREVIEW_SELF_HOSTED_DISABLED_REASON,
     areClientFeatureFlagsHonored,
@@ -20,6 +21,7 @@ import { urls } from 'scenes/urls'
 import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
 import { FeaturePreviewGateConfig } from '~/types'
 
+import { featurePreviewGateLogic } from './featurePreviewGateLogic'
 import { SceneContent } from './SceneContent'
 import { SceneTitleSection } from './SceneTitleSection'
 
@@ -33,15 +35,66 @@ export function FeaturePreviewSceneGate({
     const { featureFlags } = useValues(featureFlagLogic)
     const isEnabled = featureFlags[config.flag as keyof typeof featureFlags]
     if (isEnabled) {
-        return <>{children}</>
+        return <ServerConfirmedFeature config={config}>{children}</ServerConfirmedFeature>
     }
     return <FeaturePreviewGateContent config={config} />
+}
+
+/**
+ * Holds the user on a short "turning it on" state while the browser evaluates the flag as on but the
+ * API does not yet: the window between enabling a feature preview and the enrollment person property
+ * being ingested. Without the wait, the scene mounts and every request behind it 403s, which reads as
+ * a broken product until the user reloads. Gates without a `confirmServerAccess` probe render their
+ * scene straight away.
+ */
+function ServerConfirmedFeature({
+    config,
+    children,
+}: {
+    config: FeaturePreviewGateConfig
+    children: React.ReactNode
+}): JSX.Element {
+    const { confirmed } = useValues(
+        featurePreviewGateLogic({ flag: config.flag, confirmServerAccess: config.confirmServerAccess })
+    )
+
+    if (!confirmed) {
+        return <FeaturePreviewEnablingState config={config} />
+    }
+    return <>{children}</>
+}
+
+function FeaturePreviewEnablingState({ config }: { config: FeaturePreviewGateConfig }): JSX.Element {
+    const sceneConfig = useGateSceneConfig(config)
+
+    return (
+        <SceneContent>
+            {sceneConfig?.name && (
+                <SceneTitleSection
+                    name={sceneConfig.name}
+                    description={sceneConfig.description}
+                    resourceType={{ type: sceneConfig.iconType || 'default' }}
+                />
+            )}
+            <div className="flex items-center gap-2 text-secondary" data-attr="feature-preview-enabling" role="status">
+                <Spinner className="text-lg" />
+                <span>Turning the feature preview on. This takes a few seconds.</span>
+            </div>
+        </SceneContent>
+    )
+}
+
+type GateSceneConfig = (typeof sceneConfigurations)[keyof typeof sceneConfigurations]
+
+function useGateSceneConfig(config: FeaturePreviewGateConfig): GateSceneConfig | undefined {
+    const { activeSceneId } = useValues(sceneLogic)
+    const sceneIdForHeader = config.sceneId ?? activeSceneId
+    return sceneIdForHeader ? sceneConfigurations[sceneIdForHeader] : undefined
 }
 
 function FeaturePreviewGateContent({ config }: { config: FeaturePreviewGateConfig }): JSX.Element {
     const { earlyAccessFeatures } = useValues(featurePreviewsLogic)
     const { loadEarlyAccessFeatures, updateEarlyAccessFeatureEnrollment } = useActions(featurePreviewsLogic)
-    const { activeSceneId } = useValues(sceneLogic)
     const { preflight } = useValues(preflightLogic)
     const { openSupportForm } = useActions(supportLogic)
 
@@ -50,8 +103,7 @@ function FeaturePreviewGateContent({ config }: { config: FeaturePreviewGateConfi
     }, [loadEarlyAccessFeatures])
 
     const feature = earlyAccessFeatures.find((f) => f.flagKey === config.flag)
-    const sceneIdForHeader = config.sceneId ?? activeSceneId
-    const sceneConfig = sceneIdForHeader ? sceneConfigurations[sceneIdForHeader] : undefined
+    const sceneConfig = useGateSceneConfig(config)
     const flagsHonored = areClientFeatureFlagsHonored(preflight)
 
     // Concept ("Coming Soon") features never enable their flag, so the enrollment toggle is a

--- a/frontend/src/layout/scenes/components/featurePreviewGateLogic.test.ts
+++ b/frontend/src/layout/scenes/components/featurePreviewGateLogic.test.ts
@@ -1,0 +1,56 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { initKeaTests } from '~/test/init'
+
+import { featurePreviewGateLogic } from './featurePreviewGateLogic'
+
+describe('featurePreviewGateLogic', () => {
+    beforeEach(() => {
+        initKeaTests()
+        window.localStorage.clear()
+    })
+
+    it('confirms straight away when the gate has no probe', async () => {
+        const logic = featurePreviewGateLogic({ flag: 'gate-without-probe' })
+        logic.mount()
+
+        await expectLogic(logic).toFinishAllListeners().toMatchValues({ confirmed: true })
+    })
+
+    it('confirms once the server agrees, and caches it for the next mount', async () => {
+        const confirmServerAccess = jest.fn().mockResolvedValue(true)
+
+        const logic = featurePreviewGateLogic({ flag: 'gate-confirmed', confirmServerAccess })
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners().toMatchValues({ confirmed: true })
+        expect(confirmServerAccess).toHaveBeenCalledTimes(1)
+        logic.unmount()
+
+        const remounted = featurePreviewGateLogic({ flag: 'gate-confirmed', confirmServerAccess })
+        remounted.mount()
+        await expectLogic(remounted).toMatchValues({ confirmed: true })
+        expect(confirmServerAccess).toHaveBeenCalledTimes(1)
+    })
+
+    it('stays unconfirmed while the server still denies access', async () => {
+        const confirmServerAccess = jest.fn().mockResolvedValue(false)
+
+        const logic = featurePreviewGateLogic({ flag: 'gate-denied', confirmServerAccess })
+        logic.mount()
+
+        await expectLogic(logic).delay(1).toMatchValues({ confirmed: false })
+        expect(confirmServerAccess).toHaveBeenCalled()
+        expect(window.localStorage.length).toBe(0)
+        logic.unmount()
+    })
+
+    it('confirms when the probe itself fails, so a broken probe cannot hide the scene', async () => {
+        const confirmServerAccess = jest.fn().mockRejectedValue(new Error('network down'))
+
+        const logic = featurePreviewGateLogic({ flag: 'gate-probe-broken', confirmServerAccess })
+        logic.mount()
+
+        await expectLogic(logic).toFinishAllListeners().toMatchValues({ confirmed: true })
+        expect(confirmServerAccess).toHaveBeenCalledTimes(1)
+    })
+})

--- a/frontend/src/layout/scenes/components/featurePreviewGateLogic.ts
+++ b/frontend/src/layout/scenes/components/featurePreviewGateLogic.ts
@@ -1,0 +1,139 @@
+import {
+    BreakPointFunction,
+    MakeLogicType,
+    actions,
+    afterMount,
+    connect,
+    kea,
+    key,
+    listeners,
+    path,
+    props,
+    reducers,
+} from 'kea'
+
+import { teamLogic } from 'scenes/teamLogic'
+
+// Alias kea so kea-typegen skips this logic - the logic type is hand-written below, because the
+// props carry a probe function the generator cannot describe.
+const buildKea = kea
+
+/** How often to re-ask the server whether the flag has landed, while it answers that it hasn't. */
+const POLL_MS = 1500
+/**
+ * Ingestion normally catches up within a couple of seconds. Past this the gate opens regardless, so
+ * a probe that answers `false` forever can never lock a user out of a product they enabled: they
+ * land on the scene and read its own errors, which is what happens without a probe at all.
+ */
+const TIMEOUT_MS = 15000
+
+export interface FeaturePreviewGateLogicProps {
+    flag: string
+    /** See `FeaturePreviewGateConfig.confirmServerAccess`. Without one, the gate never waits. */
+    confirmServerAccess?: () => Promise<boolean>
+}
+
+export interface FeaturePreviewGateValues {
+    confirmed: boolean
+    currentTeamId: number | null
+}
+
+export interface FeaturePreviewGateActions {
+    confirmAccess: () => void
+    setConfirmed: () => void
+}
+
+export type FeaturePreviewGateLogicType = MakeLogicType<
+    FeaturePreviewGateValues,
+    FeaturePreviewGateActions,
+    FeaturePreviewGateLogicProps
+>
+
+function cacheKey(teamId: number, flag: string): string {
+    return `ph-feature-preview-server-access/${teamId}/${flag}`
+}
+
+// localStorage can throw (private modes, disabled storage); a cache miss only costs one probe.
+function readCachedAccess(teamId: number | null, flag: string): boolean {
+    try {
+        return !!teamId && window.localStorage.getItem(cacheKey(teamId, flag)) === '1'
+    } catch {
+        return false
+    }
+}
+
+function writeCachedAccess(teamId: number | null, flag: string): void {
+    try {
+        if (teamId) {
+            window.localStorage.setItem(cacheKey(teamId, flag), '1')
+        }
+    } catch {
+        // Nothing cached; the next visit probes again.
+    }
+}
+
+/**
+ * Answers whether the API agrees a feature preview flag is on, which the browser can be ahead of.
+ * Enrollment reaches the server as an ingested person property, so in the seconds after a user
+ * turns a preview on, posthog-js already evaluates the flag as on while every request behind the
+ * scene still 403s. The scene gate waits on `confirmed` instead of handing over a product whose
+ * queries all fail until a reload. A confirmed answer is cached per team, so the wait is paid once.
+ */
+export const featurePreviewGateLogic = buildKea<FeaturePreviewGateLogicType>([
+    props({} as FeaturePreviewGateLogicProps),
+    key((props: FeaturePreviewGateLogicProps) => props.flag),
+    path((key) => ['layout', 'scenes', 'components', 'featurePreviewGateLogic', key]),
+    connect(() => ({
+        values: [teamLogic, ['currentTeamId']],
+    })),
+    actions({
+        confirmAccess: true,
+        setConfirmed: true,
+    }),
+    reducers({
+        confirmed: [
+            false,
+            {
+                setConfirmed: () => true,
+            },
+        ],
+    }),
+    listeners(({ props, values, actions }) => ({
+        confirmAccess: async (_: void, breakpoint: BreakPointFunction) => {
+            const confirmServerAccess = props.confirmServerAccess
+            if (!confirmServerAccess) {
+                actions.setConfirmed()
+                return
+            }
+            const deadline = Date.now() + TIMEOUT_MS
+            for (;;) {
+                let outcome: 'confirmed' | 'denied' | 'unknown'
+                try {
+                    outcome = (await confirmServerAccess()) ? 'confirmed' : 'denied'
+                } catch {
+                    // The probe broke for a reason waiting cannot fix, so hand over to the scene
+                    // and let it surface the failure.
+                    outcome = 'unknown'
+                }
+                breakpoint()
+                if (outcome === 'confirmed') {
+                    writeCachedAccess(values.currentTeamId, props.flag)
+                    actions.setConfirmed()
+                    return
+                }
+                if (outcome === 'unknown' || Date.now() >= deadline) {
+                    actions.setConfirmed()
+                    return
+                }
+                await breakpoint(POLL_MS)
+            }
+        },
+    })),
+    afterMount(({ props, values, actions }) => {
+        if (!props.confirmServerAccess || readCachedAccess(values.currentTeamId, props.flag)) {
+            actions.setConfirmed()
+            return
+        }
+        actions.confirmAccess()
+    }),
+])

--- a/frontend/src/lib/api-error.ts
+++ b/frontend/src/lib/api-error.ts
@@ -6,6 +6,20 @@ export function isAccessDeniedError(error: { status?: number; code?: string | nu
     return error.status === 403 && error.code === 'permission_denied'
 }
 
+/** DRF code for `PostHogFeatureFlagPermission` (posthog/permissions.py). Keep in sync with the backend. */
+export const FEATURE_FLAG_REQUIRED_ERROR_CODE = 'feature_flag_required'
+
+/**
+ * A 403 from a feature flag gate rather than from access control: the flag behind the product
+ * isn't on for this user yet. Enrollment in an early access feature reaches the server as an
+ * ingested person property, so this is also what the seconds right after enabling a feature
+ * preview look like, while the browser already evaluates the flag as on.
+ */
+export function isFeatureFlagGatedError(error: unknown): boolean {
+    const failure = error as { status?: number; code?: string | null } | null
+    return failure?.status === 403 && failure?.code === FEATURE_FLAG_REQUIRED_ERROR_CODE
+}
+
 /** DRF code for `ClickHouseQueryMemoryLimitExceeded` (posthog/exceptions.py). Keep in sync with the backend. */
 export const CLICKHOUSE_MEMORY_LIMIT_ERROR_CODE = 'clickhouse_memory_limit_exceeded'
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -7861,6 +7861,15 @@ export interface FeaturePreviewGateConfig {
      * count as product intent the same way opting in from the feature previews page does.
      */
     productIntent?: ProductKey
+    /**
+     * Probe answering "does the API agree this flag is on for me?". Enrollment reaches the server
+     * as an ingested person property, so for a few seconds after a user enables the preview the
+     * browser evaluates the flag as on while every request still 403s. With a probe the gate waits
+     * for the server rather than handing over a scene whose queries all fail until a reload.
+     * Resolve `false` for a flag-gated 403, and throw anything else so the gate opens and lets the
+     * scene report the problem itself.
+     */
+    confirmServerAccess?: () => Promise<boolean>
 }
 
 export interface ProductManifest {

--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -1213,6 +1213,14 @@ def posthog_feature_flag_enabled(
     )
 
 
+# DRF error code for a flag-gated 403, so a client can tell "not on this alpha yet" apart from a
+# plain access-control denial. Enrollment for an early access feature reaches the server as an
+# ingested person property, so a user who has just turned the feature preview on keeps getting
+# denied for a few seconds - the frontend scene gate waits on this code instead of dropping them
+# into a scene whose every request fails.
+FEATURE_FLAG_REQUIRED_ERROR_CODE = "feature_flag_required"
+
+
 class PostHogFeatureFlagPermission(BasePermission):
     def has_permission(self, request, view) -> bool:
         user = cast(User, request.user)
@@ -1250,6 +1258,7 @@ class PostHogFeatureFlagPermission(BasePermission):
                 self.message = (
                     f"This action requires feature flag {required_flag!r} to be enabled for your organization."
                 )
+                self.code = FEATURE_FLAG_REQUIRED_ERROR_CODE
                 return False
 
         return True

--- a/posthog/test/test_permissions.py
+++ b/posthog/test/test_permissions.py
@@ -32,7 +32,12 @@ from posthog.models.organization import OrganizationMembership
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.project_secret_api_key import ProjectSecretAPIKey
 from posthog.models.utils import generate_random_token_personal, hash_key_value
-from posthog.permissions import AccessControlPermission, ActiveOrganizationPermission, PostHogFeatureFlagPermission
+from posthog.permissions import (
+    FEATURE_FLAG_REQUIRED_ERROR_CODE,
+    AccessControlPermission,
+    ActiveOrganizationPermission,
+    PostHogFeatureFlagPermission,
+)
 
 from products.access_control.backend.facade.user_access_control import UserAccessControl
 from products.access_control.backend.models.access_control import AccessControl
@@ -1350,6 +1355,13 @@ class TestPostHogFeatureFlagPermission(BaseTest):
         result = self.permission.has_permission(request, view)
 
         self.assertFalse(result)
+        # DRF passes both onto the 403 body, and the frontend scene gate waits on the code to tell a
+        # not-yet-ingested alpha enrollment apart from an access-control denial.
+        self.assertEqual(self.permission.code, FEATURE_FLAG_REQUIRED_ERROR_CODE)
+        self.assertEqual(
+            self.permission.message,
+            "This action requires feature flag 'my-flag' to be enabled for your organization.",
+        )
 
     @patch("posthog.permissions._FORCE_ENABLED_FLAGS", frozenset({"my-flag"}))
     @patch("posthoganalytics.feature_enabled")

--- a/products/metrics/frontend/emptyState/metricsSetupLogic.ts
+++ b/products/metrics/frontend/emptyState/metricsSetupLogic.ts
@@ -1,3 +1,4 @@
+import { isFeatureFlagGatedError } from 'lib/api-error'
 import { createSetupDetectionLogic } from 'lib/components/ProductEmptyState/setupDetectionLogic'
 import { retryWithBackoff } from 'lib/utils/async'
 import { addProductIntent } from 'lib/utils/product-intents'
@@ -31,8 +32,21 @@ export const metricsSetupLogic = createSetupDetectionLogic({
         if (!teamId) {
             return 'unknown'
         }
-        const response = await retryWithBackoff(() => metricsHasMetricsRetrieve(String(teamId)), { maxAttempts: 3 })
-        return response.hasMetrics ? 'has-data' : 'needs-setup'
+        try {
+            const response = await retryWithBackoff(() => metricsHasMetricsRetrieve(String(teamId)), {
+                maxAttempts: 3,
+            })
+            return response.hasMetrics ? 'has-data' : 'needs-setup'
+        } catch (error) {
+            // The alpha enrollment has not reached the server yet: it arrives as an ingested person
+            // property, so a user who just turned the feature preview on is still denied for a few
+            // seconds. That is not a detection failure worth an error toast, so report `unknown` and
+            // let the next poll answer.
+            if (isFeatureFlagGatedError(error)) {
+                return 'unknown'
+            }
+            throw error
+        }
     },
     onDetected: (status) => {
         if (status === 'needs-setup') {

--- a/products/metrics/frontend/featurePreviewGate.ts
+++ b/products/metrics/frontend/featurePreviewGate.ts
@@ -1,7 +1,11 @@
+import { isFeatureFlagGatedError } from 'lib/api-error'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { teamLogic } from 'scenes/teamLogic'
 
 import { ProductKey } from '~/queries/schema/schema-general'
 import { FeaturePreviewGateConfig } from '~/types'
+
+import { metricsHasMetricsRetrieve } from './generated/api'
 
 export const metricsFeaturePreviewGate: FeaturePreviewGateConfig = {
     flag: FEATURE_FLAGS.METRICS,
@@ -11,4 +15,20 @@ export const metricsFeaturePreviewGate: FeaturePreviewGateConfig = {
     docsURL: 'https://posthog.com/docs/metrics',
     sceneId: 'Metrics',
     productIntent: ProductKey.METRICS,
+    confirmServerAccess: async () => {
+        const teamId = teamLogic.findMounted()?.values.currentTeamId
+        if (!teamId) {
+            // Nothing to probe with yet; let the scene mount and resolve the project itself.
+            return true
+        }
+        try {
+            await metricsHasMetricsRetrieve(String(teamId))
+            return true
+        } catch (error) {
+            if (isFeatureFlagGatedError(error)) {
+                return false
+            }
+            throw error
+        }
+    },
 }


### PR DESCRIPTION
## Problem

- A user who turns the Metrics feature preview on gets an error toast ("Detect status failed: This action requires feature flag 'metrics' to be enabled for your organization") and a scene that does not load. A reload fixes it, so the product looks broken for its first few seconds.
- Enrollment is a person property. posthog-js sends its locally stored person properties with every `/flags` call, so the browser evaluates `metrics` as on immediately.
- The API has no such shortcut: `posthog_feature_flag_value` passes group context only, so the flags service reads the enrollment property from the database and keeps answering "not enrolled" until the `$feature_enrollment_update` event is ingested.
- The gate rendered the scene on the browser's answer alone, so every request behind it 403s during that window.
- The same window exists for every scene behind `FeaturePreviewSceneGate` (metrics, customer analytics, MCP analytics), not only metrics.

## Changes

- Enabling a feature preview from a gated scene now shows "Turning the feature preview on. This takes a few seconds." until the API agrees, then the scene appears with working queries. No error toast, no reload.
- `FeaturePreviewGateConfig` takes an optional `confirmServerAccess` probe. Metrics supplies one that calls `has_metrics` and reads a flag-gated 403 as "not yet".
- `featurePreviewGateLogic` polls that probe every 1.5s, caches a confirmed answer per team in localStorage, and opens the gate anyway after 15s or if the probe itself fails, so a broken probe cannot hide a product.
- Gates without a probe render their scene exactly as before.
- `PostHogFeatureFlagPermission` sets a `feature_flag_required` DRF code on its 403. Without it a client cannot tell "not on this alpha yet" from an access-control denial, since both are `permission_denied`.
- Metrics setup detection reports `unknown` for that code instead of throwing, which is what produced the toast.

> [!NOTE]
> The wait is only paid until the first confirmed answer per team. It does not add a round trip to later visits.

## How did you test this code?

Automated tests, run locally in this session:

- `frontend/src/layout/scenes/components/featurePreviewGateLogic.test.ts` (new) — a denied probe keeps the scene closed (the reported bug), a confirmed one caches and is not re-probed on remount, a throwing probe opens the gate, and a gate without a probe never waits.
- `frontend/src/layout/scenes/components/FeaturePreviewSceneGate.test.tsx` — the enabling state renders instead of the scene while the API has not caught up. Nothing covered that the flag alone could open the gate.
- `posthog/test/test_permissions.py -k PostHogFeatureFlag` — the denial carries both the code and the message, which the frontend now depends on.
- `products/metrics/frontend` Jest suites, `pnpm typescript:check`, `oxlint`, `oxfmt`, `ruff`.

Not checked: the real ingestion window in a deployed environment. The race needs a live enrollment event, so the timing constants (1.5s poll, 15s cap) are a judgment call rather than a measurement. The probe path is covered by the mocked tests above, not against a real 403.

No screenshot: the new surface is a spinner and one line of text inside the existing scene header, and the sandbox has no rendered environment for the enabling state.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code in the PostHog Slack app, from a report that enabling the preview on the Metrics page errors and then works after a refresh. Repository skills and rules invoked: the frontend guide (business logic in kea rather than a React hook, which is why the polling lives in a logic), `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, `/writing-pr-descriptions`, and the kea disposables rule.

Decisions along the way:

- A backend-only fix was rejected: the server cannot know an enrollment before ingestion delivers it, and nothing outside the analytics project records it.
- The first draft held the polling in a React hook with `useState`. It moved into `featurePreviewGateLogic` to follow the frontend convention and to make the fail-open paths testable.
- The probe is per-product config rather than a new endpoint, so no API surface is added and each product uses a call it already makes.
- Draft PR #94218 also touches this gate, but it fixes discovery for teams with no way in. It does not overlap this behavior.

Nothing in this diff carries material from the agent session.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08S66N93FX/p1789045551283469?thread_ts=1789045551.283469&cid=C08S66N93FX)*
