### PR TITLE
fix(signals): exclude report instructions from 1password autofill

### DIFF
--- a/docs/internal/signals-pr-lifecycle.md
+++ b/docs/internal/signals-pr-lifecycle.md
@@ -1,5 +1,9 @@
 # Signals implementation PR lifecycle
 
+The **Implement** menu focuses a plain text area for optional agent instructions.
+This field uses `data-1p-ignore` to exclude 1Password autofill without removing
+keyboard focus or changing instruction submission.
+
 Report PR lookups use `fetch_implementation_pr_state_for_reports` in
 `products/signals/backend/implementation_pr.py`. A non-empty assignment PR takes
 precedence. Otherwise, lookup falls back to associated task-run artefacts and

--- a/products/signals/frontend/inbox/components/detail/ImplementButton.test.tsx
+++ b/products/signals/frontend/inbox/components/detail/ImplementButton.test.tsx
@@ -81,6 +81,15 @@ describe('ImplementButton', () => {
         expect(copyToClipboard).not.toHaveBeenCalled()
     })
 
+    it('focuses a plain text area that excludes 1Password autofill', async () => {
+        await openMenu()
+
+        const instructions = screen.getByRole('textbox')
+        expect(instructions.tagName).toBe('TEXTAREA')
+        expect(instructions).toHaveAttribute('data-1p-ignore', 'true')
+        expect(instructions).toHaveFocus()
+    })
+
     it.each([
         [
             'the PostHog button',

--- a/products/signals/frontend/inbox/components/detail/ImplementButton.tsx
+++ b/products/signals/frontend/inbox/components/detail/ImplementButton.tsx
@@ -93,6 +93,7 @@ export function ImplementButton({ report }: { report: SignalReport }): JSX.Eleme
                                 maxLength={4000}
                                 rows={4}
                                 autoFocus
+                                data-1p-ignore
                                 actions={[
                                     <span key="shortcut" className="text-xs text-tertiary">
                                         Enter to implement, Shift + Enter for a new line


### PR DESCRIPTION
## Problem

**Why:** Agent instructions are plain text, not credentials. The Implement menu focuses this text area without an explicit 1Password exclusion.

## Changes

Add a field-specific `data-1p-ignore` attribute. Keep automatic focus and instruction submission unchanged. No visual layout changes.

## How did you test this code?

Ran the ImplementButton Jest suite and Oxfmt checks. The new regression test checks the rendered textarea, exclusion attribute, and focus. Chrome with 1Password was not tested.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated `docs/internal/signals-pr-lifecycle.md` with the field behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

PostHog Slack app used shell tools, GitHub CLI, and signed-commit tools. Skills: writing-pr-descriptions, reviewing-with-coderabbit, writing-user-facing-copy, writing-simplified-technical-english. CodeRabbit CLI was unavailable; no local CodeRabbit review ran.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BC8F1LZV3/p1789054555488019)*
