### PR TITLE
fix(posthog-ai): prevent duplicate tasks from url prompts

### DIFF
--- a/docs/published/handbook/engineering/ai/sandboxed-agents.md
+++ b/docs/published/handbook/engineering/ai/sandboxed-agents.md
@@ -103,6 +103,13 @@ class OriginProduct(models.TextChoices):
 
 Then create and run a Django migration.
 
+### Starting a task from a deep link
+
+In the new PostHog AI view, `/ai?ask=...` hands the prompt to the task composer once.
+The handoff removes `ask` from the current browser history entry while preserving other query parameters and the hash.
+Changing the panel state or remounting the view therefore does not submit the prompt again.
+Without organization-level AI data-processing consent, the prompt only prefills the composer.
+
 ## Fine-grained access tokens
 
 Every sandboxed agent gets a scoped OAuth access token that controls what PostHog resources it can access.

--- a/frontend/src/scenes/max/phaiAiComposerSeedLogic.test.ts
+++ b/frontend/src/scenes/max/phaiAiComposerSeedLogic.test.ts
@@ -25,7 +25,7 @@ describe('phaiAiComposerSeedLogic', () => {
         { consent: true, autoSubmit: true },
         { consent: false, autoSubmit: false },
     ])(
-        'forwards the /ai ask query as a seed with autoSubmit=$autoSubmit when consent is $consent',
+        'forwards each /ai ask navigation once with autoSubmit=$autoSubmit when consent is $consent',
         ({ consent, autoSubmit }) => {
             initKeaTests(true, undefined, undefined, {
                 ...MOCK_DEFAULT_ORGANIZATION,
@@ -34,7 +34,7 @@ describe('phaiAiComposerSeedLogic', () => {
             seedLogic = composerSeedLogic()
             seedLogic.mount()
 
-            router.actions.push(urls.ai(undefined, 'Explain this dashboard'))
+            router.actions.push(urls.ai(undefined, 'Explain this dashboard'), { source: 'homepage' }, { panel: 'max' })
 
             logic = phaiAiComposerSeedLogic()
             logic.mount()
@@ -43,6 +43,18 @@ describe('phaiAiComposerSeedLogic', () => {
                 prompt: 'Explain this dashboard',
                 autoSubmit,
             })
+            expect(router.values.searchParams).toEqual({ source: 'homepage' })
+            expect(router.values.hashParams).toEqual({ panel: 'max' })
+
+            seedLogic.actions.consumeSeed()
+            router.actions.replace(router.values.location.pathname, router.values.searchParams, {})
+            expect(seedLogic.values.seed).toBeNull()
+            logic.unmount()
+            logic.mount()
+            expect(seedLogic.values.seed).toBeNull()
+
+            router.actions.push(urls.ai(undefined, 'Explain this dashboard'))
+            expect(seedLogic.values.seed).toEqual({ prompt: 'Explain this dashboard', autoSubmit })
         }
     )
 })

--- a/frontend/src/scenes/max/phaiAiComposerSeedLogic.ts
+++ b/frontend/src/scenes/max/phaiAiComposerSeedLogic.ts
@@ -1,5 +1,5 @@
 import { MakeLogicType, connect, kea, path } from 'kea'
-import { urlToAction } from 'kea-router'
+import { router, urlToAction } from 'kea-router'
 
 import { urls } from 'scenes/urls'
 
@@ -35,12 +35,16 @@ export const phaiAiComposerSeedLogic = kea<phaiAiComposerSeedLogicType>([
     }),
 
     urlToAction(({ actions, values }) => ({
-        [urls.ai()]: (_, search) => {
+        [urls.ai()]: (_, search, hash) => {
             if (search.ask && !search.chat) {
+                const { ask, ...remainingSearch } = search
+                // Hash changes also run this handler. Remove the prompt before handing it off so they
+                // cannot submit it again.
+                router.actions.replace(router.values.location.pathname, remainingSearch, hash)
                 // `ask` is URL-controlled — same org-level AI data-processing consent gate as the legacy
                 // `askMax` path: without approval the seed only prefills the composer, and the user's own
                 // send goes through the composer's consent flow.
-                actions.setSeed({ prompt: String(search.ask), autoSubmit: values.dataProcessingAccepted })
+                actions.setSeed({ prompt: String(ask), autoSubmit: values.dataProcessingAccepted })
             }
         },
     })),


### PR DESCRIPTION
## Problem

Opening the PostHog AI panel during a homepage prompt submission can create a second task for the same prompt.

## Changes

- Each URL prompt reaches the composer once, preventing duplicate tasks from panel changes or view remounts.
- The handoff consumes `ask` before submission and preserves the remaining URL state.
- Mechanical changes extend regression coverage and document the deep-link handoff. This change does not alter the visual design.

<details>
<summary>Prompt handoff before and after</summary>

Before:

```mermaid
flowchart LR
    A[Prompt URL] --> B[Submit task]
    C[Hash change with ask still present] --> B
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    class A,C phYellow;
    class B phRed;
```

After:

```mermaid
flowchart LR
    A[Prompt URL] --> B[Remove ask] --> C[Submit task]
    D[Hash change] --> E[No prompt to resubmit]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    class A,D,E phYellow;
    class B phBlue;
    class C phRed;
```

</details>

## How did you test this code?

The [regression tests](https://github.com/PostHog/posthog/blob/d423fa3b117ea0b6c19e26ee833d91c5cab682de/frontend/src/scenes/max/phaiAiComposerSeedLogic.test.ts) cover hash changes, remounts, consent, URL-state preservation, and intentional repeat submissions.

Local checks include the composer-seed, homepage, and task-tracker Jest suites, TypeScript, lint, formatting, and strict preflight. Browser testing was not run.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated [sandboxed-agent deep links](docs/published/handbook/engineering/ai/sandboxed-agents.md#starting-a-task-from-a-deep-link).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

Codex used PostHog MCP and terminal tools. Session link unavailable.

Skills: `/writing-kea-logics`, `/writing-tests`, `/writing-code-comments`, `/running-ci-preflight`, `/writing-pr-descriptions`, and `/reviewing-with-coderabbit`.

The duplicate search found no matching fix. #91748 fixes blank-chat routing; this patch consumes the URL prompt.

CodeRabbit review was unavailable because automatic approval review blocked the external call.

The investigation used private diagnostics. The patch reuses the existing public test prompt and contains no customer material or diagnostic records.
