### PR TITLE
chore(readme): add yolo1 line

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,5 @@ The pricing for our paid plan is completely transparent and available on [our pr
 Hey! If you're reading this, you've proven yourself as a dedicated README reader.
 
 You might also make a great addition to our team. We're growing fast [and would love for you to join us](https://posthog.com/careers).
+
+yolo1


### PR DESCRIPTION
## Problem

A reader of the README needs a `yolo1` line at the end of the file, as requested.

## Changes

- Appends a `yolo1` line to the end of `README.md`. No code or behavior changes.

## How did you test this code?

No automated tests were run. The change is a single line of documentation text with no code path.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack request to add a `yolo1` line to the README. No repo skills were needed for a one-line docs edit. The CodeRabbit CLI pass is paused, so this PR opened without a local review pass. Nothing in this PR carries non-public material.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B85JA2DAA/p1789062450508979)*
