### PR TITLE
chore: add yolo1 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,5 @@ The pricing for our paid plan is completely transparent and available on [our pr
 Hey! If you're reading this, you've proven yourself as a dedicated README reader.
 
 You might also make a great addition to our team. We're growing fast [and would love for you to join us](https://posthog.com/careers).
+
+yolo1


### PR DESCRIPTION
## Problem

A `yolo1` line was requested at the end of the README.

## Changes

- Appends `yolo1` to the end of `README.md`. No code or behavior change.

## How did you test this code?

No tests apply — the change is one line of README text. No automated tests were run.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested from a Slack thread and made by the PostHog Slack app. No skills were needed for a one-line README edit. The CodeRabbit CLI pass is paused, so this PR opened without a local review pass. No duplicate open PR does this. Nothing in the diff or this description carries non-public material.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B85JA2DAA/p1789060937581319)*
