### PR TITLE
fix(posthog-ai): render execute-sql query results

### DIFF
--- a/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
+++ b/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
@@ -443,8 +443,10 @@ removes that metadata and retries the size check. Text and status still reach th
 client when the remaining event fits; events that remain oversized are dropped.
 
 Native widgets read app data, existing `structuredContent`, or a direct result object.
-They never decode TOON or JSON from result text or reconstruct an executed query from
-tool arguments. Old transcripts containing only text show the generic tool card.
+They never decode TOON or JSON from result text.
+The `execute-sql` widget builds a `HogQLQuery` from the tool arguments, preserving `connectionId` and `sendRawQuery`, and renders it through the shared Query component in a `DataVisualizationNode`.
+The Query component fetches the results for this visualization.
+Other query widgets require the executed query from the tool result. Old transcripts containing only text show the generic tool card for those tools.
 Failed calls and missing or malformed widget data also use that fallback.
 The web client resolves tool identity from ACP `_meta.posthog`, with legacy
 `_meta.claudeCode` support. Non-exec MCP tools retain their qualified metadata names

--- a/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
+++ b/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
@@ -444,9 +444,11 @@ client when the remaining event fits; events that remain oversized are dropped.
 
 Native widgets read app data, existing `structuredContent`, or a direct result object.
 They never decode TOON or JSON from result text.
-The `execute-sql` widget builds a `HogQLQuery` from the tool arguments, preserving `connectionId` and `sendRawQuery`, and renders it through the shared Query component in a `DataVisualizationNode`.
+The `execute-sql` backend returns the executed query in `structured_content` alongside its formatted text.
+The MCP handler forwards that query as widget metadata, preserving resolved saved-variable definitions, `connectionId`, and `sendRawQuery`.
+The widget renders it through the shared Query component in a `DataVisualizationNode`.
 The Query component fetches the results for this visualization.
-Other query widgets require the executed query from the tool result. Old transcripts containing only text show the generic tool card for those tools.
+All query widgets require the executed query from the tool result. Old transcripts containing only text show the generic tool card.
 Failed calls and missing or malformed widget data also use that fallback.
 The web client resolves tool identity from ACP `_meta.posthog`, with legacy
 `_meta.claudeCode` support. Non-exec MCP tools retain their qualified metadata names

--- a/ee/hogai/mcp_tool.py
+++ b/ee/hogai/mcp_tool.py
@@ -2,12 +2,19 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Generic, TypeVar
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, JsonValue
 
 from posthog.event_usage import EventSource
 from posthog.models import Team, User
 
 ArgsT = TypeVar("ArgsT", bound=BaseModel)
+
+
+class MCPToolResult(BaseModel):
+    content: str = Field(description="Formatted tool output for the model.")
+    structured_content: dict[str, JsonValue] | None = Field(
+        default=None, description="Structured tool output for native widgets."
+    )
 
 
 class MCPTool(ABC, Generic[ArgsT]):
@@ -30,12 +37,12 @@ class MCPTool(ABC, Generic[ArgsT]):
         self._event_source = event_source
 
     @abstractmethod
-    async def execute(self, args: ArgsT) -> str:
+    async def execute(self, args: ArgsT) -> str | MCPToolResult:
         """
         Execute the tool with validated args.
 
         Returns:
-            Content string for LLM consumption.
+            Model-facing text, optionally accompanied by structured widget data.
 
         Raises:
             MaxToolRetryableError: For errors that can be fixed with adjusted inputs.

--- a/ee/hogai/tools/execute_sql/mcp_tool.py
+++ b/ee/hogai/tools/execute_sql/mcp_tool.py
@@ -15,7 +15,7 @@ from products.warehouse_sources.backend.facade.models import ExternalDataSource
 from ee.hogai.chat_agent.schema_generator.parsers import PydanticOutputParserException
 from ee.hogai.chat_agent.sql.mixins import HogQLOutputParserMixin
 from ee.hogai.context.insight.context import InsightContext
-from ee.hogai.mcp_tool import MCPTool, mcp_tool_registry
+from ee.hogai.mcp_tool import MCPTool, MCPToolResult, mcp_tool_registry
 from ee.hogai.tool_errors import MaxToolRetryableError
 from ee.hogai.tools.execute_sql.direct_connection_suggestions import build_direct_connection_suggestion
 from ee.hogai.tools.execute_sql.import_suggestions import build_import_suggestion, extract_unknown_tables
@@ -60,7 +60,7 @@ class ExecuteSQLMCPTool(HogQLOutputParserMixin, MCPTool[ExecuteSQLMCPToolArgs]):
     name = "execute_sql"
     args_schema = ExecuteSQLMCPToolArgs
 
-    async def execute(self, args: ExecuteSQLMCPToolArgs) -> str:
+    async def execute(self, args: ExecuteSQLMCPToolArgs) -> MCPToolResult:
         query: AssistantHogQLQuery | HogQLQuery
         taxonomy_warnings: list[HogQLNotice] = []
         if args.connectionId:
@@ -109,7 +109,10 @@ class ExecuteSQLMCPTool(HogQLOutputParserMixin, MCPTool[ExecuteSQLMCPToolArgs]):
             prompt_template="{{{results}}}", truncate_results=args.truncate, include_prompt_framing=False
         )
 
-        return _prepend_taxonomy_warnings(results, taxonomy_warnings)
+        return MCPToolResult(
+            content=_prepend_taxonomy_warnings(results, taxonomy_warnings),
+            structured_content={"query": query.model_dump(mode="json", exclude_none=True)},
+        )
 
     async def _maybe_unknown_table_suggestion(self, validation_message: str) -> str | None:
         """When a query fails on an unknown table, say where that table actually is.

--- a/ee/hogai/tools/execute_sql/test/test_mcp_tool.py
+++ b/ee/hogai/tools/execute_sql/test/test_mcp_tool.py
@@ -6,9 +6,11 @@ from asgiref.sync import sync_to_async
 from posthog.schema import HogQLNotice, HogQLQuery
 
 from posthog.models import EventDefinition
+from posthog.sync import database_sync_to_async
 
-from products.product_analytics.backend.facade.models import Insight
+from products.product_analytics.backend.facade.models import Insight, InsightVariable
 
+from ee.hogai.context.insight.context import InsightContext
 from ee.hogai.tool_errors import MaxToolRetryableError
 from ee.hogai.tools.execute_sql.mcp_tool import (
     ExecuteSQLMCPTool,
@@ -29,24 +31,46 @@ class TestExecuteSQLMCPTool(ClickhouseTestMixin, NonAtomicBaseTest):
         _create_event(team=self.team, distinct_id="user1", event="test_event")
         _create_event(team=self.team, distinct_id="user2", event="test_event")
 
-        content = await self.tool.execute(
+        result = await self.tool.execute(
             ExecuteSQLMCPToolArgs(query="SELECT event, count() as cnt FROM events GROUP BY event"),
         )
 
-        self.assertIn("test_event", content)
+        self.assertIn("test_event", result.content)
+
+    async def test_saved_variables_survive_visualization_query_reexecution(self) -> None:
+        variable = await database_sync_to_async(InsightVariable.objects.create)(
+            team=self.team,
+            name="Organization",
+            code_name="org",
+            type=InsightVariable.Type.STRING,
+            default_value="Example organization",
+        )
+        result = await self.tool.execute(ExecuteSQLMCPToolArgs(query="SELECT {variables.org} AS org;"))
+
+        assert result.structured_content is not None
+        query = HogQLQuery.model_validate(result.structured_content["query"])
+        self.assertEqual(query.query, "SELECT {variables.org} AS org")
+        assert query.variables is not None
+        self.assertEqual(query.variables[str(variable.id)].code_name, "org")
+
+        replay = await InsightContext(team=self.team, user=self.user, query=query).execute_and_format(
+            prompt_template="{{{results}}}", include_prompt_framing=False
+        )
+        self.assertIn("Example organization", result.content)
+        self.assertEqual(replay, result.content)
 
     async def test_result_has_no_prompt_framing(self):
         _create_event(team=self.team, distinct_id="user1", event="test_event")
 
-        content = await self.tool.execute(
+        result = await self.tool.execute(
             ExecuteSQLMCPToolArgs(query="SELECT event, count() as cnt FROM events GROUP BY event"),
         )
 
         # The MCP tool returns the data table straight to an external agent, so the human-assistant
         # framing (format description + "Here is the results table of the ... insight:" reminder) is stripped.
-        self.assertIn("test_event", content)
-        self.assertNotIn("You are given a table with the results of a SQL query", content)
-        self.assertNotIn("Here is the results table", content)
+        self.assertIn("test_event", result.content)
+        self.assertNotIn("You are given a table with the results of a SQL query", result.content)
+        self.assertNotIn("Here is the results table", result.content)
 
     async def test_validation_error_for_invalid_query(self):
         with self.assertRaises(MaxToolRetryableError) as ctx:
@@ -76,47 +100,47 @@ class TestExecuteSQLMCPTool(ClickhouseTestMixin, NonAtomicBaseTest):
             query={"kind": "TrendsQuery", "series": [{"event": "$pageview", "kind": "EventsNode"}]},
         )
 
-        content = await self.tool.execute(
+        result = await self.tool.execute(
             ExecuteSQLMCPToolArgs(query="SELECT id, name FROM system.insights"),
         )
 
-        self.assertIn("Revenue Trends", content)
+        self.assertIn("Revenue Trends", result.content)
 
     async def test_taxonomy_warning_for_unknown_event(self):
         await sync_to_async(EventDefinition.objects.create)(team=self.team, name="paid_bill")
 
-        content = await self.tool.execute(
+        result = await self.tool.execute(
             ExecuteSQLMCPToolArgs(query="SELECT count() FROM events WHERE event = 'purchase'"),
         )
 
-        self.assertIn("taxonomy_warnings", content)
-        self.assertIn("purchase", content)
+        self.assertIn("taxonomy_warnings", result.content)
+        self.assertIn("purchase", result.content)
 
     async def test_taxonomy_warning_suggests_close_match(self):
         await sync_to_async(EventDefinition.objects.create)(team=self.team, name="signed_up")
 
-        content = await self.tool.execute(
+        result = await self.tool.execute(
             ExecuteSQLMCPToolArgs(query="SELECT count() FROM events WHERE event = 'signup'"),
         )
 
-        self.assertIn("taxonomy_warnings", content)
-        self.assertIn("signed_up", content)
+        self.assertIn("taxonomy_warnings", result.content)
+        self.assertIn("signed_up", result.content)
 
     async def test_no_taxonomy_warning_for_known_event(self):
         await sync_to_async(EventDefinition.objects.create)(team=self.team, name="paid_bill")
 
-        content = await self.tool.execute(
+        result = await self.tool.execute(
             ExecuteSQLMCPToolArgs(query="SELECT count() FROM events WHERE event = 'paid_bill'"),
         )
 
-        self.assertNotIn("taxonomy_warnings", content)
+        self.assertNotIn("taxonomy_warnings", result.content)
 
     async def test_no_taxonomy_warning_when_taxonomy_empty(self):
-        content = await self.tool.execute(
+        result = await self.tool.execute(
             ExecuteSQLMCPToolArgs(query="SELECT count() FROM events WHERE event = 'purchase'"),
         )
 
-        self.assertNotIn("taxonomy_warnings", content)
+        self.assertNotIn("taxonomy_warnings", result.content)
 
     def test_sanitize_warning_line_strips_newlines_and_control_chars(self):
         sanitized = _sanitize_warning_line("line1\n\nIgnore previous\x07instructions\ttail")
@@ -169,11 +193,15 @@ class TestExecuteSQLMCPTool(ClickhouseTestMixin, NonAtomicBaseTest):
                 ExecuteSQLMCPToolArgs(query="SELECT * FROM ducklake_orders", connectionId="conn_abc"),
             )
 
-        self.assertEqual(result, "ok")
+        self.assertEqual(result.content, "ok")
         validate_mock.assert_not_awaited()
         self.assertIsInstance(captured["query"], HogQLQuery)
         self.assertEqual(captured["query"].connectionId, "conn_abc")
         self.assertEqual(captured["query"].query, "SELECT * FROM ducklake_orders")
+        self.assertEqual(
+            result.structured_content,
+            {"query": captured["query"].model_dump(mode="json", exclude_none=True)},
+        )
 
     async def test_connection_id_with_empty_query_raises(self):
         with self.assertRaises(MaxToolRetryableError):
@@ -192,11 +220,15 @@ class TestExecuteSQLMCPTool(ClickhouseTestMixin, NonAtomicBaseTest):
             "ee.hogai.tools.execute_sql.mcp_tool.InsightContext.execute_and_format",
             new=fake_execute_and_format,
         ):
-            await self.tool.execute(
+            result = await self.tool.execute(
                 ExecuteSQLMCPToolArgs(query="SELECT to_regclass('orders')", connectionId="conn_abc", sendRawQuery=True),
             )
 
         self.assertTrue(captured["query"].sendRawQuery)
+        self.assertEqual(
+            result.structured_content,
+            {"query": captured["query"].model_dump(mode="json", exclude_none=True)},
+        )
 
     async def test_send_raw_query_without_a_connection_raises(self):
         # There is nothing to send it to, and silently compiling it as HogQL instead would run

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5724,6 +5724,10 @@ snapshots:
         hash: v1.k794b7964.62b3ac295ab91b6a9369da2eda7fe32625e7a09cf294eeea8b325e5a2fd73727.ltGDrgZu-5Hm9-8_mKONY3B6jSpmiHOEq4kTvjMptJE
     products-posthog-ai-threadview--error-tracking--light:
         hash: v1.k794b7964.a6d1f1caf6f9db190492f6aaf34e767039050da2fa1054ca20ff4b7f351b664f.dziwktOLa5g7S874DtTlJ4Qgow2OOF24FQ8QwX252SM
+    products-posthog-ai-threadview--execute-sql-with-variables--dark:
+        hash: v1.k794b7964.056f88152e13f9df1228665f670fa21156d2ae25331189069860fc4cf0277bb3._ccmzZyJGWprmT_pQzBm6zVVSm1XWf95e4k2RAtETRg
+    products-posthog-ai-threadview--execute-sql-with-variables--light:
+        hash: v1.k794b7964.7fc04cb62a05ca664d0a2520e44c2197502ae7bdcbebd5e65c6e1dc5aed12abe.pC_Qk-HoW9e7e1g1Vyn25RI91BJ1KrBuzn-E7zCDPkM
     products-posthog-ai-threadview--saved-insight-query--dark:
         hash: v1.k794b7964.ff266ce4b007479bd8156db3c4b65a91a8b987d226bfd7622b20085df50d5d1c.2IsZbL1hVZEqsqWd22bNC0XJvJSqSlXHKCc0LGtJzJc
     products-posthog-ai-threadview--saved-insight-query--light:

--- a/products/posthog_ai/backend/api/mcp_tools.py
+++ b/products/posthog_ai/backend/api/mcp_tools.py
@@ -26,11 +26,21 @@ from posthog.event_usage import get_event_source
 from posthog.models.user import User
 from posthog.renderers import SafeJSONRenderer
 
-from ee.hogai.mcp_tool import mcp_tool_registry
+from ee.hogai.mcp_tool import MCPToolResult, mcp_tool_registry
 from ee.hogai.tool_errors import MaxToolError
 from ee.hogai.tools.search import format_inkeep_docs_response
 
 logger = get_logger(__name__)
+
+
+class MCPToolRequest(pydantic.BaseModel):
+    args: dict[str, pydantic.JsonValue] = pydantic.Field(
+        default_factory=dict, description="Arguments validated against the selected tool's schema."
+    )
+
+
+class MCPToolResponse(MCPToolResult):
+    success: bool = pydantic.Field(description="Whether the tool completed successfully.")
 
 
 class DocsSearchRequestSerializer(serializers.Serializer):
@@ -110,7 +120,8 @@ class MCPToolsViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
 
     @extend_schema(
         parameters=[OpenApiParameter("tool_name", OpenApiTypes.STR, OpenApiParameter.PATH)],
-        responses={200: OpenApiTypes.OBJECT},
+        request=MCPToolRequest,
+        responses={200: MCPToolResponse},
     )
     @action(
         detail=False,
@@ -150,11 +161,11 @@ class MCPToolsViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
 
         try:
 
-            async def execute_tool() -> str:
+            async def execute_tool() -> str | MCPToolResult:
                 with tags_context(feature=Feature.MCP, team_id=self.team.pk, org_id=self.team.organization_id):
                     return await tool.execute(validated_args)
 
-            content = async_to_sync(execute_tool)()
+            result = async_to_sync(execute_tool)()
         except MaxToolError as e:
             return Response(
                 {
@@ -172,7 +183,9 @@ class MCPToolsViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
                 }
             )
 
-        return Response({"success": True, "content": content})
+        if isinstance(result, str):
+            result = MCPToolResult(content=result)
+        return Response({"success": True, **result.model_dump(exclude_none=True)})
 
 
 async def _run_inkeep_docs_search(client: AsyncOpenAI, query: str) -> str:

--- a/products/posthog_ai/backend/api/test_mcp_tools.py
+++ b/products/posthog_ai/backend/api/test_mcp_tools.py
@@ -3,12 +3,15 @@ from datetime import UTC, datetime
 from posthog.test.base import APIBaseTest
 from unittest.mock import AsyncMock, patch
 
+from parameterized import parameterized
 from rest_framework import status
 
 from posthog.schema import CachedTeamTaxonomyQueryResponse
 
 from posthog.event_usage import EventSource
 from posthog.models import Organization, Team
+
+from ee.hogai.mcp_tool import MCPToolResult
 
 
 class TestMCPToolsAPI(APIBaseTest):
@@ -56,9 +59,18 @@ class TestMCPToolsAPI(APIBaseTest):
         self.assertFalse(data["success"])
         self.assertIn("validation error", data["content"].lower())
 
+    @parameterized.expand([("text_only", False), ("structured_query", True)])
     @patch("ee.hogai.tools.execute_sql.mcp_tool.ExecuteSQLMCPTool.execute", new_callable=AsyncMock)
-    def test_invoke_execute_sql_success(self, mock_execute):
-        mock_execute.return_value = "event | cnt\ntest_event | 5"
+    def test_invoke_execute_sql_success(self, _name: str, structured: bool, mock_execute: AsyncMock) -> None:
+        content = "event | cnt\ntest_event | 5"
+        query = {
+            "kind": "HogQLQuery",
+            "query": "SELECT {variables.org}",
+            "variables": {"example-variable": {"variableId": "example-variable", "code_name": "org"}},
+        }
+        mock_execute.return_value = (
+            MCPToolResult(content=content, structured_content={"query": query}) if structured else content
+        )
 
         response = self.client.post(
             f"/api/environments/{self.team.id}/mcp_tools/execute_sql/",
@@ -69,7 +81,11 @@ class TestMCPToolsAPI(APIBaseTest):
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertTrue(data["success"])
-        self.assertIn("test_event", data["content"])
+        self.assertEqual(data["content"], content)
+        if structured:
+            self.assertEqual(data["structured_content"], {"query": query})
+        else:
+            self.assertNotIn("structured_content", data)
         mock_execute.assert_called_once()
 
     @patch("ee.hogai.utils.helpers.TeamTaxonomyQueryRunner")

--- a/products/posthog_ai/frontend/components/ThreadActivityGroup.test.tsx
+++ b/products/posthog_ai/frontend/components/ThreadActivityGroup.test.tsx
@@ -108,7 +108,7 @@ describe('ThreadActivityGroup', () => {
         )
         fireEvent.click(screen.getByTestId('thread-activity-toggle'))
         const chain = screen.getByTestId('thread-tool-chain')
-        expect(chain).toHaveTextContent('execute-sql· 3 calls· 1 failed')
+        expect(chain).toHaveTextContent('SQL query· 3 calls· 1 failed')
         expect(screen.queryByText('first')).not.toBeInTheDocument()
         fireEvent.click(chain.querySelector('[role="button"]')!)
         for (const id of tools.keys()) {

--- a/products/posthog_ai/frontend/components/ThreadView.stories.tsx
+++ b/products/posthog_ai/frontend/components/ThreadView.stories.tsx
@@ -69,7 +69,7 @@ const meta: Meta<ThreadFixtureProps> = {
             return unmount
         }, [streamKey, toolName, title, toolInput, rawOutput])
         return (
-            <div className="w-full max-w-180 h-160 border rounded">
+            <div className="w-180 max-w-full h-160 border rounded">
                 <BindLogic logic={runStreamLogic} props={{ streamKey }}>
                     <ThreadView />
                 </BindLogic>

--- a/products/posthog_ai/frontend/components/ThreadView.stories.tsx
+++ b/products/posthog_ai/frontend/components/ThreadView.stories.tsx
@@ -11,6 +11,7 @@ interface ThreadFixtureProps {
     streamKey: string
     toolName: string
     title: string
+    toolInput: Record<string, unknown>
     rawOutput: unknown
 }
 
@@ -20,9 +21,10 @@ const meta: Meta<ThreadFixtureProps> = {
         streamKey: 'synthetic-conversation',
         toolName: 'notebooks-create',
         title: 'Create notebook',
+        toolInput: {},
         rawOutput: { short_id: 'example-notebook', title: 'Synthetic notebook' },
     },
-    render: ({ streamKey, toolName, title, rawOutput }) => {
+    render: ({ streamKey, toolName, title, toolInput, rawOutput }) => {
         useEffect(() => {
             const logic = runStreamLogic({ streamKey })
             const unmount = logic.mount()
@@ -39,7 +41,7 @@ const meta: Meta<ThreadFixtureProps> = {
                                 serverName: 'posthog',
                                 toolName: 'exec',
                                 status: 'in_progress',
-                                rawInput: { command: `call ${toolName} {}` },
+                                rawInput: { command: `call ${toolName} ${JSON.stringify(toolInput)}` },
                                 _meta: { claudeCode: { toolName: 'mcp__posthog__exec' } },
                             },
                         },
@@ -65,9 +67,9 @@ const meta: Meta<ThreadFixtureProps> = {
                 'replay'
             )
             return unmount
-        }, [streamKey, toolName, title, rawOutput])
+        }, [streamKey, toolName, title, toolInput, rawOutput])
         return (
-            <div className="w-180 h-160 border rounded">
+            <div className="w-full max-w-180 h-160 border rounded">
                 <BindLogic logic={runStreamLogic} props={{ streamKey }}>
                     <ThreadView />
                 </BindLogic>
@@ -127,4 +129,30 @@ export const SavedInsightQuery: Story = {
             },
         }),
     ],
+}
+
+export const ExecuteSqlWithVariables: Story = {
+    ...SavedInsightQuery,
+    args: {
+        toolName: 'execute-sql',
+        title: 'Run SQL query',
+        toolInput: { query: 'SELECT {variables.example_value} AS value;' },
+        rawOutput: {
+            content: [{ type: 'text', text: 'value\n4242' }],
+            _meta: {
+                'com.posthog.mcp/app_data': {
+                    query: {
+                        kind: 'HogQLQuery',
+                        query: 'SELECT {variables.example_value} AS value',
+                        variables: {
+                            '0199c0de-1111-7000-8000-0000000000aa': {
+                                variableId: '0199c0de-1111-7000-8000-0000000000aa',
+                                code_name: 'example_value',
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
 }

--- a/products/posthog_ai/frontend/components/tool/toolRegistry.test.tsx
+++ b/products/posthog_ai/frontend/components/tool/toolRegistry.test.tsx
@@ -23,6 +23,7 @@ describe('toolRegistry', () => {
     it('resolves product declarations after importing only the registry', () => {
         expect(toolRegistry.lookup('insight-create')?.displayName).toEqual('Insight')
         expect(toolRegistry.lookup('query-trends')?.displayName).toEqual('Trends query')
+        expect(toolRegistry.lookup('execute-sql')?.keepVisible).toBe(true)
         expect(toolRegistry.lookup('query-error-tracking-issues-list')?.displayName).toEqual('Error tracking')
         expect(
             require.cache[require.resolve('products/error_tracking/frontend/posthogAi/ErrorTrackingWidget')]
@@ -71,6 +72,7 @@ describe('toolRegistry', () => {
         ['notebooks-create', 'Notebook'],
         ['dashboard-create', 'Dashboard'],
         ['query-trends', 'Trends query'],
+        ['execute-sql', 'SQL query'],
         ['insight-query', 'Insight query'],
         ['query-error-tracking-issues-list', 'Error tracking'],
     ])('gates product widget %s on a trusted PostHog-exec origin', (key, displayName) => {

--- a/products/posthog_ai/frontend/components/tool/widgets/extractors.test.ts
+++ b/products/posthog_ai/frontend/components/tool/widgets/extractors.test.ts
@@ -162,30 +162,46 @@ describe('mcp tool adapter extractors', () => {
     })
 
     describe('extractQueryResult', () => {
-        it.each([{}, { connectionId: 'example-connection', sendRawQuery: true }])(
-            'renders SQL from the input when the result is text: %j',
-            (options) => {
-                const input = { query: 'SELECT 1', ...options }
-                const result = extractQueryResult(
-                    toolMessage({ content: [{ type: 'text', text: '1' }] }, input, 'execute-sql')
+        it.each([
+            { kind: 'HogQLQuery', query: 'SELECT 1' },
+            { kind: 'HogQLQuery', query: 'SELECT 1', connectionId: 'example-connection', sendRawQuery: true },
+            {
+                kind: 'HogQLQuery',
+                query: 'SELECT {variables.org}',
+                variables: { 'example-variable': { variableId: 'example-variable', code_name: 'org' } },
+            },
+        ])('renders the executed SQL query with its resolved settings: %j', (query) => {
+            const result = extractQueryResult(
+                toolMessage(
+                    {
+                        content: [{ type: 'text', text: '1' }],
+                        _meta: { 'com.posthog.mcp/app_data': { query } },
+                    },
+                    { query: `${query.query};` },
+                    'execute-sql'
                 )
-                expect(result?.content.query).toEqual({ kind: 'HogQLQuery', ...input })
-                expect(result?.url).toBeNull()
-            }
-        )
+            )
+            expect(result?.content.query).toEqual(query)
+            expect(result?.url).toBeNull()
+        })
 
         it.each<Partial<ToolCallMessage>>([
             { status: 'pending' },
             { status: 'in_progress' },
             { status: 'failed' },
             { rawOutput: { isError: true } },
-            { innerInput: { query: '   ' } },
-            { innerInput: { query: 1 } },
-            { innerInput: undefined },
-        ])('does not render an unsuccessful or malformed SQL call: %j', (overrides) => {
+            { rawOutput: { content: [{ type: 'text', text: '1' }] } },
+            { rawOutput: { _meta: { 'com.posthog.mcp/app_data': { query: 'SELECT 1' } } } },
+            { rawOutput: { _meta: { 'com.posthog.mcp/app_data': { query: { kind: 'HogQLQuery' } } } } },
+            { rawOutput: undefined },
+        ])('falls back for incomplete SQL calls or missing query metadata: %j', (overrides) => {
             expect(
                 extractQueryResult({
-                    ...toolMessage(undefined, { query: 'SELECT 1' }, 'execute-sql'),
+                    ...toolMessage(
+                        { _meta: { 'com.posthog.mcp/app_data': { query: { kind: 'HogQLQuery', query: 'SELECT 1' } } } },
+                        { query: 'SELECT {variables.org}' },
+                        'execute-sql'
+                    ),
                     ...overrides,
                 })
             ).toBeNull()

--- a/products/posthog_ai/frontend/components/tool/widgets/extractors.test.ts
+++ b/products/posthog_ai/frontend/components/tool/widgets/extractors.test.ts
@@ -162,6 +162,35 @@ describe('mcp tool adapter extractors', () => {
     })
 
     describe('extractQueryResult', () => {
+        it.each([{}, { connectionId: 'example-connection', sendRawQuery: true }])(
+            'renders SQL from the input when the result is text: %j',
+            (options) => {
+                const input = { query: 'SELECT 1', ...options }
+                const result = extractQueryResult(
+                    toolMessage({ content: [{ type: 'text', text: '1' }] }, input, 'execute-sql')
+                )
+                expect(result?.content.query).toEqual({ kind: 'HogQLQuery', ...input })
+                expect(result?.url).toBeNull()
+            }
+        )
+
+        it.each<Partial<ToolCallMessage>>([
+            { status: 'pending' },
+            { status: 'in_progress' },
+            { status: 'failed' },
+            { rawOutput: { isError: true } },
+            { innerInput: { query: '   ' } },
+            { innerInput: { query: 1 } },
+            { innerInput: undefined },
+        ])('does not render an unsuccessful or malformed SQL call: %j', (overrides) => {
+            expect(
+                extractQueryResult({
+                    ...toolMessage(undefined, { query: 'SELECT 1' }, 'execute-sql'),
+                    ...overrides,
+                })
+            ).toBeNull()
+        })
+
         it.each([
             { kind: 'TrendsQuery', series: [] },
             { kind: 'HogQLQuery', query: 'SELECT 1' },

--- a/products/posthog_ai/frontend/components/tool/widgets/extractors.ts
+++ b/products/posthog_ai/frontend/components/tool/widgets/extractors.ts
@@ -94,31 +94,16 @@ export interface QueryResultExtraction {
  * renderer (e.g. a single LLM trace) return null and fall back to the generic card.
  */
 export function extractQueryResult(message: ToolCallMessage): QueryResultExtraction | null {
-    if (message.resolvedKey === 'execute-sql') {
-        const input = message.innerInput
-        const sql = asString(input?.query)
-        if (message.status !== 'completed' || asRecord(message.rawOutput)?.isError === true || !sql?.trim()) {
-            return null
-        }
-
-        // SQL tools return text, so the Query component fetches the visualization from the input query.
-        return {
-            content: {
-                content_type: ArtifactContentType.Visualization,
-                query: {
-                    kind: NodeKind.HogQLQuery,
-                    query: sql,
-                    ...(typeof input?.connectionId === 'string' ? { connectionId: input.connectionId } : {}),
-                    ...(typeof input?.sendRawQuery === 'boolean' ? { sendRawQuery: input.sendRawQuery } : {}),
-                },
-            },
-            url: null,
-        }
+    if (message.status !== 'completed') {
+        return null
     }
 
     const output = getToolOutputRecord(message)
     const query = asRecord(output?.query)
     if (!query || typeof query.kind !== 'string') {
+        return null
+    }
+    if (isHogQLQuery(query) && !asString(query.query)?.trim()) {
         return null
     }
 

--- a/products/posthog_ai/frontend/components/tool/widgets/extractors.ts
+++ b/products/posthog_ai/frontend/components/tool/widgets/extractors.ts
@@ -94,6 +94,28 @@ export interface QueryResultExtraction {
  * renderer (e.g. a single LLM trace) return null and fall back to the generic card.
  */
 export function extractQueryResult(message: ToolCallMessage): QueryResultExtraction | null {
+    if (message.resolvedKey === 'execute-sql') {
+        const input = message.innerInput
+        const sql = asString(input?.query)
+        if (message.status !== 'completed' || asRecord(message.rawOutput)?.isError === true || !sql?.trim()) {
+            return null
+        }
+
+        // SQL tools return text, so the Query component fetches the visualization from the input query.
+        return {
+            content: {
+                content_type: ArtifactContentType.Visualization,
+                query: {
+                    kind: NodeKind.HogQLQuery,
+                    query: sql,
+                    ...(typeof input?.connectionId === 'string' ? { connectionId: input.connectionId } : {}),
+                    ...(typeof input?.sendRawQuery === 'boolean' ? { sendRawQuery: input.sendRawQuery } : {}),
+                },
+            },
+            url: null,
+        }
+    }
+
     const output = getToolOutputRecord(message)
     const query = asRecord(output?.query)
     if (!query || typeof query.kind !== 'string') {

--- a/products/posthog_ai/frontend/generated/api.schemas.ts
+++ b/products/posthog_ai/frontend/generated/api.schemas.ts
@@ -572,6 +572,32 @@ export interface SandboxMessageResponseApi {
     just_created_run: boolean
 }
 
+export interface JsonValueApi {}
+
+/**
+ * Arguments validated against the selected tool's schema.
+ */
+export type MCPToolRequestApiArgs = { [key: string]: JsonValueApi }
+
+export interface MCPToolRequestApi {
+    /** Arguments validated against the selected tool's schema. */
+    args?: MCPToolRequestApiArgs
+}
+
+/**
+ * Structured tool output for native widgets.
+ */
+export type MCPToolResponseApiStructuredContent = { [key: string]: JsonValueApi } | null
+
+export interface MCPToolResponseApi {
+    /** Formatted tool output for the model. */
+    content: string
+    /** Structured tool output for native widgets. */
+    structured_content?: MCPToolResponseApiStructuredContent
+    /** Whether the tool completed successfully. */
+    success: boolean
+}
+
 export interface DocsSearchRequestApi {
     /** Natural-language description of what to find in the PostHog documentation. Inkeep performs hybrid (semantic + full-text) RAG, so phrase the query the way a user would ask the question. */
     query: string
@@ -592,5 +618,3 @@ export type ConversationsListParams = {
      */
     offset?: number
 }
-
-export type McpToolsCreate200 = { [key: string]: unknown }

--- a/products/posthog_ai/frontend/generated/api.ts
+++ b/products/posthog_ai/frontend/generated/api.ts
@@ -13,7 +13,8 @@ import type {
     ConversationsListParams,
     DocsSearchRequestApi,
     DocsSearchResponseApi,
-    McpToolsCreate200,
+    MCPToolRequestApi,
+    MCPToolResponseApi,
     MessageApi,
     MessageMinimalApi,
     PaginatedConversationMinimalListApi,
@@ -288,11 +289,14 @@ export const getMcpToolsCreateUrl = (projectId: string, toolName: string) => {
 export const mcpToolsCreate = async (
     projectId: string,
     toolName: string,
+    mCPToolRequestApi?: MCPToolRequestApi,
     options?: RequestInit
-): Promise<McpToolsCreate200> => {
-    return apiMutator<McpToolsCreate200>(getMcpToolsCreateUrl(projectId, toolName), {
+): Promise<MCPToolResponseApi> => {
+    return apiMutator<MCPToolResponseApi>(getMcpToolsCreateUrl(projectId, toolName), {
         ...options,
         method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(mCPToolRequestApi),
     })
 }
 

--- a/products/posthog_ai/frontend/generated/api.zod.ts
+++ b/products/posthog_ai/frontend/generated/api.zod.ts
@@ -155,6 +155,21 @@ export const ConversationsQueuePartialUpdateBody = /* @__PURE__ */ zod.looseObje
 export const ConversationsQueueClearCreateBody = /* @__PURE__ */ zod.looseObject({})
 
 /**
+ * Invoke an MCP tool by name.
+ *
+ * This endpoint allows MCP callers to invoke Max AI tools directly
+ * without going through the full LangChain conversation flow.
+ *
+ * Scopes are resolved dynamically per tool via dangerously_get_required_scopes.
+ */
+export const McpToolsCreateBody = /* @__PURE__ */ zod.object({
+    args: zod
+        .record(zod.string(), zod.unknown())
+        .optional()
+        .describe("Arguments validated against the selected tool's schema."),
+})
+
+/**
  * Run a hybrid (semantic + full-text) RAG search over the PostHog documentation via Inkeep. Returns a markdown body with title, URL, and excerpt for each match for the agent to cite back to the user.
  * @summary Search PostHog documentation
  */

--- a/products/posthog_ai/frontend/posthogAiToolRenderers.tsx
+++ b/products/posthog_ai/frontend/posthogAiToolRenderers.tsx
@@ -79,6 +79,7 @@ const DATA_TOOLS = [
 ]
 
 const QUERY_TOOLS: { key: string; displayName: string; icon: JSX.Element }[] = [
+    { key: 'execute-sql', displayName: 'SQL query', icon: <IconGraph /> },
     { key: 'insight-query', displayName: 'Insight query', icon: <IconGraph /> },
     { key: 'query-trends', displayName: 'Trends query', icon: <IconTrends /> },
     { key: 'query-funnel', displayName: 'Funnel query', icon: <IconFunnels /> },

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -48589,6 +48589,8 @@ export namespace Schemas {
       projects: JiraProject[];
     }
 
+    export interface JsonValue {}
+
     /**
      * * `2.0` - 2.0
      */
@@ -52604,6 +52606,30 @@ export namespace Schemas {
          * @nullable
          */
       readonly duration_ms: number | null;
+    }
+
+    /**
+     * Arguments validated against the selected tool's schema.
+     */
+    export type MCPToolRequestArgs = {[key: string]: JsonValue};
+
+    export interface MCPToolRequest {
+      /** Arguments validated against the selected tool's schema. */
+      args?: MCPToolRequestArgs;
+    }
+
+    /**
+     * Structured tool output for native widgets.
+     */
+    export type MCPToolResponseStructuredContent = {[key: string]: JsonValue} | null;
+
+    export interface MCPToolResponse {
+      /** Formatted tool output for the model. */
+      content: string;
+      /** Structured tool output for native widgets. */
+      structured_content?: MCPToolResponseStructuredContent;
+      /** Whether the tool completed successfully. */
+      success: boolean;
     }
 
     /**
@@ -101043,8 +101069,6 @@ export namespace Schemas {
      */
     offset?: number;
     };
-
-    export type McpToolsCreate200 = { [key: string]: unknown };
 
     export type MessagingCategoriesListParams = {
     /**

--- a/services/mcp/src/tools/posthogAiTools/executeSql.ts
+++ b/services/mcp/src/tools/posthogAiTools/executeSql.ts
@@ -1,7 +1,7 @@
 import type { z } from 'zod'
 
 import { ExecuteSQLSchema } from '@/schema/tool-inputs'
-import type { Context, ToolBase } from '@/tools/types'
+import { POSTHOG_FORMATTED_RESULTS_OVERRIDE_KEY, type Context, type ToolBase } from '@/tools/types'
 
 import { invokeMcpTool } from './invokeTool'
 
@@ -10,11 +10,12 @@ export const EXECUTE_SQL_TOOL_NAME = 'execute-sql'
 const schema = ExecuteSQLSchema
 
 type Params = z.infer<typeof schema>
+type ExecuteSqlResult = string | Record<string, unknown>
 
-export const executeSqlHandler: ToolBase<typeof schema, string>['handler'] = async (
+export const executeSqlHandler: ToolBase<typeof schema, ExecuteSqlResult>['handler'] = async (
     context: Context,
     params: Params
-) => {
+): Promise<ExecuteSqlResult> => {
     const result = await invokeMcpTool(context, 'execute_sql', {
         query: params.query,
         truncate: params.truncate ?? true,
@@ -26,10 +27,16 @@ export const executeSqlHandler: ToolBase<typeof schema, string>['handler'] = asy
         throw new Error(result.content)
     }
 
-    return result.content
+    return result.structured_content
+        ? {
+              ...result.structured_content,
+              results: result.content,
+              [POSTHOG_FORMATTED_RESULTS_OVERRIDE_KEY]: result.content,
+          }
+        : result.content
 }
 
-const tool = (): ToolBase<typeof schema, string> => ({
+const tool = (): ToolBase<typeof schema, ExecuteSqlResult> => ({
     name: EXECUTE_SQL_TOOL_NAME,
     schema,
     handler: executeSqlHandler,

--- a/services/mcp/src/tools/posthogAiTools/invokeTool.ts
+++ b/services/mcp/src/tools/posthogAiTools/invokeTool.ts
@@ -1,9 +1,7 @@
+import type { Schemas } from '@/api/generated'
 import type { Context } from '@/tools/types'
 
-export interface McpToolResult {
-    success: boolean
-    content: string
-}
+export type McpToolResult = Schemas.MCPToolResponse
 
 /**
  * Invoke an MCP tool via the PostHog API.

--- a/services/mcp/tests/tools/executeSql.integration.test.ts
+++ b/services/mcp/tests/tools/executeSql.integration.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeAll, describe, expect, it } from 'vitest'
 
+import { buildToolResultPayload } from '@/lib/build-tool-result'
 import {
     type CreatedResources,
     TEST_ORG_ID,
@@ -43,8 +44,8 @@ describe('execute-sql', { concurrent: false }, () => {
             truncate: true,
         })
 
-        expect(typeof result).toBe('string')
-        expect(result).toContain('test_string')
+        const payload = buildToolResultPayload({ handlerResult: result, toolName: 'execute-sql', params: {} })
+        expect(payload.content[0]?.text).toContain('test_string')
     })
 
     it('should execute a query with a WHERE clause', async () => {
@@ -53,9 +54,9 @@ describe('execute-sql', { concurrent: false }, () => {
             truncate: true,
         })
 
-        expect(typeof result).toBe('string')
-        expect(result).toContain('event')
-        expect(result).toContain('cnt')
+        const payload = buildToolResultPayload({ handlerResult: result, toolName: 'execute-sql', params: {} })
+        expect(payload.content[0]?.text).toContain('event')
+        expect(payload.content[0]?.text).toContain('cnt')
     })
 
     it('should execute a query with date filters', async () => {
@@ -64,7 +65,8 @@ describe('execute-sql', { concurrent: false }, () => {
             truncate: false,
         })
 
-        expect(typeof result).toBe('string')
+        const payload = buildToolResultPayload({ handlerResult: result, toolName: 'execute-sql', params: {} })
+        expect(typeof payload.content[0]?.text).toBe('string')
     })
 
     it('should throw on invalid SQL', async () => {

--- a/services/mcp/tests/tools/executeSql.test.ts
+++ b/services/mcp/tests/tools/executeSql.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ApiClient } from '@/api/client'
+import { buildToolResultPayload } from '@/lib/build-tool-result'
+import { executeSqlHandler } from '@/tools/posthogAiTools/executeSql'
+import type { Context } from '@/tools/types'
+import { APP_DATA_META_KEY } from '@/ui-apps/types'
+
+describe('executeSqlHandler', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals()
+    })
+
+    it.each([
+        { structured: false, outputFormat: 'optimized' },
+        { structured: true, outputFormat: 'optimized' },
+        { structured: true, outputFormat: 'json' },
+    ] as const)('preserves results and query metadata: %j', async ({ structured, outputFormat }) => {
+        const query = {
+            kind: 'HogQLQuery',
+            query: 'SELECT {variables.org}',
+            variables: { 'example-variable': { variableId: 'example-variable', code_name: 'org' } },
+        }
+        const content = 'org\nExample organization'
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue(
+                new Response(
+                    JSON.stringify({
+                        success: true,
+                        content,
+                        ...(structured ? { structured_content: { query } } : {}),
+                    })
+                )
+            )
+        )
+        const context = {
+            api: new ApiClient({ apiToken: 'phx_test', baseUrl: 'https://us.posthog.com' }),
+            stateManager: { getProjectId: vi.fn().mockResolvedValue(2) },
+        } as unknown as Context
+        const params = { query: `${query.query};`, truncate: true, output_format: outputFormat }
+        const handlerResult = await executeSqlHandler(context, params)
+
+        for (const includeAppData of [false, true]) {
+            const payload = buildToolResultPayload({ handlerResult, toolName: 'execute-sql', params, includeAppData })
+            if (includeAppData && outputFormat === 'json') {
+                expect(JSON.parse(payload.content[0]!.text)).toEqual({ query, results: content })
+            } else {
+                expect(payload.content).toEqual([{ type: 'text', text: content }])
+            }
+            expect(payload._meta?.[APP_DATA_META_KEY]).toEqual(
+                structured && includeAppData ? { query, results: content } : undefined
+            )
+            expect(payload.structuredContent).toBeUndefined()
+        }
+    })
+})


### PR DESCRIPTION
## Problem

PostHog AI users see SQL results only as text inside collapsed activity.
This builds on the tool-widget support in [#97494](https://github.com/PostHog/posthog/pull/97494).

## Changes

- SQL results render inline with their saved-variable definitions and connection settings intact.
- The widget uses the executed query from tool metadata; the shared Query component fetches its visualization results.
- Pending, failed, malformed, and older text-only results retain the generic card.
- API types regenerate mechanically for the optional structured tool result. Model-facing text stays available, including results in explicit JSON output.

<details>
<summary>Result flow</summary>

Before:

```mermaid
flowchart LR
    A[SQL tool] --> B[Formatted text] --> C[Collapsed activity]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phBlue;
    class B phGray;
    class C phYellow;
```

After:

```mermaid
flowchart LR
    A[SQL tool] --> B[Formatted text for the model]
    A --> C[Executed query in metadata] --> D[Query widget]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phBlue;
    class B,C phGray;
    class D phYellow;
```

</details>

The widget's appearance stays unchanged; the narrow Storybook example uses synthetic data:

![SQL widget at a narrow width](https://raw.githubusercontent.com/PostHog/pr-assets/8f77a3645c5b1e78bedfae430372b9b790a19344/2026/09/34da0f44-ab7b-4578-b6e2-cbdd5b5b3595.png)

## How did you test this code?

- Backend regression coverage executes a saved-variable query, then re-executes the returned query with the same result.
- API, MCP transport, and extractor tests cover metadata preservation, text-only compatibility, JSON results, and connection settings.
- Local validation included pytest, Vitest, Jest, both TypeScript checks, repository-wide mypy, OpenAPI generation, and preflight.
- Playwright compared the original and fixed Storybook requests: only the fixed request retained variables. The narrow render had no horizontal overflow.

Live MCP integration tests were not run.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the MCP widget documentation for executed-query metadata and text-only fallback.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

Codex used Git, GitHub CLI, Flox, and the validation tools listed above.
The follow-up replaces SQL input reconstruction with executed-query metadata after validating both review comments.
The CodeRabbit pass is paused; no local CodeRabbit review ran.

Skills: `integrating-with-posthog-ai`, `implementing-mcp-tools`, `improving-drf-endpoints`, `writing-ui-components`, `writing-tests`, `writing-user-facing-copy`, `writing-code-comments`, `writing-dataclasses`, `running-ci-preflight`, `writing-pr-descriptions`, `reviewing-with-coderabbit`, `stacking-prs`, `hogli`, and `run-posthog`.
