### PR TITLE
fix(marketing): preserve unrelated settings on partial updates

### DIFF
--- a/docs/internal/marketing-analytics-configuration-writes.md
+++ b/docs/internal/marketing-analytics-configuration-writes.md
@@ -1,0 +1,9 @@
+# Marketing configuration writes
+
+Marketing settings PATCH requests send only the setting being changed. Updating filters or attribution settings must not resend an old conversion-goal list.
+
+The configuration serializer refreshes the marketing configuration under a row lock before applying a partial update. This preserves fields changed by concurrent goal operations and source mappings. It does not lock the parent project row.
+
+Explicit conversion-goal list updates still replace the list. This change does not merge simultaneous edits to the same goal list or change the API schema.
+
+Validation covers a stale settings instance saved after goal creation and a frontend filter update that omits goals from its payload.

--- a/docs/internal/marketing-analytics-configuration-writes.md
+++ b/docs/internal/marketing-analytics-configuration-writes.md
@@ -1,9 +1,5 @@
 # Marketing configuration writes
 
-Marketing settings PATCH requests send only the setting being changed. Updating filters or attribution settings must not resend an old conversion-goal list.
+Settings updates send only the changed field and refresh the Marketing configuration under a row lock, preserving unrelated concurrent changes.
 
-The configuration serializer refreshes the marketing configuration under a row lock before applying a partial update. This preserves fields changed by concurrent goal operations and source mappings. It does not lock the parent project row.
-
-Explicit conversion-goal list updates still replace the list. This change does not merge simultaneous edits to the same goal list or change the API schema.
-
-Validation covers a stale settings instance saved after goal creation and a frontend filter update that omits goals from its payload.
+Explicit conversion-goal list updates still replace the list; simultaneous edits to that same list are not merged.

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsSettingsLogic.test.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsSettingsLogic.test.ts
@@ -1,0 +1,25 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { teamLogic } from 'scenes/teamLogic'
+
+import { initKeaTests } from '~/test/init'
+
+import { marketingAnalyticsSettingsLogic } from './marketingAnalyticsSettingsLogic'
+
+describe('marketing settings partial updates', () => {
+    beforeEach(() => initKeaTests())
+
+    it('does not submit goals when changing the test-account filter', async () => {
+        const logic = marketingAnalyticsSettingsLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        await expectLogic(logic, () => logic.actions.updateFilterTestAccounts(true))
+            .toDispatchActions([
+                teamLogic.actionCreators.updateCurrentTeam({
+                    marketing_analytics_config: { filter_test_accounts: true },
+                }),
+            ])
+            .toFinishAllListeners()
+        logic.unmount()
+    })
+})

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsSettingsLogic.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsSettingsLogic.ts
@@ -544,23 +544,23 @@ export const marketingAnalyticsSettingsLogic = kea<marketingAnalyticsSettingsLog
         ],
     }),
     listeners(({ actions, values }) => {
-        const updateCurrentTeam = (): void => {
+        const updateCurrentTeam = (field: keyof MarketingAnalyticsConfig): void => {
             if (values.marketingAnalyticsConfig) {
-                const payload = { marketing_analytics_config: values.marketingAnalyticsConfig }
+                const payload = { marketing_analytics_config: { [field]: values.marketingAnalyticsConfig[field] } }
                 actions.updateCurrentTeam(payload)
             }
         }
 
         const trackSourceConfigured = (): void => {
-            updateCurrentTeam()
+            updateCurrentTeam('sources_map')
             actions.addProductIntent({
                 product_type: ProductKey.MARKETING_ANALYTICS,
                 intent_context: ProductIntentContext.MARKETING_ANALYTICS_SOURCE_CONFIGURED,
             })
         }
 
-        const trackSettingsUpdated = (): void => {
-            updateCurrentTeam()
+        const trackSettingsUpdated = (field: keyof MarketingAnalyticsConfig): void => {
+            updateCurrentTeam(field)
             actions.addProductIntent({
                 product_type: ProductKey.MARKETING_ANALYTICS,
                 intent_context: ProductIntentContext.MARKETING_ANALYTICS_SETTINGS_UPDATED,
@@ -569,16 +569,16 @@ export const marketingAnalyticsSettingsLogic = kea<marketingAnalyticsSettingsLog
 
         return {
             updateSourceMapping: trackSourceConfigured,
-            updateConversionGoals: trackSettingsUpdated,
-            addOrUpdateConversionGoal: trackSettingsUpdated,
-            removeConversionGoal: trackSettingsUpdated,
-            updateAttributionWindowDays: trackSettingsUpdated,
-            updateAttributionMode: trackSettingsUpdated,
+            updateConversionGoals: () => trackSettingsUpdated('conversion_goals'),
+            addOrUpdateConversionGoal: () => trackSettingsUpdated('conversion_goals'),
+            removeConversionGoal: () => trackSettingsUpdated('conversion_goals'),
+            updateAttributionWindowDays: () => trackSettingsUpdated('attribution_window_days'),
+            updateAttributionMode: () => trackSettingsUpdated('attribution_mode'),
             // Persist only: this one is a dashboard filter, not a trip to the settings screen.
-            updateFilterTestAccounts: () => updateCurrentTeam(),
-            updateCampaignNameMappings: trackSettingsUpdated,
-            updateCustomSourceMappings: trackSettingsUpdated,
-            updateCampaignFieldPreferences: trackSettingsUpdated,
+            updateFilterTestAccounts: () => updateCurrentTeam('filter_test_accounts'),
+            updateCampaignNameMappings: () => trackSettingsUpdated('campaign_name_mappings'),
+            updateCustomSourceMappings: () => trackSettingsUpdated('custom_source_mappings'),
+            updateCampaignFieldPreferences: () => trackSettingsUpdated('campaign_field_preferences'),
             testMapping: async ({ tableId, sourceMap }) => {
                 try {
                     const response = await api.create(

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -801,7 +801,9 @@ class TeamMarketingAnalyticsConfigSerializer(serializers.ModelSerializer, UserAc
             internal_value["_campaign_field_preferences"] = internal_value["campaign_field_preferences"]
         return internal_value
 
+    @transaction.atomic
     def update(self, instance, validated_data):
+        instance.refresh_from_db(from_queryset=TeamMarketingAnalyticsConfig.objects.select_for_update())
         # Handle sources_map with partial updates
         if "sources_map" in validated_data:
             new_sources_map = validated_data["sources_map"]

--- a/products/marketing_analytics/backend/test_api_conversion_goals.py
+++ b/products/marketing_analytics/backend/test_api_conversion_goals.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, patch
 
 from parameterized import parameterized
 
+from posthog.api.team import TeamMarketingAnalyticsConfigSerializer
 from posthog.constants import AvailableFeature
 from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.models.organization import OrganizationMembership
@@ -59,6 +60,18 @@ class TestConversionGoalWrites(APIBaseTest):
 
     def stored_goals(self) -> list[dict]:
         return TeamMarketingAnalyticsConfig.objects.get(team=self.team).conversion_goals
+
+    def test_stale_settings_save_preserves_new_goals(self) -> None:
+        stale_config = self.team.marketing_analytics_config
+        response = self.create_goal("Purchases")
+        self.assertEqual(response.status_code, 201)
+        goals = self.stored_goals()
+
+        TeamMarketingAnalyticsConfigSerializer().update(stale_config, {"filter_test_accounts": True})
+
+        stale_config.refresh_from_db()
+        self.assertTrue(stale_config.filter_test_accounts)
+        self.assertEqual(stale_config.conversion_goals, goals)
 
     def test_create_appends_without_touching_existing_goals(self):
         first = self.create_goal("Sign ups").json()["goal"]

--- a/products/marketing_analytics/backend/test_api_conversion_goals.py
+++ b/products/marketing_analytics/backend/test_api_conversion_goals.py
@@ -1,5 +1,11 @@
-from posthog.test.base import APIBaseTest
+from concurrent.futures import ThreadPoolExecutor
+from queue import Queue
+from time import monotonic
+
+from posthog.test.base import APIBaseTest, NonAtomicBaseTest
 from unittest.mock import AsyncMock, patch
+
+from django.db import close_old_connections, connection, transaction
 
 from parameterized import parameterized
 
@@ -443,3 +449,44 @@ class TestConversionGoalIdIsOneName(APIBaseTest):
         delete = self.client.delete(f"{self.base_url}/{goal_id}/delete")
 
         assert (update.status_code, delete.status_code) == (200, 200), (update.json(), delete.json())
+
+
+class TestConcurrentMarketingSettingsWrites(NonAtomicBaseTest):
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def test_settings_wait_for_goal_write_and_preserve_it(self) -> None:
+        config = self.team.marketing_analytics_config
+        backend_pid: Queue[int] = Queue()
+
+        def save_settings() -> None:
+            close_old_connections()
+            try:
+                with connection.cursor() as cursor:
+                    cursor.execute("SET statement_timeout = '10s'")
+                    cursor.execute("SELECT pg_backend_pid()")
+                    backend_pid.put(cursor.fetchone()[0])
+                TeamMarketingAnalyticsConfigSerializer().update(config, {"filter_test_accounts": True})
+            finally:
+                close_old_connections()
+
+        goals = [{**goal_payload("Purchases", conversion_goal_id="purchase-goal"), "name": "Purchases"}]
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            with transaction.atomic():
+                locked = TeamMarketingAnalyticsConfig.objects.select_for_update().get(pk=config.pk)
+                pending = executor.submit(save_settings)
+                pid = backend_pid.get(timeout=10)
+                deadline = monotonic() + 10
+                with connection.cursor() as cursor:
+                    while True:
+                        cursor.execute("SELECT cardinality(pg_blocking_pids(%s)) > 0", [pid])
+                        if cursor.fetchone()[0]:
+                            break
+                        self.assertFalse(pending.done(), "settings finished before the goal transaction committed")
+                        self.assertLess(monotonic(), deadline, "settings did not wait for the configuration lock")
+                locked.conversion_goals = goals
+                locked.save(update_fields=["_conversion_goals"])
+            pending.result(timeout=10)
+
+        config.refresh_from_db()
+        self.assertTrue(config.filter_test_accounts)
+        self.assertEqual(config.conversion_goals, goals)


### PR DESCRIPTION
## Problem

Saving Marketing settings from a stale page can overwrite conversion goals created by another request.

## Changes

Settings saves now preserve unrelated configuration fields. The frontend sends only the changed setting, and the backend refreshes the Marketing configuration under a row lock before saving.

Explicit goal-list updates still replace that list. The UI appearance stays unchanged.

## How did you test this code?

- Backend regressions cover stale saves and overlapping transactions. The concurrent test observes a blocked writer and preserves both updates.
- Removing only the row lock makes the concurrent test fail: the settings save erases the goal.
- Frontend regression: changing the test-account filter sends no conversion goals.
- Browser: changed the attribution window, saved and reloaded, verified both goals remained, then restored the original window. Saving a goal also succeeded.
- Preflight, including OpenAPI generation, passed. Full type checking and CI remain pending.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Added `docs/internal/marketing-analytics-configuration-writes.md` with the update semantics and concurrency limitation.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

Codex used shell, browser automation, and GitHub CLI. Skills: improving-drf-endpoints, writing-kea-logics, writing-tests, run-posthog, running-ci-preflight, writing-pr-descriptions, reviewing-with-coderabbit.

The duplicate search found no matching fix. CodeRabbit CLI was unavailable; no local CodeRabbit pass ran. CI patch coverage remains pending.

