### PR TITLE
chore(ci): stop rerunning React Doctor on promotion

### DIFF
--- a/.github/workflows/desktop-react-doctor.yml
+++ b/.github/workflows/desktop-react-doctor.yml
@@ -6,7 +6,7 @@ name: Desktop React Doctor
 
 on:
     pull_request:
-        types: [opened, synchronize, reopened, ready_for_review]
+        types: [opened, synchronize, reopened]
         # Workflow-level paths only work because react-doctor is not a required
         # check. If it ever becomes required, move the skip into a gate job like
         # desktop-ci.yml, or path-skipped PRs will wait on it forever.


### PR DESCRIPTION
## Problem

Desktop contributors wait for the advisory React Doctor scan twice when a draft becomes ready, although promotion does not change its inputs or coverage.

## Changes

- The React Doctor workflow no longer listens for `ready_for_review`.
- The workflow still runs when a pull request opens, reopens, or receives a new commit.
- This change has no user-visible product effect.

```mermaid
flowchart LR
    A[Draft update] --> B[React Doctor]
    C[Ready for review] --> D[React Doctor again]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A,C phYellow;
    class B,D phBlue;
```

```mermaid
flowchart LR
    A[Draft update] --> B[React Doctor]
    C[Ready for review] --> D[No advisory rerun]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A,C phYellow;
    class B phBlue;
    class D phGray;
```

## How did you test this code?

- `bin/hogli lint:workflows`
- `actionlint -shellcheck='' .github/workflows/desktop-react-doctor.yml`
- `hogli ci:preflight --fix`

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The workflow already describes its advisory role.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

An OpenAI coding agent used `read`, `bash`, and `edit`. It invoked `/authoring-ci-workflows`, `/posthog-desktop`, `/running-ci-preflight`, and `/writing-pr-descriptions`.

The duplicate search found no overlapping React Doctor workflow PR. The CodeRabbit pass is paused, so this PR opened without a local pass.
