### PR TITLE
fix(sql-editor): hide drafts for direct connections

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.test.ts
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.test.ts
@@ -1,5 +1,7 @@
 import { expectLogic } from 'kea-test-utils'
 
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { newInternalTab } from 'lib/utils/newInternalTab'
 import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
 
@@ -8,6 +10,7 @@ import { performQuery } from '~/queries/query'
 import type { DatabaseSchemaField } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 
+import { draftsLogic } from '../draftsLogic'
 import {
     getDefaultExpandedRootIds,
     getInitialExpandedFolders,
@@ -603,6 +606,39 @@ describe('queryDatabaseLogic', () => {
             expect(newInternalTab).toHaveBeenCalledWith(
                 expect.stringContaining('/data-management/sources/managed-source-id/schemas')
             )
+        })
+
+        it('hides drafts and unsaved queries when showing a direct connection schema', () => {
+            featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.EDITOR_DRAFTS], {
+                [FEATURE_FLAGS.EDITOR_DRAFTS]: true,
+            })
+            draftsLogic.actions.setDrafts([{ id: 'draft-id', name: 'test_draft' }] as any)
+            logic.actions.loadQueryTabStateSuccess({
+                id: 'query-tab-state-id',
+                state: {
+                    editorModelsStateKey: JSON.stringify([{ name: 'Untitled 1', query: 'SELECT 1' }]),
+                },
+            } as any)
+            databaseTableListLogic.findMounted()?.actions.loadDatabaseSuccess({
+                tables: {
+                    'public.accounts': {
+                        id: 'accounts',
+                        name: 'public.accounts',
+                        type: 'data_warehouse',
+                        fields: {},
+                        source: {
+                            id: 'source-id',
+                            status: 'Running',
+                            source_type: 'Trino',
+                            prefix: '',
+                            access_method: 'direct',
+                        },
+                    },
+                },
+                joins: [],
+            } as any)
+
+            expect(logic.values.displayedTreeData.map((item) => item.name)).toEqual(['public'])
         })
 
         it('hydrates a table restored as expanded in the displayed direct-connection tree', async () => {

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
@@ -3595,7 +3595,6 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
 
                 const flattenedTables: TreeDataItem[] = []
                 const flattenedViews: TreeDataItem[] = []
-                const additionalItems: TreeDataItem[] = []
                 const defaultSchemaName =
                     typeof selectedDirectSource?.job_inputs?.schema === 'string'
                         ? selectedDirectSource.job_inputs.schema
@@ -3625,19 +3624,14 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
                     if (item.record?.type === 'managed-views') {
                         return
                     }
-
-                    additionalItems.push(item)
                 })
 
                 const hasLoadedTables = Object.keys(allTablesMap).length > 0
                 if (!databaseLoading && databaseLoadError) {
-                    return [
-                        ...createSchemaErrorNodes('direct-connection', () => actions.refreshDatabaseSchema()),
-                        ...additionalItems,
-                    ]
+                    return createSchemaErrorNodes('direct-connection', () => actions.refreshDatabaseSchema())
                 }
                 if (!databaseLoading && !hasLoadedTables) {
-                    return [...createDirectConnectionEmptyNodes(connectionId), ...additionalItems]
+                    return createDirectConnectionEmptyNodes(connectionId)
                 }
 
                 return [
@@ -3654,7 +3648,6 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
                               },
                           ]
                         : []),
-                    ...additionalItems,
                 ]
             },
         ],


### PR DESCRIPTION
## Problem

People using a direct SQL connection see project drafts and unsaved queries mixed into the connection schema browser.

The direct-connection tree preserved every unrecognized root item instead of limiting the tree to connection-backed nodes.

## Changes

- Direct connection users now see only schemas, tables, and database-backed views for the selected connection.
- Direct-connection empty and error states also exclude project drafts and unsaved queries.
- A regression test covers active drafts and unsaved query tabs alongside a Trino table.
- Screenshot omitted because the supplied reproduction is unsuitable for public upload.

## How did you test this code?

- `.codex/with-flox pnpm --filter=@posthog/frontend exec jest --runInBand --watchman=false frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.test.ts`
- `.codex/with-flox hogli ci:preflight --strict`
- Not manually tested.
- The repository-wide TypeScript check remains blocked by existing generated-type failures outside these files.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Not needed. This restores the intended SQL editor sidebar behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex authored the change using `/writing-ui-components`, `/writing-tests`, `/querying-local-postgres`, `/dev-trino-direct-access`, `/hogli`, `/signed-git-publish`, and `/writing-pr-descriptions`.
- The duplicate PR search found no open match.
- The test fixture uses invented identifiers and contains no reproduction data.
