### PR TITLE
feat(workflows): hide loop-owned workflows from the workflows list

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6579,6 +6579,8 @@ const api = {
             type?: 'messaging' | 'automation'
             /** JSON-encoded object the stored trigger must contain, e.g. `{"type":"batch"}`. */
             trigger?: string
+            /** An owning product, or `none` for workflows built in the workflows UI or over the API. */
+            origin_product?: string
             limit?: number
             offset?: number
         }): Promise<CountedPaginatedResponse<HogFlow>> {

--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -2736,7 +2736,7 @@ class HogFlowSerializer(HogFlowMinimalSerializer):
         required=False,
         allow_null=True,
         help_text="Product surface that owns this workflow (e.g. `loops` for Desktop loops). Set only when "
-        "creating a workflow. Filter the list with `?origin_product=`.",
+        "creating a workflow. Filter the list with `?origin_product=`; `none` lists workflows with no owning product.",
     )
     name = serializers.CharField(
         max_length=400, required=False, allow_null=True, allow_blank=True, help_text="Workflow name."
@@ -3828,10 +3828,12 @@ class HogFlowViewSet(
                 )
 
             origin_product = self.request.GET.get("origin_product")
-            if origin_product:
+            if origin_product == "none":
+                queryset = queryset.filter(origin_product__isnull=True)
+            elif origin_product:
                 if origin_product not in HogFlow.OriginProduct.values:
                     raise exceptions.ValidationError(
-                        {"origin_product": f"Must be one of: {', '.join(HogFlow.OriginProduct.values)}"}
+                        {"origin_product": f"Must be one of: none, {', '.join(HogFlow.OriginProduct.values)}"}
                     )
                 queryset = queryset.filter(origin_product=origin_product)
 

--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -3668,8 +3668,9 @@ def mint_audience_confirm_token(
             OpenApiParameter(
                 "origin_product",
                 OpenApiTypes.STR,
-                enum=HogFlow.OriginProduct.values,
-                description="Filter to workflows owned by a product surface, e.g. `loops` for Desktop loops.",
+                enum=["none", *HogFlow.OriginProduct.values],
+                description="Filter to workflows owned by a product surface, e.g. `loops` for Desktop loops. "
+                "`none` returns workflows with no owning product.",
             ),
             OpenApiParameter(
                 "trigger",

--- a/products/workflows/backend/api/test/test_hog_flow.py
+++ b/products/workflows/backend/api/test/test_hog_flow.py
@@ -286,6 +286,10 @@ class TestHogFlowAPI(APIBaseTest):
         assert response.status_code == 200, response.json()
         assert {flow["name"] for flow in response.json()["results"]} == {"Loop"}
 
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_flows?origin_product=none")
+        assert response.status_code == 200, response.json()
+        assert {flow["name"] for flow in response.json()["results"]} == {"Hand built"}
+
         response = self.client.get(f"/api/projects/{self.team.id}/hog_flows?origin_product=spreadsheets")
         assert response.status_code == 400
 

--- a/products/workflows/frontend/Workflows/workflowsLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowsLogic.ts
@@ -67,6 +67,7 @@ interface WorkflowsListParams {
     created_by?: string
     type?: Exclude<WorkflowTypeFilter, 'all'>
     trigger?: string
+    origin_product?: string
     limit: number
     offset: number
 }
@@ -420,6 +421,8 @@ export const workflowsLogic = kea<workflowsLogicType>([
                 type: filters.type !== 'all' ? filters.type : undefined,
                 // The API filters triggers by JSON containment, so the type goes over as a JSON object.
                 trigger: filters.triggerType !== 'all' ? JSON.stringify({ type: filters.triggerType }) : undefined,
+                // Workflows owned by another product (loops) are listed by that product, not here.
+                origin_product: 'none',
                 limit: WORKFLOWS_PER_PAGE,
                 offset: filters.page ? (filters.page - 1) * WORKFLOWS_PER_PAGE : 0,
             }),

--- a/products/workflows/frontend/emptyState/workflowsSetupLogic.ts
+++ b/products/workflows/frontend/emptyState/workflowsSetupLogic.ts
@@ -14,7 +14,7 @@ export const workflowsSetupLogic = createSetupDetectionLogic({
     path: ['products', 'workflows', 'frontend', 'emptyState', 'workflowsSetupLogic'],
     detect: async () => {
         const projectId = String(projectLogic.findMounted()?.values.currentProjectId)
-        const response = await hogFlowsList(projectId, { limit: 1 })
+        const response = await hogFlowsList(projectId, { limit: 1, origin_product: 'none' })
         return response.count > 0 ? 'has-data' : 'needs-setup'
     },
 })

--- a/products/workflows/frontend/generated/api.schemas.ts
+++ b/products/workflows/frontend/generated/api.schemas.ts
@@ -1713,7 +1713,7 @@ export type HogFlowsListParams = {
      */
     offset?: number
     /**
-     * Filter to workflows owned by a product surface, e.g. `loops` for Desktop loops.
+     * Filter to workflows owned by a product surface, e.g. `loops` for Desktop loops. `none` returns workflows with no owning product.
      */
     origin_product?: HogFlowsListOriginProduct
     /**
@@ -1741,6 +1741,7 @@ export type HogFlowsListOriginProduct = (typeof HogFlowsListOriginProduct)[keyof
 
 export const HogFlowsListOriginProduct = {
     Loops: 'loops',
+    None: 'none',
 } as const
 
 export type HogFlowsListStatus = (typeof HogFlowsListStatus)[keyof typeof HogFlowsListStatus]

--- a/products/workflows/frontend/generated/api.schemas.ts
+++ b/products/workflows/frontend/generated/api.schemas.ts
@@ -584,7 +584,7 @@ export interface HogFlowApi {
      * * `active` - Active
      * * `archived` - Archived */
     status?: HogFlowStateEnumApi
-    /** Product surface that owns this workflow (e.g. `loops` for Desktop loops). Set only when creating a workflow. Filter the list with `?origin_product=`.
+    /** Product surface that owns this workflow (e.g. `loops` for Desktop loops). Set only when creating a workflow. Filter the list with `?origin_product=`; `none` lists workflows with no owning product.
      *
      * * `loops` - Loops */
     origin_product?: HogFlowOriginProductEnumApi | null

--- a/products/workflows/frontend/generated/api.zod.ts
+++ b/products/workflows/frontend/generated/api.zod.ts
@@ -433,7 +433,7 @@ export const HogFlowsCreateBody = /* @__PURE__ */ zod
             .union([zod.enum(['loops']).describe('\* `loops` - Loops'), zod.null()])
             .optional()
             .describe(
-                'Product surface that owns this workflow (e.g. `loops` for Desktop loops). Set only when creating a workflow. Filter the list with `?origin_product=`.\n\n\* `loops` - Loops'
+                'Product surface that owns this workflow (e.g. `loops` for Desktop loops). Set only when creating a workflow. Filter the list with `?origin_product=`; `none` lists workflows with no owning product.\n\n\* `loops` - Loops'
             ),
         trigger_masking: zod
             .union([
@@ -1807,7 +1807,7 @@ export const HogFlowsInvocationsCreateBody = /* @__PURE__ */ zod.object({
                 .union([zod.enum(['loops']).describe('\* `loops` - Loops'), zod.null()])
                 .optional()
                 .describe(
-                    'Product surface that owns this workflow (e.g. `loops` for Desktop loops). Set only when creating a workflow. Filter the list with `?origin_product=`.\n\n\* `loops` - Loops'
+                    'Product surface that owns this workflow (e.g. `loops` for Desktop loops). Set only when creating a workflow. Filter the list with `?origin_product=`; `none` lists workflows with no owning product.\n\n\* `loops` - Loops'
                 ),
             created_at: zod.iso.datetime({ offset: true }),
             created_by: zod.object({
@@ -2545,7 +2545,7 @@ export const HogFlowsBulkDeleteCreateBody = /* @__PURE__ */ zod
             .union([zod.enum(['loops']).describe('\* `loops` - Loops'), zod.null()])
             .optional()
             .describe(
-                'Product surface that owns this workflow (e.g. `loops` for Desktop loops). Set only when creating a workflow. Filter the list with `?origin_product=`.\n\n\* `loops` - Loops'
+                'Product surface that owns this workflow (e.g. `loops` for Desktop loops). Set only when creating a workflow. Filter the list with `?origin_product=`; `none` lists workflows with no owning product.\n\n\* `loops` - Loops'
             ),
         trigger_masking: zod
             .union([

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -43659,7 +43659,7 @@ export namespace Schemas {
        * * `active` - Active
        * * `archived` - Archived */
       status?: HogFlowStateEnum;
-      /** Product surface that owns this workflow (e.g. `loops` for Desktop loops). Set only when creating a workflow. Filter the list with `?origin_product=`.
+      /** Product surface that owns this workflow (e.g. `loops` for Desktop loops). Set only when creating a workflow. Filter the list with `?origin_product=`; `none` lists workflows with no owning product.
        *
        * * `loops` - Loops */
       origin_product?: HogFlowOriginProductEnum | null;

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -98069,7 +98069,7 @@ export namespace Schemas {
      */
     offset?: number;
     /**
-     * Filter to workflows owned by a product surface, e.g. `loops` for Desktop loops.
+     * Filter to workflows owned by a product surface, e.g. `loops` for Desktop loops. `none` returns workflows with no owning product.
      */
     origin_product?: HogFlowsListOriginProduct;
     /**
@@ -98098,6 +98098,7 @@ export namespace Schemas {
 
     export const HogFlowsListOriginProduct = {
       Loops: 'loops',
+      None: 'none',
     } as const;
 
     export type HogFlowsListStatus = typeof HogFlowsListStatus[keyof typeof HogFlowsListStatus];

--- a/services/mcp/src/generated/workflows/api.ts
+++ b/services/mcp/src/generated/workflows/api.ts
@@ -23,9 +23,11 @@ export const HogFlowsListQueryParams = () => zod.object({
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
     origin_product: zod
-        .enum(['loops'])
+        .enum(['loops', 'none'])
         .optional()
-        .describe('Filter to workflows owned by a product surface, e.g. `loops` for Desktop loops.'),
+        .describe(
+            'Filter to workflows owned by a product surface, e.g. `loops` for Desktop loops. `none` returns workflows with no owning product.'
+        ),
     search: zod.string().optional().describe('Case-insensitive search across workflow name and description.'),
     status: zod
         .enum(['active', 'archived', 'draft'])

--- a/services/mcp/src/generated/workflows/api.ts
+++ b/services/mcp/src/generated/workflows/api.ts
@@ -87,7 +87,7 @@ export const HogFlowsCreateBody = () => zod
             .union([zod.enum(['loops']).describe('\* `loops` - Loops'), zod.null()])
             .optional()
             .describe(
-                'Product surface that owns this workflow (e.g. `loops` for Desktop loops). Set only when creating a workflow. Filter the list with `?origin_product=`.\n\n\* `loops` - Loops'
+                'Product surface that owns this workflow (e.g. `loops` for Desktop loops). Set only when creating a workflow. Filter the list with `?origin_product=`; `none` lists workflows with no owning product.\n\n\* `loops` - Loops'
             ),
         trigger_masking: zod
             .union([

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/workflows-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/workflows-create.json
@@ -538,7 +538,7 @@
                     "type": "null"
                 }
             ],
-            "description": "Product surface that owns this workflow (e.g. `loops` for Desktop loops). Set only when creating a workflow. Filter the list with `?origin_product=`.\n\n* `loops` - Loops"
+            "description": "Product surface that owns this workflow (e.g. `loops` for Desktop loops). Set only when creating a workflow. Filter the list with `?origin_product=`; `none` lists workflows with no owning product.\n\n* `loops` - Loops"
         },
         "status": {
             "description": "draft (no execution), active (live), archived (disabled).\n\n* `draft` - Draft\n* `active` - Active\n* `archived` - Archived",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/workflows-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/workflows-list.json
@@ -22,8 +22,8 @@
             "type": "number"
         },
         "origin_product": {
-            "description": "Filter to workflows owned by a product surface, e.g. `loops` for Desktop loops.",
-            "enum": ["loops"],
+            "description": "Filter to workflows owned by a product surface, e.g. `loops` for Desktop loops. `none` returns workflows with no owning product.",
+            "enum": ["loops", "none"],
             "type": "string"
         },
         "search": {


### PR DESCRIPTION
## Problem

Workflows built from Desktop loops show up in the Workflows list next to hand-built workflows. Loops list their own workflows, so the duplicate entries only add noise here.

The API can list flows for one owning product with `?origin_product=loops`, but it has no way to ask for flows that have no owning product.

## Changes

- The Workflows list no longer shows workflows owned by another product. Loops built from Desktop stay out of it.
- The list API accepts `?origin_product=none` and returns workflows with no owning product. Existing `?origin_product=loops` behavior is unchanged.
- Mechanical: regenerated OpenAPI types for the updated help text.

No screenshot: the list looks the same, it only has fewer rows when loops exist.

## How did you test this code?

- Extended `test_list_filter_by_origin_product` to cover `none`, which catches the new filter returning loop-owned flows.
- Not run: the frontend typecheck in full, because this worktree has no built quill package. The two touched frontend files report no errors.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The `origin_product` filter has no user-facing docs.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5.1) with Bash and git. Skills invoked: /writing-pr-descriptions. The default filter is sent from the list logic rather than applied server-side by default, so API and MCP callers still see every workflow.

https://claude.ai/code/session_01RQ928F9ufxwQwP3XBiDwVw
