### PR TITLE
fix(api): skip debug response validation for polymorphic proxy serializers

### DIFF
--- a/posthog/api/mixins.py
+++ b/posthog/api/mixins.py
@@ -219,7 +219,11 @@ def validated_request(
                     return result
                 response_serializer = response_config.response
                 # A PolymorphicProxySerializer only describes the schema; it cannot validate data.
-                if response_serializer is None or isinstance(response_serializer, PolymorphicProxySerializer):
+                # `many=True` wraps one in a plain ListSerializer, so the child needs the same check.
+                declares_polymorphic_proxy = isinstance(response_serializer, PolymorphicProxySerializer) or isinstance(
+                    getattr(response_serializer, "child", None), PolymorphicProxySerializer
+                )
+                if response_serializer is None or declares_polymorphic_proxy:
                     return result
 
                 context: dict[str, Any] = getattr(self, "get_serializer_context", lambda: {})()

--- a/posthog/api/mixins.py
+++ b/posthog/api/mixins.py
@@ -5,7 +5,7 @@ from typing import Any, Generic, TypeVar, cast
 from django.conf import settings
 
 import structlog
-from drf_spectacular.utils import OpenApiResponse, extend_schema
+from drf_spectacular.utils import OpenApiResponse, PolymorphicProxySerializer, extend_schema
 from pydantic import BaseModel, ValidationError
 from rest_framework import serializers
 from rest_framework.exceptions import ParseError
@@ -218,7 +218,8 @@ def validated_request(
                 if response_config is None:
                     return result
                 response_serializer = response_config.response
-                if response_serializer is None:
+                # A PolymorphicProxySerializer only describes the schema; it cannot validate data.
+                if response_serializer is None or isinstance(response_serializer, PolymorphicProxySerializer):
                     return result
 
                 context: dict[str, Any] = getattr(self, "get_serializer_context", lambda: {})()

--- a/posthog/api/test/test_mixins.py
+++ b/posthog/api/test/test_mixins.py
@@ -5,7 +5,9 @@ import pytest
 from posthog.test.base import APIBaseTest
 from unittest.mock import Mock, patch
 
-from drf_spectacular.utils import OpenApiResponse
+from django.test import override_settings
+
+from drf_spectacular.utils import OpenApiResponse, PolymorphicProxySerializer
 from rest_framework import serializers, status
 from rest_framework.response import Response
 
@@ -278,6 +280,32 @@ class TestValidatedRequestDecorator(APIBaseTest):
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data["custom_response"] == "anything goes"
+
+    @override_settings(DEBUG=True)
+    def test_polymorphic_proxy_response_bypasses_validation(self):
+        @validated_request(
+            request_serializer=EventCaptureRequestSerializer,
+            responses={
+                200: OpenApiResponse(
+                    response=PolymorphicProxySerializer(
+                        component_name="Either",
+                        serializers=[EventCaptureResponseSerializer],
+                        resource_type_field_name=None,
+                    )
+                ),
+            },
+        )
+        def mock_endpoint(view_self, request):
+            return Response({"anything": True}, status=status.HTTP_200_OK)
+
+        mock_request = Mock()
+        mock_request._full_data = {}
+        mock_request.data = {"event": "$pageview", "distinct_id": "user_123"}
+
+        response = mock_endpoint(Mock(), mock_request)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {"anything": True}
 
     def test_non_response_object_logs_warning(self):
         """Non-Response object return, should log warning and return result"""

--- a/posthog/api/test/test_mixins.py
+++ b/posthog/api/test/test_mixins.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock, patch
 from django.test import override_settings
 
 from drf_spectacular.utils import OpenApiResponse, PolymorphicProxySerializer
+from parameterized import parameterized
 from rest_framework import serializers, status
 from rest_framework.response import Response
 
@@ -281,8 +282,14 @@ class TestValidatedRequestDecorator(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         assert response.data["custom_response"] == "anything goes"
 
+    @parameterized.expand(
+        [
+            ("single", False, {"anything": True}),
+            ("many", True, [{"anything": True}]),
+        ]
+    )
     @override_settings(DEBUG=True)
-    def test_polymorphic_proxy_response_bypasses_validation(self):
+    def test_polymorphic_proxy_response_bypasses_validation(self, _name, many, payload):
         @validated_request(
             request_serializer=EventCaptureRequestSerializer,
             responses={
@@ -291,12 +298,13 @@ class TestValidatedRequestDecorator(APIBaseTest):
                         component_name="Either",
                         serializers=[EventCaptureResponseSerializer],
                         resource_type_field_name=None,
+                        many=many,
                     )
                 ),
             },
         )
         def mock_endpoint(view_self, request):
-            return Response({"anything": True}, status=status.HTTP_200_OK)
+            return Response(payload, status=status.HTTP_200_OK)
 
         mock_request = Mock()
         mock_request._full_data = {}
@@ -305,7 +313,7 @@ class TestValidatedRequestDecorator(APIBaseTest):
         response = mock_endpoint(Mock(), mock_request)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data == {"anything": True}
+        assert response.data == payload
 
     def test_non_response_object_logs_warning(self):
         """Non-Response object return, should log warning and return result"""


### PR DESCRIPTION
## Problem

Any endpoint that declares a `PolymorphicProxySerializer` response returns 500 in a local dev stack. The tasks list is one, since #96642, so PostHog Desktop shows no run history for a workflow-backed loop locally.

Under `DEBUG`, `validated_request` re-instantiates the declared response serializer to validate the payload. A `PolymorphicProxySerializer` only describes a schema, and its constructor needs arguments the wrapper does not have.

## Changes

- `validated_request` skips response validation when the declared response is a `PolymorphicProxySerializer`. The endpoint returns its payload unchanged, as it does in production.
- Production never ran this path, so nothing changes there.

## How did you test this code?

- A new mixin test declares a `PolymorphicProxySerializer` response under `DEBUG` and asserts the payload comes back. It crashed before the change.
- The tasks list endpoint returns 200 in a local dev stack after the change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code, with the `writing-pr-descriptions` skill. Split out of #98512, where the crash blocked the local run history check. Base of that PR.

https://claude.ai/code/session_013iaaSVJRxNVcZvmgwyA3kB
