### PR TITLE
feat(surveys): add an export shortcut to the summary tab

### DIFF
--- a/docs/internal/survey-responses.md
+++ b/docs/internal/survey-responses.md
@@ -19,6 +19,7 @@ These percentages use all responses matching the current filters as their denomi
 Each submission counts once in this breakdown, even when the performance summary counts unique people.
 The performance bar labels dismissals with no answers separately from responses.
 
-Use **Export responses** on the Responses tab to download answers as CSV or Excel.
+Use **Export responses** on the Summary tab to download answers as CSV or Excel.
 The export includes all responses matching the current filters, across all table pages.
+The Responses tab has an export control in the table.
 The same export remains available in the action sidebar.

--- a/docs/internal/survey-responses.md
+++ b/docs/internal/survey-responses.md
@@ -18,3 +18,7 @@ It includes a compact row with counts and percentages for **Completed**, **Dismi
 These percentages use all responses matching the current filters as their denominator, including archived responses when selected.
 Each submission counts once in this breakdown, even when the performance summary counts unique people.
 The performance bar labels dismissals with no answers separately from responses.
+
+Use **Export responses** on the Responses tab to download answers as CSV or Excel.
+The export includes all responses matching the current filters, across all table pages.
+The same export remains available in the action sidebar.

--- a/docs/published/docs/surveys/performance.md
+++ b/docs/published/docs/surveys/performance.md
@@ -8,7 +8,7 @@ The inline metrics show **Shown**, **Responses**, and **Response rate**. Turn on
 
 The results toolbar contains the date range and **Filters**, which expands response filters, property filters, and **Show archived**. The Filters badge counts active response and property filters plus the archived toggle; the visible date range is separate. **Clear filters** appears when filters are active and resets the date range, response filters, property filters, and archived toggle. Find **View insights** in the toolbar's overflow menu. Configure survey notifications in the **Notifications** tab.
 
-On the **Responses** tab, use **Export responses** on the right of the toolbar to download all answers matching the current filters as CSV or Excel, across all table pages.
+On the **Summary** tab, use **Export responses** on the right of the toolbar to download all answers matching the current filters as CSV or Excel, across all table pages. The **Responses** tab has an export control in the table.
 
 The outcome bar shows responses, dismissals without answers, and unanswered surveys. Each label includes its count and percentage, so small segments remain readable. Hover over the bar to inspect the counts in the chart tooltip.
 

--- a/docs/published/docs/surveys/performance.md
+++ b/docs/published/docs/surveys/performance.md
@@ -8,6 +8,8 @@ The inline metrics show **Shown**, **Responses**, and **Response rate**. Turn on
 
 The results toolbar contains the date range and **Filters**, which expands response filters, property filters, and **Show archived**. The Filters badge counts active response and property filters plus the archived toggle; the visible date range is separate. **Clear filters** appears when filters are active and resets the date range, response filters, property filters, and archived toggle. Find **View insights** in the toolbar's overflow menu. Configure survey notifications in the **Notifications** tab.
 
+On the **Responses** tab, use **Export responses** on the right of the toolbar to download all answers matching the current filters as CSV or Excel, across all table pages.
+
 The outcome bar shows responses, dismissals without answers, and unanswered surveys. Each label includes its count and percentage, so small segments remain readable. Hover over the bar to inspect the counts in the chart tooltip.
 
 **Response completion** describes the submissions that contain answers:

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -9560,6 +9560,10 @@ snapshots:
         hash: v1.k794b7964.d24cf21331cc08695b112c71c74fbebad505f764b5724c887e1eae2b910a5add.F78vCNK-5jT9ibk8H5w3wLowjG6acy17BWbFyM9rmhM
     scenes-app-surveys--survey-results--light:
         hash: v1.k794b7964.a1e5aa8fb1e492e5336f984ec06b48c101295863c2ac0f3d6ce75a1c7325710e.94II2OjeSRNoA0vmcSCD4VYazwhbhLOQFTU1Yvwl4LY
+    scenes-app-surveys--survey-summary-export--dark:
+        hash: v1.k794b7964.7a29422b4cb020b79b9f9908dca482a988d85cc76f0ef933119ebfc234a26102.wHOJnD6FjoTozXXkXXko9W9sSQxIk0GApIqv4sojL-g
+    scenes-app-surveys--survey-summary-export--light:
+        hash: v1.k794b7964.4c1aba9c3175866b1cd56a938768604d0cfa12158dc6881d8051cf9b4dce01b9.7SX5XrAQDCKIdIawBOoVzZMKBaDtedRucnvsxb9HLME
     scenes-app-surveys--surveys-global-settings--dark:
         hash: v1.k794b7964.476a85556bb374416ca1ae0cccfb23f8cc6f6a2e0e71d3f7d0e37a2ad3d463aa.lCKgctegJe2jQZ7Bf7sXK6YhuGh17KhGftYqoY3s5PM
     scenes-app-surveys--surveys-global-settings--light:

--- a/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyFilters.tsx
+++ b/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyFilters.tsx
@@ -42,7 +42,7 @@ function CopyResponseKeyButton({ questionId }: { questionId: string }): JSX.Elem
     )
 }
 
-export function SurveyResultsFiltersBar(): JSX.Element {
+export function SurveyResultsFiltersBar({ actions }: { actions?: React.ReactNode }): JSX.Element {
     const {
         survey,
         answerFilters,
@@ -135,15 +135,18 @@ export function SurveyResultsFiltersBar(): JSX.Element {
                         </LemonButton>
                     )}
                 </div>
-                <LemonMenu items={[{ label: 'View insights', icon: <IconGraph />, to: surveyAsInsightURL }]}>
-                    <LemonButton
-                        size="small"
-                        icon={<IconEllipsis />}
-                        aria-label="More result actions"
-                        tooltip="More result actions"
-                        data-attr="survey-results-more-actions"
-                    />
-                </LemonMenu>
+                <div className="flex flex-wrap items-center gap-2">
+                    {actions}
+                    <LemonMenu items={[{ label: 'View insights', icon: <IconGraph />, to: surveyAsInsightURL }]}>
+                        <LemonButton
+                            size="small"
+                            icon={<IconEllipsis />}
+                            aria-label="More result actions"
+                            tooltip="More result actions"
+                            data-attr="survey-results-more-actions"
+                        />
+                    </LemonMenu>
+                </div>
             </div>
 
             {resultsFiltersExpanded && (

--- a/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyViewRedesign.tsx
+++ b/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyViewRedesign.tsx
@@ -602,6 +602,7 @@ function SurveyStatusAction(): JSX.Element | null {
 function SurveySummaryContent({ onViewResponses }: { onViewResponses: () => void }): JSX.Element {
     const {
         survey,
+        dataTableQuery,
         isAnyResultsLoading,
         resultsRequeryInProgress,
         processedSurveyStats,
@@ -616,11 +617,34 @@ function SurveySummaryContent({ onViewResponses }: { onViewResponses: () => void
     const atLeastOneResponse = !!processedSurveyStats?.[SurveyEventName.SENT].total_count
     const isRefreshingResults = resultsRequeryInProgress || isAnyResultsLoading
 
+    const exportButton = (
+        <ExportButton
+            id="survey-responses-export"
+            type="secondary"
+            size="small"
+            icon={<IconDownload />}
+            buttonCopy="Export responses"
+            disabledReason={!dataTableQuery ? 'No responses to export yet.' : undefined}
+            items={
+                dataTableQuery
+                    ? [ExporterFormat.CSV, ExporterFormat.XLSX].map((format) => ({
+                          title: format === ExporterFormat.CSV ? 'Export as CSV' : 'Export as Excel',
+                          export_format: format,
+                          export_context: {
+                              source: dataTableQuery,
+                              filename: `survey-${survey.name}-responses`,
+                          },
+                      }))
+                    : []
+            }
+        />
+    )
+
     if (!isRefreshingResults && !atLeastOneResponse) {
         return (
             <div className="px-4 pb-4">
                 <div className="mx-auto w-full max-w-[1200px] space-y-6">
-                    <SurveyResultsFiltersBar />
+                    <SurveyResultsFiltersBar actions={exportButton} />
                     <SurveyStatsSummary />
                     <SurveyNoResponsesBanner
                         type="survey"
@@ -640,7 +664,7 @@ function SurveySummaryContent({ onViewResponses }: { onViewResponses: () => void
     return (
         <div className="px-4 pb-4">
             <div className="mx-auto w-full max-w-[1200px] space-y-6">
-                <SurveyResultsFiltersBar />
+                <SurveyResultsFiltersBar actions={exportButton} />
                 <SurveyResultsRefreshStatus visible={isRefreshingResults} />
                 <div
                     aria-busy={isRefreshingResults}
@@ -709,30 +733,7 @@ function SurveyResponsesContent(): JSX.Element {
 
     return (
         <div className="px-4 pb-4 space-y-6">
-            <SurveyResultsFiltersBar
-                actions={
-                    <ExportButton
-                        id="survey-responses-export"
-                        type="secondary"
-                        size="small"
-                        icon={<IconDownload />}
-                        buttonCopy="Export responses"
-                        disabledReason={!dataTableQuery ? 'No responses to export yet.' : undefined}
-                        items={
-                            dataTableQuery
-                                ? [ExporterFormat.CSV, ExporterFormat.XLSX].map((format) => ({
-                                      title: format === ExporterFormat.CSV ? 'Export as CSV' : 'Export as Excel',
-                                      export_format: format,
-                                      export_context: {
-                                          source: dataTableQuery,
-                                          filename: `survey-${survey.name}-responses`,
-                                      },
-                                  }))
-                                : []
-                        }
-                    />
-                }
-            />
+            <SurveyResultsFiltersBar />
             <SurveyResultsRefreshStatus visible={isRefreshingResults} />
             {isInitialSurveyLoad ? (
                 <LemonSkeleton />

--- a/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyViewRedesign.tsx
+++ b/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyViewRedesign.tsx
@@ -2,11 +2,12 @@ import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import { IconArchive, IconCode, IconCopy, IconTrash } from '@posthog/icons'
+import { IconArchive, IconCode, IconCopy, IconDownload, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonDialog, LemonDivider, LemonTag, Tooltip } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
+import { ExportButton } from 'lib/components/ExportButton/ExportButton'
 import { SceneDuplicate } from 'lib/components/Scenes/SceneDuplicate'
 import { SceneFile } from 'lib/components/Scenes/SceneFile'
 import { SceneMenuBarFileItems } from 'lib/components/Scenes/SceneMenuBarFileItems'
@@ -63,6 +64,7 @@ import {
     AccessControlLevel,
     AccessControlResourceType,
     ActivityScope,
+    ExporterFormat,
     ProgressStatus,
     SidePanelTab,
     Survey,
@@ -707,7 +709,30 @@ function SurveyResponsesContent(): JSX.Element {
 
     return (
         <div className="px-4 pb-4 space-y-6">
-            <SurveyResultsFiltersBar />
+            <SurveyResultsFiltersBar
+                actions={
+                    <ExportButton
+                        id="survey-responses-export"
+                        type="secondary"
+                        size="small"
+                        icon={<IconDownload />}
+                        buttonCopy="Export responses"
+                        disabledReason={!dataTableQuery ? 'No responses to export yet.' : undefined}
+                        items={
+                            dataTableQuery
+                                ? [ExporterFormat.CSV, ExporterFormat.XLSX].map((format) => ({
+                                      title: format === ExporterFormat.CSV ? 'Export as CSV' : 'Export as Excel',
+                                      export_format: format,
+                                      export_context: {
+                                          source: dataTableQuery,
+                                          filename: `survey-${survey.name}-responses`,
+                                      },
+                                  }))
+                                : []
+                        }
+                    />
+                }
+            />
             <SurveyResultsRefreshStatus visible={isRefreshingResults} />
             {isInitialSurveyLoad ? (
                 <LemonSkeleton />

--- a/frontend/src/scenes/surveys/Surveys.stories.tsx
+++ b/frontend/src/scenes/surveys/Surveys.stories.tsx
@@ -583,6 +583,17 @@ export const SurveyResults: Story = {
     ],
 }
 
+export const SurveyResponses: Story = {
+    ...SurveyResults,
+    parameters: {
+        ...SurveyResults.parameters,
+        pageUrl: `${urls.survey(MOCK_SURVEY_WITH_RESULTS.id)}?tab=responses`,
+        testOptions: {
+            waitForSelector: '#survey-responses-export',
+        },
+    },
+}
+
 export const SurveyNotFound: Story = {
     tags: ['test-skip'],
     parameters: {

--- a/frontend/src/scenes/surveys/Surveys.stories.tsx
+++ b/frontend/src/scenes/surveys/Surveys.stories.tsx
@@ -590,6 +590,7 @@ export const SurveySummaryExport: Story = {
         pageUrl: `${urls.survey(MOCK_SURVEY_WITH_RESULTS.id)}?tab=summary`,
         testOptions: {
             waitForSelector: '#survey-responses-export',
+            viewport: { width: 560, height: 800 },
         },
     },
 }

--- a/frontend/src/scenes/surveys/Surveys.stories.tsx
+++ b/frontend/src/scenes/surveys/Surveys.stories.tsx
@@ -583,11 +583,11 @@ export const SurveyResults: Story = {
     ],
 }
 
-export const SurveyResponses: Story = {
+export const SurveySummaryExport: Story = {
     ...SurveyResults,
     parameters: {
         ...SurveyResults.parameters,
-        pageUrl: `${urls.survey(MOCK_SURVEY_WITH_RESULTS.id)}?tab=responses`,
+        pageUrl: `${urls.survey(MOCK_SURVEY_WITH_RESULTS.id)}?tab=summary`,
         testOptions: {
             waitForSelector: '#survey-responses-export',
         },


### PR DESCRIPTION
## Problem

Survey owners need a visible way to download answers while reviewing the Summary tab.

## Changes

- Add **Export responses** beside the Summary toolbar overflow menu, with CSV and Excel options.
- Keep the existing table export on Responses, avoiding a duplicate shortcut there.
- Reuse the export flow, access checks, current filters, and survey filename.

| Before | After |
| --- | --- |
| ![Summary without export shortcut](https://raw.githubusercontent.com/PostHog/pr-assets/29e815bc2a123a1729136dc0b3e451c96ddec2fc/2026/09/f3daf39d-82aa-4b55-a5e3-a0740e455cda.png) | ![Summary with export menu](https://raw.githubusercontent.com/PostHog/pr-assets/c301dc1267b261f6e72db666e220912f9a24e40f/2026/09/14dc8793-0cf9-4d3a-b499-40ef2afd4aff.png) |

## How did you test this code?

Browser checks covered both tabs, the export menu, expanded filters, and narrow layouts. Frontend typecheck, lint/format, and pre-push checks passed. Downloads were not exercised.
The Storybook case pins a 560-pixel viewport to catch toolbar wrapping regressions. No new export business logic needs unit coverage.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the survey response and performance documentation under `docs/`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used Git, GitHub CLI, hogli, and browser automation with existing Storybook mock data. The local CodeRabbit pass remains paused.

Rebased onto the redesign in #97771 and moved the shortcut to Summary after reviewing the duplicate table action. These screenshots replace the earlier Responses screenshot because that placement changed. Related PR #97725 restores response columns; it does not add this shortcut.

Skills: `writing-ui-components`, `writing-user-facing-copy`, `setting-feature-flags-in-storybook`, `writing-tests`, `writing-pr-descriptions`, `running-ci-preflight`, `reviewing-with-coderabbit`, `hogli`, `stacking-prs`, `setting-up-devbox`, `run-posthog`, and `django-migrations`.
