### PR TITLE
chore: add yolo1 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,5 @@ The pricing for our paid plan is completely transparent and available on [our pr
 Hey! If you're reading this, you've proven yourself as a dedicated README reader.
 
 You might also make a great addition to our team. We're growing fast [and would love for you to join us](https://posthog.com/careers).
+
+yolo1


### PR DESCRIPTION
## Problem

A one-line marker was requested at the end of the README.

## Changes

Appends `yolo1` as the last line of `README.md`. Documentation only, no code paths affected.

## How did you test this code?

No tests run — the change is a single line of README text.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: PostHog Slack app. No repo skills were needed for a README text line.
- CodeRabbit CLI pass: paused for now, so this PR opened without a local pass.
- No duplicate: this is a trivial README edit, not a fix for a live master issue.
- Public artifact: nothing here carries non-public session material.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B85JA2DAA/p1789061259527409)*