### PR TITLE
fix(taxonomy): make $group_key selectable as a group property

### DIFF
--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -4395,7 +4395,9 @@
     "groups": {
         "$group_key": {
             "description": "Specified group key",
-            "label": "Group key"
+            "label": "Group key",
+            "type": "String",
+            "virtual": true
         },
         "$virt_mrr": {
             "description": "The current MRR for this group.",

--- a/posthog/api/test/test_property_definition.py
+++ b/posthog/api/test/test_property_definition.py
@@ -562,17 +562,27 @@ class TestPropertyDefinitionAPI(APIBaseTest):
             (
                 "Get all group1 properties",
                 "type=group&group_type_index=1",
-                ["group1 another", "group1 property", "$virt_revenue", "$virt_mrr"],
+                ["group1 another", "group1 property", "$group_key", "$virt_revenue", "$virt_mrr"],
             ),
             (
                 "Get all group2 properties",
                 "type=group&group_type_index=2",
-                ["group2 property", "$virt_revenue", "$virt_mrr"],
+                ["group2 property", "$group_key", "$virt_revenue", "$virt_mrr"],
             ),
             (
                 "Search group1 properties containing 'prop'",
                 "type=group&search=prop&group_type_index=1",
                 ["group1 property"],
+            ),
+            (
+                "Search for the group key by its name",
+                "type=group&search=group_key&group_type_index=1",
+                ["$group_key"],
+            ),
+            (
+                "Search for the group key by its label",
+                "type=group&search=Group%20key&group_type_index=1",
+                ["$group_key"],
             ),
         ]
     )

--- a/posthog/api/test/test_property_definition.py
+++ b/posthog/api/test/test_property_definition.py
@@ -987,8 +987,10 @@ class TestPropertyDefinitionAPI(APIBaseTest):
         )
         assert response.status_code == status.HTTP_200_OK
         # Virtual properties should still be included when excluding hidden
-        virtual_props = [prop for prop in response.json()["results"] if prop["name"].startswith("$virt_")]
-        assert len(virtual_props) == len(PropertyDefinitionViewSet._BUILTIN_VIRTUAL_PERSON_PROPERTIES)
+        virtual_props = [prop for prop in response.json()["results"] if prop.get("virtual")]
+        assert {p["name"] for p in virtual_props} == {
+            p["name"] for p in PropertyDefinitionViewSet._BUILTIN_VIRTUAL_PERSON_PROPERTIES
+        }
 
     @parameterized.expand(
         [
@@ -1028,35 +1030,45 @@ class TestPropertyDefinitionAPI(APIBaseTest):
         )
         assert response.status_code == status.HTTP_200_OK
         # Virtual properties should still be included when excluding core properties
-        virtual_props = [prop for prop in response.json()["results"] if prop["name"].startswith("$virt_")]
-        assert len(virtual_props) == len(PropertyDefinitionViewSet._BUILTIN_VIRTUAL_PERSON_PROPERTIES)
+        virtual_props = [prop for prop in response.json()["results"] if prop.get("virtual")]
+        assert {p["name"] for p in virtual_props} == {
+            p["name"] for p in PropertyDefinitionViewSet._BUILTIN_VIRTUAL_PERSON_PROPERTIES
+        }
 
         response = self.client.get(
             f"/api/projects/{self.team.pk}/property_definitions/?type=group&group_type_index=0&exclude_core_properties=true"
         )
         assert response.status_code == status.HTTP_200_OK
         # Virtual properties should still be included when excluding core properties
-        virtual_props = [prop for prop in response.json()["results"] if prop["name"].startswith("$virt_")]
-        assert len(virtual_props) == len(PropertyDefinitionViewSet._BUILTIN_VIRTUAL_GROUP_PROPERTIES)
+        virtual_props = [prop for prop in response.json()["results"] if prop.get("virtual")]
+        assert {p["name"] for p in virtual_props} == {
+            p["name"] for p in PropertyDefinitionViewSet._BUILTIN_VIRTUAL_GROUP_PROPERTIES
+        }
 
     def test_virtual_property_type_filter(self):
         response = self.client.get(f"/api/projects/{self.team.pk}/property_definitions/?type=person")
         assert response.status_code == status.HTTP_200_OK
         # Should include virtual properties when type=person
-        virtual_props = [prop for prop in response.json()["results"] if prop["name"].startswith("$virt_")]
-        assert len(virtual_props) == len(PropertyDefinitionViewSet._BUILTIN_VIRTUAL_PERSON_PROPERTIES)
+        virtual_props = [prop for prop in response.json()["results"] if prop.get("virtual")]
+        assert {p["name"] for p in virtual_props} == {
+            p["name"] for p in PropertyDefinitionViewSet._BUILTIN_VIRTUAL_PERSON_PROPERTIES
+        }
 
         response = self.client.get(f"/api/projects/{self.team.pk}/property_definitions/?type=group&group_type_index=0")
         assert response.status_code == status.HTTP_200_OK
         # Should include virtual properties when type=group
-        virtual_props = [prop for prop in response.json()["results"] if prop["name"].startswith("$virt_")]
-        assert len(virtual_props) == len(PropertyDefinitionViewSet._BUILTIN_VIRTUAL_GROUP_PROPERTIES)
+        virtual_props = [prop for prop in response.json()["results"] if prop.get("virtual")]
+        assert {p["name"] for p in virtual_props} == {
+            p["name"] for p in PropertyDefinitionViewSet._BUILTIN_VIRTUAL_GROUP_PROPERTIES
+        }
 
         response = self.client.get(f"/api/projects/{self.team.pk}/property_definitions/?type=event")
         assert response.status_code == status.HTTP_200_OK
         # Should include virtual event properties (bot detection)
-        virtual_props = [prop for prop in response.json()["results"] if prop["name"].startswith("$virt_")]
-        assert len(virtual_props) == len(PropertyDefinitionViewSet._BUILTIN_VIRTUAL_EVENT_PROPERTIES)
+        virtual_props = [prop for prop in response.json()["results"] if prop.get("virtual")]
+        assert {p["name"] for p in virtual_props} == {
+            p["name"] for p in PropertyDefinitionViewSet._BUILTIN_VIRTUAL_EVENT_PROPERTIES
+        }
         virtual_names = {p["name"] for p in virtual_props}
         assert "$virt_is_bot" in virtual_names
         assert "$virt_traffic_type" in virtual_names

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -251,7 +251,7 @@ GROUP_KEY_PATTERN = re.compile(r"^\$group_[0-4]$")
 GROUP_KEY_PROPERTY = "$group_key"
 
 
-def group_property_chain(group_type_index: int | float | None, key: str) -> list[str | int]:
+def group_property_chain(group_type_index: int | float | None, key: str) -> list[str]:
     """Field chain that reads group property `key` through the events table's `group_N` lazy join.
 
     `$group_key` is the `key` column, `$virt_*` properties are expression fields on the groups table, and

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -246,6 +246,27 @@ def _wildcard_bounds(value: str) -> tuple[str, str]:
 
 GROUP_KEY_PATTERN = re.compile(r"^\$group_[0-4]$")
 
+# The group's key is a column on the groups table, not an entry in its property JSON. Flag matching and
+# the release-condition blast radius already resolve it that way; HogQL has to agree everywhere.
+GROUP_KEY_PROPERTY = "$group_key"
+
+
+def group_property_chain(group_type_index: int | float | None, key: str) -> list[str | int]:
+    """Field chain that reads group property `key` through the events table's `group_N` lazy join.
+
+    `$group_key` is the `key` column, `$virt_*` properties are expression fields on the groups table, and
+    anything else lives in the property JSON. The breakdown builders and `property_to_expr` all go through
+    here so the three shapes cannot drift apart.
+    """
+    if group_type_index is None:
+        raise QueryError("A group property needs a group_type_index")
+    prefix = f"group_{int(group_type_index)}"
+    if key == GROUP_KEY_PROPERTY:
+        return [prefix, "key"]
+    if key.startswith("$virt_"):
+        return [prefix, key]
+    return [prefix, "properties", key]
+
 
 def _stringify_group_key_value(value: object) -> str | list[str]:
     """Group keys ($group_0–$group_4) are always stored as strings. A numeric filter
@@ -1269,10 +1290,10 @@ def property_to_expr(
         value = property.value
 
         # `$group_key` is the group's key column, not an entry in its property JSON. Flag
-        # matching and the blast radius already resolve it that way, so resolve it here too —
+        # matching and the blast radius already resolve it that way, so resolve it here too;
         # otherwise the same filter silently matches nothing in insights, cohorts and the
         # groups list.
-        is_group_key_column = property.type == "group" and property.key == "$group_key"
+        is_group_key_column = property.type == "group" and property.key == GROUP_KEY_PROPERTY
 
         if property.key and (is_group_key_column or GROUP_KEY_PATTERN.match(str(property.key))):
             value = _stringify_group_key_value(value)
@@ -1335,7 +1356,7 @@ def property_to_expr(
             else:
                 raise QueryError("Data warehouse person property filter value must be a string")
         elif is_group_key_column:
-            chain = ["key"] if scope == "group" else [f"group_{property.group_type_index}", "key"]
+            chain = ["key"] if scope == "group" else group_property_chain(property.group_type_index, GROUP_KEY_PROPERTY)
         elif property.type == "group" and scope != "group":
             chain = [f"group_{property.group_type_index}", "properties"]
         elif property.type == "session" and scope in ["event", "replay"]:

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -1268,7 +1268,13 @@ def property_to_expr(
         operator = cast(Optional[PropertyOperator], property.operator) or PropertyOperator.EXACT
         value = property.value
 
-        if property.key and GROUP_KEY_PATTERN.match(str(property.key)):
+        # `$group_key` is the group's key column, not an entry in its property JSON. Flag
+        # matching and the blast radius already resolve it that way, so resolve it here too —
+        # otherwise the same filter silently matches nothing in insights, cohorts and the
+        # groups list.
+        is_group_key_column = property.type == "group" and property.key == "$group_key"
+
+        if property.key and (is_group_key_column or GROUP_KEY_PATTERN.match(str(property.key))):
             value = _stringify_group_key_value(value)
 
         if property.type == "person" and property.key == "distinct_id":
@@ -1328,6 +1334,8 @@ def property_to_expr(
                 property.key = key
             else:
                 raise QueryError("Data warehouse person property filter value must be a string")
+        elif is_group_key_column:
+            chain = ["key"] if scope == "group" else [f"group_{property.group_type_index}", "key"]
         elif property.type == "group" and scope != "group":
             chain = [f"group_{property.group_type_index}", "properties"]
         elif property.type == "session" and scope in ["event", "replay"]:
@@ -1365,7 +1373,7 @@ def property_to_expr(
         # We pretend elements chain is a property, but it is actually a column on the events table
         if chain == ["properties"] and property.key == "$elements_chain":
             field = ast.Field(chain=["elements_chain"])
-        elif property.key == "":
+        elif property.key == "" or is_group_key_column:
             field = ast.Field(chain=[*chain])
         else:
             field = ast.Field(chain=[*chain, property.key])

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -169,6 +169,47 @@ class TestProperty(BaseTest):
             self._parse_expr("properties.arr > 100"),
         )
 
+    def test_property_to_expr_group_key(self):
+        # `$group_key` is the group's key column, not an entry in its property JSON
+        self.assertEqual(
+            self._property_to_expr({"type": "group", "group_type_index": 0, "key": "$group_key", "value": "org_123"}),
+            self._parse_expr("group_0.key = 'org_123'"),
+        )
+        self.assertEqual(
+            self._property_to_expr(
+                {"type": "group", "group_type_index": 2, "key": "$group_key", "value": "org_123"}, scope="group"
+            ),
+            self._parse_expr("key = 'org_123'"),
+        )
+
+        # groups.key is a String column, so a numeric key has to reach it as a string
+        self.assertEqual(
+            self._property_to_expr({"type": "group", "group_type_index": 0, "key": "$group_key", "value": 13}),
+            self._parse_expr("group_0.key = '13'"),
+        )
+
+        self.assertEqual(
+            self._property_to_expr(
+                {"type": "group", "group_type_index": 0, "key": "$group_key", "value": ["org_1", "org_2"]}
+            ),
+            self._parse_expr("group_0.key in ('org_1', 'org_2')"),
+        )
+
+        # Multi-value starts_with expands per value by recursing with the original key, so the
+        # column has to survive that round trip
+        self.assertEqual(
+            self._property_to_expr(
+                {
+                    "type": "group",
+                    "group_type_index": 0,
+                    "key": "$group_key",
+                    "operator": "starts_with",
+                    "value": ["org_1", "org_2"],
+                }
+            ),
+            self._parse_expr("toString(group_0.key) ilike 'org_1%' or toString(group_0.key) ilike 'org_2%'"),
+        )
+
     def test_property_to_expr_group_booleans(self):
         PropertyDefinition.objects.create(
             team=self.team,

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -210,6 +210,21 @@ class TestProperty(BaseTest):
             self._parse_expr("toString(group_0.key) ilike 'org_1%' or toString(group_0.key) ilike 'org_2%'"),
         )
 
+    def test_property_to_expr_group_key_prints_the_group_join(self):
+        # The AST tests above stop at `group_0.key`; this proves the resolver reaches the groups table's
+        # key column through the events lazy join and does not fall back to a JSON extract.
+        where = self._property_to_expr({"type": "group", "group_type_index": 0, "key": "$group_key", "value": "org_1"})
+        query = ast.SelectQuery(
+            select=[ast.Call(name="count", args=[])],
+            select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+            where=where,
+        )
+        context = HogQLContext(team_id=self.team.pk, enable_select_queries=True)
+        sql, _ = prepare_and_print_ast(query, context=context, dialect="clickhouse")
+        assert "groups" in sql
+        assert "group_key" in sql
+        assert "group_properties" not in sql
+
     def test_property_to_expr_group_booleans(self):
         PropertyDefinition.objects.create(
             team=self.team,

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -3774,6 +3774,10 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         "$group_key": {
             "label": "Group key",
             "description": "Specified group key",
+            "type": "String",
+            # Not a row in the group's property JSON — it is the group's key column. Marked
+            # virtual so the property definitions API still offers it as a selectable filter.
+            "virtual": True,
         },
         "$virt_revenue": {
             "description": "The total revenue for this group. This will always be the current total revenue even when referring to a group via events.",

--- a/products/product_analytics/backend/hogql_queries/funnels/test/test_funnel_event_query.py
+++ b/products/product_analytics/backend/hogql_queries/funnels/test/test_funnel_event_query.py
@@ -632,3 +632,29 @@ class TestFunnelEventQuery(ClickhouseTestMixin, APIBaseTest):
         funnel_event_query = FunnelEventQuery(context=context).to_query()
         select = format_query(funnel_event_query)
         self.assertIn(f"ifNull(toString(session.{breakdown_property}), '')", select)
+
+    @parameterized.expand(
+        [
+            ("$group_key", ["group_0", "key"]),
+            ("$virt_revenue", ["group_0", "$virt_revenue"]),
+            ("industry", ["group_0", "properties", "industry"]),
+        ]
+    )
+    @time_machine.travel("2025-11-12", tick=False)
+    def test_group_breakdown_chain(self, breakdown_property: str, expected_chain: list[str]):
+        query = FunnelsQuery(
+            series=[EventsNode(event="$pageview"), EventsNode(event="$autocapture")],
+            breakdownFilter=BreakdownFilter(
+                breakdown=breakdown_property, breakdown_type=BreakdownType.GROUP, breakdown_group_type_index=0
+            ),
+        )
+        context = FunnelQueryContext(query=query, team=self.team)
+
+        # A single group breakdown is not wrapped in an array, unlike the session breakdown above.
+        if_null = FunnelEventQuery(context=context)._get_breakdown_expr()
+        assert isinstance(if_null, ast.Call) and if_null.name == "ifNull"
+        to_string = if_null.args[0]
+        assert isinstance(to_string, ast.Call) and to_string.name == "toString"
+        field = to_string.args[0]
+        assert isinstance(field, ast.Field)
+        self.assertEqual(field.chain, expected_chain)

--- a/products/product_analytics/backend/hogql_queries/funnels/utils.py
+++ b/products/product_analytics/backend/hogql_queries/funnels/utils.py
@@ -13,7 +13,7 @@ from posthog.schema import (
 
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_expr
-from posthog.hogql.property import apply_path_cleaning
+from posthog.hogql.property import apply_path_cleaning, group_property_chain
 
 from posthog.constants import FUNNEL_WINDOW_INTERVAL_TYPES
 from posthog.hogql_queries.utils.breakdowns import ALL_USERS_COHORT_ID, NOT_IN_COHORT_ID
@@ -76,8 +76,16 @@ def get_breakdown_expr(
         if properties_column is None:
             # breakdown already refers to a top-level field
             return ast.Field(chain=[breakdown])
-        else:
-            return ast.Field(chain=[*properties_column.split("."), breakdown])
+        column_chain = properties_column.split(".")
+        # A group breakdown arrives as `group_N.properties`, but `$group_key` and `$virt_*` are not JSON entries.
+        if (
+            isinstance(breakdown, str)
+            and len(column_chain) == 2
+            and column_chain[0].startswith("group_")
+            and column_chain[1] == "properties"
+        ):
+            return ast.Field(chain=group_property_chain(int(column_chain[0].removeprefix("group_")), breakdown))
+        return ast.Field(chain=[*column_chain, breakdown])
 
     # Fail loudly rather than silently skipping cleaning if a caller forgets the team
     if path_cleaning and team is None:

--- a/products/product_analytics/backend/hogql_queries/funnels/utils.py
+++ b/products/product_analytics/backend/hogql_queries/funnels/utils.py
@@ -84,7 +84,7 @@ def get_breakdown_expr(
             and column_chain[0].startswith("group_")
             and column_chain[1] == "properties"
         ):
-            return ast.Field(chain=group_property_chain(int(column_chain[0].removeprefix("group_")), breakdown))
+            return ast.Field(chain=[*group_property_chain(int(column_chain[0].removeprefix("group_")), breakdown)])
         return ast.Field(chain=[*column_chain, breakdown])
 
     # Fail loudly rather than silently skipping cleaning if a caller forgets the team

--- a/products/product_analytics/backend/hogql_queries/retention/test/test_retention_utils.py
+++ b/products/product_analytics/backend/hogql_queries/retention/test/test_retention_utils.py
@@ -30,6 +30,10 @@ class TestBreakdownExtractExpr(SimpleTestCase):
         expr = breakdown_extract_expr("$virt_revenue", "group", group_type_index=0)
         self.assertEqual(_chain(expr), ["group_0", "$virt_revenue"])
 
+    def test_group_breakdown_group_key_reads_the_key_column(self) -> None:
+        expr = breakdown_extract_expr("$group_key", "group", group_type_index=0)
+        self.assertEqual(_chain(expr), ["group_0", "key"])
+
     def test_group_breakdown_without_index_raises_clear_error(self) -> None:
         # A missing index must fail loudly rather than emit an unresolvable `group_None` field.
         with self.assertRaises(ValueError):

--- a/products/product_analytics/backend/hogql_queries/retention/utils.py
+++ b/products/product_analytics/backend/hogql_queries/retention/utils.py
@@ -2,6 +2,7 @@ from typing import cast
 
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_expr
+from posthog.hogql.property import group_property_chain
 
 from posthog.clickhouse.query_tagging import tag_contains_user_hogql
 from posthog.hogql_queries.utils.breakdowns import strip_user_aliases
@@ -31,12 +32,7 @@ def breakdown_extract_expr(property_name: str, breakdown_type: str, group_type_i
         elif breakdown_type == "group":
             if group_type_index is None:
                 raise ValueError("group_type_index is required for group breakdowns")
-            group_index = int(group_type_index)
-            if property_name.startswith("$virt_"):
-                # Virtual properties exist as expression fields on the groups table
-                properties_chain = [f"group_{group_index}", property_name]
-            else:
-                properties_chain = [f"group_{group_index}", "properties", property_name]
+            properties_chain = group_property_chain(int(group_type_index), property_name)
         else:
             # Default to event properties
             properties_chain = ["events", "properties", property_name]

--- a/products/product_analytics/backend/hogql_queries/trends/test/test_utils.py
+++ b/products/product_analytics/backend/hogql_queries/trends/test/test_utils.py
@@ -42,6 +42,12 @@ def test_properties_chain_groups():
         assert "group_type_index missing from params" in str(e.value)
 
 
+def test_properties_chain_group_key_and_virtual_properties():
+    # The key column and the expression fields are not entries in the group's property JSON
+    assert get_properties_chain(BreakdownType.GROUP, "$group_key", 1) == ["group_1", "key"]
+    assert get_properties_chain(BreakdownType.GROUP, "$virt_revenue", 0) == ["group_0", "$virt_revenue"]
+
+
 def test_properties_chain_events():
     p1 = get_properties_chain(breakdown_type=BreakdownType.EVENT, breakdown_field="anything", group_type_index=None)
     assert p1 == ["properties", "anything"]

--- a/products/product_analytics/backend/hogql_queries/trends/utils.py
+++ b/products/product_analytics/backend/hogql_queries/trends/utils.py
@@ -17,7 +17,7 @@ from posthog.schema import (
 )
 
 from posthog.hogql import ast
-from posthog.hogql.property import action_to_expr, property_to_expr
+from posthog.hogql.property import action_to_expr, group_property_chain, property_to_expr
 
 if TYPE_CHECKING:
     from posthog.models import Team
@@ -39,12 +39,7 @@ def get_properties_chain(
         return ["session", breakdown_field]
 
     if breakdown_type == "group" and group_type_index is not None:
-        group_type_index_int = int(group_type_index)
-        if breakdown_field.startswith("$virt_"):
-            # Virtual properties exist as expression fields on the groups table
-            return [f"group_{group_type_index_int}", breakdown_field]
-        else:
-            return [f"group_{group_type_index_int}", "properties", breakdown_field]
+        return group_property_chain(int(group_type_index), breakdown_field)
     elif breakdown_type == "group" and group_type_index is None:
         raise Exception("group_type_index missing from params")
 

--- a/products/product_analytics/backend/hogql_queries/trends/utils.py
+++ b/products/product_analytics/backend/hogql_queries/trends/utils.py
@@ -39,7 +39,7 @@ def get_properties_chain(
         return ["session", breakdown_field]
 
     if breakdown_type == "group" and group_type_index is not None:
-        return group_property_chain(int(group_type_index), breakdown_field)
+        return [*group_property_chain(int(group_type_index), breakdown_field)]
     elif breakdown_type == "group" and group_type_index is None:
         raise Exception("group_type_index missing from params")
 


### PR DESCRIPTION
## Problem

Someone building a feature flag targeted at organizations cannot find the group key in the property picker. Typing "Group key" into `+ Add filter` returns "No results", although the same flag can already hold a `$group_key equals …` condition and flag evaluation honours it.

`$group_key` is the group's identity, not an entry in the group's property JSON, so it has no `PropertyDefinition` row. Unlike `$virt_revenue` and `$virt_mrr` it was also not marked `virtual`, so the property definitions API never injected it into the results. It was reachable only by copying an existing condition.

The gap goes one layer deeper. Flag evaluation (`rust/feature-flags`) and the release-condition blast radius (`_build_group_query`) both special-case `$group_key` and resolve it to the group's key. Generic HogQL did not, so the identical filter resolved to `group_N.properties.$group_key` in insights, cohorts and the groups list, where it matches nothing.

## Changes

- `$group_key` is now offered in the group property picker, and matches a search for either `group_key` or its "Group key" label. It is marked `virtual` with type `String` in the groups taxonomy, so `property_definitions?type=group` appends it the same way it already appends the two `$virt_*` group properties.
- A group `$group_key` filter now resolves to the `groups.key` column in HogQL — `key` in group scope, `group_N.key` elsewhere — so it matches wherever group properties are evaluated, not only in flag matching. Values are coerced to strings, as `groups.key` is a `String` column.
- Group breakdowns resolve `$group_key` the same way. The trends, retention and funnel builders read group properties through one shared chain helper (`group_property_chain`), which returns the `key` column for `$group_key`, the expression field for `$virt_*`, and the property JSON otherwise; `property_to_expr` uses the same helper, so a breakdown by group key no longer yields a NULL series while the filter matches.
- Mechanical: the generated `core-filter-definitions-by-group.json` is regenerated to match the taxonomy.

The alternative was to expose the property without the HogQL change. That was rejected: it would make a filter selectable in every group-property surface while silently matching nothing outside feature flags.

The picker deliberately keeps the group-key *value* editor it already has — `isGroupCardFilterKey` and the existing `$group_key` handling in `PropertyValue` need no change, so selecting the property gives the group picker rather than a free-text box.

## How did you test this code?

Run locally against Postgres and ClickHouse after the follow-up commits: `posthog/hogql/test/test_property.py` (215), `posthog/api/test/test_property_definition.py` (83), the trends, retention and funnel breakdown tests (50, 5, 23) and the experiments breakdown attribution tests (16). All pass. Repo-wide mypy is clean.

- `test_properties_chain_group_key_and_virtual_properties`, `test_group_breakdown_group_key_reads_the_key_column` and `test_group_breakdown_chain`: a group breakdown by `$group_key` resolved to `group_N.properties.$group_key` before.
- `test_virtual_property_type_filter` and `test_virtual_property_excluded_by_core` compare the returned virtual rows with the built-in lists by name; they counted `$virt_` prefixes before, which the new row broke.

- `posthog/api/test/test_property_definition.py::test_group_property_filter` — updated the two "get all group properties" expectations, and added two cases that fail without the taxonomy change: searching `group_key` and searching `Group key` (the label alias) both return `$group_key`.
- `posthog/hogql/test/test_property.py::test_property_to_expr_group_key` (new) — asserts the column resolution in group scope and event scope, string coercion of a numeric key, the multi-value `IN` form, and a multi-value `starts_with`. The last one is not redundant: that operator expands per value by recursing with the original property key, so it is what catches a regression where the branch mutates `property.key` and the recursion falls back to `group_N.properties.key`.

Verified locally without a database: the regenerated JSON is byte-identical to what `bin/build-taxonomy-json.py` renders from the edited taxonomy, which is the comparison `--check` makes in CI.

Not checked: any frontend snapshot that enumerates group properties, and manual use of the picker.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Opus 5) from a Slack thread reporting that the feature-flag property picker was slow and would not surface the group key. No repo or public skills were invoked.

The investigation started on the reported slowness, which is a separate concern and is not addressed here — the picker's 500 ms debounce, its all-categories reveal barrier, and the duplicate count request per category are all still in place. This PR only fixes the discoverability bug found along the way.

The first draft marked the property virtual and stopped there. Reading the HogQL group branch showed that only flag matching and the blast radius understood `$group_key`, which would have made the newly selectable property inert elsewhere, so the column resolution was added. A first attempt at that resolution mutated `property.key` to `"key"`; the multi-value fallback path recurses with that key, so it was rewritten to leave the property untouched and the `starts_with` test was added to pin the behaviour.

Nothing in this PR carries material from the originating thread.

Follow-up commits by the assignee (Claude Code, Fable 5.1, human-driven): the branch was rebased onto master (the stale merge base made CI select a test file the branch did not have), `$group_key` breakdown resolution was added with tests, the two broken virtual-property tests were fixed, and the comment style was aligned. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C07Q2U4BH4L/p1789027197509039?thread_ts=1789027197.509039&cid=C07Q2U4BH4L)*

