### PR TITLE
fix(billing): dedupe ai credit traces; scope free-tool exemptions

### DIFF
--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -51,6 +51,7 @@ from posthog.models.scoping import team_scope
 from posthog.models.sharing_configuration import SharingConfiguration
 from posthog.session_recordings.queries.test.session_replay_sql import produce_replay_summary
 from posthog.tasks.usage_report import (
+    AI_BILLING_TRACED_PRODUCTS,
     MCP_ANALYTICS_EVENT_METRICS,
     OrgReport,
     UsageReportCounters,
@@ -4934,6 +4935,167 @@ class TestAIEventsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickhouse
 
         # 1.0 USD * 100 * 1.2 = 120
         self.assertEqual(result, [(self.org_1_team_1.id, 120)])
+
+    def _create_ai_billing_trace(
+        self, team: Team, trace_id: str, tool_calls: list[dict[str, Any]], timestamp: datetime
+    ) -> None:
+        _create_event(
+            event="$ai_trace",
+            team=team,
+            distinct_id="user_1",
+            timestamp=timestamp,
+            properties={
+                "$ai_trace_id": trace_id,
+                "$ai_output_state": {"messages": [{"tool_calls": tool_calls}]},
+                "$group_1": "https://us.posthog.com",
+            },
+        )
+
+    def _create_ai_billing_generation(
+        self, team: Team, trace_id: str, ai_product: str, cost_usd: float, timestamp: datetime
+    ) -> None:
+        _create_event(
+            event="$ai_generation",
+            team=team,
+            distinct_id="user_1",
+            timestamp=timestamp,
+            properties={
+                "team_id": self.org_1_team_1.id,
+                "$ai_trace_id": trace_id,
+                "$ai_total_cost_usd": cost_usd,
+                "$ai_billable": True,
+                "ai_product": ai_product,
+                "$group_1": "https://us.posthog.com",
+            },
+        )
+
+    @parameterized.expand([("slack_app",), ("workflows",), ("alert_investigation_agent",)])
+    @patch("posthog.tasks.usage_report.get_instance_region")
+    def test_free_trace_does_not_exempt_a_product_that_emits_no_trace(
+        self, ai_product: str, mock_region: MagicMock
+    ) -> None:
+        """A docs-only $ai_trace sharing a traceless product's trace id leaves its generation billable."""
+        mock_region.return_value = "US"
+        self._setup_teams()
+        analytics_org = Organization.objects.create(name="PostHog Analytics")
+        analytics_team = Team.objects.create(pk=2, organization=analytics_org, name="Analytics")
+        self._setup_instance_group_mapping(analytics_team)
+
+        period = get_previous_day(at=now() + relativedelta(days=1))
+
+        self._create_ai_billing_trace(
+            analytics_team,
+            "trace_free_elsewhere",
+            [{"name": "search", "args": {"kind": "docs"}}],
+            period.start + relativedelta(hours=1),
+        )
+        self._create_ai_billing_generation(
+            analytics_team, "trace_free_elsewhere", ai_product, 1.0, period.start + relativedelta(hours=1, minutes=1)
+        )
+
+        flush_persons_and_events()
+
+        result = get_teams_with_ai_credits_used_in_period(period.start, period.end)
+
+        # 1.0 USD * 100 * 1.2 = 120
+        self.assertEqual(result, [(self.org_1_team_1.id, 120)])
+
+    @patch("posthog.tasks.usage_report.get_instance_region")
+    def test_free_trace_exempts_traced_product(self, mock_region: MagicMock) -> None:
+        """A traced product keeps the free-tools policy, while its generation with no trace still bills."""
+        mock_region.return_value = "US"
+        self._setup_teams()
+        analytics_org = Organization.objects.create(name="PostHog Analytics")
+        analytics_team = Team.objects.create(pk=2, organization=analytics_org, name="Analytics")
+        self._setup_instance_group_mapping(analytics_team)
+
+        period = get_previous_day(at=now() + relativedelta(days=1))
+
+        self._create_ai_billing_trace(
+            analytics_team,
+            "trace_free",
+            [{"name": "search", "args": {"kind": "docs"}}],
+            period.start + relativedelta(hours=1),
+        )
+        self._create_ai_billing_generation(
+            analytics_team, "trace_free", "posthog_ai", 2.0, period.start + relativedelta(hours=1, minutes=1)
+        )
+        self._create_ai_billing_generation(
+            analytics_team, "trace_untraced", "posthog_ai", 1.0, period.start + relativedelta(hours=2)
+        )
+
+        flush_persons_and_events()
+
+        result = get_teams_with_ai_credits_used_in_period(period.start, period.end)
+
+        # Only the 1.0 USD generation with no trace bills: 1.0 * 100 * 1.2 = 120
+        self.assertEqual(result, [(self.org_1_team_1.id, 120)])
+
+    @patch("posthog.tasks.usage_report.get_instance_region")
+    def test_billable_trace_row_outranks_a_free_one(self, mock_region: MagicMock) -> None:
+        """A docs-only $ai_trace sharing a billable trace's id leaves the turn billed once."""
+        mock_region.return_value = "US"
+        self._setup_teams()
+        analytics_org = Organization.objects.create(name="PostHog Analytics")
+        analytics_team = Team.objects.create(pk=2, organization=analytics_org, name="Analytics")
+        self._setup_instance_group_mapping(analytics_team)
+
+        period = get_previous_day(at=now() + relativedelta(days=1))
+
+        self._create_ai_billing_trace(
+            analytics_team, "trace_shared", [{"name": "query_executor"}], period.start + relativedelta(hours=1)
+        )
+        self._create_ai_billing_trace(
+            analytics_team,
+            "trace_shared",
+            [{"name": "search", "args": {"kind": "docs"}}],
+            period.start + relativedelta(hours=1, minutes=2),
+        )
+        self._create_ai_billing_generation(
+            analytics_team, "trace_shared", "posthog_ai", 1.0, period.start + relativedelta(hours=1, minutes=1)
+        )
+
+        flush_persons_and_events()
+
+        result = get_teams_with_ai_credits_used_in_period(period.start, period.end)
+
+        # 1.0 USD * 100 * 1.2 = 120
+        self.assertEqual(result, [(self.org_1_team_1.id, 120)])
+
+    @patch("posthog.tasks.usage_report.get_instance_region")
+    def test_duplicate_billable_trace_rows_bill_generation_once(self, mock_region: MagicMock) -> None:
+        """Repeated $ai_trace rows for one trace id do not multiply its generation's cost."""
+        mock_region.return_value = "US"
+        self._setup_teams()
+        analytics_org = Organization.objects.create(name="PostHog Analytics")
+        analytics_team = Team.objects.create(pk=2, organization=analytics_org, name="Analytics")
+        self._setup_instance_group_mapping(analytics_team)
+
+        period = get_previous_day(at=now() + relativedelta(days=1))
+
+        self._create_ai_billing_trace(
+            analytics_team, "trace_repeated", [{"name": "query_executor"}], period.start + relativedelta(hours=1)
+        )
+        self._create_ai_billing_trace(
+            analytics_team,
+            "trace_repeated",
+            [{"name": "query_executor"}],
+            period.start + relativedelta(hours=1, minutes=2),
+        )
+        self._create_ai_billing_generation(
+            analytics_team, "trace_repeated", "posthog_ai", 1.0, period.start + relativedelta(hours=1, minutes=1)
+        )
+
+        flush_persons_and_events()
+
+        result = get_teams_with_ai_credits_used_in_period(period.start, period.end)
+
+        # Billed once: 1.0 USD * 100 * 1.2 = 120
+        self.assertEqual(result, [(self.org_1_team_1.id, 120)])
+
+    def test_traced_products_are_pinned(self) -> None:
+        # Changing this set changes which products a free trace can exempt; update the parametrized tests with it.
+        self.assertEqual(set(AI_BILLING_TRACED_PRODUCTS), {"posthog_ai"})
 
     def test_has_non_zero_usage_counts_signals_credits(self) -> None:
         """A signals-only org must survive has_non_zero_usage so its report still reaches billing."""

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -4974,7 +4974,6 @@ class TestAIEventsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickhouse
     def test_free_trace_does_not_exempt_a_product_that_emits_no_trace(
         self, ai_product: str, mock_region: MagicMock
     ) -> None:
-        """A docs-only $ai_trace sharing a traceless product's trace id leaves its generation billable."""
         mock_region.return_value = "US"
         self._setup_teams()
         analytics_org = Organization.objects.create(name="PostHog Analytics")
@@ -5002,7 +5001,6 @@ class TestAIEventsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickhouse
 
     @patch("posthog.tasks.usage_report.get_instance_region")
     def test_free_trace_exempts_traced_product(self, mock_region: MagicMock) -> None:
-        """A traced product keeps the free-tools policy, while its generation with no trace still bills."""
         mock_region.return_value = "US"
         self._setup_teams()
         analytics_org = Organization.objects.create(name="PostHog Analytics")
@@ -5033,7 +5031,6 @@ class TestAIEventsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickhouse
 
     @patch("posthog.tasks.usage_report.get_instance_region")
     def test_billable_trace_row_outranks_a_free_one(self, mock_region: MagicMock) -> None:
-        """A docs-only $ai_trace sharing a billable trace's id leaves the turn billed once."""
         mock_region.return_value = "US"
         self._setup_teams()
         analytics_org = Organization.objects.create(name="PostHog Analytics")
@@ -5064,7 +5061,6 @@ class TestAIEventsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickhouse
 
     @patch("posthog.tasks.usage_report.get_instance_region")
     def test_duplicate_billable_trace_rows_bill_generation_once(self, mock_region: MagicMock) -> None:
-        """Repeated $ai_trace rows for one trace id do not multiply its generation's cost."""
         mock_region.return_value = "US"
         self._setup_teams()
         analytics_org = Organization.objects.create(name="PostHog Analytics")
@@ -5094,7 +5090,7 @@ class TestAIEventsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickhouse
         self.assertEqual(result, [(self.org_1_team_1.id, 120)])
 
     def test_traced_products_are_pinned(self) -> None:
-        # Changing this set changes which products a free trace can exempt; update the parametrized tests with it.
+        # Update the parametrized free-trace tests when this set changes.
         self.assertEqual(set(AI_BILLING_TRACED_PRODUCTS), {"posthog_ai"})
 
     def test_has_non_zero_usage_counts_signals_credits(self) -> None:

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -1732,6 +1732,9 @@ AI_COST_MARKUP_PERCENT = 0.2
 POSTHOG_CODE_COST_MARKUP_PERCENT = 0.0
 # Tools excluded from AI billing (traces with only these tools are not billed)
 AI_BILLING_EXCLUDED_TOOLS = ["summarize_sessions", "search"]
+# ai_product values whose runs emit an $ai_trace. A free-tools verdict comes from a turn's own trace,
+# so it applies only to these products; any other product bills on its generation alone.
+AI_BILLING_TRACED_PRODUCTS = ("posthog_ai",)
 AI_BILLING_INSTANCE_GROUP_TYPE = "instance"
 # Region-to-team mapping for where AI events are stored
 CLOUD_REGION_TO_TEAM_ID = {
@@ -1792,14 +1795,14 @@ def _get_teams_with_ai_credits_for_products(
     `ai_product` event property — only generations tagged with an `ai_products` value are billed.
 
     A billable $ai_generation (with positive cost) is billed when its trace is billable OR it has no
-    trace. Products that emit a paired $ai_trace (e.g. posthog_ai) are billed only on a billable trace;
+    trace. Products in AI_BILLING_TRACED_PRODUCTS (e.g. posthog_ai) are billed only on a billable trace;
     a trace is billable only if it contains tool calls including at least one non-excluded tool. Free
     (non-billable) traces:
         - Traces that only contain 'summarize_sessions' tool calls
         - Traces that only contain 'search' tool calls with kind='docs'
 
-    Products that emit no $ai_trace (e.g. signals, slack_app) have no matching trace, so they are
-    billed via the empty-trace fallback.
+    Every other product (e.g. slack_app) bills on its generation alone, even when an $ai_trace shares
+    its trace id, because a product that emits no trace has no turn of its own for a verdict to come from.
 
     We are also performing additional filtering to maintain current trace tool calls and not all messages
     in the ongoing conversation thread (otherwise we might end up billing for traces we would not want to)
@@ -1876,7 +1879,7 @@ def _get_teams_with_ai_credits_for_products(
                 WITH %(excluded_tools)s AS excluded_tools
                 SELECT
                     trace_id,
-                    multiIf(
+                    max(multiIf(
                         length(tool_calls) > 0
                         AND arrayAll(
                             i ->
@@ -1893,7 +1896,7 @@ def _get_teams_with_ai_credits_for_products(
                         ),
                         0,  -- all tool calls are excluded → NOT billable
                         1   -- everything else → billable
-                    ) AS is_billable
+                    )) AS is_billable
                 FROM (
                     SELECT
                         {trace_id_expr} AS trace_id,
@@ -1921,16 +1924,20 @@ def _get_teams_with_ai_credits_for_products(
                         AND timestamp < %(end)s
                         AND event = '$ai_trace'
                 )
+                -- one row per trace id so the join cannot fan out, and a billable row outranks a free one
+                GROUP BY trace_id
             ),
             costs AS (
                 SELECT
                     customer_team_id,
                     trace_id,
+                    ai_product,
                     cost_usd
                 FROM (
                     SELECT
                         toInt64OrZero({customer_team_id_expr}) AS customer_team_id,
                         {trace_id_expr} AS trace_id,
+                        {ai_product_expr} AS ai_product,
                         toDecimal32OrNull(
                             {total_cost_expr},
                             5
@@ -1967,6 +1974,8 @@ def _get_teams_with_ai_credits_for_products(
                 -- on $ai_billable alone, already enforced in the costs CTE). Use empty(), not
                 -- IS NULL: join_use_nulls=0 yields '' — not NULL — for an unmatched trace_id.
                 t.is_billable = 1 OR empty(t.trace_id)
+                -- a free verdict comes from a turn's own trace, so it applies only to products that emit one
+                OR c.ai_product NOT IN %(traced_ai_products)s
             GROUP BY
                 c.customer_team_id
             HAVING
@@ -1980,6 +1989,7 @@ def _get_teams_with_ai_credits_for_products(
                 "end": end,
                 "markup_multiplier": 1 + markup_percent,
                 "excluded_tools": AI_BILLING_EXCLUDED_TOOLS,
+                "traced_ai_products": AI_BILLING_TRACED_PRODUCTS,
                 "ai_products": tuple(ai_products),
                 "unbilled_task_origins": UNBILLED_TASK_ORIGIN_PRODUCTS,
                 **region_filter_params,

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -1732,8 +1732,7 @@ AI_COST_MARKUP_PERCENT = 0.2
 POSTHOG_CODE_COST_MARKUP_PERCENT = 0.0
 # Tools excluded from AI billing (traces with only these tools are not billed)
 AI_BILLING_EXCLUDED_TOOLS = ["summarize_sessions", "search"]
-# ai_product values whose runs emit an $ai_trace. A free-tools verdict comes from a turn's own trace,
-# so it applies only to these products; any other product bills on its generation alone.
+# ai_product values whose runs emit their own $ai_trace, the only products a free-tools verdict exempts.
 AI_BILLING_TRACED_PRODUCTS = ("posthog_ai",)
 AI_BILLING_INSTANCE_GROUP_TYPE = "instance"
 # Region-to-team mapping for where AI events are stored
@@ -1802,7 +1801,7 @@ def _get_teams_with_ai_credits_for_products(
         - Traces that only contain 'search' tool calls with kind='docs'
 
     Every other product (e.g. slack_app) bills on its generation alone, even when an $ai_trace shares
-    its trace id, because a product that emits no trace has no turn of its own for a verdict to come from.
+    its trace id.
 
     We are also performing additional filtering to maintain current trace tool calls and not all messages
     in the ongoing conversation thread (otherwise we might end up billing for traces we would not want to)
@@ -1974,7 +1973,6 @@ def _get_teams_with_ai_credits_for_products(
                 -- on $ai_billable alone, already enforced in the costs CTE). Use empty(), not
                 -- IS NULL: join_use_nulls=0 yields '' — not NULL — for an unmatched trace_id.
                 t.is_billable = 1 OR empty(t.trace_id)
-                -- a free verdict comes from a turn's own trace, so it applies only to products that emit one
                 OR c.ai_product NOT IN %(traced_ai_products)s
             GROUP BY
                 c.customer_team_id


### PR DESCRIPTION
## Problem

- A PostHog AI generation bills once for every trace event that shares its trace id, so a repeated trace event multiplies the charge.
- The free-tools exemption covers turns that only call `summarize_sessions` or docs search. It also exempts another product's generation that shares the trace id.

## Changes

- **A generation bills once per trace.** `trace_analysis` returns one row per trace id, and a billable row wins over a free one.
- **The free-tools exemption applies only to `posthog_ai`**, the one billed product whose runs emit their own `$ai_trace`. `AI_BILLING_TRACED_PRODUCTS` holds that list.
- No other billed product emits an `$ai_trace`, so their bills do not change.
- Mechanical: the costs CTE carries `ai_product` for the new filter.

## How did you test this code?

New tests in `posthog/tasks/test/test_usage_report.py`, each named for the regression it catches:

- `test_duplicate_billable_trace_rows_bill_generation_once`: repeated trace rows multiply the charge.
- `test_billable_trace_row_outranks_a_free_one`: a free row suppresses a billable turn.
- `test_free_trace_exempts_traced_product` and `test_free_trace_does_not_exempt_a_product_that_emits_no_trace`: the exemption scope, in both directions.
- `test_traced_products_are_pinned`: the list's membership.

Reverting each change fails the test written for it. Not checked: the `/usage` slash command, which runs its own copy of this query.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (Claude Opus 5); requires human review.
- Skills invoked: `writing-code-comments`, `writing-pr-descriptions`.
- #86448 subtracts a docs-search deduction after this query and composes with it. #97193 reworks the `/usage` copy of this query, and the matching `/usage` change follows once it lands.
- No CodeRabbit CLI pass: the CLI is not installed here.
