### PR TITLE
feat(marketing): track setup usage and suggestion outcomes

### DIFF
--- a/docs/internal/marketing-analytics-configuration-writes.md
+++ b/docs/internal/marketing-analytics-configuration-writes.md
@@ -5,3 +5,9 @@ Settings updates send only the changed field and refresh the Marketing configura
 Explicit conversion-goal list updates still replace the list; simultaneous edits to that same list are not merged.
 
 Loading a project replaces the current and saved Marketing settings with that project’s configuration, including an empty configuration when none exists.
+
+Setup usage emits `marketing analytics setup section viewed` on entry and section changes.
+Suggestion review, dismissal, restoration, batch review, capability filters, rescans and navigation have separate events.
+`marketing analytics setup change submitted`, `change completed` and `change failed` share the same prefix and report operation types, counts, source and whether the change is an undo. Completed reports the server's applied count, which may be zero.
+`marketing analytics setup sync retry completed` reports requested and failed counts; it measures scheduling retries, not completed syncs.
+Payloads exclude suggestion IDs, titles, evidence, goal names and UTM values. Source navigation measures entry into connection flows; existing warehouse connection events measure their completion.

--- a/frontend/src/scenes/marketing-analytics/Setup/SetupTab.tsx
+++ b/frontend/src/scenes/marketing-analytics/Setup/SetupTab.tsx
@@ -1,4 +1,5 @@
 import { useActions, useValues } from 'kea'
+import posthog from 'posthog-js'
 import { useEffect } from 'react'
 
 import { LemonButton, LemonTag } from '@posthog/lemon-ui'
@@ -69,6 +70,10 @@ export function SetupTab(): JSX.Element {
     }, [])
 
     const active = sections.find((section) => section.key === setupSection) ?? sections[0]
+
+    useEffect(() => {
+        posthog.capture('marketing analytics setup section viewed', { section: active.key })
+    }, [active.key])
 
     return (
         <div className="flex flex-col md:flex-row gap-6 mt-4">

--- a/frontend/src/scenes/marketing-analytics/Setup/navigateOps.ts
+++ b/frontend/src/scenes/marketing-analytics/Setup/navigateOps.ts
@@ -1,3 +1,5 @@
+import posthog from 'posthog-js'
+
 import api from 'lib/api'
 import { urls } from 'scenes/urls'
 import type { ApplyOp } from 'scenes/web-analytics/tabs/marketing-analytics/frontend/logic/setupPlanLogic'
@@ -11,6 +13,12 @@ import type { ApplyOp } from 'scenes/web-analytics/tabs/marketing-analytics/fron
  * loses their place in it.
  */
 export function runNavigateOp(op: ApplyOp): boolean {
+    if (['open_oauth', 'open_source_wizard', 'open_settings'].includes(op.op)) {
+        posthog.capture('marketing analytics setup navigation opened', {
+            destination: op.op,
+            integration: op.kind,
+        })
+    }
     switch (op.op) {
         case 'open_oauth':
             window.open(

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/setupPlanLogic.test.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/setupPlanLogic.test.ts
@@ -1,4 +1,5 @@
 import { expectLogic } from 'kea-test-utils'
+import posthog from 'posthog-js'
 
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
@@ -6,6 +7,8 @@ import { initKeaTests } from '~/test/init'
 import { marketingAnalyticsSettingsLogic } from './marketingAnalyticsSettingsLogic'
 import type { ApplyOp, SetupPlanResponse, Suggestion } from './setupPlanLogic'
 import { setupPlanLogic } from './setupPlanLogic'
+
+jest.mock('posthog-js')
 
 const suggestion = (overrides: Partial<Suggestion> = {}): Suggestion => ({
     id: 'add_source_mapping:meta_ads:fb-ads',
@@ -43,6 +46,7 @@ describe('setupPlanLogic', () => {
     let applyRequests: any[]
 
     beforeEach(() => {
+        jest.mocked(posthog.capture).mockClear()
         applyRequests = []
         useMocks({
             get: {
@@ -75,6 +79,13 @@ describe('setupPlanLogic', () => {
         await expectLogic(logic, () => logic.actions.applySuggestion(suggestion())).toFinishAllListeners()
 
         expect(applyRequests[0].ops).toEqual([suggestion().apply])
+        expect(posthog.capture).toHaveBeenCalledWith('marketing analytics setup change completed', {
+            source: 'setup_tab',
+            operation_types: ['add_custom_source_mapping'],
+            requested_count: 1,
+            applied_count: 0,
+            is_undo: false,
+        })
     })
 
     it('collapses the row optimistically once the op succeeds', async () => {
@@ -122,6 +133,13 @@ describe('setupPlanLogic', () => {
         ).toFinishAllListeners()
 
         expect(applyRequests[0].ops).toEqual(UNDO_OPS)
+        expect(posthog.capture).toHaveBeenCalledWith('marketing analytics setup change completed', {
+            source: 'setup_tab',
+            operation_types: ['remove_custom_source_mapping'],
+            requested_count: 1,
+            applied_count: 0,
+            is_undo: true,
+        })
     })
 
     it('batches only the safe suggestions', async () => {
@@ -137,6 +155,13 @@ describe('setupPlanLogic', () => {
 
         await expectLogic(logic, () => logic.actions.applyAllSafe()).toFinishAllListeners()
         expect(applyRequests[0].ops).toEqual([suggestion().apply])
+        expect(posthog.capture).toHaveBeenCalledWith('marketing analytics setup change completed', {
+            source: 'apply_all_safe',
+            operation_types: ['add_custom_source_mapping'],
+            requested_count: 1,
+            applied_count: 0,
+            is_undo: false,
+        })
         // `source` is recorded against the change server-side, so a one-item batch still
         // has to report where the click came from rather than being inferred from length.
         expect(applyRequests[0].source).toEqual('apply_all_safe')
@@ -217,6 +242,17 @@ describe('setupPlanLogic', () => {
         await expectLogic(logic, () => logic.actions.confirmReviewedSuggestion(suggestion())).toFinishAllListeners()
 
         expect(logic.values.reviewingSuggestion).not.toBeNull()
+        expect(posthog.capture).toHaveBeenCalledWith('marketing analytics setup change failed', {
+            source: 'setup_tab',
+            operation_types: ['add_custom_source_mapping'],
+            requested_count: 1,
+            is_undo: false,
+        })
+        expect(
+            jest
+                .mocked(posthog.capture)
+                .mock.calls.filter(([event]) => event === 'marketing analytics setup change completed')
+        ).toHaveLength(0)
     })
 
     it('closes the review modal once the apply lands', async () => {
@@ -242,6 +278,28 @@ describe('setupPlanLogic', () => {
 
         expect(logic.values.visibleSuggestions).toHaveLength(0)
         expect(applyRequests).toHaveLength(0)
+        expect(posthog.capture).toHaveBeenCalledWith('marketing analytics setup suggestion dismissed', {
+            kind: 'add_source_mapping',
+        })
+    })
+
+    it('tracks reviews without event evidence and does not count closing as another review', async () => {
+        await expectLogic(logic, () => logic.actions.reviewSuggestion(suggestion())).toFinishAllListeners()
+        await expectLogic(logic, () => logic.actions.reviewSuggestion(null)).toFinishAllListeners()
+        expect(
+            jest
+                .mocked(posthog.capture)
+                .mock.calls.filter(([event]) => event === 'marketing analytics setup suggestion reviewed')
+        ).toEqual([
+            [
+                'marketing analytics setup suggestion reviewed',
+                {
+                    kind: 'add_source_mapping',
+                    source: 'deterministic',
+                    integration: 'MetaAds',
+                },
+            ],
+        ])
     })
 
     describe('reviewing what was dismissed', () => {

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/setupPlanLogic.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/setupPlanLogic.ts
@@ -1,5 +1,6 @@
 import { MakeLogicType, actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
+import posthog from 'posthog-js'
 
 import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
@@ -409,6 +410,44 @@ export const setupPlanLogic = kea<setupPlanLogicType>([
         ],
     }),
     listeners(({ actions, values }) => ({
+        reviewSuggestion: ({ suggestion }) => {
+            if (suggestion) {
+                posthog.capture('marketing analytics setup suggestion reviewed', {
+                    kind: suggestion.kind,
+                    source: suggestion.source,
+                    integration: suggestion.integration,
+                })
+            }
+        },
+        reviewSafeBatch: () => {
+            posthog.capture('marketing analytics setup batch reviewed', { count: values.safeBatch.length })
+        },
+        dismissSuggestion: ({ id }) => {
+            const suggestion = values.suggestions.find((item) => item.id === id)
+            if (suggestion) {
+                posthog.capture('marketing analytics setup suggestion dismissed', { kind: suggestion.kind })
+            }
+        },
+        restoreSuggestion: ({ id }) => {
+            const suggestion = values.suggestions.find((item) => item.id === id)
+            if (suggestion) {
+                posthog.capture('marketing analytics setup suggestion restored', { kind: suggestion.kind })
+            }
+        },
+        restoreAllDismissed: () => {
+            posthog.capture('marketing analytics setup suggestions restored')
+        },
+        toggleShowDismissed: () => {
+            posthog.capture('marketing analytics setup dismissed toggled', { shown: values.showDismissed })
+        },
+        focusCapability: () => {
+            posthog.capture('marketing analytics setup capability filtered', { capability: values.focusedCapability })
+        },
+        loadSetupPlan: ({ refresh } = {}) => {
+            if (refresh) {
+                posthog.capture('marketing analytics setup rescan requested')
+            }
+        },
         retrySync: async ({ suggestionId, targets }) => {
             // Goes straight to the warehouse endpoint rather than through
             // apply_setup_ops: the warehouse owns this action and its permissions, and
@@ -426,6 +465,10 @@ export const setupPlanLogic = kea<setupPlanLogicType>([
                         failed.push(target.display_name)
                     }
                 }
+                posthog.capture('marketing analytics setup sync retry completed', {
+                    requested_count: targets.length,
+                    failed_count: failed.length,
+                })
                 if (failed.length === targets.length) {
                     lemonToast.error(`Could not retry ${failed.join(', ')}.`)
                 } else if (failed.length) {
@@ -520,12 +563,23 @@ export const setupPlanLogic = kea<setupPlanLogicType>([
             // the global set meant an undo — which starts no rows of its own — would
             // adopt a concurrent apply's ids and mark those rows applied when it landed.
             const inFlight = options.suggestionIds ?? []
+            const properties = {
+                source: options.source,
+                operation_types: [...new Set(ops.map(({ op }) => op))],
+                requested_count: ops.length,
+                is_undo: !options.undoable,
+            }
+            posthog.capture('marketing analytics setup change submitted', properties)
             try {
                 const response: ApplyResponse = await api.create(
                     `api/projects/${values.currentTeamId}/marketing_analytics/apply_setup_ops`,
                     { ops, source: options.source }
                 )
 
+                posthog.capture('marketing analytics setup change completed', {
+                    ...properties,
+                    applied_count: response.applied.length,
+                })
                 actions.markApplied(inFlight)
                 lemonToast.success(options.label, {
                     button:
@@ -544,6 +598,7 @@ export const setupPlanLogic = kea<setupPlanLogicType>([
                             : undefined,
                 })
             } catch (error: any) {
+                posthog.capture('marketing analytics setup change failed', properties)
                 lemonToast.error(error?.detail ?? 'Could not apply that change.')
             } finally {
                 actions.setApplying(inFlight, false)


### PR DESCRIPTION
## Problem

Marketing analytics needs usage metrics to identify which Setup sections and suggestions help users configure their project.

## Changes

- Track section visits, suggestion interactions, rescans, navigation, change outcomes and undo.
- Report operation types and counts without suggestion evidence, goal names or UTM values.
- No visible UI changes. Manual settings saves and dashboard insights remain follow-ups.

## How did you test this code?

- Ran `setupPlanLogic.test.ts`; assertions cover single/batch origins, undo, failures and review payloads without evidence.
- Verified section navigation, review, dismiss, restore, apply and undo in the local UI with SDK console output.
- Local capture returned HTTP 403, so ingestion was not verified. OAuth completion and sync retries were not browser-tested.
- Ran scoped Oxlint, preflight and diff checks. Full TypeScript validation is left to CI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated `docs/internal/marketing-analytics-configuration-writes.md` with event scope and payload semantics.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used shell and browser tools, guided by writing-kea-logics, writing-ui-components, writing-tests, run-posthog and writing-pr-descriptions.
Opened without a local CodeRabbit pass. Changes are limited to Marketing analytics and existing synthetic test fixtures.
