### PR TITLE
fix(bing_ads): keep urllib transport failures retryable and unreported

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/source.py
@@ -163,6 +163,13 @@ class BingAdsSource(ResumableSource[BingAdsSourceConfig, BingAdsResumeConfig], O
             # Bing's queue, so the next Temporal attempt submits a fresh request and normally clears it.
             # Match the SDK's stable message text, which carries no request or account values.
             "Reporting file download tracking status timeout",
+            # A urllib transport failure reaching Bing's SOAP endpoints — connection refused, DNS or
+            # TLS failure, socket timeout — which suds surfaces as `URLError` and our wrapper re-raises
+            # as `ValueError(... URLError: <urlopen error ...>)`. The endpoints are fixed (see
+            # utils.ENVIRONMENT), so nothing at this layer is customer-configured or deterministic: the
+            # next Temporal attempt normally clears it. Match the exception name plus urllib's fixed
+            # message prefix, which together carry no request or account values.
+            "URLError: <urlopen error",
         }
 
     @property

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_source.py
@@ -375,6 +375,10 @@ class TestBingAdsSource:
             # submits a fresh report request, so this must stay retryable rather than disable the schema.
             "Failed to generate ad_group_performance_report report: ReportingDownloadException: "
             "Reporting file download tracking status timeout.",
+            # A urllib transport failure against Bing's fixed SOAP endpoint. The endpoint is not
+            # customer-configured, so a refused connection is a network blip the next attempt clears —
+            # it must stay retryable rather than report as a bug or disable the schema.
+            "Failed to fetch customer ID: URLError: <urlopen error [Errno 111] Connection refused>",
         ],
     )
     def test_transient_failures_are_retryable_not_disabling(self, error_message):


### PR DESCRIPTION
## Problem

A Bing Ads sync that cannot reach Microsoft's SOAP endpoint fails the run and reports the blip to error tracking as a bug, so a network hiccup pages an engineer and looks like a defect in the connector.

- `BingAdsClient.get_customer_id` wraps whatever the SDK raises, so a urllib transport failure arrives as `ValueError("Failed to fetch customer ID: URLError: <urlopen error ...>")`.
- The source classifies neither shape, so `_handle_import_error` falls through to its default branch, logs at `exception`, and re-raises a reportable error.
- Observed as a live error tracking issue: [ValueError: Failed to fetch customer ID (URLError)](https://us.posthog.com/project/2/error_tracking/01a08c9c-dd8a-7292-96bf-ab79d611bb1c).

## Changes

- A refused, timed-out or unresolvable connection to Bing now logs as a warning and stays out of error tracking. The sync still fails and Temporal still retries it, so nothing changes for the customer.
- `BingAdsSource.get_retryable_errors` matches `URLError: <urlopen error`, next to the existing bare-400 and report-timeout entries.
- The endpoints are fixed in `utils.ENVIRONMENT` and are not customer-configured, so no failure at this layer is deterministic or actionable. That is why this is retryable rather than an entry in `get_non_retryable_errors`, which would disable a schema over a network blip.
- The pattern matches the exception name plus urllib's fixed message prefix. The reason text that follows is a socket error string and carries no request or account values.

## How did you test this code?

- Extended the existing `test_transient_failures_are_retryable_not_disabling` case list with the refused-connection shape. It catches a regression no existing test covers: a transport failure against Bing being reported as a bug, or a future non-retryable pattern widening far enough to disable a schema on a blip.
- Ran `products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_source.py` locally; it passes.
- Not run: the rest of the warehouse sources suite, and any live sync against Bing Ads. No manual testing was done.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged from an error tracking issue with Claude Code, using the PostHog MCP error tracking tools to confirm the stack frame, exception type and frequency before reading the source.
- Skills invoked: `/writing-pr-descriptions`.
- The first question was whether this belonged in `get_non_retryable_errors`. It does not: the failure is transient infrastructure, and disabling a schema over it would make a customer re-enable a sync they never broke. `get_retryable_errors` keeps the retry and removes only the false alarm.
- No duplicate: `gh pr list --state open` searched for the module path, the exception type and the maintainer's own open PRs. Nothing open touches this error in the Bing Ads source.
- CodeRabbit CLI pass: paused, so this PR opened without a local review pass.
- Public artifact: the committed pattern and test string are generic urllib text. No customer values appear in the diff, the commit message or this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
