### PR TITLE
fix(conversations): trim blank space from new support messages

### DIFF
--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -445,7 +445,7 @@ export const supportLogic = kea<supportLogicType>([
                               ? 'Please enter a valid email address'
                               : undefined
                         : undefined,
-                    message: !message ? 'Please enter a message' : undefined,
+                    message: !message.trim() ? 'Please enter a message' : undefined,
                 }
             },
             submit: async (formValues) => {
@@ -539,10 +539,11 @@ export const supportLogic = kea<supportLogicType>([
             actions.updateUrlParams()
         },
         submitSupportTicket: async (formValues: SupportFormFields) => {
-            const { name, kind, message, exception_event } = formValues
+            const { name, kind, exception_event } = formValues
             // Trimmed before validating and sending: restore-by-email matches the stored trait
             // exactly, so stray whitespace would make the ticket unrecoverable
             const email = formValues.email.trim()
+            const message = formValues.message.trim()
             const { ai_conversation_id, ai_trace_id, ai_feedback_rating } = formValues
 
             // Attribute PostHog AI (/ticket, feedback) handovers to the conversation. The ticket id

--- a/posthog/api/comments.py
+++ b/posthog/api/comments.py
@@ -22,6 +22,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.utils import ClassicBehaviorBooleanFieldSerializer, action
 from posthog.comment.access import task_comment_target_is_accessible
+from posthog.comment.formatting import trim_rich_content
 from posthog.event_usage import groups
 from posthog.exceptions import Conflict
 from posthog.helpers.slack_thread_mirror import post_comment_to_slack_thread, slack_author_from_user
@@ -328,14 +329,6 @@ class CommentSerializer(serializers.ModelSerializer):
             data["is_task"] = False
         return data
 
-    def has_empty_paragraph(self, doc):
-        for node in doc.get("content", []):
-            if node.get("type") == "paragraph":
-                content = node.get("content", [])
-                if len(content) == 1 and content[0].get("type") == "text" and content[0].get("text", "") == "":
-                    return True
-        return False
-
     def validate(self, data):
         request = self.context["request"]
         instance = cast(Comment, self.instance)
@@ -435,10 +428,16 @@ class CommentSerializer(serializers.ModelSerializer):
         # Skip content validation when soft-deleting a comment
         is_deleting = data.get("deleted") is True
         if not is_deleting:
-            content = data.get("content", "")
-            rich_content = data.get("rich_content")
+            content = (data.get("content") or "").strip()
+            if isinstance(data.get("content"), str):
+                data["content"] = content
 
-            if not content.strip() and (not rich_content or self.has_empty_paragraph(rich_content)):
+            rich_content = trim_rich_content(data.get("rich_content"))
+            if "rich_content" in data:
+                data["rich_content"] = rich_content
+
+            has_rich_content = isinstance(rich_content, dict) and bool(rich_content.get("content"))
+            if not content and not has_rich_content:
                 raise exceptions.ValidationError("A comment must have content")
 
         if isinstance(data.get("item_context"), dict):

--- a/posthog/comment/formatting.py
+++ b/posthog/comment/formatting.py
@@ -663,6 +663,57 @@ def _serialize_list_to_markdown(node: JSON, ordered: bool, indent: str, include_
     return "\n".join(lines)
 
 
+def _is_blank_inline_node(node: JSON) -> bool:
+    node_type = node.get("type")
+    if node_type == "hardBreak":
+        return True
+    return node_type == "text" and not node.get("text", "").strip()
+
+
+def _is_blank_paragraph(node: JSON) -> bool:
+    if node.get("type") != "paragraph":
+        return False
+    return all(_is_blank_inline_node(child) for child in node.get("content") or [])
+
+
+def _trim_paragraph_edge(node: JSON, *, leading: bool) -> JSON:
+    """Remove blank inline nodes and outer whitespace from one end of a paragraph."""
+    if node.get("type") != "paragraph":
+        return node
+
+    content = list(node.get("content") or [])
+    edge = 0 if leading else -1
+    while content and _is_blank_inline_node(content[edge]):
+        content.pop(edge)
+    if content and content[edge].get("type") == "text":
+        text = content[edge].get("text", "")
+        content[edge] = {**content[edge], "text": text.lstrip() if leading else text.rstrip()}
+    return {**node, "content": content}
+
+
+def trim_rich_content(rich_content: JSON | None) -> JSON | None:
+    """Remove leading and trailing blank space from a rich content doc.
+
+    The markdown and Slack serializers already drop blank paragraphs at the two ends, but
+    the HTML serializer emits a `<p></p>` for each one. Without this, an author who ends a
+    message with a few empty lines sends empty lines to the customer's inbox.
+    """
+    if not isinstance(rich_content, dict) or rich_content.get("type") != "doc":
+        return rich_content
+
+    content = list(rich_content.get("content") or [])
+    while content and _is_blank_paragraph(content[0]):
+        content.pop(0)
+    while content and _is_blank_paragraph(content[-1]):
+        content.pop()
+
+    if content:
+        content[0] = _trim_paragraph_edge(content[0], leading=True)
+        content[-1] = _trim_paragraph_edge(content[-1], leading=False)
+
+    return {**rich_content, "content": content}
+
+
 def rich_content_to_markdown(rich_content: JSON | None, include_images: bool = True) -> str:
     """Serialize PostHog rich content JSON to markdown text."""
     if not rich_content:

--- a/products/conversations/backend/api/tests/test_formatting.py
+++ b/products/conversations/backend/api/tests/test_formatting.py
@@ -14,6 +14,7 @@ from posthog.comment.formatting import (
     rich_content_to_markdown,
     rich_content_to_slack_payload,
     slack_to_content_and_rich_content,
+    trim_rich_content,
 )
 from posthog.models import Organization, User
 
@@ -842,6 +843,51 @@ class TestRichContentBlockNodes(SimpleTestCase):
         }
         html = rich_content_to_html(doc)
         assert "<blockquote>see<br><ul><li>one</li></ul></blockquote>" in html
+
+
+class TestTrimRichContent(SimpleTestCase):
+    @parameterized.expand(
+        [
+            (
+                "leading_and_trailing_empty_paragraphs",
+                {"type": "doc", "content": [{"type": "paragraph"}, _paragraph("hi"), _paragraph("")]},
+                [_paragraph("hi")],
+            ),
+            (
+                "outer_whitespace_in_the_edge_paragraphs",
+                {"type": "doc", "content": [_paragraph("  lead"), _paragraph("end  ")]},
+                [_paragraph("lead"), _paragraph("end")],
+            ),
+            (
+                "trailing_hard_breaks",
+                {
+                    "type": "doc",
+                    "content": [
+                        {"type": "paragraph", "content": [{"type": "text", "text": "x"}, {"type": "hardBreak"}]}
+                    ],
+                },
+                [_paragraph("x")],
+            ),
+            (
+                "blank_paragraph_between_two_blocks_is_kept",
+                {"type": "doc", "content": [_paragraph("a"), {"type": "paragraph"}, _paragraph("b")]},
+                [_paragraph("a"), {"type": "paragraph"}, _paragraph("b")],
+            ),
+            (
+                "whitespace_only_doc",
+                {"type": "doc", "content": [{"type": "paragraph"}, _paragraph("   ")]},
+                [],
+            ),
+        ]
+    )
+    def test_trim_rich_content(self, _name: str, doc: dict, expected_content: list) -> None:
+        assert trim_rich_content(doc) == {"type": "doc", "content": expected_content}
+
+    def test_trim_rich_content_keeps_a_trailing_empty_paragraph_out_of_the_email_html(self) -> None:
+        doc = {"type": "doc", "content": [_paragraph("thanks"), {"type": "paragraph"}, {"type": "paragraph"}]}
+
+        assert "<p></p>" in rich_content_to_html(doc)
+        assert "<p></p>" not in rich_content_to_html(trim_rich_content(doc))
 
 
 class TestSlackMentionScoping(BaseTest):

--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -43,6 +43,7 @@ from posthog.api.tagged_item import (
     TaggedItemViewSetMixin,
     set_tags_on_object,
 )
+from posthog.comment.formatting import trim_rich_content
 from posthog.dataclasses import frozen
 from posthog.event_usage import report_user_action
 from posthog.exceptions_capture import capture_exception
@@ -147,6 +148,19 @@ class TicketFullEmailSerializer(serializers.Serializer):
     content = serializers.CharField(read_only=True, help_text="Full inbound email body in Markdown.")
 
 
+def _validate_rich_content(value: object) -> object:
+    """Check the size of a TipTap doc and remove its leading and trailing blank space."""
+    if value is None:
+        return value
+    try:
+        serialized = json.dumps(value)
+    except (TypeError, ValueError) as e:
+        raise serializers.ValidationError("Rich content must be JSON-serializable.") from e
+    if len(serialized) > 100_000:
+        raise serializers.ValidationError("Rich content too large (max 100KB).")
+    return trim_rich_content(value) if isinstance(value, dict) else value
+
+
 class TicketNoteUpdateRequestSerializer(serializers.Serializer):
     """Payload for updating a private note on a ticket."""
 
@@ -169,15 +183,7 @@ class TicketNoteUpdateRequestSerializer(serializers.Serializer):
         return value.strip()
 
     def validate_rich_content(self, value: object) -> object:
-        if value is None:
-            return value
-        try:
-            serialized = json.dumps(value)
-        except (TypeError, ValueError) as e:
-            raise serializers.ValidationError("Rich content must be JSON-serializable.") from e
-        if len(serialized) > 100_000:
-            raise serializers.ValidationError("Rich content too large (max 100KB).")
-        return value
+        return _validate_rich_content(value)
 
 
 class TicketReplyRequestSerializer(serializers.Serializer):
@@ -206,15 +212,7 @@ class TicketReplyRequestSerializer(serializers.Serializer):
         return value.strip()
 
     def validate_rich_content(self, value: object) -> object:
-        if value is None:
-            return value
-        try:
-            serialized = json.dumps(value)
-        except (TypeError, ValueError) as e:
-            raise serializers.ValidationError("Rich content must be JSON-serializable.") from e
-        if len(serialized) > 100_000:
-            raise serializers.ValidationError("Rich content too large (max 100KB).")
-        return value
+        return _validate_rich_content(value)
 
 
 class AiFeedbackRequestSerializer(serializers.Serializer):
@@ -267,15 +265,7 @@ class ComposeTicketSerializer(serializers.Serializer):
         return value.strip()
 
     def validate_rich_content(self, value: object) -> object:
-        if value is None:
-            return value
-        try:
-            serialized = json.dumps(value)
-        except (TypeError, ValueError) as e:
-            raise serializers.ValidationError("Rich content must be JSON-serializable.") from e
-        if len(serialized) > 100_000:
-            raise serializers.ValidationError("Rich content too large (max 100KB).")
-        return value
+        return _validate_rich_content(value)
 
 
 class ComposeTicketResponseSerializer(serializers.Serializer):


### PR DESCRIPTION
## Problem

A support agent who ends a reply with empty lines sends those empty lines to the customer's inbox.

- `serializeToMarkdown` trims the markdown body, but nothing trims the TipTap `rich_content` doc that travels beside it.
- `rich_content_to_html` builds the outbound email and emits a `<p></p>` for every empty paragraph.
- The markdown and Slack serializers already drop blank paragraphs at both ends, so the agent's own thread view looks right and the email does not.

## Changes

- A new message now stores the doc without its leading and trailing blank paragraphs, so the email matches what the composer showed.
- A blank paragraph between two blocks stays, because that is deliberate spacing.
- `trim_rich_content` in `posthog/comment/formatting.py` does the work. It drops blank edge paragraphs, drops leading and trailing `hardBreak` nodes, and strips outer whitespace from the first and last text nodes.
- Four write paths call it: the ticket reply, note and compose serializers, and `CommentSerializer`.
- `CommentSerializer` is in that list because the agent composer posts new replies through the generic comments API, not through the ticket reply endpoint. Trimming only `tickets.py` would have missed the main composer.
- `CommentSerializer` now tests emptiness against the trimmed doc, so a whitespace-only message still returns a 400.
- The in-app support form trims the message before it appends exception context, and validates the trimmed value.
- Mechanical: the three identical copies of `validate_rich_content` in `tickets.py` collapse into one shared function.

Nothing looks different, so there are no screenshots. The one visible behavior change is in the support form, where a message of pure whitespace now shows "Please enter a message" instead of submitting.

## How did you test this code?

- `TestTrimRichContent` adds six parameterized cases in `products/conversations/backend/api/tests/test_formatting.py`, covering blank edge paragraphs, outer whitespace, trailing hard breaks, a kept middle blank, and an all-blank doc.
- One case renders a doc with two trailing empty paragraphs to email HTML and asserts the `<p></p>` is gone after trimming. That is the regression this PR fixes, and no existing test rendered that shape.
- Not run: `posthog/api/test/test_comments.py` and the other database-backed suites. The local `test_posthog` has an inconsistent migration history that fails every database test at setup, on this branch and on master alike. CI covers them.
- No manual testing in the app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow, API contract or setting changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: Claude Code, Opus 5.
- Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- The trim sits on the backend write paths rather than in the composer, so API and MCP clients get it too. The composer already trims the markdown half.
- Removing `has_empty_paragraph` was needed: it returned true for any empty paragraph anywhere in the doc, which after trimming no longer describes an empty message.
- Public artifact: the diff, tests and this description carry nothing from the session that is not already in this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
