### PR TITLE
fix(experiments): leave null session ids out of the watch shelf comparison

### DIFF
--- a/products/experiments/backend/session_event_deltas.py
+++ b/products/experiments/backend/session_event_deltas.py
@@ -742,9 +742,15 @@ class _QuerySetup:
                 right=ast.Constant(value=self.window_end),
             ),
             ast.CompareOperation(
-                op=ast.CompareOperationOp.NotEq,
+                # An SDK that sends `$session_id: null` leaves the string "null" in the column,
+                # because the materialization keeps the raw JSON token. Without this it passes as a
+                # session id, and every such event of every exposed person groups into one session
+                # whose last activity is always the most recent, so it wins a slot of the session
+                # ceiling and people get read from a session they never had. HogQL's own property
+                # read of `$session_id` treats both values as absent.
+                op=ast.CompareOperationOp.NotIn,
                 left=ast.Field(chain=["$session_id"]),
-                right=ast.Constant(value=""),
+                right=ast.Constant(value=["", "null"]),
             ),
         ]
 

--- a/products/experiments/backend/session_event_deltas.py
+++ b/products/experiments/backend/session_event_deltas.py
@@ -743,11 +743,12 @@ class _QuerySetup:
             ),
             ast.CompareOperation(
                 # An SDK that sends `$session_id: null` leaves the string "null" in the column,
-                # because the materialization keeps the raw JSON token. Without this it passes as a
-                # session id, and every such event of every exposed person groups into one session
-                # whose last activity is always the most recent, so it wins a slot of the session
-                # ceiling and people get read from a session they never had. HogQL's own property
-                # read of `$session_id` treats both values as absent.
+                # because the materialization keeps the raw JSON token. That string is a non-empty
+                # value, so it needs its own exclusion. Without it, every such event of every
+                # exposed person groups into one session whose last activity is always the most
+                # recent. That session takes a slot of the session ceiling, and the scan reads
+                # people from a session they never had. HogQL's own property read of `$session_id`
+                # treats both values as absent.
                 op=ast.CompareOperationOp.NotIn,
                 left=ast.Field(chain=["$session_id"]),
                 right=ast.Constant(value=["", "null"]),

--- a/products/experiments/backend/test/test_session_event_deltas_api.py
+++ b/products/experiments/backend/test/test_session_event_deltas_api.py
@@ -203,9 +203,9 @@ class TestExperimentSessionEventDeltas(ClickhouseTestMixin, APILicensedTest):
             )
 
     def _sessionless_backend_event(self, distinct_id: str, event: str, *, at: datetime) -> None:
-        # An SDK that sends an explicit JSON null for `$session_id` leaves the string "null" in the
-        # column, because the materialization keeps the raw JSON token. That is a different trace
-        # from `_unsessioned_exposure`, which omits the key and leaves the column empty.
+        # An explicit JSON null leaves the string "null" in the `$session_id` column, because the
+        # materialization keeps the raw JSON token. That is a different trace from
+        # `_unsessioned_exposure`, which omits the key and leaves the column empty.
         _create_event(
             team=self.team, event=event, distinct_id=distinct_id, timestamp=at, properties={"$session_id": None}
         )

--- a/products/experiments/backend/test/test_session_event_deltas_api.py
+++ b/products/experiments/backend/test/test_session_event_deltas_api.py
@@ -202,6 +202,14 @@ class TestExperimentSessionEventDeltas(ClickhouseTestMixin, APILicensedTest):
                 at=EXPOSED_AT + timedelta(minutes=30),
             )
 
+    def _sessionless_backend_event(self, distinct_id: str, event: str, *, at: datetime) -> None:
+        # An SDK that sends an explicit JSON null for `$session_id` leaves the string "null" in the
+        # column, because the materialization keeps the raw JSON token. That is a different trace
+        # from `_unsessioned_exposure`, which omits the key and leaves the column empty.
+        _create_event(
+            team=self.team, event=event, distinct_id=distinct_id, timestamp=at, properties={"$session_id": None}
+        )
+
     def _post_deltas(self, experiment: Experiment, **body: Any) -> Any:
         return self.client.post(
             f"/api/projects/{self.team.id}/experiments/{experiment.id}/session_event_deltas/",
@@ -362,6 +370,12 @@ class TestExperimentSessionEventDeltas(ClickhouseTestMixin, APILicensedTest):
         self._session(
             variants=[], events=["after_event"], distinct_id=returns_after, at=EXPOSED_AT + timedelta(hours=1)
         )
+        # Backend calls that carry no session. One lands between returns_after's exposure and their
+        # next session, so it must not become the session they are read from. The other is the only
+        # thing api_only ever does after exposure, so they have no session to compare at all.
+        self._sessionless_backend_event(returns_after, "api_call", at=EXPOSED_AT + timedelta(minutes=10))
+        api_only = self._unsessioned_exposure("control", distinct_id="api_only", at=EXPOSED_AT)
+        self._sessionless_backend_event(api_only, "api_call", at=EXPOSED_AT + timedelta(minutes=10))
         flush_persons_and_events()
 
         data = self._post_deltas(experiment).json()
@@ -375,7 +389,7 @@ class TestExperimentSessionEventDeltas(ClickhouseTestMixin, APILicensedTest):
         # sessions all ended before their exposure is not counted at all.
         carded_events = {card["event"] for card in self._cards(data, "behavior")}
         assert "after_event" in carded_events
-        assert {"stale_event", "before_event"}.isdisjoint(carded_events)
+        assert {"stale_event", "before_event", "api_call"}.isdisjoint(carded_events)
         # People counted once; the sessions total still says how much material sits behind the variant.
         assert [(variant["persons"], variant["sessions"]) for variant in data["variants"]] == [(1, 4), (2, 2)]
 


### PR DESCRIPTION
## Problem

- The "What to watch" shelf on an experiment reports arm sizes that count people who had no session in the window, and it reads some people's behavior from a session they never had.
- The shelf's session scan guarded only on `$session_id != ''`. An SDK that sends an explicit JSON null for `$session_id` leaves the string `"null"` in the column, because the materialization keeps the raw JSON token, and that string passed the guard.
- Every such event of every exposed person then grouped into one pseudo-session. Backend traffic never stops, so that pseudo-session always held the most recent activity. It took a slot of the session ceiling and became the session people were read from. A project whose backend sends null session ids gets an inflated comparison, and the shelf can report more compared people than the scan nominated sessions.

## Changes

- Arm sizes on the shelf stop counting people through backend calls that carry no real session, and each person is read from a session they actually had.
- `_QuerySetup.window_conditions` now excludes both `""` and `"null"`. HogQL's own property read of `$session_id` treats both values as absent, so the shelf matches it. That one predicate feeds the coverage nomination, the per-person scan and the card recordings lookup.
- The same `!= ''` guard in `session_buckets.py` and `replay_linkage.py` stays as it is. A `"null"` candidate there fails the replay existence check or matches no recording, so a change would add review surface for no behavior change.
- The response shape does not change, so cached shelves stay readable and expire on their own TTL. No frontend, OpenAPI or MCP change.

## How did you test this code?

- Extended `test_a_person_is_counted_once_and_read_from_their_first_exposed_session` rather than adding a test. It already pins which session each person is read from and the per-variant `(persons, sessions)` totals, which is exactly what this defect corrupts.
- The added fixtures catch two regressions no existing test caught. A person with a null-session backend call between two real sessions must still be read from their real session. A person whose only activity after exposure is a null-session backend call must not count toward their variant at all.
- On unfixed code the extension fails as predicted: `AssertionError: assert 'after_event' in {'checkout_start', 'pricing_faq'}`.
- Not checked: the shelf against production data. That comes after deploy, once the response cache expires.

- The whole `test_session_event_deltas_api.py` file passes in the task sandbox against local Postgres and ClickHouse.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The change fixes an internal query predicate and adds no documented behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written in a PostHog Desktop cloud task with Claude Code (Opus 5), from a plan a person wrote and reviewed first.
- Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- CodeRabbit CLI: unavailable in this sandbox, so the PR opened without a local review pass.
- No duplicate: `gh pr list --state open --search` over `session_event_deltas`, the shelf and null session ids found no open PR on this module, drafts included.
- Test-first order: the test extension landed and failed on unfixed code before the predicate changed.
- Public artifact: the work drew on production reads and an internal plan document. None of that reached the diff, the commit message or this description. Every test fixture is invented.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

