### PR TITLE
fix(warehouse-sources): validate the BigQuery key file token endpoint

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
@@ -173,6 +173,31 @@ BIGQUERY_INVALID_KEY_FILE_ERROR = (
     "corrupted. Please download a fresh service account key from Google Cloud and re-upload the JSON file."
 )
 
+# `token_uri` comes from the uploaded key file, and google-auth POSTs the service-account grant to
+# whatever URL that field names. The field therefore decides where a worker sends an outbound
+# request, so it must name an endpoint we accept rather than one the file supplies. Google issues
+# service-account keys with only these two endpoints, so any other value is hand-edited.
+# Shared with the sync-path classifier for lockstep.
+GOOGLE_SERVICE_ACCOUNT_TOKEN_URIS = frozenset(
+    {"https://oauth2.googleapis.com/token", "https://accounts.google.com/o/oauth2/token"}
+)
+BIGQUERY_INVALID_TOKEN_URI_ERROR = (
+    "The token_uri in your Google Cloud JSON key file is not Google's OAuth token endpoint. Please download "
+    "a fresh service account key from Google Cloud and re-upload the JSON file without editing it."
+)
+
+
+class BigQueryInvalidTokenUriError(Exception):
+    pass
+
+
+def _require_google_token_uri(token_uri: str) -> str:
+    token_uri = token_uri.strip()
+    if token_uri not in GOOGLE_SERVICE_ACCOUNT_TOKEN_URIS:
+        raise BigQueryInvalidTokenUriError(BIGQUERY_INVALID_TOKEN_URI_ERROR)
+    return token_uri
+
+
 # Onboarding-time messages. Unlike the sync-path classifier these are only reached during credential
 # validation, where the fix is to correct the input and try again rather than re-enable a sync.
 BIGQUERY_MISSING_KEY_FILE_FIELDS_ERROR = (
@@ -425,6 +450,7 @@ def bigquery_client(
 ) -> typing.Iterator[bigquery.Client]:
     """Manage a BigQuery client."""
     project_id = _normalize_identifier(project_id)
+    token_uri = _require_google_token_uri(token_uri)
     credentials = service_account.Credentials.from_service_account_info(
         {
             "private_key": private_key,
@@ -483,6 +509,7 @@ def bigquery_storage_read_client(
 ):
     """Manage a BigQuery Storage client."""
     project_id = _normalize_identifier(project_id)
+    token_uri = _require_google_token_uri(token_uri)
     credentials = service_account.Credentials.from_service_account_info(
         {
             "private_key": private_key,
@@ -652,6 +679,10 @@ def validate_bigquery_credentials(
 
     if not project_id or not private_key or not private_key_id or not client_email or not token_uri:
         return False, BIGQUERY_MISSING_KEY_FILE_FIELDS_ERROR
+    try:
+        _require_google_token_uri(token_uri)
+    except BigQueryInvalidTokenUriError as e:
+        return False, str(e)
 
     # Trim copy-paste whitespace from the identifiers before they reach BigQuery,
     # which otherwise rejects them with an opaque `Invalid project ID`/`Invalid dataset ID`.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
@@ -173,14 +173,14 @@ BIGQUERY_INVALID_KEY_FILE_ERROR = (
     "corrupted. Please download a fresh service account key from Google Cloud and re-upload the JSON file."
 )
 
-# `token_uri` comes from the uploaded key file, and google-auth POSTs the service-account grant to
-# whatever URL that field names. The field therefore decides where a worker sends an outbound
-# request, so it must name an endpoint we accept rather than one the file supplies. Google issues
-# service-account keys with only these two endpoints, so any other value is hand-edited.
-# Shared with the sync-path classifier for lockstep.
+# `token_uri` comes from the uploaded key file, and google-auth posts the service-account grant to
+# whatever URL it names, so the field decides where a worker sends an outbound request. Google
+# issues service-account keys with only these two endpoints, so any other value is hand-edited.
 GOOGLE_SERVICE_ACCOUNT_TOKEN_URIS = frozenset(
     {"https://oauth2.googleapis.com/token", "https://accounts.google.com/o/oauth2/token"}
 )
+
+# Matched in `BigQuerySource.get_non_retryable_errors`, so it must stay free of volatile data.
 BIGQUERY_INVALID_TOKEN_URI_ERROR = (
     "The token_uri in your Google Cloud JSON key file is not Google's OAuth token endpoint. Please download "
     "a fresh service account key from Google Cloud and re-upload the JSON file without editing it."

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
@@ -17,6 +17,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.b
     BIGQUERY_DATASET_NOT_FOUND_ERROR,
     BIGQUERY_INVALID_IDENTIFIER_ERROR,
     BIGQUERY_INVALID_KEY_FILE_ERROR,
+    BIGQUERY_INVALID_TOKEN_URI_ERROR,
     BIGQUERY_ON_DEMAND_RATIO_EXCEEDED_ERROR,
     BIGQUERY_RESOURCES_EXCEEDED_ERROR,
     BIGQUERY_TOKEN_RESPONSE_ERROR,
@@ -75,6 +76,10 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
             # be repaired by retrying — the user must re-upload an intact JSON key file. Matched on the
             # stable "Unable to load PEM file" wording rather than the volatile InvalidData detail.
             "Unable to load PEM file": BIGQUERY_INVALID_KEY_FILE_ERROR,
+            # Raised from `bigquery_client` before any request is made when the key file's `token_uri`
+            # is not one of Google's token endpoints. The key file is the problem, so retrying can't
+            # help; the user must re-upload an unedited key.
+            BIGQUERY_INVALID_TOKEN_URI_ERROR: BIGQUERY_INVALID_TOKEN_URI_ERROR,
             # Writing query results into the `__posthog_import_...` temp tables PostHog creates
             # (`WRITE_TRUNCATE` in `_run_destination_query_with_job_retry`, on incremental / view /
             # row-filtered reads) needs write access on the dataset those tables live in. When the

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
@@ -76,9 +76,8 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
             # be repaired by retrying — the user must re-upload an intact JSON key file. Matched on the
             # stable "Unable to load PEM file" wording rather than the volatile InvalidData detail.
             "Unable to load PEM file": BIGQUERY_INVALID_KEY_FILE_ERROR,
-            # Raised from `bigquery_client` before any request is made when the key file's `token_uri`
-            # is not one of Google's token endpoints. The key file is the problem, so retrying can't
-            # help; the user must re-upload an unedited key.
+            # Raised before any request when the key file's token endpoint is not Google's. The key
+            # file is the problem, so retrying cannot help; the user must re-upload an unedited key.
             BIGQUERY_INVALID_TOKEN_URI_ERROR: BIGQUERY_INVALID_TOKEN_URI_ERROR,
             # Writing query results into the `__posthog_import_...` temp tables PostHog creates
             # (`WRITE_TRUNCATE` in `_run_destination_query_with_job_retry`, on incremental / view /

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -27,6 +27,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.b
     BIGQUERY_DATASET_NOT_FOUND_ERROR,
     BIGQUERY_INVALID_IDENTIFIER_ERROR,
     BIGQUERY_INVALID_KEY_FILE_ERROR,
+    BIGQUERY_INVALID_TOKEN_URI_ERROR,
     BIGQUERY_MISSING_KEY_FILE_FIELDS_ERROR,
     BIGQUERY_QUERY_CREATE_RETRY,
     BIGQUERY_QUERY_JOB_RETRY,
@@ -39,6 +40,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.b
     BigQueryDatasetNotFoundError,
     BigQueryImplementation,
     BigQueryInvalidIdentifierError,
+    BigQueryInvalidTokenUriError,
     BigQueryTokenRefreshError,
     _bq_select_clause,
     _get_primary_keys_for_table,
@@ -108,7 +110,7 @@ def _make_config(
             private_key="private-key",
             private_key_id="private-key-id",
             client_email="client-email",
-            token_uri="token-uri",
+            token_uri="https://oauth2.googleapis.com/token",
         ),
         dataset_id=dataset_id,
         dataset_project=dataset_project,
@@ -867,7 +869,7 @@ def _run_delete_all_temp_destination_tables(side_effect, logger):
             private_key="private-key",
             private_key_id="private-key-id",
             client_email="client-email",
-            token_uri="token-uri",
+            token_uri="https://oauth2.googleapis.com/token",
             logger=logger,
         )
     return mock_capture
@@ -1103,7 +1105,7 @@ def test_bigquery_validate_credentials_trims_whitespace_before_calling_bigquery(
                 "private_key": "private-key",
                 "private_key_id": "private-key-id",
                 "client_email": "client-email",
-                "token_uri": "token-uri",
+                "token_uri": "https://oauth2.googleapis.com/token",
             },
             dataset_project_id=None,
             location=None,
@@ -1119,7 +1121,7 @@ def _valid_key_file() -> dict[str, str]:
         "private_key": "private-key",
         "private_key_id": "private-key-id",
         "client_email": "client-email",
-        "token_uri": "token-uri",
+        "token_uri": "https://oauth2.googleapis.com/token",
     }
 
 
@@ -1136,6 +1138,49 @@ def test_bigquery_validate_credentials_missing_fields_reports_actionable_message
     assert message == BIGQUERY_MISSING_KEY_FILE_FIELDS_ERROR
     # A malformed key file must be caught before we try to reach BigQuery.
     mock_client.assert_not_called()
+
+
+_NON_GOOGLE_TOKEN_URIS = [
+    "https://attacker.example.com/relay",
+    "http://oauth2.googleapis.com/token",
+    "https://oauth2.googleapis.com.example.com/token",
+    "http://169.254.169.254/latest/meta-data/",
+]
+
+
+@pytest.mark.parametrize("token_uri", _NON_GOOGLE_TOKEN_URIS)
+def test_bigquery_validate_credentials_rejects_non_google_token_uri_before_any_request(token_uri):
+    key_file = {**_valid_key_file(), "token_uri": token_uri}
+
+    with mock.patch.object(bq_module, "bigquery_client") as mock_client:
+        ok, message = validate_bigquery_credentials(
+            dataset_id="my_dataset", key_file=key_file, dataset_project_id=None, location=None
+        )
+
+    assert ok is False
+    assert message == BIGQUERY_INVALID_TOKEN_URI_ERROR
+    mock_client.assert_not_called()
+
+
+@pytest.mark.parametrize("token_uri", _NON_GOOGLE_TOKEN_URIS)
+@pytest.mark.parametrize("client_factory", ["bigquery_client", "bigquery_storage_read_client"])
+def test_bigquery_clients_refuse_non_google_token_uri_before_building_credentials(client_factory, token_uri):
+    kwargs = {"location": None} if client_factory == "bigquery_client" else {}
+
+    with mock.patch.object(bq_module.service_account.Credentials, "from_service_account_info") as mock_creds:
+        with pytest.raises(BigQueryInvalidTokenUriError) as exc_info:
+            with getattr(bq_module, client_factory)(
+                project_id="project-id",
+                private_key="private-key",
+                private_key_id="private-key-id",
+                client_email="client-email",
+                token_uri=token_uri,
+                **kwargs,
+            ):
+                pass
+
+    mock_creds.assert_not_called()
+    assert str(exc_info.value) in BigQuerySource().get_non_retryable_errors()
 
 
 @pytest.mark.parametrize(
@@ -1211,7 +1256,7 @@ def test_bigquery_source_validate_credentials_wires_config_and_region(use_custom
     dataset_id, key_file, dataset_project_id, region = mock_validate.call_args.args
     assert dataset_id == "dataset-id"
     assert key_file["project_id"] == "project-id"
-    assert key_file["token_uri"] == "token-uri"
+    assert key_file["token_uri"] == "https://oauth2.googleapis.com/token"
     assert dataset_project_id is None
     # A custom region only flows through when the toggle is enabled and non-empty.
     assert region == expected_region
@@ -1940,7 +1985,7 @@ def test_bigquery_storage_read_client_disables_grpc_message_size_limit():
             private_key="private-key",
             private_key_id="private-key-id",
             client_email="client-email",
-            token_uri="token-uri",
+            token_uri="https://oauth2.googleapis.com/token",
         ):
             pass
 
@@ -1967,7 +2012,7 @@ def test_bigquery_client_retries_transient_token_refresh_failures():
             private_key="private-key",
             private_key_id="private-key-id",
             client_email="client-email",
-            token_uri="token-uri",
+            token_uri="https://oauth2.googleapis.com/token",
         ) as client:
             auth_request_session = client._http._auth_request.session
             adapter = cast(HTTPAdapter, auth_request_session.get_adapter("https://oauth2.googleapis.com"))

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -1148,6 +1148,22 @@ _NON_GOOGLE_TOKEN_URIS = [
 ]
 
 
+@pytest.mark.parametrize(
+    "token_uri",
+    ["https://oauth2.googleapis.com/token", "https://accounts.google.com/o/oauth2/token"],
+)
+def test_bigquery_validate_credentials_accepts_both_google_token_endpoints(token_uri):
+    key_file = {**_valid_key_file(), "token_uri": token_uri}
+
+    with mock.patch.object(bq_module, "bigquery_client") as mock_client:
+        ok, message = validate_bigquery_credentials(
+            dataset_id="my_dataset", key_file=key_file, dataset_project_id=None, location=None
+        )
+
+    assert (ok, message) == (True, None)
+    assert mock_client.call_args.args[5] == token_uri
+
+
 @pytest.mark.parametrize("token_uri", _NON_GOOGLE_TOKEN_URIS)
 def test_bigquery_validate_credentials_rejects_non_google_token_uri_before_any_request(token_uri):
     key_file = {**_valid_key_file(), "token_uri": token_uri}


### PR DESCRIPTION
## Problem

Anyone who can add a BigQuery source chooses the URL that PostHog's import worker sends its OAuth token request to.

- The uploaded service account key file carries a `token_uri` field, which we store and use as given.
- `google-auth` posts the signed service-account grant to whatever URL that field names.
- The request goes out during credential validation, so creating a source is enough to send it. No sync has to run.
- Google issues service account keys with one of two token endpoints, so no genuine key file needs another value.

## Changes

- The setup form now rejects a key file whose token endpoint is not Google's. The message names the field and asks for a fresh, unedited key.
- Both BigQuery client builders check the value before they construct credentials, so a stored source with an edited key file stops at its next sync without sending the request.
- That failure is registered as non-retryable, so the sync stops instead of retrying a request that cannot succeed.
- The allowlist holds the two exact URLs Google issues: `https://oauth2.googleapis.com/token`, and the legacy `https://accounts.google.com/o/oauth2/token`.
- Exact URLs, rather than the host check the database sources use through `ValidateDatabaseHostMixin`: the correct value is a published constant, so there is no host to resolve and no redirect target to re-check.
- Mechanical: the test fixtures now carry a real token endpoint instead of a placeholder string.

A user whose key file came from Google unedited sees no difference. This PR changes no UI, so there is nothing to screenshot.

## How did you test this code?

Two parameterized tests in `test_source.py` cover a relay URL, a plain-HTTP Google URL, a lookalike host, and a link-local address:

- Validation returns the error without building a client. A check placed after the client is built would still send the request.
- Both client builders raise before credentials exist, and the message they raise is a key in `get_non_retryable_errors`. A stored source would otherwise retry the failure forever.

Ran locally: the BigQuery source tests, the generated config tests, the BigQuery API tests in `test_external_data_source.py` against an isolated test database, and repo-wide mypy.

Not run: a live BigQuery sync, which needs real Google service account credentials.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No page under `docs/` describes the contents of the key file.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, `/announcing-behavior-changes`, `/writing-pr-descriptions`, `/reviewing-with-coderabbit`.

- **CodeRabbit CLI pass:** none. The CLI is installed under flox but signed out, and signing in opens a browser, so this PR opens without a local pass.
- **In-app notice:** `/announcing-behavior-changes` says no. A user with an unedited key file sees no change, the sync error already explains the failure to anyone else, and the frontend cannot evaluate the condition because key files are encrypted.
- **No duplicate:** a search over open and merged PRs found earlier `token_uri` work on error classification only, in [#80182](https://github.com/PostHog/posthog/pull/80182) and [#64841](https://github.com/PostHog/posthog/pull/64841). Neither validates the value.
- **Public artifact:** the code, comments, tests, and this description carry nothing from the session that is not already public. The test URLs are invented or use reserved domains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
