### PR TITLE
chore(readme): add yolo

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,5 @@ The pricing for our paid plan is completely transparent and available on [our pr
 Hey! If you're reading this, you've proven yourself as a dedicated README reader.
 
 You might also make a great addition to our team. We're growing fast [and would love for you to join us](https://posthog.com/careers).
+
+yolo


### PR DESCRIPTION
## Problem

A README change was requested from Slack: add "yolo" to the repository README.

## Changes

- Appends a `yolo` line at the end of `README.md`. No code or behavior changes.

## How did you test this code?

No tests apply — the diff is one line of Markdown text. No manual testing was done.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread request. No repo skills were needed for a one-line Markdown edit. Nothing in this PR carries non-public material.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B85JA2DAA/p1789047823454469)*
