### PR TITLE
fix(data-modeling): say why a query failed, not that its stream broke

### DIFF
--- a/posthog/temporal/common/asyncpa.py
+++ b/posthog/temporal/common/asyncpa.py
@@ -11,7 +11,17 @@ CONTINUATION_BYTES = b"\xff\xff\xff\xff"
 
 
 class InvalidMessageFormat(Exception):
-    pass
+    """Raised when the stream is not an encapsulated IPC message.
+
+    `unparsed` carries the bytes that failed to parse. A server that aborts a query
+    mid-response writes the reason into the stream it was already sending, so these
+    bytes are often an error message rather than corruption. Only the caller knows
+    whose message it is, so hand them over instead of describing them.
+    """
+
+    def __init__(self, message: str, unparsed: bytes = b""):
+        super().__init__(message)
+        self.unparsed = unparsed
 
 
 class AsyncMessageReader:
@@ -45,8 +55,10 @@ class AsyncMessageReader:
         await self.read_until(4)
 
         if self._buffer[:4] != CONTINUATION_BYTES:
+            unparsed = await self.drain()
             raise InvalidMessageFormat(
-                f"Encapsulated IPC message format must begin with continuation bytes, received: '{self._buffer[:4]}'"
+                f"Encapsulated IPC message format must begin with continuation bytes, received: {unparsed[:4]!r}",
+                unparsed=unparsed,
             )
 
         await self.read_until(8)
@@ -76,6 +88,19 @@ class AsyncMessageReader:
         self._bytes_consumed += total_message_size
 
         return msg
+
+    async def drain(self, limit: int = 8192) -> bytes:
+        """Return the buffer plus whatever else the stream still holds, up to `limit`.
+
+        Called on the way out of a failed parse, so a stream that breaks again while
+        draining must not replace the message being built: keep what was read.
+        """
+        try:
+            while len(self._buffer) < limit:
+                self._buffer.extend(await anext(self._bytes))
+        except Exception:
+            pass
+        return bytes(self._buffer[:limit])
 
     async def read_until(self, n: int) -> None:
         """Read from self._bytes until there are at least n bytes in self._buffer."""

--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -100,6 +100,12 @@ class ClickHouseQueryStatus(enum.StrEnum):
     ERROR = "Error"
 
 
+# ClickHouse writes `system.query_log` on a flush interval, so a query that has only
+# just died is not in it yet. Wait past one interval before asking about a query we
+# watched fail moments ago.
+QUERY_LOG_FLUSH_WAIT_SECONDS = 10.0
+
+
 class ChunkBytesAsyncStreamIterator:
     """Async iterator of HTTP chunk bytes.
 
@@ -419,7 +425,10 @@ class ClickHouseClient:
     async def acheck_response(self, response, query) -> None:
         """Asynchronously check the HTTP response received from ClickHouse."""
         if response.status != 200:
-            error_message = await response.text()
+            # A query that fails once ClickHouse has already written result bytes leaves
+            # them in the body ahead of the error text, so a strict decode raises on the
+            # binary instead of reporting what went wrong.
+            error_message = (await response.read()).decode("utf-8", errors="replace")
             self.raise_clickhouse_error(error_message, query=query)
 
     def check_response(self, response, query) -> None:
@@ -830,6 +839,42 @@ class ClickHouseClient:
             self.logger.warning("Failed to read written rows from query log", query_id=query_id, exc_info=True)
             return None
 
+    async def araise_error_behind_broken_stream(
+        self, query_id: str | None, stream_error: BaseException
+    ) -> typing.NoReturn:
+        """Raise the error that stopped a query, in place of the broken stream it left.
+
+        ClickHouse answers 200 as soon as it starts streaming, so a query that dies after
+        that point cannot report through the status code. It writes the error into the tail
+        of the response it was already sending, then cuts the connection. Whether we hold
+        that text is a race with the cut, and the two outcomes need different answers:
+
+        - the tail arrived, and the bytes we could not parse as Arrow are the error itself
+        - the cut won, nothing arrived, and only ClickHouse still knows
+
+        Re-raises `stream_error` when neither answers, because a stream we cannot explain
+        is still a stream we could not read.
+        """
+        if isinstance(stream_error, asyncpa.InvalidMessageFormat) and stream_error.unparsed:
+            trailer = stream_error.unparsed.decode("utf-8", errors="replace")
+            if "DB::Exception" in trailer:
+                try:
+                    self.raise_clickhouse_error(trailer, query_id=query_id)
+                except ClickHouseError as recorded:
+                    raise recorded from stream_error
+
+        if query_id is not None:
+            await asyncio.sleep(QUERY_LOG_FLUSH_WAIT_SECONDS)
+            try:
+                await self.acheck_query(query_id, raise_on_error=True)
+            except (ClickHouseQueryNotFound, ClickHouseCheckQueryStatusError):
+                # The log cannot answer. Not finding a record is not finding a success.
+                pass
+            except ClickHouseError as recorded:
+                raise recorded from stream_error
+
+        raise stream_error
+
     async def acheck_query_in_process_list(self, query_id: str) -> bool:
         """Check if a query is running in the ClickHouse process list.
 
@@ -933,10 +978,18 @@ class ClickHouseClient:
         """
         async with self.apost_query(query, *data, query_parameters=query_parameters, query_id=query_id) as response:
             reader = asyncpa.AsyncRecordBatchReader(ChunkBytesAsyncStreamIterator(response.content))
-            if on_schema is not None:
-                on_schema(await reader.get_schema())
-            async for batch in reader:
-                yield batch
+
+            try:
+                if on_schema is not None:
+                    on_schema(await reader.get_schema())
+
+                async for batch in reader:
+                    yield batch
+            except Exception as stream_error:
+                # Only a failure to read arrives here. A consumer that raises inside its own
+                # loop closes this generator with GeneratorExit, which is a BaseException and
+                # passes straight through, so their error is never swapped for the query's.
+                await self.araise_error_behind_broken_stream(query_id, stream_error)
 
     async def aproduce_query_as_arrow_record_batches(
         self,

--- a/posthog/temporal/data_modeling/activities/materialize_view.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view.py
@@ -656,9 +656,13 @@ async def hogql_table(
         arrow_prepared_hogql_query, context=context, dialect="clickhouse", stack=[], settings=settings
     )
 
+    # Named so that a query dying mid-stream can be looked up in ClickHouse's query log,
+    # which holds the real error where the torn response does not.
+    query_id = str(uuid.uuid4())
+
     # The query goes in a field rather than the message: only the message is copied into the
     # log_entries row users can read, and the compiled query is the saved query's own SQL.
-    await logger.adebug("Running clickhouse query", query=arrow_printed)
+    await logger.adebug("Running clickhouse query", query=arrow_printed, query_id=query_id)
 
     async with (
         _clickhouse_query_semaphore,
@@ -678,6 +682,7 @@ async def hogql_table(
             arrow_printed,
             query_parameters=context.values,
             on_schema=capture_arrow_schema,
+            query_id=query_id,
         ):
             batches_size = batches_size + batch.nbytes
             batches.append(batch)

--- a/posthog/temporal/tests/test_clickhouse.py
+++ b/posthog/temporal/tests/test_clickhouse.py
@@ -6,6 +6,8 @@ import contextlib
 import pytest
 from unittest.mock import MagicMock, patch
 
+import aiohttp
+
 from posthog.clickhouse.query_tagging import QueryTags
 from posthog.temporal.common.clickhouse import (
     ClickHouseAllReplicasAreStaleError,
@@ -551,3 +553,108 @@ async def test_stream_query_as_jsonl_handles_whitespace_only_lines(clickhouse_cl
     assert results[0] == {"id": 1}
     assert results[1] == {"id": 2}
     assert results[2] == {"id": 3}
+
+
+# A query killed inside ClickHouse writes its reason into the response it had already
+# started sending. Those bytes are not Arrow, which is why they reach us as a parse error.
+CLICKHOUSE_TRAILER = (
+    b"Code: 241. DB::Exception: Memory limit (total) exceeded: would use 226.99 GiB. "
+    b"(MEMORY_LIMIT_EXCEEDED) (version 26.6.4.55 (official build))\n"
+    b"282 ogwjwxxtaytridhz\n"
+    b"__exception__\n"
+)
+
+
+@pytest.mark.parametrize(
+    "chunks,recorded,expected_type,expected_fragment,reads_log",
+    [
+        ([(CLICKHOUSE_TRAILER, True)], None, ClickHouseMemoryLimitExceededError, "241", False),
+        (
+            None,
+            ClickHouseTooManyBytesError("Code: 307. Limit for bytes to read exceeded"),
+            ClickHouseTooManyBytesError,
+            "307",
+            True,
+        ),
+        (None, ClickHouseQueryNotFound("some-query-id"), aiohttp.ClientPayloadError, "not completed", True),
+        (None, None, aiohttp.ClientPayloadError, "not completed", True),
+    ],
+    ids=["trailer_names_the_error", "cut_first_log_answers", "cut_first_log_silent", "query_finished_fine"],
+)
+async def test_astream_query_as_arrow_reports_why_the_query_stopped(
+    clickhouse_client, chunks, recorded, expected_type, expected_fragment, reads_log
+):
+    """ClickHouse sends 200 before it streams, so a later failure arrives as a torn stream.
+
+    Two facts have to survive. The error belongs to the query, not the transport, whether
+    it is read from the tail of the response or from the query log. And when neither can
+    say, the transport error stays, because "the query ran fine" and "we could not find
+    out" are different answers and only one of them is the caller's.
+    """
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.content.at_eof = lambda: True
+
+    if chunks is None:
+
+        async def mock_readchunk():
+            raise aiohttp.ClientPayloadError("Response payload is not completed")
+    else:
+        remaining = list(chunks)
+
+        async def mock_readchunk():
+            return remaining.pop(0) if remaining else (b"", False)
+
+    mock_response.content.readchunk = mock_readchunk
+
+    @contextlib.asynccontextmanager
+    async def mock_post(*args, **kwargs):
+        yield mock_response
+
+    log_reads = []
+
+    async def mock_check(query_id, raise_on_error=True):
+        log_reads.append(query_id)
+        if recorded is not None:
+            raise recorded
+        return ClickHouseQueryStatus.FINISHED
+
+    with (
+        patch.object(clickhouse_client, "apost_query", mock_post),
+        patch.object(clickhouse_client, "acheck_query", mock_check),
+        patch("posthog.temporal.common.clickhouse.QUERY_LOG_FLUSH_WAIT_SECONDS", 0),
+    ):
+        with pytest.raises(expected_type) as exc_info:
+            async for _ in clickhouse_client.astream_query_as_arrow("SELECT 1", query_id="some-query-id"):
+                pass
+
+    assert expected_fragment in str(exc_info.value)
+    # Waiting out a flush interval to be told what the response already said would be
+    # latency spent on an answer we hold.
+    assert bool(log_reads) is reads_log
+
+
+async def test_astream_query_as_arrow_keeps_the_stream_error_when_no_query_id(clickhouse_client):
+    """Without a query id there is nothing to look up, so the caller keeps the error it got."""
+    mock_response = MagicMock()
+    mock_response.status = 200
+
+    async def mock_readchunk():
+        raise aiohttp.ClientPayloadError("Response payload is not completed")
+
+    mock_response.content.readchunk = mock_readchunk
+
+    @contextlib.asynccontextmanager
+    async def mock_post(*args, **kwargs):
+        yield mock_response
+
+    async def fail_if_called(query_id, raise_on_error=True):
+        raise AssertionError("must not look up a query log entry without a query id")
+
+    with (
+        patch.object(clickhouse_client, "apost_query", mock_post),
+        patch.object(clickhouse_client, "acheck_query", fail_if_called),
+    ):
+        with pytest.raises(aiohttp.ClientPayloadError):
+            async for _ in clickhouse_client.astream_query_as_arrow("SELECT 1"):
+                pass


### PR DESCRIPTION
## Problem

A materialization that fails inside ClickHouse tells its owner the response stream broke, not what the query did wrong.

ClickHouse answers `200` as soon as it starts streaming, so a query that dies after that point cannot report through the status code. It writes the reason into the tail of the response it is already sending, then cuts the connection. Those trailing bytes are not Arrow, so the client raises a parse or transport error, and that is the text the customer reads:

| what the customer is told | what actually happened |
|---|---|
| `InvalidMessageFormat` | `Code: 307` — the query read past a 50 TiB limit |
| `Response payload is not completed` | `Code: 159` — the query passed its 600s timeout |
| `InvalidMessageFormat` | `Code: 1002` — a string column outgrew Arrow's 2 GiB cap |

Every one of those is actionable. None of them is visible. After five such runs the model is suspended, and the reason recorded against it names the transport.

Which of the two errors surfaces is a race between the tail arriving and the connection closing. Across the suspended nodes on both regions it lands almost exactly half and half, so a single recovery path leaves half the failures unexplained.

## Changes

- `asyncpa.InvalidMessageFormat` carries the bytes it could not parse, and the reader drains the rest of the stream to collect them. When the tail won the race, the error text is already in hand.
- `astream_query_as_arrow` names its query, so the case where the cut won can be resolved by asking ClickHouse's own log after one flush interval.
- On a broken stream: read the reason out of the unparsed bytes; failing that, look it up; failing both, raise the transport error unchanged. The recovered error is chained to it, so the original stays in the traceback.
- `acheck_response` decodes an error body with replacement instead of strict UTF-8. When ClickHouse *can* still answer with an error status, it may already have written Arrow bytes ahead of the error text, and strict decoding raised `UnicodeDecodeError` on the first one — the same reason lost a different way. One live suspension carries exactly that.
- The guard wraps only the read. A consumer that raises inside its own loop closes the generator with `GeneratorExit`, a `BaseException`, so their error is never swapped for the query's.

## How did you test this code?

Unit tests cover the branch points: a torn stream whose unparsed bytes name a read limit and a memory limit, a torn stream the log explains, a torn stream nothing explains, and a stream failure on a query with no id. The fixture is the byte sequence ClickHouse 26.6 actually sends, captured off the wire rather than written from memory.

Beyond that, an A/B against **ClickHouse 26.6.4.55 in Docker — the same minor version both production regions run** (`26.6.2.158`), calling the real client with master's two files swapped in and then the branch's:

| failure shape | master | this branch |
|---|---|---|
| error after ~20 MB streamed | `InvalidMessageFormat`, no code | `Code: 395` |
| error after ~400 KB streamed | `InvalidMessageFormat`, no code | `Code: 395` |
| error before any bytes | `Code: 395` | `Code: 395` |

The middle row is the production symptom, reproduced on master and fixed on the branch. The third row is the control: master already handled that shape, and the branch does not regress it.

The same harness run against ClickHouse 24.8 and 25.3 shows this is version-dependent — 24.8 sends the reason with no marker, 25.3 sends nothing the client can classify. The branch reads the reason on every version that sends one.

**Not verified:**

- The `Response payload is not completed` half never reproduced locally on 26.6. Its evidence is production markers, plus the structural fact that an `aiohttp` payload error is not an `InvalidMessageFormat` and so can only be served by the log path.
- The log path itself is unexercised here: it queries `clusterAllReplicas('posthog', system.query_log)`, and a single-node container has no such cluster. Production does, and batch exports queries it the same way. Worth noting that the A/B above passed *with that path unavailable* — the unparsed bytes carried all three shapes on their own.
- The one flush interval before the log lookup is reasoned from ClickHouse's flush setting, not measured against production lag.

## Does this work well for both Cloud and self-hosted?

Yes. No configuration, no schema change. The log lookup is best-effort and its failure is caught, so an instance without a readable query log falls back to today's behavior rather than breaking.

## Related issues / notes

Nothing here changes which models get suspended. Every recovered error is a genuine failure, and none of them belong to the set that is exempt from the failure counter. What changes is that the owner can read why.

One recovered error is ours rather than the customer's: a string column crossing Arrow's 2 GiB cap. That needs its own fix; this PR only makes it legible.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)
**Agent:** Claude Code (Opus 5)
**Skills invoked:** `/writing-tests`, `/writing-pr-descriptions`

Found while auditing which suspensions were the customer's fault and which were ours, after a reliability flag widened. The audit read production data; none of it is in this diff. Error strings, query ids and test payloads are invented or captured from a local container.

The first version of this fix polled the query log five times over 15s and did not touch the parser. Half the failures already held the answer in a discarded buffer, so that version waited 15s for something it was throwing away. The parser was dropping the bytes because it was answering a narrower question than its caller was asking — invalid *as Arrow* is not invalid *as an error message*.

An earlier revision also hand-unrolled the batch iterator to keep the guard off the `yield`. A four-line async experiment showed a consumer's exception arrives as `GeneratorExit`, which `except Exception` never catches, so that came back out.

CodeRabbit CLI was unavailable in this environment, so no local review pass ran.
