### PR TITLE
chore: add yolo to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,5 @@ The pricing for our paid plan is completely transparent and available on [our pr
 Hey! If you're reading this, you've proven yourself as a dedicated README reader.
 
 You might also make a great addition to our team. We're growing fast [and would love for you to join us](https://posthog.com/careers).
+
+yolo


### PR DESCRIPTION
## Problem

Nothing is broken. A request came in to put `yolo` in the README, so this does exactly that and nothing else.

## Changes

- Appends a `yolo` line at the end of `README.md`. Anyone who reads to the bottom of the README now sees it. No code, config, or behavior changes.

## How did you test this code?

No tests apply — the change is one line of prose in `README.md`. I did not run the suite, and no manual testing was done.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app from a Slack request to add `yolo` to the README. No repo skills were needed for a one-line prose edit. No duplicate: `gh pr list --search "readme yolo"` found nothing open. Nothing in this diff or description comes from non-public session material.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B85JA2DAA/p1789047589148589)*
