### PR TITLE
fix(marketing): refresh settings when a project loads

### DIFF
--- a/docs/internal/marketing-analytics-configuration-writes.md
+++ b/docs/internal/marketing-analytics-configuration-writes.md
@@ -3,3 +3,5 @@
 Settings updates send only the changed field and refresh the Marketing configuration under a row lock, preserving unrelated concurrent changes.
 
 Explicit conversion-goal list updates still replace the list; simultaneous edits to that same list are not merged.
+
+Loading a project replaces the current and saved Marketing settings with that project’s configuration, including an empty configuration when none exists.

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsSettingsLogic.test.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsSettingsLogic.test.ts
@@ -2,11 +2,13 @@ import { expectLogic } from 'kea-test-utils'
 
 import { teamLogic } from 'scenes/teamLogic'
 
+import { ConversionGoalFilter, NodeKind } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
+import { TeamType } from '~/types'
 
 import { marketingAnalyticsSettingsLogic } from './marketingAnalyticsSettingsLogic'
 
-describe('marketing settings partial updates', () => {
+describe('marketing settings project changes', () => {
     beforeEach(() => initKeaTests())
 
     it('does not submit goals when changing the test-account filter', async () => {
@@ -20,6 +22,35 @@ describe('marketing settings partial updates', () => {
                 }),
             ])
             .toFinishAllListeners()
+        logic.unmount()
+    })
+
+    it('replaces prior-project goals and clears them for an unconfigured project', async () => {
+        const logic = marketingAnalyticsSettingsLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        const goal = (id: string): ConversionGoalFilter => ({
+            kind: NodeKind.EventsNode,
+            event: 'purchase',
+            conversion_goal_id: id,
+            conversion_goal_name: 'Purchases',
+            schema_map: {},
+        })
+        for (const [id, goals] of [
+            [101, [goal('first')]],
+            [102, [goal('second')]],
+            [103, []],
+        ] as const) {
+            await expectLogic(logic, () =>
+                teamLogic.actions.loadCurrentTeamSuccess({
+                    ...teamLogic.values.currentTeam!,
+                    id,
+                    marketing_analytics_config: { conversion_goals: [...goals] },
+                } as TeamType)
+            ).toFinishAllListeners()
+            expect(logic.values.conversion_goals).toEqual(goals)
+            expect(logic.values.savedMarketingAnalyticsConfig.conversion_goals).toEqual(goals)
+        }
         logic.unmount()
     })
 })

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsSettingsLogic.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsSettingsLogic.ts
@@ -286,6 +286,10 @@ export const marketingAnalyticsSettingsLogic = kea<marketingAnalyticsSettingsLog
         marketingAnalyticsConfig: [
             null as MarketingAnalyticsConfig | null,
             {
+                [teamLogic.actionTypes.loadCurrentTeamSuccess]: (
+                    _,
+                    { currentTeam }: { currentTeam: TeamType | TeamPublicType | null }
+                ) => currentTeam?.marketing_analytics_config || createEmptyConfig(),
                 updateConversionGoals: (state: MarketingAnalyticsConfig | null, { conversionGoals }) => {
                     if (!state) {
                         return { ...createEmptyConfig(), conversion_goals: conversionGoals }
@@ -404,6 +408,10 @@ export const marketingAnalyticsSettingsLogic = kea<marketingAnalyticsSettingsLog
         savedMarketingAnalyticsConfig: [
             values.currentTeam?.marketing_analytics_config || createEmptyConfig(),
             {
+                [teamLogic.actionTypes.loadCurrentTeamSuccess]: (
+                    _,
+                    { currentTeam }: { currentTeam: TeamType | TeamPublicType | null }
+                ) => currentTeam?.marketing_analytics_config || createEmptyConfig(),
                 updateCurrentTeam: (_, { marketing_analytics_config }) => {
                     return marketing_analytics_config || createEmptyConfig()
                 },


### PR DESCRIPTION
## Problem

Marketing can keep outdated goals and settings when another project loads while its settings logic remains mounted.

## Changes

Loading a project now replaces the current and saved Marketing configuration. Projects without configuration receive empty settings.

This follows #98501. No visual layout changes or new components.

## How did you test this code?

- Kea regression loads consecutive projects in one mounted logic and verifies their goals replace the previous state. Removing the fix makes it fail.
- Browser verification switched between configured and empty projects: two goals, zero goals, then two goals again. This checks normal navigation, not the mounted-state regression.
- The existing partial-update test and scoped preflight passed. Full type checking remains pending.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Added project-loading behavior to the configuration notes from #98501.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

Codex used shell, browser automation, and GitHub CLI. Skills: writing-kea-logics, writing-tests, running-ci-preflight, writing-pr-descriptions, stacking-prs.

No duplicate fix appeared in the PR search. CodeRabbit CLI was unavailable; no local CodeRabbit pass ran.
