### PR TITLE
fix(signals): keep implement button stationary on hover

### DIFF
--- a/docs/internal/signals-pr-lifecycle.md
+++ b/docs/internal/signals-pr-lifecycle.md
@@ -1,5 +1,8 @@
 # Signals implementation PR lifecycle
 
+The report detail **Implement** button stays in place on hover so its border
+remains visible. This uses a local hover-depth override, not a shared button change.
+
 Report PR lookups use `fetch_implementation_pr_state_for_reports` in
 `products/signals/backend/implementation_pr.py`. A non-empty assignment PR takes
 precedence. Otherwise, lookup falls back to associated task-run artefacts and

--- a/docs/internal/signals-pr-lifecycle.md
+++ b/docs/internal/signals-pr-lifecycle.md
@@ -1,8 +1,5 @@
 # Signals implementation PR lifecycle
 
-The report detail **Implement** button stays in place on hover so its border
-remains visible. This uses a local hover-depth override, not a shared button change.
-
 Report PR lookups use `fetch_implementation_pr_state_for_reports` in
 `products/signals/backend/implementation_pr.py`. A non-empty assignment PR takes
 precedence. Otherwise, lookup falls back to associated task-run artefacts and

--- a/products/signals/frontend/inbox/components/detail/ImplementButton.tsx
+++ b/products/signals/frontend/inbox/components/detail/ImplementButton.tsx
@@ -67,6 +67,7 @@ export function ImplementButton({ report }: { report: SignalReport }): JSX.Eleme
         <LemonButton
             type="primary"
             size="small"
+            className="[--lemon-button-hover-depth:0px]"
             icon={<IconPullRequest />}
             onClick={() => submit('')}
             loading={isCreatingPr}


### PR DESCRIPTION
## Problem

The report detail Implement control needs a stable hover position so its border stays visible.

## Changes

Disable hover lift on this button only. Shared button styles, click feedback, and implementation actions stay unchanged.

<details>
<summary>Before and after (Storybook)</summary>

Before, with the local override removed:
![implement-before](https://raw.githubusercontent.com/PostHog/pr-assets/7d25996826502edce4b3e97e657652a605adbd57/2026/09/de5f1463-f16e-453a-9e14-881d8f7ab7f3.png)

After:
![implement-after](https://raw.githubusercontent.com/PostHog/pr-assets/7d25996826502edce4b3e97e657652a605adbd57/2026/09/7ce76b9f-f074-4986-9586-1cf14cbbca75.png)

</details>

## How did you test this code?

Chromium rendered the existing Storybook story. Hover movement changed from -0.5px to 0px. Frontend lint and formatting passed. Full typecheck was killed with exit 137 on both attempts, including a memory-limited, low-concurrency retry. Scoped CI preflight passed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This fix only changes the button hover style.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Slack app used shell, Playwright, GitHub CLI, and signed-commit tools. Skills: `writing-pr-descriptions`, `reviewing-with-coderabbit`, `running-ci-preflight`, and `writing-simplified-technical-english`. CodeRabbit CLI was unavailable, so no local review ran. The targeted open-PR search found no duplicate. Screenshots use the existing Storybook fixture.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BC8F1LZV3/p1789055302891279)*


