### PR TITLE
fix(embedding-worker): return 400/403 from ad hoc embedding endpoint

### DIFF
--- a/posthog/api/embedding_worker.py
+++ b/posthog/api/embedding_worker.py
@@ -64,12 +64,15 @@ def _build_embedding_payload(team: Team, content: str, model: str | None, no_tru
 def _raise_for_embedding_response(response) -> None:
     """raise_for_status() with a clearer hint when the worker rejects ad-hoc requests
     because the organization has not opted into AI data processing — a common dev
-    foot-gun where the underlying 403 body is hidden behind a generic HTTPStatusError.
+    foot-gun otherwise hidden behind a generic HTTPStatusError.
+
+    The worker returns 403 for the opt-in gate and nothing else, and sends no body
+    with it, so the status alone identifies the case.
     """
-    if response.status_code == 403 and "ai" in response.text.lower():
+    if response.status_code == 403:
         raise httpx.HTTPStatusError(
-            f"Embedding worker returned 403: {response.text}. "
-            "Likely the organization has not opted into AI data processing — "
+            "Embedding worker returned 403. "
+            "The organization has not opted into AI data processing — "
             "set Organization.is_ai_data_processing_approved=True (Settings > AI, "
             "or via SQL in local dev) and retry.",
             request=response.request,

--- a/posthog/api/test/test_embedding_worker.py
+++ b/posthog/api/test/test_embedding_worker.py
@@ -1,8 +1,11 @@
 from datetime import UTC, datetime
 
+import pytest
 from unittest.mock import MagicMock, patch
 
-from posthog.api.embedding_worker import DocumentKey, get_recently_seen_documents
+import httpx
+
+from posthog.api.embedding_worker import DocumentKey, _raise_for_embedding_response, get_recently_seen_documents
 
 
 def _doc(document_id: str, product: str = "signals") -> DocumentKey:
@@ -67,3 +70,29 @@ class TestRecentlySeenLookup:
     def test_empty_input_makes_no_request(self, mock_requests):
         assert get_recently_seen_documents([], team_id=1) == {}
         mock_requests.post.assert_not_called()
+
+
+class TestRaiseForEmbeddingResponse:
+    def test_bodyless_403_explains_the_ai_opt_in_gate(self):
+        # The worker sends a bare status with no body, so a helper that looked for
+        # explanatory text in the response would never recognise the opt-in gate.
+        response = MagicMock(status_code=403, text="")
+
+        with pytest.raises(httpx.HTTPStatusError, match="not opted into AI data processing"):
+            _raise_for_embedding_response(response)
+
+        response.raise_for_status.assert_not_called()
+
+    def test_other_errors_fall_through_to_raise_for_status(self):
+        response = MagicMock(status_code=500, text="")
+
+        _raise_for_embedding_response(response)
+
+        response.raise_for_status.assert_called_once()
+
+    def test_success_is_passed_through(self):
+        response = MagicMock(status_code=200, text="")
+
+        _raise_for_embedding_response(response)
+
+        response.raise_for_status.assert_called_once()

--- a/rust/embedding-worker/src/ad_hoc.rs
+++ b/rust/embedding-worker/src/ad_hoc.rs
@@ -1,8 +1,9 @@
 use std::sync::Arc;
 
-use anyhow::Result;
+use axum::{extract::Json, http::StatusCode};
 use common_types::embedding::EmbeddingModel;
 use serde::{Deserialize, Serialize};
+use tracing::{error, warn};
 
 use crate::{
     app_context::AppContext, generate_embedding, metrics_utils::RequestLabels,
@@ -26,34 +27,59 @@ pub struct AdHocEmbeddingResponse {
     pub did_truncate: bool,
 }
 
+/// Callers retry 5xx and give up on 4xx, so the status code has to separate the two:
+/// an opted-out organization and over-long content are permanent and never succeed on
+/// retry, while anything else here is transient enough to be worth retrying.
 pub async fn handle_ad_hoc_request(
     context: Arc<AppContext>,
     request: AdHocEmbeddingRequest,
-) -> Result<AdHocEmbeddingResponse> {
+) -> Result<Json<AdHocEmbeddingResponse>, StatusCode> {
     let team_id = request.team_id;
-    let Some(request) = apply_ai_opt_in(&context, request, team_id).await? else {
-        return Err(anyhow::anyhow!("Organization not opted in to ai features"));
+    let request = match apply_ai_opt_in(&context, request, team_id).await {
+        Ok(Some(request)) => request,
+        Ok(None) => {
+            warn!("Ad hoc embedding request for team {team_id} rejected: organization not opted in to ai features");
+            return Err(StatusCode::FORBIDDEN);
+        }
+        Err(e) => {
+            error!(
+                "Ad hoc embedding request for team {team_id} failed to resolve organization: {:?}",
+                e
+            );
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        }
     };
 
     let would_truncate = check_would_truncate(&request.content, &request.model);
 
     if would_truncate && !request.no_truncate {
-        return Err(anyhow::anyhow!("Content too long"));
+        warn!("Ad hoc embedding request for team {team_id} rejected: content too long");
+        return Err(StatusCode::BAD_REQUEST);
     }
 
-    let (embedding, token_count) = generate_embedding(
+    let (embedding, token_count) = match generate_embedding(
         context.clone(),
         request.model,
         &request.content,
         &RequestLabels::from(&request),
     )
-    .await?;
+    .await
+    {
+        Ok(result) => result,
+        Err(e) => {
+            error!(
+                "Ad hoc embedding request for team {team_id} failed: {:?}",
+                e
+            );
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    };
 
-    Ok(AdHocEmbeddingResponse {
+    Ok(Json(AdHocEmbeddingResponse {
         embedding,
         tokens_used: token_count,
         did_truncate: would_truncate,
-    })
+    }))
 }
 
 pub fn check_would_truncate(content: &str, model: &EmbeddingModel) -> bool {

--- a/rust/embedding-worker/src/ad_hoc.rs
+++ b/rust/embedding-worker/src/ad_hoc.rs
@@ -7,7 +7,7 @@ use tracing::{error, warn};
 
 use crate::{
     app_context::AppContext, generate_embedding, metrics_utils::RequestLabels,
-    organization::apply_ai_opt_in,
+    organization::apply_ai_opt_in, CL100K_ENCODER,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -85,14 +85,75 @@ pub async fn handle_ad_hoc_request(
 pub fn check_would_truncate(content: &str, model: &EmbeddingModel) -> bool {
     match model {
         EmbeddingModel::OpenAITextEmbeddingSmall | EmbeddingModel::OpenAITextEmbeddingLarge => {
-            let encoder = tiktoken_rs::cl100k_base().expect("We can construct the encoder");
-            let tokens: Vec<_> = encoder
-                .encode_with_special_tokens(content)
-                .into_iter()
-                .take(model.model_input_window())
-                .collect();
-            let token_count = tokens.len();
+            // Count every token: capping the count at the input window first would make the
+            // comparison below unsatisfiable.
+            let token_count = CL100K_ENCODER.encode_with_special_tokens(content).len();
             token_count > model.model_input_window()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Build text of an exact token length by decoding that many tokens off a longer
+    // stream. Repeated whole words keep every cut on a token boundary, so the result
+    // re-encodes to the same count.
+    fn content_with_tokens(count: usize) -> String {
+        let encoder = &*CL100K_ENCODER;
+        let stream = "word ".repeat(count + 16);
+        let tokens: Vec<_> = encoder
+            .encode_with_special_tokens(&stream)
+            .into_iter()
+            .take(count)
+            .collect();
+        let content = encoder.decode(tokens).expect("fixture decodes cleanly");
+        assert_eq!(
+            encoder.encode_with_special_tokens(&content).len(),
+            count,
+            "fixture should hold exactly {count} tokens"
+        );
+        content
+    }
+
+    #[test]
+    fn short_content_does_not_truncate() {
+        assert!(!check_would_truncate(
+            "hello world",
+            &EmbeddingModel::OpenAITextEmbeddingSmall
+        ));
+    }
+
+    #[test]
+    fn content_over_the_input_window_truncates() {
+        // The check used to take() the input window's worth of tokens before comparing the
+        // count against that same window, so it could never report a truncation.
+        for model in [
+            EmbeddingModel::OpenAITextEmbeddingSmall,
+            EmbeddingModel::OpenAITextEmbeddingLarge,
+        ] {
+            let content = content_with_tokens(model.model_input_window() + 1);
+            assert!(
+                check_would_truncate(&content, &model),
+                "{model:?} should truncate one token past its input window"
+            );
+        }
+    }
+
+    #[test]
+    fn content_at_the_input_window_does_not_truncate() {
+        // generate_embedding_text only drops tokens beyond the window, so content sitting
+        // exactly on it survives intact.
+        for model in [
+            EmbeddingModel::OpenAITextEmbeddingSmall,
+            EmbeddingModel::OpenAITextEmbeddingLarge,
+        ] {
+            let content = content_with_tokens(model.model_input_window());
+            assert!(
+                !check_would_truncate(&content, &model),
+                "{model:?} should not truncate content exactly at its input window"
+            );
         }
     }
 }

--- a/rust/embedding-worker/src/main.rs
+++ b/rust/embedding-worker/src/main.rs
@@ -50,14 +50,7 @@ async fn ad_hoc_handler(
     State(context): State<Arc<AppContext>>,
     Json(request): Json<AdHocEmbeddingRequest>,
 ) -> Result<Json<AdHocEmbeddingResponse>, StatusCode> {
-    match handle_ad_hoc_request(context, request).await {
-        Ok(response) => Ok(Json(response)),
-        Err(e) => {
-            // TODO - this is a hack until I do a proper pass and add real error enums
-            error!("Ad hoc embedding request failed: {:?}", e);
-            Err(StatusCode::INTERNAL_SERVER_ERROR)
-        }
-    }
+    handle_ad_hoc_request(context, request).await
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
## Problem

Callers of the ad hoc embedding endpoint cannot tell a permanent failure from a transient one, so they retry conditions that will never succeed.

`ad_hoc_handler` collapsed every error out of `handle_ad_hoc_request` into a bare `500`, behind a `// TODO - this is a hack until I do a proper pass and add real error enums`. Two of those errors are permanent: an organization that has not opted in to AI data processing, and content over the model input window. A caller that retries 5xx — which is the reasonable thing to do with a 500 — will retry those forever, and the request never succeeds. In the Signals grouping pipeline this is enough to keep a single failing batch cycling indefinitely, because nothing downstream can classify the error as terminal and give up.

Separately, the content-too-long guard could not fire at all. `check_would_truncate` collected `.take(model.model_input_window())` tokens and then tested `token_count > model.model_input_window()`, which cannot hold after the take. It always returned `false`, so the guard was dead and `did_truncate` was always `false`.

## Changes

- `handle_ad_hoc_request` returns `Result<Json<AdHocEmbeddingResponse>, StatusCode>` instead of `anyhow::Result<AdHocEmbeddingResponse>`, and picks the status itself:
  - `403` — organization not opted in to AI data processing
  - `400` — content too long
  - `500` — failure resolving the organization, or the embedding request itself
- Each branch logs before returning, so the detail the `anyhow` message used to carry is still in the worker log. Permanent rejections log at `warn`, genuine failures at `error`.
- `check_would_truncate` counts every token, so it can actually report a truncation and the `400` above is reachable. It also reuses the crate's shared `CL100K_ENCODER` instead of building a BPE table on every call.
- `_raise_for_embedding_response` in `posthog/api/embedding_worker.py` keys its opt-in hint off the 403 status alone. It previously also required `"ai"` in the response body, which nothing has ever sent — see below.
- `ad_hoc_handler` is now a pass-through. Mechanical.

A caller can now retry only 5xx and stop on 4xx.

**No caller changes behavior today.** `generate_embedding` and `async_generate_embedding` both default `no_truncate` to `True`, and every Python caller uses those wrappers, so nothing currently asks to be rejected on over-long content — those requests still truncate in `generate_embedding_text` and succeed. `did_truncate` becomes accurate rather than always `false`, and no production code branches on it. The `400` is there for a caller that opts into `no_truncate=false`.

This is still a status-code mapping rather than real error types; moving the crate off `anyhow` to `thiserror` is the deeper fix and is not attempted here.

```mermaid
flowchart LR
    A[ad_hoc request] --> B[handle_ad_hoc_request]
    B -->|not opted in| C[anyhow error]
    B -->|content too long: unreachable| C
    B -->|embedding failed| C
    C --> D[ad_hoc_handler]
    D --> E[500 for everything]
    E --> F[caller retries forever]
    style E fill:#F54E00,stroke:#2D2D2D,color:#fff
    style F fill:#F54E00,stroke:#2D2D2D,color:#fff
```

```mermaid
flowchart LR
    A[ad_hoc request] --> B[handle_ad_hoc_request]
    B -->|not opted in| C[403]
    B -->|content too long| D[400]
    B -->|embedding failed| E[500]
    C --> F[caller stops]
    D --> F
    E --> G[caller retries]
    style C fill:#1D4AFF,stroke:#2D2D2D,color:#fff
    style D fill:#1D4AFF,stroke:#2D2D2D,color:#fff
    style E fill:#F9BD2B,stroke:#2D2D2D,color:#2D2D2D
    style F fill:#1D4AFF,stroke:#2D2D2D,color:#fff
```

### On the `"ai"` body check

`_raise_for_embedding_response` was added in #59705 (2026-05-22) and has been dead since. It required a 403 whose body mentioned `"ai"`, but the worker's history contains no 403 at all: at that commit `ad_hoc_handler` already mapped every error to `INTERNAL_SERVER_ERROR`, and no commit touching `main.rs`, `ad_hoc.rs`, or `organization.rs` has ever mentioned `403` or `FORBIDDEN`. So the hint was written against a response shape that never existed, and the opt-in case surfaced as a generic `HTTPStatusError` the whole time — the exact foot-gun the helper was meant to remove. It was also an undescribed extra in that PR, whose stated scope was three dev-infra files.

This PR gives the worker a real 403, and the response carries a status and no body, so matching on the status is both necessary and sufficient.

## How did you test this code?

Automated only — nothing was exercised against a running worker, so the `403` and `500` paths are unverified end to end.

- `cargo test -p embedding-worker` — 12 pass, including three new `check_would_truncate` tests.
- `cargo clippy -p embedding-worker --all-targets` — clean, no warnings.
- `cargo fmt -p embedding-worker`.
- `pytest posthog/api/test/test_embedding_worker.py` — 5 pass, including three new `_raise_for_embedding_response` tests.
- `ruff check` and `ruff format` on the changed Python files.

The Rust tests cover both embedding models: short content, content one token past the input window, and content exactly on the window. `content_over_the_input_window_truncates` is the regression test for the `.take` — it was confirmed to fail when the `.take` is put back and pass once it is removed, so it is not vacuous. The boundary test pins the `>` rather than `>=`, matching `generate_embedding_text`, which leaves content sitting exactly on the window intact.

The Python tests pin the behavior that was broken: `test_bodyless_403_explains_the_ai_opt_in_gate` was likewise confirmed to fail when the `"ai"` body check is restored. The other two cover the fall-through to `raise_for_status` on a 500 and on a success.

The three status-code branches have no unit tests. Each needs an `AppContext` with a database and an outbound embedding provider, which the crate's current test setup does not stand up; the branches are a straight-line mapping from error to constant with no logic to get wrong. Worth revisiting if the crate gains harness support for `handle_ad_hoc_request`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- No duplicate: `gh pr list --state open --search "embedding worker status code ad_hoc"` and a search for `ad_hoc embedding 403` both returned nothing open.
- Public artifact: nothing here carries non-public material. The endpoint behavior was reached by reading `rust/embedding-worker/` and the Signals grouping code in this repo; no customer data, identifiers, or operational figures appear in the diff or this description.
- Patch coverage: the `check_would_truncate` and `_raise_for_embedding_response` changes are covered; the Rust status-code branches are not, with the reason under "How did you test this code?".
- Authored by the PostHog Slack app (Claude Code) at the direction of the PR assignee. The first commit was scoped to the signature and status-code mapping, deliberately leaving `check_would_truncate` alone on the assumption that fixing it would start rejecting requests that currently succeed. The assignee then asked for the `take` to go, and checking the callers showed the concern did not apply — every caller passes `no_truncate=True` — so the second commit removes it and the earlier caveat is dropped from this description. The third commit followed a question about why the helper expected `"ai"` in the body; the history search that answered it is summarised above. Skills invoked: `debugging-signals-pipeline`, for background on the pipeline rather than to shape this diff. CodeRabbit CLI was not available in the environment, so the PR opens without a local review pass.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BQ8KW9Q5B/p1789054694318559?thread_ts=1789054694.318559&cid=C0BQ8KW9Q5B)*


