### PR TITLE
fix(settings): align project secret API key limit

### DIFF
--- a/frontend/src/scenes/settings/project/ProjectSecretAPIKeys.test.tsx
+++ b/frontend/src/scenes/settings/project/ProjectSecretAPIKeys.test.tsx
@@ -7,8 +7,8 @@ import { cleanup, render, screen } from '@testing-library/react'
 import { OrganizationMembershipLevel } from 'lib/constants'
 import { teamLogic } from 'scenes/teamLogic'
 
-import { initKeaTests } from '~/test/init'
 import { ProjectSecretAPIKeyApi } from '~/generated/core/api.schemas'
+import { initKeaTests } from '~/test/init'
 
 import { ProjectSecretAPIKeys } from './ProjectSecretAPIKeys'
 import { MAX_PROJECT_API_KEYS_PER_PROJECT, projectSecretAPIKeysLogic } from './projectSecretAPIKeysLogic'

--- a/frontend/src/scenes/settings/project/ProjectSecretAPIKeys.test.tsx
+++ b/frontend/src/scenes/settings/project/ProjectSecretAPIKeys.test.tsx
@@ -8,7 +8,7 @@ import { OrganizationMembershipLevel } from 'lib/constants'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { initKeaTests } from '~/test/init'
-import { ProjectSecretAPIKeyApi } from '~/types'
+import { ProjectSecretAPIKeyApi } from '~/generated/core/api.schemas'
 
 import { ProjectSecretAPIKeys } from './ProjectSecretAPIKeys'
 import { MAX_PROJECT_API_KEYS_PER_PROJECT, projectSecretAPIKeysLogic } from './projectSecretAPIKeysLogic'
@@ -20,7 +20,13 @@ const createKeys = (count: number): ProjectSecretAPIKeyApi[] =>
         value: '',
         mask_value: null,
         created_at: '2026-01-01T00:00:00Z',
-        created_by: { id: 1, uuid: 'test-user', first_name: 'Test', email: 'test@example.com' },
+        created_by: {
+            id: 1,
+            uuid: 'test-user',
+            first_name: 'Test',
+            email: 'test@example.com',
+            hedgehog_config: null,
+        },
         last_used_at: null,
         last_rolled_at: null,
         scopes: ['endpoint:read'],
@@ -44,22 +50,26 @@ describe('<ProjectSecretAPIKeys />', () => {
         logic.unmount()
     })
 
-    it('allows creation through the backend limit and blocks it at that limit', () => {
-        logic.actions.loadKeysSuccess(createKeys(MAX_PROJECT_API_KEYS_PER_PROJECT - 1))
-        const { unmount } = render(<ProjectSecretAPIKeys />)
-
-        expect(screen.getByText('Create project secret API key').closest('button')).not.toHaveAttribute(
-            'aria-disabled',
-            'true'
-        )
-
-        unmount()
-        logic.actions.loadKeysSuccess(createKeys(MAX_PROJECT_API_KEYS_PER_PROJECT))
+    it.each([
+        {
+            description: 'below the backend limit',
+            keyCount: MAX_PROJECT_API_KEYS_PER_PROJECT - 1,
+            expectedDisabled: false,
+        },
+        {
+            description: 'at the backend limit',
+            keyCount: MAX_PROJECT_API_KEYS_PER_PROJECT,
+            expectedDisabled: true,
+        },
+    ])('sets creation availability $description', ({ keyCount, expectedDisabled }) => {
+        logic.actions.loadKeysSuccess(createKeys(keyCount))
         render(<ProjectSecretAPIKeys />)
 
-        expect(screen.getByText('Create project secret API key').closest('button')).toHaveAttribute(
-            'aria-disabled',
-            'true'
-        )
+        const button = screen.getByText('Create project secret API key').closest('button')
+        if (expectedDisabled) {
+            expect(button).toHaveAttribute('aria-disabled', 'true')
+        } else {
+            expect(button).not.toHaveAttribute('aria-disabled', 'true')
+        }
     })
 })

--- a/frontend/src/scenes/settings/project/ProjectSecretAPIKeys.test.tsx
+++ b/frontend/src/scenes/settings/project/ProjectSecretAPIKeys.test.tsx
@@ -1,0 +1,65 @@
+import { MOCK_DEFAULT_TEAM } from 'lib/api.mock'
+
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { OrganizationMembershipLevel } from 'lib/constants'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { initKeaTests } from '~/test/init'
+import { ProjectSecretAPIKeyApi } from '~/types'
+
+import { ProjectSecretAPIKeys } from './ProjectSecretAPIKeys'
+import { MAX_PROJECT_API_KEYS_PER_PROJECT, projectSecretAPIKeysLogic } from './projectSecretAPIKeysLogic'
+
+const createKeys = (count: number): ProjectSecretAPIKeyApi[] =>
+    Array.from({ length: count }, (_, index) => ({
+        id: String(index),
+        label: `Key ${index}`,
+        value: '',
+        mask_value: null,
+        created_at: '2026-01-01T00:00:00Z',
+        created_by: { id: 1, uuid: 'test-user', first_name: 'Test', email: 'test@example.com' },
+        last_used_at: null,
+        last_rolled_at: null,
+        scopes: ['endpoint:read'],
+    }))
+
+describe('<ProjectSecretAPIKeys />', () => {
+    const logic = projectSecretAPIKeysLogic()
+
+    beforeEach(() => {
+        initKeaTests()
+        teamLogic.mount()
+        teamLogic.actions.loadCurrentTeamSuccess({
+            ...MOCK_DEFAULT_TEAM,
+            effective_membership_level: OrganizationMembershipLevel.Admin,
+        })
+        logic.mount()
+    })
+
+    afterEach(() => {
+        cleanup()
+        logic.unmount()
+    })
+
+    it('allows creation through the backend limit and blocks it at that limit', () => {
+        logic.actions.loadKeysSuccess(createKeys(MAX_PROJECT_API_KEYS_PER_PROJECT - 1))
+        const { unmount } = render(<ProjectSecretAPIKeys />)
+
+        expect(screen.getByText('Create project secret API key').closest('button')).not.toHaveAttribute(
+            'aria-disabled',
+            'true'
+        )
+
+        unmount()
+        logic.actions.loadKeysSuccess(createKeys(MAX_PROJECT_API_KEYS_PER_PROJECT))
+        render(<ProjectSecretAPIKeys />)
+
+        expect(screen.getByText('Create project secret API key').closest('button')).toHaveAttribute(
+            'aria-disabled',
+            'true'
+        )
+    })
+})

--- a/frontend/src/scenes/settings/project/projectSecretAPIKeysLogic.tsx
+++ b/frontend/src/scenes/settings/project/projectSecretAPIKeysLogic.tsx
@@ -29,7 +29,7 @@ export type EditingProjectKeyFormValues = ProjectSecretAPIKeyRequest & {
     preset?: string
 }
 
-export const MAX_PROJECT_API_KEYS_PER_PROJECT = 10
+export const MAX_PROJECT_API_KEYS_PER_PROJECT = 50
 
 // llm_gateway powers the new AI gateway here, so label it "AI gateway" (PAKs keep "LLM gateway").
 const PROJECT_SECRET_SCOPE_OBJECT_NAMES: Record<string, string> = {


### PR DESCRIPTION
## Problem

Project administrators cannot create a project secret API key after the UI limit, although the API accepts more keys.

Why: The settings page must show the same limit that the server enforces.

## Changes

- The create control now uses the server limit of 50 keys per project.
- The UI test verifies that creation stays available below the limit and blocks at the limit.
- No visual style changes apply.

## How did you test this code?

- `pnpm --filter=@posthog/frontend jest frontend/src/scenes/settings/project/ProjectSecretAPIKeys.test.tsx` verifies both boundary states.
- `pnpm --filter=@posthog/frontend fix` completed.
- Not confirmed: the full TypeScript check did not return a final result from this sandbox.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The related user docs do not state this limit.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex updated the settings limit and added its boundary test.
- Skills: `writing-tests` and `writing-pr-descriptions`.
- The open-PR search found no matching UI fix. The local CodeRabbit CLI is unavailable.
- The change contains no data from the support report.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C02E3BKC78F/p1789052785968479?thread_ts=1789052785.968479&cid=C02E3BKC78F)*