### PR TITLE
fix(warehouse-sources): keep scope-gated HubSpot tables in discovery

### DIFF
--- a/posthog/models/test/integration/test_oauth.py
+++ b/posthog/models/test/integration/test_oauth.py
@@ -128,6 +128,17 @@ class TestOauthIntegrationModel(BaseTest):
             assert "code_challenge" not in url
             assert cache.get("oauth_pkce_verifier/no_pkce_state_token") is None
 
+    def test_hubspot_authorize_url_requests_plan_gated_read_scopes_as_optional(self):
+        # A plan-gated scope in the mandatory `scope` fails the whole authorization for a portal
+        # that cannot grant it. Dropping it from `optional_scope` is just as bad: the connection
+        # authorizes without the scope and the tables it covers 403 on every sync.
+        with self.settings(**self.mock_settings):
+            url = OauthIntegration.authorize_url("hubspot", token="state_token", next="/projects/test")
+            params = {k: v[0] for k, v in parse_qs(url.partition("?")[2]).items()}
+
+            assert "crm.objects.leads.read" in params["optional_scope"].split(" ")
+            assert "crm.objects.leads.read" not in params["scope"].split(" ")
+
     def test_authorize_url_with_additional_authorize_params(self):
         with self.settings(**self.mock_settings):
             url = OauthIntegration.authorize_url("google-ads", token="state_token", next="/projects/test")

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/source.py
@@ -193,13 +193,8 @@ class HubspotSource(ResumableSource[HubspotSourceConfig | HubspotSourceOldConfig
         force_refresh: bool = False,
         api_version: str | None = None,
     ) -> list[SourceSchema]:
-        unreadable = self._endpoints_missing_scopes(config, team_id)
-
         schemas = []
         for endpoint in HUBSPOT_ENDPOINTS:
-            if endpoint in unreadable:
-                continue
-
             metadata_config = HUBSPOT_METADATA_ENDPOINT_CONFIGS.get(endpoint)
             if metadata_config is not None:
                 # Lookup tables have no server-side timestamp filter, so they are full refresh only.
@@ -232,35 +227,52 @@ class HubspotSource(ResumableSource[HubspotSourceConfig | HubspotSourceOldConfig
 
         return schemas
 
-    def _endpoints_missing_scopes(
-        self, config: HubspotSourceConfig | HubspotSourceOldConfig, team_id: int
-    ) -> frozenset[str]:
-        """Endpoints this connection provably cannot read, for want of an optional scope.
+    def get_endpoint_permissions(
+        self,
+        config: HubspotSourceConfig | HubspotSourceOldConfig,
+        team_id: int,
+        endpoints: list[str],
+        api_version: str | None = None,
+    ) -> dict[str, str | None]:
+        missing = self._missing_scopes(config, team_id)
+        reasons: dict[str, str | None] = {}
+        for endpoint in endpoints:
+            scope = missing.get(endpoint)
+            reasons[endpoint] = (
+                f"Reconnect your HubSpot account to grant the {scope} permission. Not every HubSpot plan includes it."
+                if scope is not None
+                else None
+            )
+        return reasons
 
-        Keeping them out of discovery means nobody can select a table whose every sync would 403,
-        and an already-selected one gets turned off by the next discovery run.
+    def _missing_scopes(self, config: HubspotSourceConfig | HubspotSourceOldConfig, team_id: int) -> dict[str, str]:
+        """Optional scopes this connection lacks, keyed by the endpoint that needs one.
+
+        Discovery still lists these endpoints. A table that the picker never shows leaves the user
+        with nothing to reconnect for, so the gap is reported next to the table instead.
         """
         if not SCOPE_GATED_OBJECTS or not isinstance(config, HubspotSourceConfig):
-            return frozenset()
+            return {}
 
         try:
             integration = self.get_oauth_integration(config.hubspot_integration_id, team_id)
         except ValueError as e:
-            # A missing or deleted integration is permanent, but discovery stays best-effort
+            # A missing or deleted integration is permanent, but the scope check stays best-effort
             # because the sync path already surfaces it with an actionable message.
-            logger.warning(f"Hubspot scope gating skipped, integration lookup failed: {e}", team_id=team_id)
-            return frozenset()
+            logger.warning(f"Hubspot scope check skipped, integration lookup failed: {e}", team_id=team_id)
+            return {}
         except Exception:
-            # Dropping tables on a transient lookup failure would churn schema rows, so gating
-            # fails open. Log it so a gating no-op is distinguishable from unknown scopes.
-            logger.exception("Hubspot scope gating skipped, integration lookup failed", team_id=team_id)
-            return frozenset()
+            # A transient lookup failure must not mark a readable table as unreadable, so the check
+            # fails open. Log it so a no-op check is distinguishable from complete scopes.
+            logger.exception("Hubspot scope check skipped, integration lookup failed", team_id=team_id)
+            return {}
 
-        return frozenset(
-            endpoint
-            for endpoint in SCOPE_GATED_OBJECTS
-            if missing_scope_for_endpoint(endpoint, integration.config) is not None
-        )
+        missing = {}
+        for endpoint in SCOPE_GATED_OBJECTS:
+            scope = missing_scope_for_endpoint(endpoint, integration.config)
+            if scope is not None:
+                missing[endpoint] = scope
+        return missing
 
     def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[HubspotResumeConfig]:
         return ResumableSourceManager[HubspotResumeConfig](inputs, HubspotResumeConfig)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/test/test_hubspot_scopes.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/test/test_hubspot_scopes.py
@@ -118,20 +118,25 @@ class TestScopeGatingInSource:
 
     @parameterized.expand(
         [
-            ("granted", {"scopes": [LEADS_SCOPE]}, True),
-            ("not_granted", {"scopes": ["tickets"]}, False),
-            ("unknown", {}, True),
+            ("granted", {"scopes": [LEADS_SCOPE]}, None),
+            ("not_granted", {"scopes": ["tickets"]}, LEADS_SCOPE),
+            ("unknown", {}, None),
         ]
     )
-    def test_leads_offered_only_when_the_scope_is_not_provably_missing(
-        self, _name: str, integration_config: dict[str, Any], expected: bool
+    def test_leads_is_always_offered_and_names_the_scope_it_needs(
+        self, _name: str, integration_config: dict[str, Any], expected_scope: str | None
     ) -> None:
         source = HubspotSource()
         with patch.object(source, "get_oauth_integration", return_value=_integration(integration_config)):
             names = {schema.name for schema in source.get_schemas(self._config(), team_id=1)}
+            permissions = source.get_endpoint_permissions(self._config(), 1, ["leads", "deals"])
 
-        assert ("leads" in names) is expected
-        assert "deals" in names
+        assert {"leads", "deals"} <= names
+        assert permissions["deals"] is None
+        if expected_scope is None:
+            assert permissions["leads"] is None
+        else:
+            assert expected_scope in (permissions["leads"] or "")
 
     def test_sync_fails_with_an_actionable_error_when_the_scope_is_missing(self) -> None:
         source = HubspotSource()


### PR DESCRIPTION
## Problem

- A HubSpot user whose account was never granted the Leads permission loses the Leads table from their source, and nothing in the product says why.
- Schema discovery drops any endpoint behind an optional OAuth scope the grant does not carry, so the table never reaches the schema list.
- The next discovery run then soft-deletes the stored row for that table, because a table nobody could see is a table nobody enabled.
- The user has nothing left to act on. The reason to reconnect the account is exactly the thing that was removed from the screen.
- HubSpot grants an optional scope silently, so no failure names the gap either.

## Changes

- The schema picker now lists a scope-gated table, names the permission to reconnect for, and keeps the row unselectable. It used to show nothing at all.
- `get_schemas` lists every endpoint. `get_endpoint_permissions` reports the missing scope per endpoint.
- The reason travels on the existing `permission_error` field, which the picker already renders and refuses to select for Stripe. No new field and no regenerated types.
- The sync-time gate in `source_for_pipeline` is unchanged, and these tables stay off by default, so nothing starts to sync on its own.
- A soft-deleted row is revived by rediscovery, so a table hidden by the old gate returns on the next run, still switched off.
- The rejected alternative was to keep hiding the table and improve the sync error. That error only reaches a user who can select the table, which is the state the gate prevents.

Nothing else in the diff is mechanical. No frontend code changed.

> [!NOTE]
> A user who reconnects and gains the scope sees the table return on its own, switched off. A user who cannot gain it now sees the table with the reason instead of an empty list.

## How did you test this code?

- `test_leads_is_always_offered_and_names_the_scope_it_needs` replaces the test that asserted the old hiding behavior. It catches a return to dropping the endpoint, which silently soft-deletes the stored row. Verified failing against master's `source.py`, on the case where the scope is absent.
- `test_hubspot_authorize_url_requests_plan_gated_read_scopes_as_optional` covers both ways the request can break: a plan-gated read scope in the mandatory `scope` fails authorization for every portal without that plan, and the same scope missing from `optional_scope` authorizes a connection whose tables then answer 403. No test read the requested scope split.
- Not done: no manual pass over the schema picker. The string is served by the existing `permission_error` path and no frontend code changed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The supported table list is unchanged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by Claude (PostHog Code) while triaging two support reports of the same symptom. Skills invoked: `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-tests`, `/announcing-behavior-changes`, `/writing-pr-descriptions`, `/reviewing-with-coderabbit`.
- CodeRabbit CLI pass: paused, so this PR opened without a local pass.
- `/announcing-behavior-changes`: no in-app notice. The change makes a missing table reappear switched off, which is what the affected users asked for, and only the backend can tell who is affected.
- No duplicate: `gh pr list --state all --search "hubspot in:title"` found #74909, merged, which added the gate this PR opens, and #96374, open, which moves the HubSpot write scopes to optional. #96374 edits the same block of `oauth.py` but does not touch discovery. Nothing open fixes this.
- Public artifact: the work started from customer reports. Nothing from those sessions reaches the diff. No portal, account, identifier, or error string from any customer appears, and the tests use scope constants already in the repo.
