### PR TITLE
fix(toolbox): point the prod-us jumphost at the golden namespace

### DIFF
--- a/tools/infra-scripts/clitools/test_toolbox.py
+++ b/tools/infra-scripts/clitools/test_toolbox.py
@@ -1029,6 +1029,7 @@ class TestToolbox(unittest.TestCase):
                 "namespace_by_environment": {
                     "dev": "flags-cache-jumphost",
                     "prod-eu": "flags-cache-jumphost",
+                    "prod-us": "flags-cache-jumphost",
                 },
                 "app_label": "flags-cache-jumphost",
                 "claimed_label_key": "flags-jumphost-claimed",
@@ -1037,21 +1038,31 @@ class TestToolbox(unittest.TestCase):
 
     @patch.dict(os.environ, {}, clear=False)
     def test_resolve_namespace_uses_golden_namespace_for_migrated_environments(self):
-        """dev and prod-eu run the jumphost on the golden chart, in its own namespace."""
+        """Every environment now runs the jumphost on the golden chart, in its own namespace."""
         os.environ.pop("KUBE_NAMESPACE", None)
         pool = toolbox_script.POOLS["flags-cache-jumphost"]
 
-        for context in ("dev-eks", "dev-admin", "prod-eu-eks", "prod-eu-admin", "prod-eu", "dev"):
+        for context in (
+            "dev-eks",
+            "dev-admin",
+            "prod-eu-eks",
+            "prod-eu-admin",
+            "prod-us-eks",
+            "prod-us-admin",
+            "prod-eu",
+            "dev",
+            "prod-us",
+        ):
             with self.subTest(context=context):
                 self.assertEqual(toolbox_script.resolve_namespace(pool, context), "flags-cache-jumphost")
 
     @patch.dict(os.environ, {}, clear=False)
     def test_resolve_namespace_keeps_unmigrated_environments_on_default(self):
-        """prod-us still runs the posthog-rust release, so it stays in `posthog`."""
+        """A context that names no migrated environment falls back to the default namespace."""
         os.environ.pop("KUBE_NAMESPACE", None)
         pool = toolbox_script.POOLS["flags-cache-jumphost"]
 
-        for context in ("prod-us-eks", "prod-us-admin", None):
+        for context in (None, "unknown-eks"):
             with self.subTest(context=context):
                 self.assertEqual(toolbox_script.resolve_namespace(pool, context), "posthog")
 

--- a/tools/infra-scripts/clitools/toolbox.py
+++ b/tools/infra-scripts/clitools/toolbox.py
@@ -50,6 +50,7 @@ POOLS = {
         "namespace_by_environment": {
             "dev": "flags-cache-jumphost",
             "prod-eu": "flags-cache-jumphost",
+            "prod-us": "flags-cache-jumphost",
         },
         "app_label": "flags-cache-jumphost",
         "claimed_label_key": "flags-jumphost-claimed",


### PR DESCRIPTION
## Problem

`flags-cache-jumphost` now runs on the `posthog-app` golden chart in prod-us too (PostHog/charts#15470), in its own namespace. `namespace_by_environment` lists only `dev` and `prod-eu` (#97898), so prod-us falls back to `default_namespace: "posthog"` and `bin/rust-jumphost` looks in the legacy namespace.

While both releases run this is only confusing: the wrapper claims the posthog-rust pod and nothing looks broken. It becomes a real failure once the legacy prod-us element is removed (PostHog/charts#15481), because the wrapper would poll a namespace with no jumphost pods and time out after five minutes with a healthy pod one namespace over. Dev hit this before #96258.

## Changes

- Add `"prod-us": "flags-cache-jumphost"` to the pool's `namespace_by_environment`.
- Update the two resolution tests: every environment now resolves to the golden namespace, and the fallback case covers a context naming no known environment rather than prod-us.

All three environments are now listed, so the mapping can collapse back into a single `default_namespace`. The comment above the block already says so. I left that cleanup for the decommission PR rather than doing it while the posthog-rust releases still run, since `KUBE_NAMESPACE=posthog` has to keep working as the rollback.

## How did you test this code?

I am an agent (Claude Code). These are the checks I ran:

- `python3 -m unittest test_toolbox`: **85 tests, all passing**, both with and without `KUBE_NAMESPACE` set in the environment (the isolation added in #97898 keeps that honest).
- `ruff format --check` and `ruff check`: clean.

I did not run `bin/rust-jumphost` against the prod-us cluster; that needs cluster access. The rollback if it misbehaves is one environment variable, `KUBE_NAMESPACE=posthog`, which a test covers.

## Publish to changelog?

No.
