### PR TITLE
fix(actions): parse selectors with nth-child text and no colon

### DIFF
--- a/posthog/models/event/event.py
+++ b/posthog/models/event/event.py
@@ -39,7 +39,7 @@ class SelectorPart:
             self.data[f"attributes__attr__{result[2]}"] = result[3]
             self.ch_attributes[result[2]] = result[3]
             tag = result[1]
-        if "nth-child(" in tag:
+        if ":nth-child(" in tag:
             parts = tag.split(":nth-child(")
             self.data["nth_child"] = parts[1].replace(")", "")
             self.ch_attributes["nth-child"] = self.data["nth_child"]

--- a/posthog/models/test/test_event_model.py
+++ b/posthog/models/test/test_event_model.py
@@ -107,6 +107,19 @@ class TestSelectors(BaseTest):
         self.assertEqual(selector1.parts[1].direct_descendant, True)
         self.assertEqual(selector1.parts[1].unique_order, 0)
 
+    @parameterized.expand(
+        [
+            (
+                "a class name that contains the pseudo-class text",
+                "div.foo-nth-child(2)",
+                [{"tag_name": "div", "attr_class__contains": ["foo-nth-child(2)"]}],
+            ),
+            ("the pseudo-class text with no colon", "nth-child(2)", [{"tag_name": "nth-child(2)"}]),
+        ]
+    )
+    def test_nth_child_without_a_colon_is_not_a_positional_selector(self, _name, selector, expected):
+        self.assertEqual([part.data for part in Selector(selector).parts], expected)
+
     def test_unique_order(self):
         selector1 = Selector("div > div")
         self.assertEqual(selector1.parts[0].data, {"tag_name": "div"})


### PR DESCRIPTION
## Problem

An action whose CSS selector contains the text `nth-child(` without a leading colon breaks every insight that references it, with a 500 rather than a wrong number.

- `SelectorPart.__init__` tests for `nth-child(` but splits on `:nth-child(`.
- A selector without the colon passes the test, splits into one element, and raises `IndexError` on `parts[1]`.
- `selector_to_expr` parses the selector on every query, so the action fails at query time, not at save time.
- A class name is enough to trigger it: `div.foo-nth-child(2)` raises, and so does `div nth-child(2)` when someone drops the colon.

At least one such selector exists in production. A fleet-wide sweep of saved action selectors aborted on it during discovery.

## Changes

- An action using one of these selectors now returns results instead of erroring.
- The test uses the same string as the split, so `div.foo-nth-child(2)` reads `foo-nth-child(2)` as a class on `div`.
- A real `:nth-child(n)` selector parses exactly as before.

The change is one character. It only converts a raise into a parse: every selector that parsed before still parses to the same data, so no existing action changes what it matches.

[#80653](https://github.com/PostHog/posthog/pull/80653) also fixes this, as a side effect of replacing the split with a regex. That PR changes autocapture matching semantics in both directions and is still in review, so this one carries the crash fix on its own.

## How did you test this code?

- Added two parameterized cases to `TestSelectors` in `posthog/models/test/test_event_model.py`. They catch the `IndexError`, which no existing test did: every current case puts a colon before `nth-child(`.
- Checked the three parses against the real parser in a Django shell: both new cases match the asserted data, and `div > span:nth-child(3)` from the existing `test_nth_child` is unchanged.
- `ruff check` and `ruff format --check` pass. `hogli ci:preflight --strict` reports 0 failures.
- Not run: `TestSelectors` itself, because it inherits `BaseTest` and this sandbox has no Postgres. CI runs it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- Found while running the selector audit from [#83177](https://github.com/PostHog/posthog/pull/83177) across all projects. The run died in discovery, and the vendored pre-#80653 compiler in that PR turned out to be a faithful copy of this bug rather than the cause of it.
- The guard fix was chosen over adopting #80653's regex parser so the change stays minimal and can land while that PR is in review.
- No duplicate: a search of open PRs found only #80653, which fixes this inside a larger semantics change. Nothing else covers it.
- Public artifact: no customer data, selector, or team identifier appears in the diff or this description. The test selectors are invented.
- CodeRabbit CLI: unavailable in this environment, so the PR opens without a local pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LcpFy4YYqTqXnMfg3VEy5P

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcpFy4YYqTqXnMfg3VEy5P)_