### PR TITLE
chore(frontend): update hedgehog mode

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -76,7 +76,7 @@
         "@posthog/brand": "catalog:",
         "@posthog/docs-onboarding": "workspace:*",
         "@posthog/esbuilder": "workspace:*",
-        "@posthog/hedgehog-mode": "^0.0.54",
+        "@posthog/hedgehog-mode": "^0.0.56",
         "@posthog/hogql-parser": "1.3.84",
         "@posthog/hogvm": "workspace:*",
         "@posthog/icons": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -621,8 +621,8 @@ importers:
         specifier: workspace:*
         version: link:../common/esbuilder
       '@posthog/hedgehog-mode':
-        specifier: ^0.0.54
-        version: 0.0.54(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^0.0.56
+        version: 0.0.56(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/hogql-parser':
         specifier: 1.3.84
         version: 1.3.84
@@ -10460,8 +10460,8 @@ packages:
   '@posthog/core@1.52.1':
     resolution: {integrity: sha512-WT4TUgmsyBYHAmhsifg+LdaFH9wzOcp3UNWnIaeVOgodfMeG/X39V9n0lyebaxoHLR/NMCMq8gsrF69ldzuMhg==}
 
-  '@posthog/hedgehog-mode@0.0.54':
-    resolution: {integrity: sha512-FBNsdZcqmSu++YkLXoGnWGEogWLKDIle8iMFDNbBKOdBoiNeKkiezwz5DnKvShZpKNLEvUVpoJh93vMOcuuLjQ==}
+  '@posthog/hedgehog-mode@0.0.56':
+    resolution: {integrity: sha512-I6PjNTR4BfVMXbgO3XQOPTirclJx8hHaR58j6ebB9ZXJohHVkS3eFUmLmJuc+q4baKs9ZU1kGn0K76pYhOUHFg==}
     engines: {node: '>=18'}
     peerDependencies:
       react: 18.3.1
@@ -30035,10 +30035,9 @@ snapshots:
     dependencies:
       '@posthog/types': 1.410.0
 
-  '@posthog/hedgehog-mode@0.0.54(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@posthog/hedgehog-mode@0.0.56(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       gsap: 3.14.2
-      lodash: 4.18.1
       matter-js: 0.20.0
       pixi.js: 8.19.0
       react: 18.3.1


### PR DESCRIPTION
## Problem

The frontend needs the current Hedgehog Mode release.

**Why:** The package update keeps the application on the current published runtime and asset bundle.

## Changes

- Updates @posthog/hedgehog-mode to release 0.0.56.
- Updates its locked package metadata.

## How did you test this code?

- Ran a frozen-lockfile install and confirmed the installed package version is 0.0.56.
- Ran frontend formatting and lint checks.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None. This is a dependency-only update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Slack app updated the published dependency. Related open PRs change Hedgehog Mode behavior, not its package version.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/D03N18XLESG/p1788851894115009?thread_ts=1788851894.115009&cid=D03N18XLESG)*
