### PR TITLE
chore(flags): guard mcp group-targeting merge against type drift

### DIFF
--- a/products/feature_flags/backend/test/test_filters_validation.py
+++ b/products/feature_flags/backend/test/test_filters_validation.py
@@ -7,10 +7,11 @@ from rest_framework import serializers
 from rest_framework.exceptions import ErrorDetail
 
 from products.feature_flags.backend.api.feature_flag import _reject_serde_unsafe_filters
-from products.feature_flags.backend.api.filters_schema import FeatureFlagFiltersSerializer
+from products.feature_flags.backend.api.filters_schema import FEATURE_FLAG_PROPERTY_TYPES, FeatureFlagFiltersSerializer
 from products.feature_flags.backend.encrypted_flag_payloads import REDACTED_PAYLOAD_VALUE
 from products.feature_flags.backend.filters_validation import (
     CROSS_FIELD_CHECKS,
+    PERSON_AGGREGATED_PROPERTY_TYPES,
     Violation,
     check_groups_non_empty_for_create,
     check_variant_rollout_sum,
@@ -323,6 +324,20 @@ class TestFiltersValidation(SimpleTestCase):
             "contextual.groups_empty_on_create"
         ]
         assert check_groups_non_empty_for_create({"groups": [{"properties": []}]}) == []
+
+    def test_group_is_the_only_property_type_outside_person_aggregation(self) -> None:
+        assert set(FEATURE_FLAG_PROPERTY_TYPES) - set(PERSON_AGGREGATED_PROPERTY_TYPES) == {"group"}, (
+            "services/mcp/src/tools/featureFlags/preserveGroupTargeting.ts encodes the person-aggregation rule as "
+            "`type !== 'group'` (in mergeConditionGroup and mergeProperty). That is the complement of "
+            "PERSON_AGGREGATED_PROPERTY_TYPES only while 'group' is the sole type outside it. A group-side type "
+            "that slips through as person-aggregated lets that merge helper silently clear a flag's group "
+            "targeting. If the new type belongs under person aggregation, add it to "
+            "PERSON_AGGREGATED_PROPERTY_TYPES and the TypeScript needs no change. If the difference came out "
+            "empty instead, 'group' was added to PERSON_AGGREGATED_PROPERTY_TYPES, and the merge helper's "
+            "`!== 'group'` check no longer separates the two aggregations at all; that change needs its own "
+            "review, not a wider tuple here. Otherwise update the merge helper and "
+            "services/mcp/tests/unit/preserve-group-targeting.test.ts, then this assertion."
+        )
 
 
 class TestRejectSerdeUnsafeFilters(SimpleTestCase):


### PR DESCRIPTION
## Problem

A merge helper added in #78678 (`services/mcp/src/tools/featureFlags/preserveGroupTargeting.ts`) reimplements a backend feature-flag property-type rule in TypeScript, with nothing tying the two together. A future change to that backend rule could silently break the TypeScript's assumption, with no test catching it.

## Changes

- Adds a test asserting `group` is the only property type outside `PERSON_AGGREGATED_PROPERTY_TYPES`, the invariant `type !== 'group'` checks in the merge helper rely on.
- The failure message names the exact TypeScript file, functions, and test to update.
- It covers both drift directions: a new type landing on the wrong side, or `group` moving onto the person-aggregated side.
- `preserveGroupTargeting.ts` does not exist on master until #78678 merges, so this PR adds only the Python guard; the pointer comments inside that file follow in a separate PR once #78678 lands.

## How did you test this code?

Added one test to the existing `TestFiltersValidation` class (`SimpleTestCase`, no database). No existing test compares these two constants, so nothing already covered this. Verified it catches the drift: mutated each constant in turn, confirmed the failure named the TypeScript file, then reverted both.

Not run: services/mcp tests, since this PR does not touch that tree.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Internal test only, no user-facing behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: Claude Code, [session](https://claude.ai/code/session_011dok7EVgJedxkdHVfEtfr5).
- Skills invoked: `/writing-tests` before adding the test, a `code-reviewer` subagent before committing, `/create-pr`, `/writing-pr-descriptions`, and `/reviewing-with-coderabbit` for this PR.
- CodeRabbit CLI is signed out in this environment and sign-in needs a browser, so this PR opens without a local CodeRabbit pass.
- The `code-reviewer` subagent found two convention fixes (a bare `assert` instead of `self.assertEqual`, a missing `-> None`) and one content gap (the message covered only one of two drift directions). All three are fixed in the commit.
- No duplicate: searched open PRs for this test and found none. #78678 introduces the TypeScript file this test protects but does not add this test.
- Patch coverage: the new lines are a single test method; nothing else to cover.
- Public artifact: everything here comes from reading this repository's own code. No customer or internal-only material.
