### PR TITLE
feat(warehouse-sources): let MySQL verify the server certificate

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs/mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs/mysql.py
@@ -14,4 +14,5 @@ class MySQLSourceConfig(config.Config):
     port: int = config.value(converter=int)
     schema: str | None = None
     using_ssl: bool = config.value(default=config.str_to_bool("true"), converter=config.str_to_bool)
+    verify_server_certificate: bool = config.value(default=config.str_to_bool("false"), converter=config.str_to_bool)
     ssh_tunnel: SSHTunnelConfig | None = None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
@@ -16,6 +16,7 @@ module-scope primitives.
 
 from __future__ import annotations
 
+import ssl
 import time
 import socket
 import datetime
@@ -701,6 +702,25 @@ def _open_pymysql_connection(kwargs: dict[str, Any], team_id: int | None) -> pym
     return connection
 
 
+def _require_negotiated_tls(connection: pymysql.Connection) -> None:
+    """Fail a connection that asked for a verified certificate and did not get TLS at all.
+
+    pymysql wraps the socket only when the server advertises the TLS capability, and the check has
+    no else branch, so a server that offers no TLS is served in plaintext and raises nothing. The
+    handshake has already sent the credentials by the time we can see this, so the check stops us
+    reading data over an unverified connection rather than protecting that first exchange.
+    """
+    # `_sock` is private, so it is not in the stubs. Reading it defensively also fails closed if a
+    # later pymysql renames it: no socket to inspect is treated as no TLS.
+    if isinstance(getattr(connection, "_sock", None), ssl.SSLSocket):
+        return
+    raise pymysql.err.OperationalError(
+        CR.CR_SSL_CONNECTION_ERROR,
+        "The MySQL server did not offer a TLS connection. Turn off certificate verification for "
+        "this source, or enable TLS on the server.",
+    )
+
+
 def _connect_with_transient_retry(kwargs: dict[str, Any], team_id: int | None) -> pymysql.Connection:
     """Open a pymysql connection, retrying a transient drop or timeout on connect.
 
@@ -1052,9 +1072,17 @@ class MySQLImplementation(SQLSourceImplementation[MySQLSourceConfig, pymysql.Con
         so multi-GB filesorts don't drop on middlebox timeouts before the
         first rows are ready.
         """
+        verify_certificate = config.verify_server_certificate
         ssl_ca: str | None = None
-        if config.using_ssl:
+        # Verification implies TLS, so a user who asks us to check the certificate gets the
+        # encrypted connection that check needs, whatever `using_ssl` says.
+        if config.using_ssl or verify_certificate:
             ssl_ca = "/etc/ssl/cert.pem" if settings.DEBUG else "/etc/ssl/certs/ca-certificates.crt"
+
+        # The tunnel presents the database on a loopback address, so the certificate's hostname
+        # cannot match the address pymysql dials. The chain check still applies there.
+        tunnel = config.ssh_tunnel
+        verify_hostname = verify_certificate and not (tunnel is not None and tunnel.enabled)
 
         with self._ssh_tunnel_endpoint(config, team_id) as (host, port):
             kwargs: dict[str, Any] = {
@@ -1067,12 +1095,18 @@ class MySQLImplementation(SQLSourceImplementation[MySQLSourceConfig, pymysql.Con
                 "password": config.password,
                 "connect_timeout": 10,
                 "ssl_ca": ssl_ca,
+                # pymysql resolves `ssl_ca` on its own to `verify_mode=CERT_NONE`, so only an
+                # explicit True verifies. None leaves that prior behavior untouched.
+                "ssl_verify_cert": True if verify_certificate else None,
+                "ssl_verify_identity": True if verify_hostname else None,
                 "conv": _MYSQL_SAFE_CONVERSIONS,
                 "init_command": "SET workload = 'OLAP';" if host.endswith("psdb.cloud") else None,
             }
             if read_timeout is not None:
                 kwargs["read_timeout"] = read_timeout
             with _connect_with_transient_retry(kwargs, team_id) as conn:
+                if verify_certificate:
+                    _require_negotiated_tls(conn)
                 yield conn
 
     @contextmanager

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
@@ -16,7 +16,6 @@ module-scope primitives.
 
 from __future__ import annotations
 
-import ssl
 import time
 import socket
 import datetime
@@ -32,7 +31,7 @@ import pyarrow as pa
 import pymysql
 import structlog
 import pymysql.converters
-from pymysql.constants import CR, FIELD_TYPE
+from pymysql.constants import CLIENT, CR, FIELD_TYPE
 from pymysql.cursors import Cursor, SSCursor
 from structlog.types import FilteringBoundLogger
 
@@ -689,36 +688,45 @@ def _reconnect_pinned(connection: pymysql.Connection, team_id: int | None) -> No
     connection.connect(sock=_pinned_socket(connection.host, connection.port, connection.connect_timeout, team_id))
 
 
+class _TLSRequiredConnection(pymysql.Connection):
+    """A connection that refuses to authenticate when the server offers no TLS.
+
+    pymysql wraps the socket only when the server advertises the TLS capability, and that check
+    has no else branch, so a missing or stripped flag is served in plaintext and raises nothing.
+    Refusing here stops the credentials before they cross that connection, and covers every
+    reconnect as well: `Connection.connect()` runs this method each time it reopens the socket.
+    """
+
+    def _request_authentication(self) -> None:
+        # The stubs declare neither the handshake hook nor the capability flags it reads.
+        offers_tls = bool(self.server_capabilities & CLIENT.SSL)  # type: ignore[attr-defined]
+        if self.ssl and not offers_tls:
+            raise pymysql.err.OperationalError(
+                CR.CR_SSL_CONNECTION_ERROR,
+                "The MySQL server did not offer a TLS connection. Turn off certificate "
+                "verification for this source, or enable TLS on the server.",
+            )
+        super()._request_authentication()  # type: ignore[misc]
+
+
+def _new_connection(kwargs: dict[str, Any], **extra: Any) -> pymysql.Connection:
+    """Build the connection, refusing plaintext when this source verifies the certificate."""
+    if kwargs.get("ssl_verify_cert"):
+        return _TLSRequiredConnection(**kwargs, **extra)
+    return pymysql.connect(**kwargs, **extra)
+
+
 def _open_pymysql_connection(kwargs: dict[str, Any], team_id: int | None) -> pymysql.Connection:
     sock = _pinned_socket(kwargs["host"], kwargs["port"], kwargs["connect_timeout"], team_id)
     if sock is None:
-        return pymysql.connect(**kwargs)
+        return _new_connection(kwargs)
 
     # `host` stays the hostname so pymysql sends it as the TLS server name, and PlanetScale, which
     # turns on `ssl_verify_identity`, verifies the certificate against it. Python sends no SNI for
     # an IP literal. Only the TCP connect goes to the pinned address.
-    connection = pymysql.connect(**kwargs, defer_connect=True)
+    connection = _new_connection(kwargs, defer_connect=True)
     connection.connect(sock=sock)
     return connection
-
-
-def _require_negotiated_tls(connection: pymysql.Connection) -> None:
-    """Fail a connection that asked for a verified certificate and did not get TLS at all.
-
-    pymysql wraps the socket only when the server advertises the TLS capability, and the check has
-    no else branch, so a server that offers no TLS is served in plaintext and raises nothing. The
-    handshake has already sent the credentials by the time we can see this, so the check stops us
-    reading data over an unverified connection rather than protecting that first exchange.
-    """
-    # `_sock` is private, so it is not in the stubs. Reading it defensively also fails closed if a
-    # later pymysql renames it: no socket to inspect is treated as no TLS.
-    if isinstance(getattr(connection, "_sock", None), ssl.SSLSocket):
-        return
-    raise pymysql.err.OperationalError(
-        CR.CR_SSL_CONNECTION_ERROR,
-        "The MySQL server did not offer a TLS connection. Turn off certificate verification for "
-        "this source, or enable TLS on the server.",
-    )
 
 
 def _connect_with_transient_retry(kwargs: dict[str, Any], team_id: int | None) -> pymysql.Connection:
@@ -1105,8 +1113,6 @@ class MySQLImplementation(SQLSourceImplementation[MySQLSourceConfig, pymysql.Con
             if read_timeout is not None:
                 kwargs["read_timeout"] = read_timeout
             with _connect_with_transient_retry(kwargs, team_id) as conn:
-                if verify_certificate:
-                    _require_negotiated_tls(conn)
                 yield conn
 
     @contextmanager

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -179,6 +179,23 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
                             SourceFieldSelectConfigOption(label="No", value="false"),
                         ],
                     ),
+                    SourceFieldSelectConfig(
+                        name="verify_server_certificate",
+                        label="Verify the server certificate?",
+                        required=True,
+                        defaultValue="false",
+                        converter=SourceFieldSelectConfigConverter.STR_TO_BOOL,
+                        caption=(
+                            "Check that your database's TLS certificate comes from a trusted authority. "
+                            "A self-signed certificate or a private authority does not pass, so leave this off "
+                            "if you use one. Through an SSH tunnel we check the certificate chain but not the "
+                            "hostname, because the tunnel presents your database on a local address."
+                        ),
+                        options=[
+                            SourceFieldSelectConfigOption(label="Yes", value="true"),
+                            SourceFieldSelectConfigOption(label="No", value="false"),
+                        ],
+                    ),
                     SourceFieldSSHTunnelConfig(name="ssh_tunnel", label="Use SSH tunnel?"),
                 ],
             ),

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -1,4 +1,3 @@
-import ssl
 import socket
 import datetime
 from collections.abc import Generator, Iterator
@@ -11,6 +10,7 @@ from unittest.mock import MagicMock, patch
 from django.test import override_settings
 
 import pymysql
+from pymysql.constants import CLIENT
 from sshtunnel import BaseSSHTunnelForwarderError
 
 from posthog.dataclasses import frozen
@@ -54,6 +54,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysq
     _safe_convert_date,
     _safe_convert_datetime,
     _sanitize_identifier,
+    _TLSRequiredConnection,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.mysql.source import (
     _INVALID_CREDENTIALS_ERROR,
@@ -2808,10 +2809,10 @@ def _loopback_tunnel() -> Iterator[tuple[str, int]]:
 
 class TestConnectCertificateVerification:
     @staticmethod
-    def _connect_kwargs(mocker, *, using_ssl: str, verify: str, tunneled: bool) -> dict:
+    def _connect(mocker, *, using_ssl: str, verify: str, tunneled: bool) -> tuple[dict, bool]:
         connection = MagicMock()
-        connection.__enter__.return_value._sock = MagicMock(spec=ssl.SSLSocket)
-        mock_connect = mocker.patch(f"{_MYSQL_MODULE}.pymysql.connect", return_value=connection)
+        plain = mocker.patch(f"{_MYSQL_MODULE}.pymysql.connect", return_value=connection)
+        refusing = mocker.patch(f"{_MYSQL_MODULE}._TLSRequiredConnection", return_value=connection)
         overrides: dict = {"using_ssl": using_ssl, "verify_server_certificate": verify}
         if tunneled:
             overrides["ssh_tunnel"] = {"enabled": "true", "host": "bastion.example.com", "port": "22"}
@@ -2820,7 +2821,8 @@ class TestConnectCertificateVerification:
         with MySQLImplementation().connect(_make_config(**overrides)):
             pass
 
-        return mock_connect.call_args.kwargs
+        used = refusing if refusing.called else plain
+        return used.call_args.kwargs, refusing.called
 
     @pytest.mark.parametrize(
         "using_ssl,verify,tunneled,expected_ca,expected_cert,expected_identity",
@@ -2835,31 +2837,30 @@ class TestConnectCertificateVerification:
     def test_verification_kwargs(
         self, mocker, using_ssl, verify, tunneled, expected_ca, expected_cert, expected_identity
     ):
-        # pymysql resolves `ssl_ca` on its own to `verify_mode=CERT_NONE`, so these three kwargs
-        # decide whether TLS is verified. A default that stopped being None would start verifying
-        # every existing source, and a private CA or self-signed certificate fails that check.
-        # `ssl_verify_identity` through the tunnel would check the certificate against the
-        # loopback address the forwarder binds, which no certificate carries.
-        kwargs = self._connect_kwargs(mocker, using_ssl=using_ssl, verify=verify, tunneled=tunneled)
+        # pymysql resolves `ssl_ca` on its own to `verify_mode=CERT_NONE`, so a default that stopped
+        # being None would start verifying every existing source. `ssl_verify_identity` through the
+        # tunnel would check the certificate against the loopback address the forwarder binds.
+        kwargs, refuses_plaintext = self._connect(mocker, using_ssl=using_ssl, verify=verify, tunneled=tunneled)
 
         assert (kwargs["ssl_ca"] is not None) is expected_ca
         assert kwargs["ssl_verify_cert"] is expected_cert
         assert kwargs["ssl_verify_identity"] is expected_identity
+        assert refuses_plaintext is (expected_cert is True)
 
-    @pytest.mark.parametrize("verify,expected_error", [("true", True), ("false", False)])
-    def test_a_server_that_offers_no_tls(self, mocker, verify, expected_error):
-        # pymysql wraps the socket only when the server advertises the TLS capability and has no
-        # else branch, so an unverified source keeps reading data over a plaintext connection.
-        connection = MagicMock()
-        connection.__enter__.return_value._sock = MagicMock(spec=socket.socket)
-        mocker.patch(f"{_MYSQL_MODULE}.pymysql.connect", return_value=connection)
-        config = _make_config(using_ssl="true", verify_server_certificate=verify)
+    @pytest.mark.parametrize("capabilities,refused", [(0, True), (CLIENT.SSL, False)])
+    def test_authentication_against_a_server_that_advertises_tls_or_not(self, mocker, capabilities, refused):
+        # The credentials go out during `_request_authentication`, and every reconnect runs it
+        # again, so refusing here is what keeps both off a plaintext connection.
+        connection = _TLSRequiredConnection(
+            host="db.example.com", user="u", password="p", ssl_ca="/etc/ssl/cert.pem", defer_connect=True
+        )
+        connection.server_capabilities = capabilities  # type: ignore[attr-defined]
+        delegate = mocker.patch.object(pymysql.connections.Connection, "_request_authentication")
 
-        if not expected_error:
-            with MySQLImplementation().connect(config):
-                pass
-            return
-
-        with pytest.raises(pymysql.err.OperationalError, match="did not offer a TLS connection"):
-            with MySQLImplementation().connect(config):
-                pass
+        if refused:
+            with pytest.raises(pymysql.err.OperationalError, match="did not offer a TLS connection"):
+                connection._request_authentication()
+            delegate.assert_not_called()
+        else:
+            connection._request_authentication()
+            delegate.assert_called_once()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -2851,8 +2851,10 @@ class TestConnectCertificateVerification:
     def test_authentication_against_a_server_that_advertises_tls_or_not(self, mocker, capabilities, refused):
         # The credentials go out during `_request_authentication`, and every reconnect runs it
         # again, so refusing here is what keeps both off a plaintext connection.
+        # `ssl_verify_cert` is what the connect path passes, and it sets `ssl` without reading a CA
+        # file off disk, which no fixed path can promise across a developer machine and CI.
         connection = _TLSRequiredConnection(
-            host="db.example.com", user="u", password="p", ssl_ca="/etc/ssl/cert.pem", defer_connect=True
+            host="db.example.com", user="u", password="p", ssl_verify_cert=True, defer_connect=True
         )
         connection.server_capabilities = capabilities  # type: ignore[attr-defined]
         delegate = mocker.patch.object(pymysql.connections.Connection, "_request_authentication")

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -1,3 +1,4 @@
+import ssl
 import socket
 import datetime
 from collections.abc import Generator, Iterator
@@ -2798,3 +2799,67 @@ class TestMySQLConnectDialsOnlyValidatedAddresses:
 
         cloud.create_connection.assert_not_called()
         connection.connect.assert_not_called()
+
+
+@contextmanager
+def _loopback_tunnel() -> Iterator[tuple[str, int]]:
+    yield "127.0.0.1", 13306
+
+
+class TestConnectCertificateVerification:
+    @staticmethod
+    def _connect_kwargs(mocker, *, using_ssl: str, verify: str, tunneled: bool) -> dict:
+        connection = MagicMock()
+        connection.__enter__.return_value._sock = MagicMock(spec=ssl.SSLSocket)
+        mock_connect = mocker.patch(f"{_MYSQL_MODULE}.pymysql.connect", return_value=connection)
+        overrides: dict = {"using_ssl": using_ssl, "verify_server_certificate": verify}
+        if tunneled:
+            overrides["ssh_tunnel"] = {"enabled": "true", "host": "bastion.example.com", "port": "22"}
+            mocker.patch(f"{_MYSQL_MODULE}.open_ssh_tunnel", return_value=_loopback_tunnel())
+
+        with MySQLImplementation().connect(_make_config(**overrides)):
+            pass
+
+        return mock_connect.call_args.kwargs
+
+    @pytest.mark.parametrize(
+        "using_ssl,verify,tunneled,expected_ca,expected_cert,expected_identity",
+        [
+            ("true", "false", False, True, None, None),
+            ("false", "false", False, False, None, None),
+            ("true", "true", False, True, True, True),
+            ("true", "true", True, True, True, None),
+            ("false", "true", False, True, True, True),
+        ],
+    )
+    def test_verification_kwargs(
+        self, mocker, using_ssl, verify, tunneled, expected_ca, expected_cert, expected_identity
+    ):
+        # pymysql resolves `ssl_ca` on its own to `verify_mode=CERT_NONE`, so these three kwargs
+        # decide whether TLS is verified. A default that stopped being None would start verifying
+        # every existing source, and a private CA or self-signed certificate fails that check.
+        # `ssl_verify_identity` through the tunnel would check the certificate against the
+        # loopback address the forwarder binds, which no certificate carries.
+        kwargs = self._connect_kwargs(mocker, using_ssl=using_ssl, verify=verify, tunneled=tunneled)
+
+        assert (kwargs["ssl_ca"] is not None) is expected_ca
+        assert kwargs["ssl_verify_cert"] is expected_cert
+        assert kwargs["ssl_verify_identity"] is expected_identity
+
+    @pytest.mark.parametrize("verify,expected_error", [("true", True), ("false", False)])
+    def test_a_server_that_offers_no_tls(self, mocker, verify, expected_error):
+        # pymysql wraps the socket only when the server advertises the TLS capability and has no
+        # else branch, so an unverified source keeps reading data over a plaintext connection.
+        connection = MagicMock()
+        connection.__enter__.return_value._sock = MagicMock(spec=socket.socket)
+        mocker.patch(f"{_MYSQL_MODULE}.pymysql.connect", return_value=connection)
+        config = _make_config(using_ssl="true", verify_server_certificate=verify)
+
+        if not expected_error:
+            with MySQLImplementation().connect(config):
+                pass
+            return
+
+        with pytest.raises(pymysql.err.OperationalError, match="did not offer a TLS connection"):
+            with MySQLImplementation().connect(config):
+                pass


### PR DESCRIPTION
## Problem

- A user connecting a production MySQL database cannot tell which server answered. The connection is encrypted, and PostHog accepts any certificate the server presents.
- The MySQL source passes `ssl_ca` and nothing else. pymysql 1.1.1 resolves `ssl_ca` on its own to `verify_mode=CERT_NONE` and `check_hostname=False`, so the CA bundle is loaded and never used. See `Connection.__init__` and `_create_ssl_ctx`.
- pymysql wraps the socket only when the server advertises the TLS capability, and that check has no else branch. A server that offers no TLS is served in plaintext and raises nothing.
- PlanetScale MySQL already sets `ssl_verify_cert` and `ssl_verify_identity`. It can set both because it has no tunnel option.

## Changes

- MySQL setup now offers "Verify the server certificate?". Turning it on checks the certificate against the system trust store on every connect, and a certificate that fails the check fails the connection.
- The field defaults to off, so every existing source keeps today's behavior. No rollout is needed and nothing breaks for a source on a private authority or a self-signed certificate.
- Verification implies TLS. A user who turns it on gets the encrypted connection the check needs, whatever "Use SSL?" says.
- A server that offers no TLS is refused before the credentials go out. `_TLSRequiredConnection` overrides pymysql's handshake hook, which `Connection.connect()` runs on every reopen, so a mid-sync reconnect carries the same guard as the first connect.
- PlanetScale MySQL shares this connect path and already sets `ssl_verify_cert`, so it picks up the same refusal. PlanetScale always serves TLS, so the guard fires only on a stripped capability flag.
- The field caption states that a self-signed certificate or a private authority does not pass, so a user picks the right answer before the first sync fails.

> [!WARNING]
> Hostname verification applies only to a direct connection. Through an SSH tunnel, pymysql dials the loopback address the forwarder binds, and `ssl_verify_identity` would check the certificate against that address rather than the database hostname. It would fail every tunneled MySQL source.
>
> Handing pymysql the real hostname while dialing the tunnel needs `defer_connect`, which this PR's base already uses for address pinning. The blocker is the reconnect path: `_reconnect_pinned` re-dials `connection.host`, so a hostname there would send a mid-sync reconnect straight at the database and around the tunnel. That is a worse hole than the one it closes, so a tunneled source gets chain verification only, and the caption says so.

> [!NOTE]
> Out of scope, and unchanged by this PR:
>
> - The "Require TLS through tunnel?" control renders for every tunneled source, and only the Postgres family reads it (`postgres/postgres.py:177`). It has no effect on MySQL, MSSQL, Redshift or ClickHouse.
> - Postgres never verifies a certificate either. `_get_sslmode` returns `require` or `prefer`, never `verify-ca` or `verify-full`.
> - SFTP connects without checking the server host key.

## How did you test this code?

`TestConnectCertificateVerification` in `products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py`:

- `test_verification_kwargs` covers the three TLS kwargs across five combinations of "Use SSL?", verification, and the tunnel, and asserts which connection class each combination selects. The default row is the one that matters most: a default that stopped being `None` would start verifying every existing source, and a private authority or self-signed certificate fails that check. The tunneled row locks in `ssl_verify_identity=None`, which is the trap in the warning above.
- `test_authentication_against_a_server_that_advertises_tls_or_not` asserts the superclass handshake is never reached when the server advertises no TLS, so the credentials never cross that connection, and that it is reached when the server does advertise it.

314 tests in the MySQL suite pass, and the source config codegen snapshot passes.

One correction to an earlier revision of this description. `test_authentication_against_a_server_that_advertises_tls_or_not` built a real connection with the macOS CA bundle path, so pymysql opened a file the Linux runner does not have and both cases failed on CI while passing locally. The test now passes `ssl_verify_cert`, which is the kwarg the connect path passes and reads nothing off disk.

Not run: the database-backed API suites. The test persons database in this sandbox carries a migration this branch does not resolve, which fails setup for every database-backed test, including ones this PR does not touch.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No in-repo doc covers the MySQL source's TLS toggles. The public source docs live on posthog.com. The field caption carries what a user needs at setup.

## 🤖 Agent context

**Autonomy:** Supervised

- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/writing-user-facing-copy`, `/writing-code-comments`, `/reviewing-with-coderabbit`.
- No CodeRabbit pass. The CLI is installed but signed out, and signing in needs a browser. Comment `@coderabbitai review` to get one.
- `hogli build:openapi` produces no diff, so the generated types are current.
- Stacked on #97454, which rewrites the MySQL connect path. Landing this on master first would conflict there.
- Read the pymysql 1.1.1 source rather than its docs to confirm the `CERT_NONE` resolution and the missing else branch on the TLS capability check.
- `pnpm generate:source-configs` rewrites all 1335 generated config modules. Only `generated_configs/mysql.py` is kept here; the other 22 rewrites are reverted.
- The opt-in default is deliberate. The codegen ties a select field's wizard default to its dataclass default, so a default of "yes" would also flip every source that has no stored value. Turning the default on is a follow-up, once we know how many MySQL sources present a publicly trusted certificate.
- Review findings from `greptile-apps` and `parameterai`, both on the TLS guard, are fixed rather than rejected. Both were right: the old post-connect check ran after pymysql had authenticated, and `_reconnect_pinned` never repeated it. Moving the guard into the connection class fixes both at once and stops the plaintext credential exchange the post-connect check could not.
- No customer material reached the diff or this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*


