### PR TITLE
fix(warehouse-sources): recover a table's sync when its schedule is missing

### DIFF
--- a/products/warehouse_sources/backend/presentation/views/external_data_schema.py
+++ b/products/warehouse_sources/backend/presentation/views/external_data_schema.py
@@ -186,6 +186,21 @@ def _reset_cdc_for_full_resnapshot(instance: ExternalDataSchema) -> None:
     instance.save(update_fields=["status", "updated_at"])
 
 
+def _trigger_schema_sync(instance: ExternalDataSchema) -> None:
+    """Trigger the schema's sync, creating its Temporal schedule first if it has none.
+
+    A schema can reach the UI with no schedule behind it (never created, or dropped), and
+    triggering one that isn't there raises NOT_FOUND. Retrying can't fix that, so recover the
+    same way the source-level reload does instead of dead-ending a single table's sync.
+    """
+    try:
+        trigger_external_data_workflow(instance)
+    except temporalio.service.RPCError as e:
+        if e.status != temporalio.service.RPCStatusCode.NOT_FOUND:
+            raise
+        sync_external_data_job_workflow(instance, create=True, should_sync=instance.should_sync)
+
+
 # Sync frequencies below the 5-minute floor. No longer accepted as input (dropped from the
 # serializer's choices), but rows written before the floor may still carry one until the
 # migrate_sub_5min_sync_frequencies command bumps them — so the interval mappings keep parsing
@@ -1663,13 +1678,13 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             )
 
         try:
-            trigger_external_data_workflow(instance)
+            _trigger_schema_sync(instance)
         except temporalio.service.RPCError as e:
             # Only mark the schema Running once the trigger succeeded: a Running status with no
             # workflow behind it sticks forever (nothing finalizes it) and blocks cancel.
             logger.exception(f"Could not trigger external data job for schema {instance.id}", exc_info=e)
             return Response(
-                data={"detail": "Couldn't start the sync. Please try again."},
+                data={"detail": "Couldn't start the sync. Try again in a few minutes."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         except Exception as e:
@@ -1735,14 +1750,14 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             instance.initial_sync_complete = False
 
         try:
-            trigger_external_data_workflow(instance)
+            _trigger_schema_sync(instance)
         except temporalio.service.RPCError as e:
             # Only mark the schema Running once the trigger succeeded: a Running status with no
             # workflow behind it sticks forever (nothing finalizes it) and blocks cancel. The
             # sync_type_config reset above stays; the schema's intent is still "resync next run".
             logger.exception(f"Could not trigger external data job for schema {instance.id}", exc_info=e)
             return Response(
-                data={"detail": "Couldn't start the sync. Please try again."},
+                data={"detail": "Couldn't start the sync. Try again in a few minutes."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 

--- a/products/warehouse_sources/backend/tests/api/test_external_data_schema.py
+++ b/products/warehouse_sources/backend/tests/api/test_external_data_schema.py
@@ -3185,6 +3185,31 @@ class TestTriggerFailureDoesNotPaintRunning(APIBaseTest):
         schema.refresh_from_db()
         assert schema.status == ExternalDataSchema.Status.FAILED
 
+    @parameterized.expand([("reload",), ("resync",)])
+    @mock.patch(
+        "products.warehouse_sources.backend.presentation.views.external_data_schema.sync_external_data_job_workflow"
+    )
+    @mock.patch(
+        "products.warehouse_sources.backend.presentation.views.external_data_schema.trigger_external_data_workflow"
+    )
+    def test_missing_schedule_is_created_so_the_sync_starts(self, endpoint, mock_trigger, mock_create_schedule):
+        # A schema with no schedule behind it can't be triggered, and retrying never fixes it. The
+        # source-level reload already recovers by creating the schedule; one table must too.
+        from temporalio.service import RPCError
+
+        schema = self._create_schema()
+        mock_trigger.side_effect = RPCError("schedule not found", RPCStatusCode.NOT_FOUND, b"")
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}/{endpoint}/",
+        )
+
+        assert response.status_code == 200
+        mock_create_schedule.assert_called_once_with(schema, create=True, should_sync=True)
+
+        schema.refresh_from_db()
+        assert schema.status == ExternalDataSchema.Status.RUNNING
+
 
 class TestExternalDataSchemaAPIKeyScopes(APIBaseTest):
     def _make_api_key(self, scopes: list[str]) -> str:


### PR DESCRIPTION
## Problem

Someone who has just connected a source clicks **Sync** on a single table and gets "Couldn't start the sync. Please try again." Retrying never works. Clicking **Sync now** on the whole source, on the same tables, succeeds.

The two paths handle a missing Temporal schedule differently. The source-level reload catches the `NOT_FOUND` from triggering a schedule that isn't there and creates it (`ExternalDataSource.reload_schemas`). The per-schema `reload` and `resync` endpoints return a 400 instead, so a schema that reached the UI without a schedule — never created, or dropped — has no way back from its own row.

## Changes

- Syncing or resyncing a single table now creates the schedule when none exists, so the sync starts instead of failing. Same recovery the source-level reload already does, and the same recovery the schema update path uses when an enabled schema has no schedule.
- The remaining trigger failures (Temporal genuinely unreachable) still return a 400 and leave the status alone. Their message drops "Please" for house voice and says when retrying is worth it.
- The new schedule inherits the schema's own `should_sync`, so recovering a disabled table doesn't quietly start scheduling it. A manual trigger runs regardless of the paused state.

## How did you test this code?

`products/warehouse_sources/backend/tests/api/test_external_data_schema.py::TestTriggerFailureDoesNotPaintRunning` — 4 passed locally (2 pre-existing, 2 new).

The new parameterized case covers the regression nothing else caught: `reload` and `resync` returning 400 on a `NOT_FOUND` trigger rather than creating the schedule. The pre-existing case pins the other half — a non-`NOT_FOUND` RPC failure must still 400 and must not paint the schema Running.

No manual testing: this needs a live Temporal schedule in a state the local stack doesn't reproduce.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no documented behavior changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Written by Claude Code, from a review of Replay Vision session summaries of the data-warehouse new-source onboarding flow. One session showed a per-table sync failing while a whole-source sync of the same tables succeeded, which pointed at the asymmetric `NOT_FOUND` handling.
- Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, `/improving-drf-endpoints`, `/writing-pr-descriptions`.
- No duplicate: searched open PRs for "Couldn't start the sync", "schema reload", "schedule NOT_FOUND", "missing schedule", "resync schedule", and listed the maintainer's open PRs. The closest hit, #94635, changes the admin ad-hoc sync helper (`ad_hoc_sync.py`) rather than these endpoints — no overlap.
- Public artifact: nothing here carries session material. The diff and this description describe the code path only; no customer, org, host, or identifier from the reviewed sessions appears in any file, comment, test, or message.
- Considered making the whole recovery live in `trigger_external_data_workflow` instead. Kept it local to the two endpoints so the sync-behavior change stays inside the paths a person clicks, rather than reaching every caller of the service helper.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
