### PR TITLE
fix(warehouse-sources): keep tuple element names in the S3 structure

### DIFF
--- a/products/data_warehouse/backend/models/test/test_table.py
+++ b/products/data_warehouse/backend/models/test/test_table.py
@@ -713,7 +713,7 @@ class TestTable(BaseTest):
         assert len(definition.fields) == 2
         assert (
             definition.structure
-            == "`id` Nullable(String), `nested` Array(Tuple( Nullable(String),  Tuple( Nullable(DateTime64(6, 'UTC')),  Nullable(String)),  Nullable(String),  Nullable(String),  Nullable(String),  Tuple( Nullable(String),  Map(String, Nullable(String))),  Tuple( Nullable(String),  Nullable(String),  Map(String, Nullable(String))),  Nullable(Float64),  Nullable(Bool),  Tuple( Array(Nullable(String)),  Array(Nullable(String)),  Map(String, Nullable(String))),  Tuple( Nullable(String),  Nullable(String),  Nullable(String),  Nullable(Bool),  Map(String, Nullable(String))),  Nullable(String),  Nullable(String),  Map(String, Nullable(String))))"
+            == "`id` Nullable(String), `nested` Array(Tuple(url Nullable(String), date Tuple(member0 Nullable(DateTime64(6, 'UTC')), member1 Nullable(String)), text Nullable(String), type Nullable(String), email Nullable(String), field Tuple(id Nullable(String), _airbyte_additional_properties Map(String, Nullable(String))), choice Tuple(id Nullable(String), label Nullable(String), _airbyte_additional_properties Map(String, Nullable(String))), number Nullable(Float64), boolean Nullable(Bool), choices Tuple(ids Array(Nullable(String)), labels Array(Nullable(String)), _airbyte_additional_properties Map(String, Nullable(String))), payment Tuple(name Nullable(String), last4 Nullable(String), amount Nullable(String), success Nullable(Bool), _airbyte_additional_properties Map(String, Nullable(String))), file_url Nullable(String), phone_number Nullable(String), _airbyte_additional_properties Map(String, Nullable(String))))"
         )
 
     def test_hogql_definition_tuple_patch(self):
@@ -741,7 +741,7 @@ class TestTable(BaseTest):
         )
         self.assertEqual(
             definition.structure,
-            "`id` String, `timestamp` DateTime64(3, 'UTC'), `mrr` Nullable(Int64), `complex_field` Array(Tuple( Nullable(String),  Nullable(String),  Map(String, Nullable(String)))), `tuple_field` Tuple(type Nullable(String), value Nullable(String), _airbyte_additional_properties Map(String, Nullable(String))), `offset` UInt32",
+            "`id` String, `timestamp` DateTime64(3, 'UTC'), `mrr` Nullable(Int64), `complex_field` Array(Tuple(type Nullable(String), value Nullable(String), _airbyte_additional_properties Map(String, Nullable(String)))), `tuple_field` Tuple(type Nullable(String), value Nullable(String), _airbyte_additional_properties Map(String, Nullable(String))), `offset` UInt32",
         )
 
     def test_hogql_definition_nullable(self):
@@ -987,7 +987,10 @@ class TestTable(BaseTest):
         result = remove_named_tuples("Array(Tuple(`1` String, `2` String, `3` Nullable(String)))")
         assert result == "Array(Tuple( String,  String,  Nullable(String)))"
 
-    def test_hogql_definition_tuple_with_backtick_positional_names(self):
+    def test_hogql_definition_keeps_tuple_element_names(self):
+        # The structure is how ClickHouse parses every read of the table. A row-oriented format
+        # matches object keys to the element names, so dropping them makes the column a positional
+        # array and each read raises CANNOT_PARSE_INPUT_ASSERTION_FAILED.
         credential = DataWarehouseCredential.objects.create(access_key="test", access_secret="test", team=self.team)
         table = DataWarehouseTable.objects.create(
             name="test_table",
@@ -1006,7 +1009,10 @@ class TestTable(BaseTest):
         )
         definition = table.hogql_definition()
         assert isinstance(definition, HogQLDataWarehouseTable)
-        assert definition.structure == "`id` String, `deal_details` Array(Tuple( String,  String,  Nullable(String)))"
+        assert (
+            definition.structure
+            == "`id` String, `deal_details` Array(Tuple(`1` String, `2` String, `3` Nullable(String)))"
+        )
 
     def assert_raises_with_invalid_hog_column_type(self, column_type):
         credential = DataWarehouseCredential.objects.create(access_key="test", access_secret="test", team=self.team)

--- a/products/warehouse_sources/backend/models/table.py
+++ b/products/warehouse_sources/backend/models/table.py
@@ -57,7 +57,6 @@ from products.warehouse_sources.backend.models.util import (
     STR_TO_HOGQL_MAPPING,
     clean_type,
     reconstruct_ordered_columns,
-    remove_named_tuples,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.consts import PARTITION_KEY
 from products.warehouse_sources.backend.types import DataWarehouseTableCreatedVia, DataWarehouseTableFormat
@@ -252,6 +251,10 @@ def hogql_fields_and_structure_for_columns(
     tables; direct virtual tables ignore them. ``column_order`` restores the SELECT order the
     jsonb column store drops (see ``reconstruct_ordered_columns``); omit it for column dicts
     whose insertion order is already meaningful.
+
+    A nested ``Tuple`` keeps the element names the stored type carries. A row-oriented format
+    matches object keys to the structure by name, so a nameless ``Tuple`` inside an ``Array`` is
+    read as a positional array and every read of that table fails to parse.
     """
     fields: dict[str, FieldOrTable] = {}
     structure = []
@@ -267,10 +270,6 @@ def hogql_fields_and_structure_for_columns(
         if clickhouse_type.startswith("Nullable("):
             clickhouse_type = clickhouse_type.replace("Nullable(", "")[:-1]
             is_nullable = True
-
-        # TODO: remove when addressed https://github.com/ClickHouse/ClickHouse/issues/37594
-        if clickhouse_type.startswith("Array("):
-            clickhouse_type = remove_named_tuples(clickhouse_type)
 
         if isinstance(type, dict):
             column_invalid = not type.get("valid", True)

--- a/products/warehouse_sources/backend/tests/test_table.py
+++ b/products/warehouse_sources/backend/tests/test_table.py
@@ -1,4 +1,6 @@
+import tempfile
 import subprocess
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -14,6 +16,7 @@ from parameterized import parameterized
 from posthog.hogql.database.direct_clickhouse_table import DirectClickHouseTable
 from posthog.hogql.database.models import DatabaseField, StringDatabaseField, UUIDDatabaseField
 from posthog.hogql.database.s3_table import DataWarehouseTable as HogQLDataWarehouseTable
+from posthog.hogql.escape_sql import escape_param_clickhouse
 
 from posthog.exceptions import ClickHouseAtCapacity
 
@@ -238,6 +241,50 @@ class TestRunChdbQuery:
                 run_chdb_query("DESCRIBE TABLE s3('https://example.com/table/')")
 
         assert not DataWarehouseTable()._is_suppressed_chdb_error(exc_info.value)
+
+
+class TestStructureAgainstTheEngine(BaseTest):
+    # chdb embeds the same ClickHouse engine that introspects a table and that every warehouse read
+    # runs against, over local files instead of S3. These cases therefore prove what the engine does
+    # with a structure we built, which no mock-based test can.
+
+    def _json_file(self, lines: list[str]) -> str:
+        path = Path(tempfile.mkdtemp()) / "rows.json"
+        path.write_text("".join(f"{line}\n" for line in lines))
+        return str(path)
+
+    def test_array_of_objects_is_readable_through_the_stored_structure(self) -> None:
+        # The element names are what makes the column parseable. Without them ClickHouse reads
+        # `items` as a positional array, so every query over the table raises code 27, including
+        # queries that never mention the column.
+        import chdb
+
+        table = DataWarehouseTable(
+            name="orders",
+            format=DataWarehouseTable.TableFormat.JSON,
+            team=self.team,
+            url_pattern="s3://bucket/team_1/orders/*",
+            columns={
+                "id": {"clickhouse": "Nullable(Int64)", "hogql": "IntegerDatabaseField", "valid": True},
+                "items": {
+                    "clickhouse": "Array(Tuple(sku Nullable(String), qty Nullable(Int64)))",
+                    "hogql": "StringArrayDatabaseField",
+                    "valid": True,
+                },
+            },
+        )
+        path = self._json_file(['{"id": 1, "items": [{"sku": "widget", "qty": 2}]}'])
+
+        definition = table.hogql_definition()
+        assert isinstance(definition, HogQLDataWarehouseTable)
+        assert definition.structure is not None
+        result = chdb.query(
+            f"SELECT items.sku FROM file({escape_param_clickhouse(path)}, JSONEachRow, "
+            f"{escape_param_clickhouse(definition.structure)})",
+            output_format="CSV",
+        )
+
+        assert "widget" in str(result)
 
 
 class TestGetHogqlFieldForColumn(SimpleTestCase):


### PR DESCRIPTION
## Problem

A query over a self-managed S3 table in the JSON format fails with "Cannot parse input" when the table has an array-of-objects column, even when the query never mentions that column.

- The stored column type is the one `DESCRIBE` reported, for example `Array(Tuple(sku String, qty Int64))`.
- `hogql_fields_and_structure_for_columns` stripped the element names before writing that type into the S3 table function's `structure`.
- ClickHouse reads a nameless `Tuple` positionally, so it expects `[["widget", 2]]` while the file holds `[{"sku": "widget", "qty": 2}]`.
- The read then raises code 27 `CANNOT_PARSE_INPUT_ASSERTION_FAILED` for the whole table.
- `validate_column_type` cannot flag the column, because its `count(col)` probe succeeds through column pruning.
- The stripping worked around [ClickHouse/ClickHouse#37594](https://github.com/ClickHouse/ClickHouse/issues/37594), a 2022 parser bug that no longer applies.

## Changes

- An array-of-objects column in a JSON table is readable again, and its subfields resolve (`items.sku`).
- The structure keeps the element names the stored type carries.
- Parameterized inner types stop being mangled. The stripping turned `Array(Decimal(10, 2))` into `Array(Decimal(, ))` and `Array(FixedString(16))` into `Array(FixedString())`, and ClickHouse rejects both.
- Parquet and Delta tables read as before, because ClickHouse matches a parquet struct by position whether or not the structure names its elements.
- `remove_named_tuples` stays where `clean_type` calls it, which only needs the base type name.

## How did you test this code?

Verified against chdb 3.3.0, the pinned version and the engine `get_columns` runs first, over local fixture files.

| structure for `items` | JSONEachRow | Parquet |
| --- | --- | --- |
| `Array(Tuple(sku String, qty Int64))` | reads, and `items.sku` resolves | reads |
| `Array(Tuple(String, Int64))` | code 27 `CANNOT_PARSE_INPUT_ASSERTION_FAILED` | reads |

- New test: reads an array-of-objects file through the structure the model builds, using the same chdb engine. A mock cannot catch a revert here, because the defect is what ClickHouse does with the string.
- Updated three existing assertions that pinned the stripped structure, including two that cover Typeform-shaped nested types.
- Ran locally: `products/warehouse_sources/backend/tests/test_table.py`, `products/data_warehouse/backend/models/test/test_table.py`, `products/data_warehouse/backend/tests/api/test_table.py`.
- Not run: the rest of the backend suite, and no manual test against a real bucket.

## Automatic notifications

- [ ] Publish to changelog?

Nothing to announce. An error that stops happening needs no notice, and the columns that become readable were already in the catalog.

## Docs update

None. No doc under `docs/` covers warehouse table introspection.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus 5) while taking over #94289, which needs this fix first: widening schema inference discovers array-of-objects columns that narrow inference missed, and each one would enter the structure nameless and make the whole table unqueryable.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, `/announcing-behavior-changes`, `/stacking-prs`, `/reviewing-with-coderabbit`. The CodeRabbit pass is paused, so this PR opened without a local CodeRabbit review.

Nothing in this PR carries material from the agent session. The fixture data is invented.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
