### PR TITLE
fix(github): stop returning files over 1 MB as empty

### DIFF
--- a/posthog/models/github_integration_base.py
+++ b/posthog/models/github_integration_base.py
@@ -2364,6 +2364,7 @@ class GitHubIntegrationBase:
         timeout: int = 10,
         retry_transient: bool | None = None,
         priority: Priority | None = None,
+        stream: bool = False,
     ) -> requests.Response:
         """Authenticated request against ``https://api.github.com`` returning the raw response.
 
@@ -2409,6 +2410,7 @@ class GitHubIntegrationBase:
                     params=params,
                     json=json_body,
                     timeout=timeout,
+                    stream=stream,
                 )
             except requests.RequestException as exc:
                 if retry_transient and attempt == 0:

--- a/posthog/models/integration/github.py
+++ b/posthog/models/integration/github.py
@@ -37,6 +37,7 @@ _GITHUB_COMMIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
 # Upper bound on the diff text we return, to keep a pathological diff (generated/vendored
 # files) from bloating the JSON response and worker memory. ~1 MB of text.
 _MAX_DIFF_CHARS = 1_000_000
+_MAX_FILE_CONTENTS_BYTES = 10 * 1024 * 1024
 
 
 def _is_safe_github_repo_path(repo_path: str) -> bool:
@@ -839,7 +840,7 @@ class GitHubIntegration(GitHubIntegrationBase):
         exist — a missing file is a normal state, not an error. The SHA lets a caller
         pass it straight to ``update_file`` for a conflict-safe write. Counterpart to
         ``update_file``, kept here so URL and token handling stay inside the client.
-        Raises ``GitHubIntegrationError`` instead of returning a partial file.
+        Raises ``GitHubIntegrationError`` rather than return a partial or oversized file.
         """
         repo_path = repository if "/" in repository else f"{self.organization()}/{repository}"
 
@@ -857,26 +858,38 @@ class GitHubIntegration(GitHubIntegrationBase):
                 status_code=response.status_code,
             )
         payload = response.json()
+        size = payload["size"]
+        if size > _MAX_FILE_CONTENTS_BYTES:
+            raise GitHubIntegrationError(
+                f"{file_path} in {repository} is {size} bytes, over the {_MAX_FILE_CONTENTS_BYTES} byte limit"
+            )
+        content: bytes | bytearray
         if payload["encoding"] == "none":
-            # The contents API leaves `content` empty for files over 1 MB. The blob endpoint serves files up to
-            # 100 MB, and reading by SHA guarantees the content matches the SHA this method returns.
+            # The contents API omits content above 1 MB.
             blob_response = self.api_request(
                 "GET",
                 f"/repos/{repo_path}/git/blobs/{payload['sha']}",
                 endpoint="/repos/{owner}/{repo}/git/blobs/{file_sha}",
+                headers={"Accept": "application/vnd.github.raw+json"},
+                stream=True,
             )
-            if blob_response.status_code != 200:
-                raise GitHubIntegrationError(
-                    f"Failed to read {file_path} from {repository}: {blob_response.text}",
-                    status_code=blob_response.status_code,
-                )
-            payload = blob_response.json()
-        content = base64.b64decode(payload["content"])
-        # A short read passed to `update_file` overwrites the file with the truncated text.
-        if len(content) != payload["size"]:
-            raise GitHubIntegrationError(
-                f"Read {len(content)} of {payload['size']} bytes of {file_path} from {repository}"
-            )
+            try:
+                if blob_response.status_code != 200:
+                    raise GitHubIntegrationError(
+                        f"Failed to read {file_path} from {repository}: {blob_response.text}",
+                        status_code=blob_response.status_code,
+                    )
+                content = bytearray()
+                for chunk in blob_response.iter_content(chunk_size=64 * 1024):
+                    content += chunk
+                    if len(content) > size:
+                        break
+            finally:
+                blob_response.close()
+        else:
+            content = base64.b64decode(payload["content"])
+        if len(content) != size:
+            raise GitHubIntegrationError(f"Read {len(content)} of {size} bytes of {file_path} from {repository}")
         return {"content": content.decode("utf-8"), "sha": payload["sha"]}
 
     def create_pull_request(

--- a/posthog/models/integration/github.py
+++ b/posthog/models/integration/github.py
@@ -839,6 +839,7 @@ class GitHubIntegration(GitHubIntegrationBase):
         exist — a missing file is a normal state, not an error. The SHA lets a caller
         pass it straight to ``update_file`` for a conflict-safe write. Counterpart to
         ``update_file``, kept here so URL and token handling stay inside the client.
+        Raises ``GitHubIntegrationError`` instead of returning a partial file.
         """
         repo_path = repository if "/" in repository else f"{self.organization()}/{repository}"
 
@@ -856,7 +857,27 @@ class GitHubIntegration(GitHubIntegrationBase):
                 status_code=response.status_code,
             )
         payload = response.json()
-        return {"content": base64.b64decode(payload["content"]).decode("utf-8"), "sha": payload["sha"]}
+        if payload["encoding"] == "none":
+            # The contents API leaves `content` empty for files over 1 MB. The blob endpoint serves files up to
+            # 100 MB, and reading by SHA guarantees the content matches the SHA this method returns.
+            blob_response = self.api_request(
+                "GET",
+                f"/repos/{repo_path}/git/blobs/{payload['sha']}",
+                endpoint="/repos/{owner}/{repo}/git/blobs/{file_sha}",
+            )
+            if blob_response.status_code != 200:
+                raise GitHubIntegrationError(
+                    f"Failed to read {file_path} from {repository}: {blob_response.text}",
+                    status_code=blob_response.status_code,
+                )
+            payload = blob_response.json()
+        content = base64.b64decode(payload["content"])
+        # A short read passed to `update_file` overwrites the file with the truncated text.
+        if len(content) != payload["size"]:
+            raise GitHubIntegrationError(
+                f"Read {len(content)} of {payload['size']} bytes of {file_path} from {repository}"
+            )
+        return {"content": content.decode("utf-8"), "sha": payload["sha"]}
 
     def create_pull_request(
         self, repository: str, title: str, body: str, head_branch: str, base_branch: str | None = None

--- a/posthog/models/test/integration/test_github.py
+++ b/posthog/models/test/integration/test_github.py
@@ -2,6 +2,7 @@
 
 import time
 import base64
+from collections.abc import Iterator
 from datetime import UTC, datetime, timedelta
 from typing import Any, Optional
 
@@ -37,6 +38,7 @@ from posthog.models.integration import (
     Integration,
     invalidate_github_repository_caches_for_installation,
 )
+from posthog.models.integration.github import _MAX_FILE_CONTENTS_BYTES
 from posthog.models.user_integration import UserGitHubIntegration, UserIntegration
 
 
@@ -603,40 +605,53 @@ class TestGitHubIntegrationModel(BaseTest):
         assert "truncated" in result["diff"]
 
     @parameterized.expand([("inline", False), ("over_contents_api_limit", True)])
-    def test_get_file_contents_returns_whole_file(self, _name, over_contents_api_limit):
-        integration = self.create_integration(sensitive_config={"access_token": "ACCESS_TOKEN"})
-        github = GitHubIntegration(integration)
-        text = "version: 1\nsnapshots: {}\n"
-        blob = {
+    def test_get_file_contents_returns_whole_file(self, _name: str, over_contents_api_limit: bool) -> None:
+        github = GitHubIntegration(self.create_integration(sensitive_config={"access_token": "ACCESS_TOKEN"}))
+        text = b"version: 1\nsnapshots: {}\n"
+        contents = {
             "sha": "abc123",
             "size": len(text),
             "encoding": "base64",
-            "content": base64.b64encode(text.encode()).decode(),
+            "content": base64.b64encode(text).decode(),
         }
-        responses = {"/repos/PostHog/posthog/contents/snapshots.yml": blob}
+        responses: dict[str, MagicMock] = {}
         if over_contents_api_limit:
-            responses["/repos/PostHog/posthog/contents/snapshots.yml"] = {**blob, "encoding": "none", "content": ""}
-            responses["/repos/PostHog/posthog/git/blobs/abc123"] = blob
+            contents = {**contents, "encoding": "none", "content": ""}
+            responses["/repos/PostHog/posthog/git/blobs/abc123"] = MagicMock(
+                status_code=200, iter_content=MagicMock(return_value=[text[:8], text[8:]])
+            )
+        responses["/repos/PostHog/posthog/contents/snapshots.yml"] = MagicMock(
+            status_code=200, json=MagicMock(return_value=contents)
+        )
 
-        def request(method, path, **kwargs):
-            return MagicMock(status_code=200, json=MagicMock(return_value=responses[path]))
-
-        with patch.object(github, "api_request", side_effect=request):
+        with patch.object(github, "api_request", side_effect=lambda method, path, **kwargs: responses[path]):
             result = github.get_file_contents("PostHog/posthog", "snapshots.yml")
-        assert result == {"content": text, "sha": "abc123"}
+        assert result == {"content": text.decode(), "sha": "abc123"}
 
-    def test_get_file_contents_raises_on_short_read(self):
-        integration = self.create_integration(sensitive_config={"access_token": "ACCESS_TOKEN"})
-        github = GitHubIntegration(integration)
-        short = {
-            "sha": "abc123",
-            "size": 2_000_000,
-            "encoding": "base64",
-            "content": base64.b64encode(b"version: 1\n").decode(),
+    @parameterized.expand(
+        [
+            ("over_size_limit", {"size": _MAX_FILE_CONTENTS_BYTES + 1, "encoding": "none", "content": ""}),
+            (
+                "inline_shorter_than_size",
+                {"size": 100, "encoding": "base64", "content": base64.b64encode(b"version: 1\n").decode()},
+            ),
+            ("blob_longer_than_size", {"size": 4, "encoding": "none", "content": ""}),
+        ]
+    )
+    def test_get_file_contents_rejects_file_it_cannot_return_whole(self, _name: str, contents: dict[str, Any]) -> None:
+        github = GitHubIntegration(self.create_integration(sensitive_config={"access_token": "ACCESS_TOKEN"}))
+
+        def blob_chunks(chunk_size: int) -> Iterator[bytes]:
+            yield b"version: 1\n"
+            raise AssertionError("read past the declared size")
+
+        responses = {
+            "/repos/PostHog/posthog/contents/snapshots.yml": MagicMock(
+                status_code=200, json=MagicMock(return_value={"sha": "abc123", **contents})
+            ),
+            "/repos/PostHog/posthog/git/blobs/abc123": MagicMock(status_code=200, iter_content=blob_chunks),
         }
-        with patch.object(
-            github, "api_request", return_value=MagicMock(status_code=200, json=MagicMock(return_value=short))
-        ):
+        with patch.object(github, "api_request", side_effect=lambda method, path, **kwargs: responses[path]):
             with pytest.raises(GitHubIntegrationError):
                 github.get_file_contents("PostHog/posthog", "snapshots.yml")
 

--- a/posthog/models/test/integration/test_github.py
+++ b/posthog/models/test/integration/test_github.py
@@ -1,6 +1,7 @@
 """Tests for the GitHub App integration."""
 
 import time
+import base64
 from datetime import UTC, datetime, timedelta
 from typing import Any, Optional
 
@@ -600,6 +601,44 @@ class TestGitHubIntegrationModel(BaseTest):
         assert len(result["diff"]) < len(oversized)
         assert result["diff"].startswith("x" * 100)
         assert "truncated" in result["diff"]
+
+    @parameterized.expand([("inline", False), ("over_contents_api_limit", True)])
+    def test_get_file_contents_returns_whole_file(self, _name, over_contents_api_limit):
+        integration = self.create_integration(sensitive_config={"access_token": "ACCESS_TOKEN"})
+        github = GitHubIntegration(integration)
+        text = "version: 1\nsnapshots: {}\n"
+        blob = {
+            "sha": "abc123",
+            "size": len(text),
+            "encoding": "base64",
+            "content": base64.b64encode(text.encode()).decode(),
+        }
+        responses = {"/repos/PostHog/posthog/contents/snapshots.yml": blob}
+        if over_contents_api_limit:
+            responses["/repos/PostHog/posthog/contents/snapshots.yml"] = {**blob, "encoding": "none", "content": ""}
+            responses["/repos/PostHog/posthog/git/blobs/abc123"] = blob
+
+        def request(method, path, **kwargs):
+            return MagicMock(status_code=200, json=MagicMock(return_value=responses[path]))
+
+        with patch.object(github, "api_request", side_effect=request):
+            result = github.get_file_contents("PostHog/posthog", "snapshots.yml")
+        assert result == {"content": text, "sha": "abc123"}
+
+    def test_get_file_contents_raises_on_short_read(self):
+        integration = self.create_integration(sensitive_config={"access_token": "ACCESS_TOKEN"})
+        github = GitHubIntegration(integration)
+        short = {
+            "sha": "abc123",
+            "size": 2_000_000,
+            "encoding": "base64",
+            "content": base64.b64encode(b"version: 1\n").decode(),
+        }
+        with patch.object(
+            github, "api_request", return_value=MagicMock(status_code=200, json=MagicMock(return_value=short))
+        ):
+            with pytest.raises(GitHubIntegrationError):
+                github.get_file_contents("PostHog/posthog", "snapshots.yml")
 
     @parameterized.expand(
         [

--- a/products/visual_review/backend/tests/conftest.py
+++ b/products/visual_review/backend/tests/conftest.py
@@ -258,6 +258,7 @@ def mock_github_api(local_git_repo):
                         "content": encoded,
                         "sha": blob_sha,
                         "encoding": "base64",
+                        "size": len(content.encode()),
                     }
                 ),
             )

--- a/products/visual_review/backend/tests/test_github_integration.py
+++ b/products/visual_review/backend/tests/test_github_integration.py
@@ -163,6 +163,7 @@ def mock_github_api(local_git_repo):
                         "content": encoded,
                         "sha": blob_sha,
                         "encoding": "base64",
+                        "size": len(content.encode()),
                     }
                 ),
             )


### PR DESCRIPTION
## Problem

- Approving snapshots in Visual Review deletes the rest of the baseline once the baseline file is over 1 MB.
- GitHub's contents API returns empty `content` and `encoding: "none"` for files between 1 and 100 MB ([docs](https://docs.github.com/en/rest/repos/contents#get-repository-content)).
- `GitHubIntegration.get_file_contents` decoded that empty string, so the approval rebuilt the file from the approved snapshots alone.
- Example: bot commit [ead52454](https://github.com/PostHog/posthog/commit/ead52454ac91c1aa673081f622d6da60260788f6) deleted 10,516 lines and reported "14 updated".
- `frontend/snapshots.yml` on master is a few hundred bytes under the limit. Past it, every run also reads an empty baseline and flags all snapshots as new.

## Changes

- Files over 1 MB now read in full. The reader streams the raw blob from `GET /git/blobs/{sha}`.
- Reading by SHA keeps the content in step with the SHA that `update_file` sends for its conflict check.
- Files over 10 MB raise before any download, because anyone who can push to the repo controls the file size.
- The blob stream stops once it passes the reported `size`, so worker memory stays bounded.
- The reader raises when the bytes read differ from `size`, so a partial read fails instead of committing a truncated file.
- The fix covers every caller: Visual Review runs, approvals, CLI auto-approve, and the engineering analytics quarantine file.
- Mechanical: `api_request` gains a `stream` flag, and the Visual Review GitHub mocks now send `size` like GitHub does.

## How did you test this code?

- `test_get_file_contents_returns_whole_file` (over-limit case) fails without the fix with `content: ''`, the production symptom.
- `test_get_file_contents_rejects_file_it_cannot_return_whole` covers a file over the cap, a short inline read, and a blob longer than `size`.
- The blob endpoint returned all 1,051,053 bytes of the file at [cdee419b](https://github.com/PostHog/posthog/commit/cdee419b9e466fcdde0765ced2bda6fadf6cc165), checked with `gh api`.
- Not tested: the streamed raw blob read against real GitHub, the blob endpoint's non-200 branch, and an approval end to end.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code from a [Slack report](https://posthog.slack.com/archives/C09G8QA6740/p1789065437351619) of a wiped baseline.
- Skills: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, `/code-review`, `qa-team`. The CodeRabbit pass is paused, so this PR opened without a local pass.
- The review found the missing `size` in Visual Review mocks and the unbounded download. Both are fixed in the second commit.
- An open-PR search for `get_file_contents`, `snapshots.yml` and the blob endpoint found no existing fix.
- Shrinking `frontend/snapshots.yml` was considered and dropped because it only delays the limit.
- After deploy, revert ead52454 on [declare tool widgets in a central manifest](https://github.com/PostHog/posthog/pull/97264) to restore its baseline.

https://claude.ai/code/session_01N78FkESvqnwi2DUW6SPaR5
