### PR TITLE
fix(api): skip the DEBUG response check for polymorphic response schemas

### DIFF
--- a/posthog/api/mixins.py
+++ b/posthog/api/mixins.py
@@ -5,7 +5,7 @@ from typing import Any, Generic, TypeVar, cast
 from django.conf import settings
 
 import structlog
-from drf_spectacular.utils import OpenApiResponse, extend_schema
+from drf_spectacular.utils import OpenApiResponse, PolymorphicProxySerializer, extend_schema
 from pydantic import BaseModel, ValidationError
 from rest_framework import serializers
 from rest_framework.exceptions import ParseError
@@ -219,6 +219,15 @@ def validated_request(
                     return result
                 response_serializer = response_config.response
                 if response_serializer is None:
+                    return result
+
+                # A PolymorphicProxySerializer declares a schema union for documentation only.
+                # It cannot validate data, and re-instantiating it from its type drops the
+                # union config its __init__ requires, so the check would 500 the endpoint.
+                if isinstance(response_serializer, PolymorphicProxySerializer) or (
+                    isinstance(response_serializer, serializers.ListSerializer)
+                    and isinstance(response_serializer.child, PolymorphicProxySerializer)
+                ):
                     return result
 
                 context: dict[str, Any] = getattr(self, "get_serializer_context", lambda: {})()

--- a/posthog/api/test/test_mixins.py
+++ b/posthog/api/test/test_mixins.py
@@ -5,7 +5,7 @@ import pytest
 from posthog.test.base import APIBaseTest
 from unittest.mock import Mock, patch
 
-from drf_spectacular.utils import OpenApiResponse
+from drf_spectacular.utils import OpenApiResponse, PolymorphicProxySerializer
 from rest_framework import serializers, status
 from rest_framework.response import Response
 
@@ -208,6 +208,34 @@ class TestValidatedRequestDecorator(APIBaseTest):
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data["wrong_field"] == "value"
+
+    def test_polymorphic_response_serializer_skips_the_debug_check(self):
+        @validated_request(
+            request_serializer=EventCaptureRequestSerializer,
+            responses={
+                200: OpenApiResponse(
+                    response=PolymorphicProxySerializer(
+                        component_name="CaptureResult",
+                        serializers=[EventCaptureResponseSerializer, ErrorResponseSerializer],
+                        resource_type_field_name=None,
+                    ),
+                ),
+            },
+        )
+        def mock_endpoint(view_self, request):
+            return Response({"status": "ok"}, status=status.HTTP_200_OK)
+
+        view_instance = Mock()
+        view_instance.get_serializer_context = Mock(return_value={})
+        mock_request = Mock()
+        mock_request._full_data = {}
+        mock_request.data = {"event": "$pageview", "distinct_id": "user_123"}
+
+        with patch("posthog.api.mixins.settings") as mock_settings:
+            mock_settings.DEBUG = True
+            response = mock_endpoint(view_instance, mock_request)
+
+        assert response.status_code == status.HTTP_200_OK
 
     def test_response_serializer_that_raises_while_parsing_logs_warning(self):
         @validated_request(


### PR DESCRIPTION
## Problem

Every dev running the local stack gets a 500 from `GET /api/projects/:id/tasks` since today, so the Tasks panel shows "We couldn't load your tasks."

- The `@validated_request` DEBUG-only response check re-instantiates the declared response serializer from its type: `type(response_serializer)(data=data, context=context)`.
- A `PolymorphicProxySerializer` requires `component_name`, `serializers`, and `resource_type_field_name` in `__init__`, so the re-instantiation raises `TypeError` and the endpoint 500s.
- #97999 made the tasks list response polymorphic (`TaskListItemSerializer`), which exposed it. Any endpoint declaring a polymorphic response hits the same wall.
- Prod is unaffected: the check runs only under `settings.DEBUG` (or `strict_response_validation`).

## Changes

- The tasks list (and any endpoint with a polymorphic response schema) works again in local dev.
- The DEBUG check now skips `PolymorphicProxySerializer` (and a `ListSerializer` wrapping one): it declares a schema union for documentation and cannot validate data.
- No user-visible change outside DEBUG.

## How did you test this code?

- New test: an endpoint declaring a `PolymorphicProxySerializer` response returns 200 under `DEBUG=True`. It raises the `TypeError` without the fix (verified by reverting `mixins.py`).
- Full `test_mixins.py` suite passes (28 tests).
- No duplicate: `gh pr list --state open --search "PolymorphicProxySerializer"` finds no open fix.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) diagnosed a local-dev 500 reported with a screenshot, reproduced it via the Django test client to capture the traceback, and traced it to the interaction of #97999's polymorphic response with the mixin's DEBUG revalidation. Skills invoked: `/writing-pr-descriptions`. Patch coverage: the new branch lines are exercised by the added test.
