### PR TITLE
feat(feature-flags): attribute PostHog AI's flag writes to PostHog AI

### DIFF
--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -183,6 +183,10 @@ def _flag_write_source(request: Any) -> str:
     # below would read it as an unidentified caller.
     if getattr(request, "is_system", False):
         return "internal"
+    # PostHog AI builds its own request shim with no authenticator, so without this it lands
+    # in the same bucket as a caller we failed to identify.
+    if getattr(request, "is_posthog_ai", False):
+        return "posthog_ai"
     headers = getattr(request, "headers", None) or {}
     if headers.get("x-posthog-mcp-user-agent") or "posthog-mcp" in (headers.get("User-Agent") or ""):
         return "mcp"

--- a/products/feature_flags/backend/max_tools.py
+++ b/products/feature_flags/backend/max_tools.py
@@ -282,6 +282,7 @@ class CreateFeatureFlagTool(MaxTool):
                 user=self._user,
                 method="POST",
                 successful_authenticator=None,
+                is_posthog_ai=True,
                 session={},
                 data=serializer_data,
                 META={},

--- a/products/feature_flags/backend/test/test_max_tools.py
+++ b/products/feature_flags/backend/test/test_max_tools.py
@@ -8,6 +8,7 @@ from posthog.schema import FeatureFlagGroupType, GroupPropertyFilter, PersonProp
 from posthog.sync import database_sync_to_async
 from posthog.test.persons import create_group_type_mapping
 
+from products.feature_flags.backend.api.feature_flag import FLAG_FILTERS_WRITE_COUNTER
 from products.feature_flags.backend.max_tools import (
     CreateFeatureFlagTool,
     FeatureFlagCreationSchema,
@@ -35,6 +36,16 @@ class TestCreateFeatureFlagTool(APIBaseTest):
             tool_call_id="test-call",
             state=AssistantState(messages=[]),
         )
+
+    async def test_flag_writes_are_attributed_to_posthog_ai(self):
+        counted = FLAG_FILTERS_WRITE_COUNTER.labels(operation="create", outcome="accepted", source="posthog_ai")
+        before = counted._value.get()
+
+        await self._create_tool()._arun_impl(
+            feature_flag=FeatureFlagCreationSchema(key="attributed-flag", name="Attributed", groups=[ALL_USERS_GROUP])
+        )
+
+        assert counted._value.get() == before + 1
 
     async def test_create_flag_minimal(self):
         tool = self._create_tool()


### PR DESCRIPTION
## Problem

PostHog AI creates feature flags when someone asks it to, and it can create one that breaks a filters validation rule. Those writes currently count as `other`, the bucket for a caller we could not identify.

That hides the cheapest fix there is. A violation from PostHog AI is our own code, fixed without involving anyone. A violation from an unknown external caller needs investigation and probably a customer conversation. Both look identical today.

Follows PostHog/posthog#98424, which added the source label so the #50084 rollout can pick the next rule by caller.

## Changes

- PostHog AI's flag writes now count as `posthog_ai`, matching the naming already used by `NotebookCreationSource.MAX_AI` and the `products/posthog_ai/` product.
- PostHog AI declares itself on the request shim it builds, and the attribution reads that declaration, the same way it reads `is_system` for facade writes.

Both the write counter and the violation counter share this attribution, so each gains the bucket at once.

## How did you test this code?

Added one test to `TestCreateFeatureFlagTool` that creates a flag through the tool and asserts the write counted under `posthog_ai`.

It runs the real tool rather than the helper, so it covers the wiring: that the tool sets the marker, and that the attribution reads it. A function-level test would pass while the tool stayed unmarked.

Verified it fails for the right reason. Removing the marker makes the count stay at zero.

Not checked: the bucket appearing in Grafana, which needs a deploy.
