### PR TITLE
chore(readme): add yolo2

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,5 @@ The pricing for our paid plan is completely transparent and available on [our pr
 Hey! If you're reading this, you've proven yourself as a dedicated README reader.
 
 You might also make a great addition to our team. We're growing fast [and would love for you to join us](https://posthog.com/careers).
+
+yolo2


### PR DESCRIPTION
## Problem

A request came in from Slack to add the line `yolo2` to the repository README. No behavior changes for users.

## Changes

- Appends a `yolo2` line at the end of `README.md`. Documentation only, no code paths touched.

## How did you test this code?

No tests apply. The change is a single line of README text.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack request. No repo skills were needed for a one-line README edit. A search for open PRs found nothing overlapping, and nothing in this PR carries non-public material.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B85JA2DAA/p1789047699866649)*
