### PR TITLE
fix(hogli): exclude codex from zombie cleanup

### DIFF
--- a/docs/published/handbook/engineering/developing-locally.md
+++ b/docs/published/handbook/engineering/developing-locally.md
@@ -219,6 +219,11 @@ If you see `Error while fetching server API version: 500 Server Error for http+d
 **Port conflicts**
 `hogli start` automatically cleans up orphaned PostHog processes before launching, which resolves most port conflicts. To skip this, set `HOGLI_SKIP_ZOMBIE_CHECK=1`. If you still see a port binding error for 5432, you likely have Postgres running locally. Use `lsof -i :5432` to find the process, then `sudo service postgresql stop` to stop it. You may also see errors like `role "posthog" does not exist`, which could indicate that a local PostgreSQL instance is being used instead of the expected containerized one.
 
+For manual cleanup, preview the targets with `hogli doctor:zombies --dry-run`, then run `hogli doctor:zombies` to select processes to stop.
+Default cleanup preserves dev jobs owned by live Codex sessions, phrocs (including detached stacks), and recognized terminals such as Warp.
+Use `--all --dry-run` to preview cleanup that also includes managed dev jobs.
+Even with `--all`, Codex itself, its Node launchers and runtime helpers across all sessions, and the cleanup command's ancestors stay excluded.
+
 **GeoLite database missing**
 The feature-flags container needs the GeoLite database in `/share`. If it's missing, run `./bin/download-mmdb` and then `chmod 0755 ./share/GeoLite2-City.mmdb`.
 

--- a/docs/published/handbook/engineering/developing-locally.md
+++ b/docs/published/handbook/engineering/developing-locally.md
@@ -219,11 +219,6 @@ If you see `Error while fetching server API version: 500 Server Error for http+d
 **Port conflicts**
 `hogli start` automatically cleans up orphaned PostHog processes before launching, which resolves most port conflicts. To skip this, set `HOGLI_SKIP_ZOMBIE_CHECK=1`. If you still see a port binding error for 5432, you likely have Postgres running locally. Use `lsof -i :5432` to find the process, then `sudo service postgresql stop` to stop it. You may also see errors like `role "posthog" does not exist`, which could indicate that a local PostgreSQL instance is being used instead of the expected containerized one.
 
-For manual cleanup, preview the targets with `hogli doctor:zombies --dry-run`, then run `hogli doctor:zombies` to select processes to stop.
-Default cleanup preserves dev jobs owned by live Codex sessions, phrocs (including detached stacks), and recognized terminals such as Warp.
-Use `--all --dry-run` to preview cleanup that also includes managed dev jobs.
-Even with `--all`, Codex itself, its Node launchers and runtime helpers across all sessions, and the cleanup command's ancestors stay excluded.
-
 **GeoLite database missing**
 The feature-flags container needs the GeoLite database in `/share`. If it's missing, run `./bin/download-mmdb` and then `chmod 0755 ./share/GeoLite2-City.mmdb`.
 

--- a/tools/hogli-commands/hogli_commands/doctor.py
+++ b/tools/hogli-commands/hogli_commands/doctor.py
@@ -981,7 +981,7 @@ def _format_size(bytes_size: float) -> str:
 # ---------------------------------------------------------------------------
 
 # Executable basenames that should never be reported as PostHog dev processes.
-# Matched against the executable's basename only (not the full args string)
+# Matched against the first token's basename only (not the full args string)
 # to avoid false positives from directory names like "/Users/x/code/github/...".
 _EXCLUDED_EXECUTABLES: frozenset[str] = frozenset(
     {
@@ -1039,10 +1039,7 @@ class DevProcess:
 )
 @click.option("--dry-run", is_flag=True, help="Show what would be killed without killing")
 @click.option("--yes", "-y", is_flag=True, help="Auto-confirm kill of all orphaned processes")
-@click.option(
-    "--all", "include_all", is_flag=True, help="Include managed dev processes; Codex infrastructure stays excluded"
-)
-def doctor_zombies(dry_run: bool, yes: bool, include_all: bool) -> None:
+def doctor_zombies(dry_run: bool, yes: bool) -> None:
     """Find and kill orphaned PostHog dev processes left behind after an unclean shutdown."""
 
     def _record() -> None:
@@ -1060,37 +1057,22 @@ def doctor_zombies(dry_run: bool, yes: bool, include_all: bool) -> None:
 
     orphans = [p for p in processes if p.is_orphan]
     managed = [p for p in processes if not p.is_orphan]
-    targets = processes if include_all else orphans
+    targets = orphans
 
     if not targets:
         click.echo(f"No orphaned processes found ({len(managed)} process(es) under an active process manager).")
-        click.echo("Use --all to include managed processes.")
         _record()
         return
 
-    if include_all:
-        # Show orphans and managed groups separately
-        if orphans:
-            _display_process_table(orphans, "Orphaned processes", REPO_ROOT, number_offset=0)
-        if managed:
-            # Group managed processes by their manager
-            managers: dict[str, list[DevProcess]] = {}
-            for p in managed:
-                managers.setdefault(p.manager, []).append(p)
-            offset = len(orphans)
-            for mgr, procs in managers.items():
-                _display_process_table(procs, f"Managed by {mgr}", REPO_ROOT, number_offset=offset)
-                offset += len(procs)
-    else:
-        _display_process_table(orphans, "Orphaned processes", REPO_ROOT)
+    _display_process_table(orphans, "Orphaned processes", REPO_ROOT)
 
-    if managed and not include_all:
+    if managed:
         # Summarize managed groups
         managed_groups: dict[str, list[DevProcess]] = {}
         for p in managed:
             managed_groups.setdefault(p.manager, []).append(p)
         parts = [f"{len(procs)} under {mgr}" for mgr, procs in managed_groups.items()]
-        click.echo(f"   ({', '.join(parts)} — use --all to include)\n")
+        click.echo(f"   ({', '.join(parts)})\n")
 
     total_rss = sum(p.memory_rss_kb for p in targets)
     click.echo(f"   Total: {len(targets)} process(es) using ~{_format_rss(total_rss)}\n")
@@ -1137,10 +1119,9 @@ def _scan_posthog_processes(repo_root: Path) -> list[DevProcess]:
 
     # Build a full PID→(PPID, args) map for ancestor lookups
     all_procs: dict[int, tuple[int, str]] = {pid: (ppid, args) for pid, ppid, _, _, _, args in parsed}
-    executables = _get_process_executables()
-    codex_pids = _codex_infrastructure_pids(all_procs, executables)
 
-    own_tree = _get_own_process_tree(all_procs)
+    codex_pids = _codex_infrastructure_pids(all_procs, _get_process_executables())
+    own_tree = _get_own_process_tree()
     repo_str = str(repo_root)
     repo_prefix = repo_str + "/"
 
@@ -1152,12 +1133,11 @@ def _scan_posthog_processes(repo_root: Path) -> list[DevProcess]:
     cwd_pids: list[int] = []
     for entry in parsed:
         pid, _, _, _, _, args = entry
-        executable = executables.get(pid) or _command_executable(args)
-        if pid in own_tree or pid in codex_pids or _is_excluded(args, executable):
+        if pid in own_tree or pid in codex_pids or _is_excluded(args):
             continue
         if _matches_repo_path(args, repo_str, repo_prefix):
             candidates.append((entry, True))
-        elif _has_known_executable(executable):
+        elif _has_known_executable(args):
             candidates.append((entry, False))
             cwd_pids.append(pid)
 
@@ -1172,9 +1152,9 @@ def _scan_posthog_processes(repo_root: Path) -> list[DevProcess]:
             if cwd is None or not (cwd == repo_str or cwd.startswith(repo_prefix)):
                 continue
 
-        name = Path(executables.get(pid) or _command_executable(args)).name
+        name = _extract_process_name(args)
         category = _categorize_process(args)
-        is_orphan, manager = _resolve_orphan_status(pid, all_procs, executables, codex_pids)
+        is_orphan, manager = _resolve_orphan_status(pid, all_procs)
 
         processes.append(
             DevProcess(
@@ -1194,17 +1174,12 @@ def _scan_posthog_processes(repo_root: Path) -> list[DevProcess]:
     return processes
 
 
-def _resolve_orphan_status(
-    pid: int,
-    all_procs: dict[int, tuple[int, str]],
-    executables: dict[int, str],
-    codex_pids: set[int],
-) -> tuple[bool, str]:
+def _resolve_orphan_status(pid: int, all_procs: dict[int, tuple[int, str]]) -> tuple[bool, str]:
     """Walk the ancestor chain to determine if a process is orphaned or managed.
 
     Returns (is_orphan, manager_description).
-    PID 1 also parents live applications, so only an unmanaged dev executable
-    or leftover shell at that boundary is evidence of an abandoned process tree.
+    A process is orphaned if any ancestor has PPID=1 (reparented to launchd).
+    Otherwise, identifies the nearest recognizable manager.
     """
 
     visited: set[int] = {pid}
@@ -1212,16 +1187,15 @@ def _resolve_orphan_status(
 
     while current in all_procs:
         ppid, args = all_procs[current]
-        executable = executables.get(current) or _command_executable(args)
-
-        manager_name = "Codex" if current in codex_pids else _identify_manager(executable, args)
-        if manager_name:
-            return False, f"{manager_name} (PID {current})"
 
         if ppid <= 1:
-            if ppid == 1 and (_has_known_executable(executable) or Path(executable).name in _SHELL_EXECUTABLES):
-                return True, ""
-            break
+            # Reached launchd — this process (or ancestor) is orphaned
+            return True, ""
+
+        # Check if the parent is a known process manager
+        manager_name = _identify_manager(args)
+        if manager_name:
+            return False, f"{manager_name} (PID {current})"
 
         if ppid in visited:
             break
@@ -1246,25 +1220,18 @@ _KNOWN_MANAGERS = (
     ("kitty", "kitty"),
     ("alacritty", "alacritty"),
     ("wezterm", "wezterm"),
-    ("wezterm-gui", "wezterm"),
     ("Terminal", "Terminal.app"),
     ("iTerm", "iTerm2"),
-    ("iTerm2", "iTerm2"),
 )
 
 
-def _identify_manager(executable: str, args: str) -> str | None:
-    if executable.endswith(("/Warp.app/Contents/MacOS/stable", "/WarpPreview.app/Contents/MacOS/stable")):
-        return "Warp"
+def _identify_manager(args: str) -> str | None:
+    """Check if a command line belongs to a known process manager or terminal."""
 
-    names = {Path(executable).name, Path(_command_executable(args, executable)).name}
     for keyword, display_name in _KNOWN_MANAGERS:
-        if keyword in names:
+        if keyword in args:
             return display_name
     return None
-
-
-_SHELL_EXECUTABLES = frozenset({"sh", "bash", "zsh", "fish", "dash", "ksh"})
 
 
 def _get_process_executables() -> dict[int, str]:
@@ -1280,9 +1247,7 @@ def _get_process_executables() -> dict[int, str]:
     return executables
 
 
-def _command_executable(args: str, executable: str = "") -> str:
-    if executable and (args == executable or args.startswith(executable + " ")):
-        return executable
+def _command_executable(args: str) -> str:
     try:
         return next(_command_words(args), "")
     except ValueError:
@@ -1372,18 +1337,27 @@ def _parse_ps_line(line: str) -> _PsLine | None:
     return pid, ppid, cpu, rss, start_time, args
 
 
-def _get_own_process_tree(all_procs: dict[int, tuple[int, str]]) -> set[int]:
+def _get_own_process_tree() -> set[int]:
     """Return PIDs of the current process and all its ancestors up to PID 1."""
 
     pids: set[int] = set()
     pid = os.getpid()
 
     # Walk up the PPID chain
-    while pid > 1 and pid not in pids:
+    while pid > 1:
         pids.add(pid)
-        if pid not in all_procs:
+        result = subprocess.run(
+            ["ps", "-o", "ppid=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
             break
-        pid = all_procs[pid][0]
+        try:
+            pid = int(result.stdout.strip())
+        except ValueError:
+            break
 
     return pids
 
@@ -1403,39 +1377,20 @@ def _matches_repo_path(args: str, repo_str: str, repo_prefix: str) -> bool:
         idx = end
 
 
-def _is_excluded(args: str, executable: str | None = None) -> bool:
+def _is_excluded(args: str) -> bool:
     """Check if the executable basename is in the exclusion set."""
     if not args or not args.strip():
         return False
-    # Script launchers can retain their own argv[0] while ps identifies the interpreter.
-    names = {Path(executable or "").name, Path(_command_executable(args, executable or "")).name}
-    return bool(names & _EXCLUDED_EXECUTABLES)
+    basename = args.split()[0].rsplit("/", 1)[-1]
+    return basename in _EXCLUDED_EXECUTABLES
 
 
-def _has_known_executable(executable: str) -> bool:
-    known = (
-        "node",
-        "nodejs",
-        "celery",
-        "granian",
-        "uvicorn",
-        "gunicorn",
-        "dagster",
-        "cargo",
-        "air",
-        "tsx",
-        "esbuild",
-        "pnpm",
-        "capture",
-        "feature-flags",
-        "property-defs-rs",
-        "cymbal",
-        "cyclotron",
-        "personhog",
-        "batch-import",
-    )
-    name = Path(executable).name
-    return name in known or re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", name) is not None
+def _has_known_executable(args: str) -> bool:
+    """Check if the command starts with a known PostHog dev executable."""
+
+    known = ("python", "node", "celery", "granian", "uvicorn", "dagster", "cargo", "air", "tsx", "esbuild", "pnpm")
+    first_word = args.split()[0].rsplit("/", 1)[-1] if args else ""
+    return first_word in known
 
 
 def _get_process_cwds(pids: Sequence[int]) -> dict[int, str]:
@@ -1471,6 +1426,13 @@ def _get_process_cwds(pids: Sequence[int]) -> dict[int, str]:
         elif tag == "n" and current is not None:
             cwds[current] = value
     return cwds
+
+
+def _extract_process_name(args: str) -> str:
+    """Extract a short display name from a full command line."""
+
+    first = args.split()[0] if args else ""
+    return first.rsplit("/", 1)[-1]
 
 
 def _categorize_process(args: str) -> str:

--- a/tools/hogli-commands/hogli_commands/doctor.py
+++ b/tools/hogli-commands/hogli_commands/doctor.py
@@ -7,6 +7,7 @@ import enum
 import json
 import time
 import fcntl
+import shlex
 import select
 import shutil
 import signal
@@ -15,7 +16,7 @@ import platform
 import tempfile
 import importlib
 import subprocess
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -980,7 +981,7 @@ def _format_size(bytes_size: float) -> str:
 # ---------------------------------------------------------------------------
 
 # Executable basenames that should never be reported as PostHog dev processes.
-# Matched against the first token's basename only (not the full args string)
+# Matched against the executable's basename only (not the full args string)
 # to avoid false positives from directory names like "/Users/x/code/github/...".
 _EXCLUDED_EXECUTABLES: frozenset[str] = frozenset(
     {
@@ -1038,7 +1039,9 @@ class DevProcess:
 )
 @click.option("--dry-run", is_flag=True, help="Show what would be killed without killing")
 @click.option("--yes", "-y", is_flag=True, help="Auto-confirm kill of all orphaned processes")
-@click.option("--all", "include_all", is_flag=True, help="Include processes under an active phrocs, not just orphans")
+@click.option(
+    "--all", "include_all", is_flag=True, help="Include managed dev processes; Codex infrastructure stays excluded"
+)
 def doctor_zombies(dry_run: bool, yes: bool, include_all: bool) -> None:
     """Find and kill orphaned PostHog dev processes left behind after an unclean shutdown."""
 
@@ -1134,8 +1137,10 @@ def _scan_posthog_processes(repo_root: Path) -> list[DevProcess]:
 
     # Build a full PID→(PPID, args) map for ancestor lookups
     all_procs: dict[int, tuple[int, str]] = {pid: (ppid, args) for pid, ppid, _, _, _, args in parsed}
+    executables = _get_process_executables()
+    codex_pids = _codex_infrastructure_pids(all_procs, executables)
 
-    own_tree = _get_own_process_tree()
+    own_tree = _get_own_process_tree(all_procs)
     repo_str = str(repo_root)
     repo_prefix = repo_str + "/"
 
@@ -1147,11 +1152,12 @@ def _scan_posthog_processes(repo_root: Path) -> list[DevProcess]:
     cwd_pids: list[int] = []
     for entry in parsed:
         pid, _, _, _, _, args = entry
-        if pid in own_tree or _is_excluded(args):
+        executable = executables.get(pid) or _command_executable(args)
+        if pid in own_tree or pid in codex_pids or _is_excluded(args, executable):
             continue
         if _matches_repo_path(args, repo_str, repo_prefix):
             candidates.append((entry, True))
-        elif _has_known_executable(args):
+        elif _has_known_executable(executable):
             candidates.append((entry, False))
             cwd_pids.append(pid)
 
@@ -1166,9 +1172,9 @@ def _scan_posthog_processes(repo_root: Path) -> list[DevProcess]:
             if cwd is None or not (cwd == repo_str or cwd.startswith(repo_prefix)):
                 continue
 
-        name = _extract_process_name(args)
+        name = Path(executables.get(pid) or _command_executable(args)).name
         category = _categorize_process(args)
-        is_orphan, manager = _resolve_orphan_status(pid, all_procs)
+        is_orphan, manager = _resolve_orphan_status(pid, all_procs, executables, codex_pids)
 
         processes.append(
             DevProcess(
@@ -1188,12 +1194,17 @@ def _scan_posthog_processes(repo_root: Path) -> list[DevProcess]:
     return processes
 
 
-def _resolve_orphan_status(pid: int, all_procs: dict[int, tuple[int, str]]) -> tuple[bool, str]:
+def _resolve_orphan_status(
+    pid: int,
+    all_procs: dict[int, tuple[int, str]],
+    executables: dict[int, str],
+    codex_pids: set[int],
+) -> tuple[bool, str]:
     """Walk the ancestor chain to determine if a process is orphaned or managed.
 
     Returns (is_orphan, manager_description).
-    A process is orphaned if any ancestor has PPID=1 (reparented to launchd).
-    Otherwise, identifies the nearest recognizable manager.
+    PID 1 also parents live applications, so only an unmanaged dev executable
+    or leftover shell at that boundary is evidence of an abandoned process tree.
     """
 
     visited: set[int] = {pid}
@@ -1201,15 +1212,16 @@ def _resolve_orphan_status(pid: int, all_procs: dict[int, tuple[int, str]]) -> t
 
     while current in all_procs:
         ppid, args = all_procs[current]
+        executable = executables.get(current) or _command_executable(args)
 
-        if ppid <= 1:
-            # Reached launchd — this process (or ancestor) is orphaned
-            return True, ""
-
-        # Check if the parent is a known process manager
-        manager_name = _identify_manager(args)
+        manager_name = "Codex" if current in codex_pids else _identify_manager(executable, args)
         if manager_name:
             return False, f"{manager_name} (PID {current})"
+
+        if ppid <= 1:
+            if ppid == 1 and (_has_known_executable(executable) or Path(executable).name in _SHELL_EXECUTABLES):
+                return True, ""
+            break
 
         if ppid in visited:
             break
@@ -1234,18 +1246,104 @@ _KNOWN_MANAGERS = (
     ("kitty", "kitty"),
     ("alacritty", "alacritty"),
     ("wezterm", "wezterm"),
+    ("wezterm-gui", "wezterm"),
     ("Terminal", "Terminal.app"),
     ("iTerm", "iTerm2"),
+    ("iTerm2", "iTerm2"),
 )
 
 
-def _identify_manager(args: str) -> str | None:
-    """Check if a command line belongs to a known process manager or terminal."""
+def _identify_manager(executable: str, args: str) -> str | None:
+    if executable.endswith(("/Warp.app/Contents/MacOS/stable", "/WarpPreview.app/Contents/MacOS/stable")):
+        return "Warp"
 
+    names = {Path(executable).name, Path(_command_executable(args, executable)).name}
     for keyword, display_name in _KNOWN_MANAGERS:
-        if keyword in args:
+        if keyword in names:
             return display_name
     return None
+
+
+_SHELL_EXECUTABLES = frozenset({"sh", "bash", "zsh", "fish", "dash", "ksh"})
+
+
+def _get_process_executables() -> dict[int, str]:
+    # macOS comm contains the full path, but Linux comm can be a truncated title.
+    # Keep the path in the final column so spaces cannot split its identity.
+    field = "comm" if platform.system() == "Darwin" else "exe"
+    result = subprocess.run(["ps", "-eo", f"pid=,{field}="], capture_output=True, text=True, check=False)
+    executables: dict[int, str] = {}
+    for line in result.stdout.splitlines():
+        parts = line.strip().split(maxsplit=1)
+        if len(parts) == 2 and parts[0].isdigit() and parts[1] != "-":
+            executables[int(parts[0])] = parts[1]
+    return executables
+
+
+def _command_executable(args: str, executable: str = "") -> str:
+    if executable and (args == executable or args.startswith(executable + " ")):
+        return executable
+    try:
+        return next(_command_words(args), "")
+    except ValueError:
+        return args.split()[0] if args else ""
+
+
+def _command_words(args: str) -> Iterator[str]:
+    words = shlex.shlex(args, posix=True)
+    words.whitespace_split = True
+    words.commenters = ""
+    return iter(words)
+
+
+def _is_codex_entrypoint(args: str, executable: str) -> bool:
+    # ps does not quote argv[0], which can itself contain spaces.
+    try:
+        if args.startswith(executable + " "):
+            arguments = _command_words(args[len(executable) :])
+        else:
+            arguments = _command_words(args)
+            next(arguments, None)
+        return _is_codex_script(arguments)
+    except ValueError:
+        return False
+
+
+def _is_codex_script(arguments: Iterable[str]) -> bool:
+    options = iter(arguments)
+    for argument in options:
+        if argument in {"--eval", "--print"} or argument.startswith(("-e", "-p", "--eval=", "--print=")):
+            return False
+        if argument in {"-r", "--require", "--import", "--loader", "--experimental-loader"}:
+            next(options, None)
+            continue
+        if argument.startswith("-") and argument != "-":
+            continue
+        return argument == "codex" or argument.endswith(("/bin/codex", "/@openai/codex/bin/codex.js"))
+    return False
+
+
+def _codex_infrastructure_pids(all_procs: dict[int, tuple[int, str]], executables: dict[int, str]) -> set[int]:
+    native: set[int] = set()
+    nodes: set[int] = set()
+    protected: set[int] = set()
+    for pid, (_, args) in all_procs.items():
+        executable = executables.get(pid) or _command_executable(args)
+        path = Path(executable)
+        if path.name == "codex":
+            native.add(pid)
+        if path.name in {"codex", "codex-code-mode-host"}:
+            protected.add(pid)
+        elif "cua_node" in path.parts and path.name in {"node", "node_repl", "node-repl", "repl"}:
+            protected.add(pid)
+        elif path.name in {"node", "nodejs"}:
+            nodes.add(pid)
+            if _is_codex_entrypoint(args, executable):
+                protected.add(pid)
+
+    # Launchers can run through symlinks whose names do not identify Codex.
+    protected.update(all_procs[pid][0] for pid in native if all_procs[pid][0] in nodes)
+    return protected
 
 
 _PsLine = tuple[int, int, float, int, str, str]
@@ -1254,7 +1352,7 @@ _PsLine = tuple[int, int, float, int, str, str]
 def _parse_ps_line(line: str) -> _PsLine | None:
     """Parse a single ps output line into (pid, ppid, cpu%, rss_kb, start_time, args)."""
 
-    parts = line.split()
+    parts = line.split(maxsplit=9)
     # Need at least: pid ppid cpu rss + 5 date tokens + 1 args token = 10
     if len(parts) < 10:
         return None
@@ -1269,32 +1367,23 @@ def _parse_ps_line(line: str) -> _PsLine | None:
 
     # lstart is always 5 tokens: Day Mon DD HH:MM:SS YYYY
     start_time = " ".join(parts[4:9])
-    args = " ".join(parts[9:])
+    args = parts[9]
 
     return pid, ppid, cpu, rss, start_time, args
 
 
-def _get_own_process_tree() -> set[int]:
+def _get_own_process_tree(all_procs: dict[int, tuple[int, str]]) -> set[int]:
     """Return PIDs of the current process and all its ancestors up to PID 1."""
 
     pids: set[int] = set()
     pid = os.getpid()
 
     # Walk up the PPID chain
-    while pid > 1:
+    while pid > 1 and pid not in pids:
         pids.add(pid)
-        result = subprocess.run(
-            ["ps", "-o", "ppid=", "-p", str(pid)],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if result.returncode != 0 or not result.stdout.strip():
+        if pid not in all_procs:
             break
-        try:
-            pid = int(result.stdout.strip())
-        except ValueError:
-            break
+        pid = all_procs[pid][0]
 
     return pids
 
@@ -1314,20 +1403,39 @@ def _matches_repo_path(args: str, repo_str: str, repo_prefix: str) -> bool:
         idx = end
 
 
-def _is_excluded(args: str) -> bool:
+def _is_excluded(args: str, executable: str | None = None) -> bool:
     """Check if the executable basename is in the exclusion set."""
     if not args or not args.strip():
         return False
-    basename = args.split()[0].rsplit("/", 1)[-1]
-    return basename in _EXCLUDED_EXECUTABLES
+    # Script launchers can retain their own argv[0] while ps identifies the interpreter.
+    names = {Path(executable or "").name, Path(_command_executable(args, executable or "")).name}
+    return bool(names & _EXCLUDED_EXECUTABLES)
 
 
-def _has_known_executable(args: str) -> bool:
-    """Check if the command starts with a known PostHog dev executable."""
-
-    known = ("python", "node", "celery", "granian", "uvicorn", "dagster", "cargo", "air", "tsx", "esbuild", "pnpm")
-    first_word = args.split()[0].rsplit("/", 1)[-1] if args else ""
-    return first_word in known
+def _has_known_executable(executable: str) -> bool:
+    known = (
+        "node",
+        "nodejs",
+        "celery",
+        "granian",
+        "uvicorn",
+        "gunicorn",
+        "dagster",
+        "cargo",
+        "air",
+        "tsx",
+        "esbuild",
+        "pnpm",
+        "capture",
+        "feature-flags",
+        "property-defs-rs",
+        "cymbal",
+        "cyclotron",
+        "personhog",
+        "batch-import",
+    )
+    name = Path(executable).name
+    return name in known or re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", name) is not None
 
 
 def _get_process_cwds(pids: Sequence[int]) -> dict[int, str]:
@@ -1363,13 +1471,6 @@ def _get_process_cwds(pids: Sequence[int]) -> dict[int, str]:
         elif tag == "n" and current is not None:
             cwds[current] = value
     return cwds
-
-
-def _extract_process_name(args: str) -> str:
-    """Extract a short display name from a full command line."""
-
-    first = args.split()[0] if args else ""
-    return first.rsplit("/", 1)[-1]
 
 
 def _categorize_process(args: str) -> str:

--- a/tools/hogli-commands/hogli_commands/tests/test_doctor.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_doctor.py
@@ -175,8 +175,6 @@ def zombie_snapshot(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> list[lis
 12 11 /opt/Codex Runtime/cua_node/bin/node | /opt/Codex Runtime/cua_node/bin/node --experimental-repl-await /repo/posthog
 13 1 /opt/Codex Runtime/cua_node/bin/node_repl | /opt/Codex Runtime/cua_node/bin/node_repl /repo/posthog
 14 10 /usr/bin/node | node /repo/posthog/frontend/dev.js
-15 10 /usr/bin/phrocs | phrocs -c /repo/posthog/mprocs.yaml
-16 15 /usr/bin/python3.13 | python /repo/posthog/manage.py runserver
 18 10 /usr/bin/hogli | hogli doctor:zombies
 20 1 /usr/bin/node | node /opt/node_modules/@openai/codex/bin/codex.js
 21 20 /opt/codex/bin/codex | codex --cwd /repo/posthog
@@ -194,49 +192,22 @@ def zombie_snapshot(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> list[lis
 37 1 /usr/bin/node | node /repo/posthog/codex/frontend/dev.js
 38 1 /usr/bin/node | node /repo/posthog/frontend/dev.js --runtime /opt/cua_node/bin/node
 39 1 /usr/bin/node | node --import /opt/node_modules/@openai/codex/bin/codex.js /repo/posthog/frontend/dev.js
-40 1 /Applications/Warp.app/Contents/MacOS/stable | /Applications/Warp.app/Contents/MacOS/stable
-41 40 /bin/zsh | -zsh
-42 41 /usr/bin/node | node /repo/posthog/frontend/dev.js
-43 1 /Applications/Terminal Tools/WarpPreview.app/Contents/MacOS/stable | /Applications/Terminal Tools/WarpPreview.app/Contents/MacOS/stable
-44 43 /usr/bin/node | node /repo/posthog/frontend/dev.js
-50 1 /usr/bin/phrocs | phrocs --daemon -c /repo/posthog/mprocs.yaml
-51 50 /usr/bin/granian | granian /repo/posthog/asgi.py
 60 1 /usr/bin/node | node /repo/posthog/frontend/dev.js
-61 1 /bin/bash | /bin/bash -c python /repo/posthog/manage.py runserver
-62 61 /usr/bin/python3.13 | python /repo/posthog/manage.py runserver
-63 1 /repo/posthog/rust/target/debug/capture | /repo/posthog/rust/target/debug/capture
-64 60 /usr/bin/node | node /repo/posthog/frontend/worker.js
-70 1 /opt/application | /opt/application --project /repo/posthog
-71 70 /usr/bin/node | node /repo/posthog/frontend/dev.js
-72 9999 /usr/bin/node | node /repo/posthog/frontend/dev.js
-73 74 /usr/bin/node | node /repo/posthog/frontend/dev.js
-74 73 /bin/bash | /bin/bash /repo/posthog/bin/worker
-75 1 /opt/stable | /opt/stable --project /repo/posthog --terminal /Applications/Warp.app/Contents/MacOS/stable
-76 75 /usr/bin/node | node /repo/posthog/frontend/dev.js
-77 1 /usr/bin/node | node /repo/posthog/frontend/dev.js --label codex-code-mode-host phrocs Terminal iTerm
-78 1 /opt/unknown | /opt/unknown --project /repo/posthog --codex /opt/codex/bin/codex
-80 1 /Applications/Terminal.app/Contents/MacOS/Terminal | /Applications/Terminal.app/Contents/MacOS/Terminal
+80 100 /Applications/Terminal.app/Contents/MacOS/Terminal | /Applications/Terminal.app/Contents/MacOS/Terminal
 81 80 /usr/bin/node | node /repo/posthog/frontend/dev.js
-82 1 /opt/Python  Runtime/bin/python3.13 | /opt/Python  Runtime/bin/python3.13 manage.py runserver
-83 1 /usr/bin/tmux | tmux new
-84 83 /usr/bin/node | node /repo/posthog/frontend/dev.js
-85 1 /Applications/iTerm.app/Contents/MacOS/iTerm2 | /Applications/iTerm.app/Contents/MacOS/iTerm2
-86 85 /usr/bin/node | node /repo/posthog/frontend/dev.js
 90 1 /usr/bin/node | node unrelated.js
 91 1 /work/codex/bin/node | /work/codex/bin/node frontend/dev.js
-92 1 /usr/bin/node | node /repo/posthog/frontend/dev.js --output /tmp/git
-93 1 /usr/bin/python3.13 | hogli --repo /repo/posthog doctor
-94 1 /opt/claude/1.0.0 | claude --cwd /repo/posthog
-95 1 /opt/code tools/bin/node | /opt/code tools/bin/node frontend/dev.js
 900 80 /usr/bin/node | node /repo/posthog/tools/terminal.js
 901 900 /bin/bash | /bin/bash -c hogli /repo/posthog
 902 901 /usr/bin/hogli | hogli doctor:zombies
 """
     ps_lines: list[str] = []
     executable_lines: list[str] = []
+    parents: dict[str, str] = {}
     for row in rows.strip().splitlines():
         identity, args = row.split(" | ", 1)
         pid, ppid, executable = identity.split(maxsplit=2)
+        parents[pid] = ppid
         ps_lines.append(f"{pid} {ppid} 0.0 1024 Thu Sep 10 12:00:00 2026 {args}")
         executable_lines.append(f"{pid} {executable}")
     calls: list[list[str]] = []
@@ -245,6 +216,8 @@ def zombie_snapshot(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> list[lis
         calls.append(cmd)
         if cmd == ["ps", "-eo", "pid=,ppid=,pcpu=,rss=,lstart=,args="]:
             output = "\n".join(ps_lines)
+        elif cmd[:4] == ["ps", "-o", "ppid=", "-p"]:
+            output = parents.get(cmd[4], "1")
         elif cmd in (["ps", "-eo", "pid=,comm="], ["ps", "-eo", "pid=,exe="]):
             output = "\n".join(executable_lines)
         elif cmd[:3] == ["lsof", "-a", "-p"] and cmd[4:] == ["-d", "cwd", "-Fpn"]:
@@ -266,48 +239,25 @@ def zombie_snapshot(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> list[lis
     return calls
 
 
-_ORPHAN_PIDS = {34, 35, 36, 37, 38, 39, 60, 61, 62, 63, 64, 77, 82, 91, 92, 95}
-_PRESERVED_MANAGERS = {
-    14: "Codex (PID 10)",
-    15: "phrocs (PID 15)",
-    16: "phrocs (PID 15)",
-    22: "Codex (PID 21)",
-    42: "Warp (PID 40)",
-    44: "Warp (PID 43)",
-    50: "phrocs (PID 50)",
-    51: "phrocs (PID 50)",
-    70: "PID 1",
-    71: "PID 70",
-    72: "PID 9999",
-    73: "PID 74",
-    74: "PID 73",
-    75: "PID 1",
-    76: "PID 75",
-    78: "PID 1",
-    81: "Terminal.app (PID 80)",
-    84: "tmux (PID 83)",
-    86: "iTerm2 (PID 85)",
-}
+_ORPHAN_PIDS = {14, 22, 34, 35, 36, 37, 38, 39, 60, 91}
 
 
 @pytest.mark.parametrize("system,field", [("Darwin", "comm"), ("Linux", "exe")])
-def test_zombie_snapshot_classification(
+def test_zombie_scan_excludes_codex_infrastructure(
     zombie_snapshot: list[list[str]], monkeypatch: pytest.MonkeyPatch, system: str, field: str
 ) -> None:
     monkeypatch.setattr("hogli_commands.doctor.platform.system", lambda: system)
 
     processes = _scan_posthog_processes(Path("/repo/posthog"))
 
-    assert {p.pid for p in processes} == _ORPHAN_PIDS | _PRESERVED_MANAGERS.keys()
+    assert {p.pid for p in processes} == _ORPHAN_PIDS | {81}
     assert {p.pid for p in processes if p.is_orphan} == _ORPHAN_PIDS
-    assert {p.pid: p.manager for p in processes if not p.is_orphan} == _PRESERVED_MANAGERS
-    python = next(p for p in processes if p.pid == 82)
-    assert python.name == "python3.13"
-    assert python.cmdline == "/opt/Python  Runtime/bin/python3.13 manage.py runserver"
-    assert zombie_snapshot == [
+    assert [cmd for cmd in zombie_snapshot if cmd[:2] == ["ps", "-eo"]] == [
         ["ps", "-eo", "pid=,ppid=,pcpu=,rss=,lstart=,args="],
         ["ps", "-eo", f"pid=,{field}="],
-        ["lsof", "-a", "-p", "82,90,91,95", "-d", "cwd", "-Fpn"],
+    ]
+    assert [cmd for cmd in zombie_snapshot if cmd[0] == "lsof"] == [
+        ["lsof", "-a", "-p", "90,91", "-d", "cwd", "-Fpn"],
     ]
     assert _check_zombies(Path("/repo/posthog")).summary == f"{len(_ORPHAN_PIDS)} orphaned"
 
@@ -315,7 +265,7 @@ def test_zombie_snapshot_classification(
 @pytest.mark.parametrize("own_pid", [18, 902], ids=["from-codex", "from-another-terminal"])
 @pytest.mark.parametrize(
     "arguments",
-    [["--yes"], ["--all", "--yes"], ["--dry-run"], ["--all", "--yes", "--dry-run"]],
+    [["--yes"], ["--dry-run"], ["--yes", "--dry-run"], ["--all", "--yes"]],
 )
 def test_doctor_zombies_signals_only_selected_dev_processes(
     zombie_snapshot: list[list[str]], monkeypatch: pytest.MonkeyPatch, own_pid: int, arguments: list[str]
@@ -333,6 +283,12 @@ def test_doctor_zombies_signals_only_selected_dev_processes(
 
     result = CliRunner().invoke(doctor_zombies, arguments)
 
+    if "--all" in arguments:
+        assert result.exit_code == 2
+        assert "No such option: --all" in result.output
+        assert signals == []
+        return
+
     assert result.exit_code == 0, result.output
     if "--dry-run" in arguments:
         assert signals == []
@@ -340,10 +296,6 @@ def test_doctor_zombies_signals_only_selected_dev_processes(
         return
 
     expected = set(_ORPHAN_PIDS)
-    if "--all" in arguments:
-        expected.update(_PRESERVED_MANAGERS)
-        if own_pid == 18:
-            expected.update({900, 901})
     assert {pid for pid, _ in signals} == expected
     assert sorted(pid for pid, sig in signals if sig == signal.SIGTERM) == sorted(expected)
     assert [pid for pid, sig in signals if sig == signal.SIGKILL] == [60]

--- a/tools/hogli-commands/hogli_commands/tests/test_doctor.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_doctor.py
@@ -3,6 +3,7 @@ import json
 import time
 import fcntl
 import shutil
+import signal
 import hashlib
 import threading
 import subprocess
@@ -19,6 +20,7 @@ from hogli_commands.doctor import (
     FLOX_LOG_MAX_TOTAL_BYTES,
     _binary_arches,
     _check_git_health,
+    _check_zombies,
     _collect_import_targets,
     _config_procs,
     _confirm_stack_teardown,
@@ -44,12 +46,14 @@ from hogli_commands.doctor import (
     _run_ok,
     _sanitize_compose_name,
     _scan_port_holders,
+    _scan_posthog_processes,
     _scan_unheld_via_lsof,
     _select_flox_logs_to_remove,
     _tail,
     doctor_git,
     doctor_migrate_volumes,
     doctor_ports,
+    doctor_zombies,
 )
 
 _QUARTER_BUDGET = FLOX_LOG_MAX_TOTAL_BYTES // 4
@@ -161,6 +165,189 @@ def test_is_excluded_does_not_match_posthog_processes(args: str) -> None:
 
 def test_is_excluded_empty_string() -> None:
     assert _is_excluded("") is False
+
+
+@pytest.fixture
+def zombie_snapshot(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> list[list[str]]:
+    rows = """
+10 1 /opt/codex/bin/codex | /opt/codex/bin/codex --cwd /repo/posthog
+11 10 /opt/codex/bin/codex-code-mode-host | /opt/codex/bin/codex-code-mode-host /repo/posthog
+12 11 /opt/Codex Runtime/cua_node/bin/node | /opt/Codex Runtime/cua_node/bin/node --experimental-repl-await /repo/posthog
+13 1 /opt/Codex Runtime/cua_node/bin/node_repl | /opt/Codex Runtime/cua_node/bin/node_repl /repo/posthog
+14 10 /usr/bin/node | node /repo/posthog/frontend/dev.js
+15 10 /usr/bin/phrocs | phrocs -c /repo/posthog/mprocs.yaml
+16 15 /usr/bin/python3.13 | python /repo/posthog/manage.py runserver
+18 10 /usr/bin/hogli | hogli doctor:zombies
+20 1 /usr/bin/node | node /opt/node_modules/@openai/codex/bin/codex.js
+21 20 /opt/codex/bin/codex | codex --cwd /repo/posthog
+22 21 /usr/bin/node | node /repo/posthog/frontend/dev.js
+23 1 /usr/bin/node | node /usr/local/bin/session-agent /repo/posthog
+24 23 /opt/codex/bin/codex | codex --cwd /repo/posthog
+25 24 /opt/codex/bin/codex-code-mode-host | codex-code-mode-host /repo/posthog
+30 1 /usr/bin/node | node --enable-source-maps /usr/local/bin/codex fix the project's /repo/posthog config
+31 1 /usr/bin/node | node --require bootstrap.js "/opt/Agent Tools/node_modules/@openai/codex/bin/codex.js" /repo/posthog
+32 1 /opt/Node  Runtime/bin/node | /opt/Node  Runtime/bin/node /opt/node_modules/@openai/codex/bin/codex.js /repo/posthog
+33 1 /opt/Agent  Tools/bin/codex | /opt/Agent  Tools/bin/codex /repo/posthog
+34 1 /usr/bin/node | node /repo/posthog/frontend/dev.js --input /opt/node_modules/@openai/codex/bin/codex.js
+35 1 /usr/bin/node | node --eval process.exit() /usr/local/bin/codex /repo/posthog
+36 1 /usr/bin/node | node -eprocess.exit() /usr/local/bin/codex /repo/posthog
+37 1 /usr/bin/node | node /repo/posthog/codex/frontend/dev.js
+38 1 /usr/bin/node | node /repo/posthog/frontend/dev.js --runtime /opt/cua_node/bin/node
+39 1 /usr/bin/node | node --import /opt/node_modules/@openai/codex/bin/codex.js /repo/posthog/frontend/dev.js
+40 1 /Applications/Warp.app/Contents/MacOS/stable | /Applications/Warp.app/Contents/MacOS/stable
+41 40 /bin/zsh | -zsh
+42 41 /usr/bin/node | node /repo/posthog/frontend/dev.js
+43 1 /Applications/Terminal Tools/WarpPreview.app/Contents/MacOS/stable | /Applications/Terminal Tools/WarpPreview.app/Contents/MacOS/stable
+44 43 /usr/bin/node | node /repo/posthog/frontend/dev.js
+50 1 /usr/bin/phrocs | phrocs --daemon -c /repo/posthog/mprocs.yaml
+51 50 /usr/bin/granian | granian /repo/posthog/asgi.py
+60 1 /usr/bin/node | node /repo/posthog/frontend/dev.js
+61 1 /bin/bash | /bin/bash -c python /repo/posthog/manage.py runserver
+62 61 /usr/bin/python3.13 | python /repo/posthog/manage.py runserver
+63 1 /repo/posthog/rust/target/debug/capture | /repo/posthog/rust/target/debug/capture
+64 60 /usr/bin/node | node /repo/posthog/frontend/worker.js
+70 1 /opt/application | /opt/application --project /repo/posthog
+71 70 /usr/bin/node | node /repo/posthog/frontend/dev.js
+72 9999 /usr/bin/node | node /repo/posthog/frontend/dev.js
+73 74 /usr/bin/node | node /repo/posthog/frontend/dev.js
+74 73 /bin/bash | /bin/bash /repo/posthog/bin/worker
+75 1 /opt/stable | /opt/stable --project /repo/posthog --terminal /Applications/Warp.app/Contents/MacOS/stable
+76 75 /usr/bin/node | node /repo/posthog/frontend/dev.js
+77 1 /usr/bin/node | node /repo/posthog/frontend/dev.js --label codex-code-mode-host phrocs Terminal iTerm
+78 1 /opt/unknown | /opt/unknown --project /repo/posthog --codex /opt/codex/bin/codex
+80 1 /Applications/Terminal.app/Contents/MacOS/Terminal | /Applications/Terminal.app/Contents/MacOS/Terminal
+81 80 /usr/bin/node | node /repo/posthog/frontend/dev.js
+82 1 /opt/Python  Runtime/bin/python3.13 | /opt/Python  Runtime/bin/python3.13 manage.py runserver
+83 1 /usr/bin/tmux | tmux new
+84 83 /usr/bin/node | node /repo/posthog/frontend/dev.js
+85 1 /Applications/iTerm.app/Contents/MacOS/iTerm2 | /Applications/iTerm.app/Contents/MacOS/iTerm2
+86 85 /usr/bin/node | node /repo/posthog/frontend/dev.js
+90 1 /usr/bin/node | node unrelated.js
+91 1 /work/codex/bin/node | /work/codex/bin/node frontend/dev.js
+92 1 /usr/bin/node | node /repo/posthog/frontend/dev.js --output /tmp/git
+93 1 /usr/bin/python3.13 | hogli --repo /repo/posthog doctor
+94 1 /opt/claude/1.0.0 | claude --cwd /repo/posthog
+95 1 /opt/code tools/bin/node | /opt/code tools/bin/node frontend/dev.js
+900 80 /usr/bin/node | node /repo/posthog/tools/terminal.js
+901 900 /bin/bash | /bin/bash -c hogli /repo/posthog
+902 901 /usr/bin/hogli | hogli doctor:zombies
+"""
+    ps_lines: list[str] = []
+    executable_lines: list[str] = []
+    for row in rows.strip().splitlines():
+        identity, args = row.split(" | ", 1)
+        pid, ppid, executable = identity.split(maxsplit=2)
+        ps_lines.append(f"{pid} {ppid} 0.0 1024 Thu Sep 10 12:00:00 2026 {args}")
+        executable_lines.append(f"{pid} {executable}")
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> SimpleNamespace:
+        calls.append(cmd)
+        if cmd == ["ps", "-eo", "pid=,ppid=,pcpu=,rss=,lstart=,args="]:
+            output = "\n".join(ps_lines)
+        elif cmd in (["ps", "-eo", "pid=,comm="], ["ps", "-eo", "pid=,exe="]):
+            output = "\n".join(executable_lines)
+        elif cmd[:3] == ["lsof", "-a", "-p"] and cmd[4:] == ["-d", "cwd", "-Fpn"]:
+            output = "\n".join(
+                f"p{pid}\nn{'/somewhere/else' if pid == '90' else '/repo/posthog'}" for pid in cmd[3].split(",")
+            )
+        else:
+            raise AssertionError(f"Unexpected OS call: {cmd}")
+        return SimpleNamespace(returncode=0, stdout=output, stderr="")
+
+    def unexpected_kill(pid: int, sig: int) -> None:
+        raise AssertionError(f"Unexpected signal {sig} to PID {pid}")
+
+    monkeypatch.setattr("hogli_commands.doctor.subprocess.run", fake_run)
+    monkeypatch.setattr("hogli_commands.doctor.os.getpid", lambda: 902)
+    monkeypatch.setattr("hogli_commands.doctor.os.kill", unexpected_kill)
+    monkeypatch.setattr("hogli_commands.doctor.REPO_ROOT", Path("/repo/posthog"))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    return calls
+
+
+_ORPHAN_PIDS = {34, 35, 36, 37, 38, 39, 60, 61, 62, 63, 64, 77, 82, 91, 92, 95}
+_PRESERVED_MANAGERS = {
+    14: "Codex (PID 10)",
+    15: "phrocs (PID 15)",
+    16: "phrocs (PID 15)",
+    22: "Codex (PID 21)",
+    42: "Warp (PID 40)",
+    44: "Warp (PID 43)",
+    50: "phrocs (PID 50)",
+    51: "phrocs (PID 50)",
+    70: "PID 1",
+    71: "PID 70",
+    72: "PID 9999",
+    73: "PID 74",
+    74: "PID 73",
+    75: "PID 1",
+    76: "PID 75",
+    78: "PID 1",
+    81: "Terminal.app (PID 80)",
+    84: "tmux (PID 83)",
+    86: "iTerm2 (PID 85)",
+}
+
+
+@pytest.mark.parametrize("system,field", [("Darwin", "comm"), ("Linux", "exe")])
+def test_zombie_snapshot_classification(
+    zombie_snapshot: list[list[str]], monkeypatch: pytest.MonkeyPatch, system: str, field: str
+) -> None:
+    monkeypatch.setattr("hogli_commands.doctor.platform.system", lambda: system)
+
+    processes = _scan_posthog_processes(Path("/repo/posthog"))
+
+    assert {p.pid for p in processes} == _ORPHAN_PIDS | _PRESERVED_MANAGERS.keys()
+    assert {p.pid for p in processes if p.is_orphan} == _ORPHAN_PIDS
+    assert {p.pid: p.manager for p in processes if not p.is_orphan} == _PRESERVED_MANAGERS
+    python = next(p for p in processes if p.pid == 82)
+    assert python.name == "python3.13"
+    assert python.cmdline == "/opt/Python  Runtime/bin/python3.13 manage.py runserver"
+    assert zombie_snapshot == [
+        ["ps", "-eo", "pid=,ppid=,pcpu=,rss=,lstart=,args="],
+        ["ps", "-eo", f"pid=,{field}="],
+        ["lsof", "-a", "-p", "82,90,91,95", "-d", "cwd", "-Fpn"],
+    ]
+    assert _check_zombies(Path("/repo/posthog")).summary == f"{len(_ORPHAN_PIDS)} orphaned"
+
+
+@pytest.mark.parametrize("own_pid", [18, 902], ids=["from-codex", "from-another-terminal"])
+@pytest.mark.parametrize(
+    "arguments",
+    [["--yes"], ["--all", "--yes"], ["--dry-run"], ["--all", "--yes", "--dry-run"]],
+)
+def test_doctor_zombies_signals_only_selected_dev_processes(
+    zombie_snapshot: list[list[str]], monkeypatch: pytest.MonkeyPatch, own_pid: int, arguments: list[str]
+) -> None:
+    signals: list[tuple[int, int]] = []
+
+    def fake_kill(pid: int, sig: int) -> None:
+        signals.append((pid, sig))
+        if sig == 0 and pid != 60:
+            raise ProcessLookupError
+
+    monkeypatch.setattr("hogli_commands.doctor.os.getpid", lambda: own_pid)
+    monkeypatch.setattr("hogli_commands.doctor.os.kill", fake_kill)
+    monkeypatch.setattr("hogli_commands.doctor.time.sleep", lambda _: None)
+
+    result = CliRunner().invoke(doctor_zombies, arguments)
+
+    assert result.exit_code == 0, result.output
+    if "--dry-run" in arguments:
+        assert signals == []
+        assert "[DRY-RUN] No processes were killed." in result.output
+        return
+
+    expected = set(_ORPHAN_PIDS)
+    if "--all" in arguments:
+        expected.update(_PRESERVED_MANAGERS)
+        if own_pid == 18:
+            expected.update({900, 901})
+    assert {pid for pid, _ in signals} == expected
+    assert sorted(pid for pid, sig in signals if sig == signal.SIGTERM) == sorted(expected)
+    assert [pid for pid, sig in signals if sig == signal.SIGKILL] == [60]
+    assert {pid for pid, sig in signals if sig == 0} == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

Developers can lose live Codex sessions when zombie cleanup mistakes their launchers or runtime helpers for abandoned dev jobs.
The automatic cleanup in `hogli start` uses the same scan.

## Changes

- Cleanup excludes native Codex, its Node launchers, and bundled runtime helpers across all sessions.
- The command only targets orphans and no longer accepts `--all`.
- A batched executable lookup identifies Codex without treating ordinary Node jobs in Codex-named directories as infrastructure.
- Mechanical parsing changes preserve spaces in executable paths.

## How did you test this code?

- Synthetic snapshots cover Codex exclusions across sessions, paths containing spaces, and ordinary Node jobs that remain eligible.
- CLI tests mock OS boundaries and assert signal recipients, dry-run behavior, and rejection of `--all`.
- Automated Linux dry-run and CLI help checks verify the resulting interface. macOS validation uses synthetic snapshots.

```sh
.codex/with-flox hogli test tools/hogli-commands/hogli_commands/tests/test_doctor.py
.codex/with-flox hogli ci:preflight --fix
```

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used shell tools and GitHub CLI.
Skills: /hogli, /writing-tests, /writing-code-comments, /writing-user-facing-copy, /running-ci-preflight, and /writing-pr-descriptions.

Duplicate searches found no matching open PR.
Process fixtures are synthetic and contain no customer material.


The final scope excludes the documentation and broader ownership-classification changes.
