### PR TITLE
fix(desktop): keep unopened local tasks idle after restart

### DIFF
--- a/products/desktop/docs/ARCHITECTURE.md
+++ b/products/desktop/docs/ARCHITECTURE.md
@@ -80,6 +80,11 @@ has a prompt to send. A task description or an existing run does not imply that 
 prompt is pending. This lets an empty session open after a failed startup instead
 of keeping it in the loading view. Opening it does not resend the description.
 
+A local task without a session is idle in the space sidebar after an app restart.
+The sidebar shows startup only when a startup marker or a live session reports it.
+The open chat can still show loading while it waits for its local connection.
+The shared lifecycle state must not treat an unopened task as an active startup.
+
 New cloud runs seed the full user message before subscribing to setup progress.
 The chat renders that message immediately, including its space context chip.
 Reopened transcripts reconcile the plain initial prompt with its context-bearing

--- a/products/desktop/packages/core/src/sessions/sessionViewState.test.ts
+++ b/products/desktop/packages/core/src/sessions/sessionViewState.test.ts
@@ -1,7 +1,10 @@
 import type { AgentSession } from "@posthog/shared";
 import type { Task, TaskRunStatus } from "@posthog/shared/domain-types";
 import { describe, expect, it } from "vitest";
-import { deriveSessionViewState } from "./sessionViewState";
+import {
+  deriveSessionLifecycleState,
+  deriveSessionViewState,
+} from "./sessionViewState";
 
 function makeTask(runStatus: TaskRunStatus, runId = "run-1"): Task {
   return {
@@ -193,16 +196,26 @@ describe("deriveSessionViewState", () => {
     expect(state.isInitializing).toBe(false);
   });
 
-  it("shows loading while a local session reconnects after reload", () => {
-    const task = makeTask("in_progress");
-    if (task.latest_run) {
-      task.latest_run.environment = "local";
-    }
+  it.each(["queued", "in_progress", "completed"] as const)(
+    "keeps an unopened local %s run idle while its chat waits to reconnect",
+    (status) => {
+      const task = makeTask(status);
+      if (task.latest_run) {
+        task.latest_run.environment = "local";
+      }
 
-    expect(
-      deriveSessionViewState(undefined, task, null, false).isInitializing,
-    ).toBe(true);
-  });
+      expect(
+        deriveSessionLifecycleState(undefined, task, false).isInitializing,
+      ).toBe(false);
+      expect(
+        deriveSessionLifecycleState(undefined, task, false, true)
+          .isInitializing,
+      ).toBe(true);
+      expect(
+        deriveSessionViewState(undefined, task, null, false).isInitializing,
+      ).toBe(true);
+    },
+  );
 
   it("keeps a local session loading until its first prompt", () => {
     const task = makeTask("in_progress");

--- a/products/desktop/packages/core/src/sessions/sessionViewState.ts
+++ b/products/desktop/packages/core/src/sessions/sessionViewState.ts
@@ -65,10 +65,9 @@ export function deriveSessionLifecycleState(
     isInitializing = effectiveIsCloud;
     if (!effectiveIsCloud) {
       isInitializing =
-        !session ||
-        (sessionMatchesActiveRun &&
-          (session.status === "connecting" ||
-            (session.status === "connected" && expectsInitialPrompt)));
+        sessionMatchesActiveRun &&
+        (session.status === "connecting" ||
+          (session.status === "connected" && expectsInitialPrompt));
     }
   }
 
@@ -127,7 +126,7 @@ export function deriveSessionViewState(
     events,
     isPromptPending,
     promptStartedAt,
-    isInitializing,
+    isInitializing: isInitializing || (!effectiveIsCloud && !session),
     cloudBranch,
     errorTitle: session?.errorTitle,
     errorMessage:

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemPreview.stories.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemPreview.stories.tsx
@@ -170,3 +170,17 @@ export const Crowded: Story = {
     ),
   },
 };
+
+export const LocalAfterRestart: Story = {
+  args: {
+    item: item(
+      run({
+        environment: "local",
+        status: "queued",
+        completed_at: null,
+        state: { mode: "background" },
+      }),
+      { environment: "local" },
+    ),
+  },
+};


### PR DESCRIPTION
## Problem

**Why:** Desktop users see a loading spinner on idle local tasks after a full restart.
The shared status helper treats a missing local session as startup, although unopened tasks have no session.

## Changes

- Unopened local tasks now show an idle status without a click.
- Active startup markers and connecting sessions still show loading.
- The open chat keeps its connection loading state. Cloud behavior stays unchanged.

The task preview uses the same status helper as the space sidebar:

![Before and after a local task restart](https://raw.githubusercontent.com/PostHog/pr-assets/b4e7c9d563bb003d4b24741838ebde2336e5c268/2026/09/bd5bd6c5-532a-4b23-9939-c872ff5b5b56.png)

## How did you test this code?

- Extended the reconnect test with red/green cases for queued, in-progress, and completed local runs, explicit startup, and the open chat.
- Scoped core/UI tests, both typechecks, and Biome pass. Storybook checks cover three widths and cloud startup.
- Not tested: a full Electron restart with a real worktree.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the startup rules in `products/desktop/docs/ARCHITECTURE.md`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex through PostHog Desktop. The duplicate search found no matching fix. The story reuses existing repository fixtures.
The CodeRabbit pass is paused; this PR has no local CodeRabbit pass.

Skills: `posthog-desktop`, `writing-tests`, `writing-user-facing-copy`, `announcing-behavior-changes`, `writing-pr-descriptions`, `running-ci-preflight`, `reviewing-with-coderabbit`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
