### PR TITLE
fix(api): scope the hourly read budget to /query and inline endpoint runs

### DIFF
--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -304,12 +304,13 @@ class QueryViewSet(QueryCoalescingMixin, TeamAndOrgViewSetMixin, PydanticModelMi
                 limit_context = None
 
             reset_request_query_cost()
+            is_query_service = get_query_tag_value("access_method") == "personal_api_key"
+            if is_query_service:
+                tag_queries(api_queries_budgeted=True)
             with tracer.start_as_current_span("posthog.query.process_query_model") as process_span:
                 process_span.set_attribute("team_id", self.team.pk)
                 process_span.set_attribute("query.kind", getattr(query, "kind", "Other"))
-                process_span.set_attribute(
-                    "query.is_query_service", get_query_tag_value("access_method") == "personal_api_key"
-                )
+                process_span.set_attribute("query.is_query_service", is_query_service)
                 if limit_context is not None:
                     process_span.set_attribute("query.limit_context", limit_context.value)
                 result = process_query_model(
@@ -318,7 +319,7 @@ class QueryViewSet(QueryCoalescingMixin, TeamAndOrgViewSetMixin, PydanticModelMi
                     execution_mode=execution_mode,
                     query_id=client_query_id,
                     user=request.user,  # type: ignore[arg-type]
-                    is_query_service=(get_query_tag_value("access_method") == "personal_api_key"),
+                    is_query_service=is_query_service,
                     limit_context=limit_context,
                     analytics_props=analytics_props,
                 )

--- a/posthog/api_queries_budget.py
+++ b/posthog/api_queries_budget.py
@@ -3,7 +3,7 @@
 Each team has a token bucket in Redis measured in bytes read. The rate comes from the team's
 organization, since the subscription belongs to the organization: teams of a paying organization
 refill API_QUERIES_BUDGET_PAID_MULTIPLIER times faster. The ClickHouse client debits what every
-chargeable query read after it runs (posthog/clickhouse/client/execute.py) and the query runner
+budgeted query read after it runs (posthog/clickhouse/client/execute.py) and the query runner
 reads the balance before admitting one. Refill is lazy: the balance is only brought up to date
 when it is read, so a debit never needs to know the team's rate. The balance floors at minus one
 hour of refill, so the query that crosses the line can never lock a team out for longer than an

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -560,9 +560,7 @@ def sync_execute(
                 # A query killed mid-scan (timeout, memory limit) has already cost the read, so
                 # keep the progress the server reported before it died. The Redis write happens
                 # in the outer finally, once the connection is back in the pool.
-                # Materialized endpoint runs are chargeable for billing but exempt from the read
-                # budget (see QueryRunner._call_with_rate_limits), so they are not debited either.
-                if tags.chargeable and tags.team_id and tags.workload != Workload.ENDPOINTS:
+                if tags.chargeable and tags.team_id and not tags.api_queries_budget_exempt:
                     chargeable_query_info = _chargeable_query_info(client, query_info_before)
             if (
                 "INSERT INTO" in prepared_sql

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -560,9 +560,9 @@ def sync_execute(
                 # A query killed mid-scan (timeout, memory limit) has already cost the read, so
                 # keep the progress the server reported before it died. The Redis write happens
                 # in the outer finally, once the connection is back in the pool.
-                # Endpoint runs are chargeable for billing but exempt from the read budget (see
-                # QueryRunner._call_with_rate_limits), so they are not debited either.
-                if tags.chargeable and tags.team_id and tags.feature != Feature.ENDPOINT_EXECUTION:
+                # Materialized endpoint runs are chargeable for billing but exempt from the read
+                # budget (see QueryRunner._call_with_rate_limits), so they are not debited either.
+                if tags.chargeable and tags.team_id and tags.workload != Workload.ENDPOINTS:
                     chargeable_query_info = _chargeable_query_info(client, query_info_before)
             if (
                 "INSERT INTO" in prepared_sql

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -562,7 +562,7 @@ def sync_execute(
                 # in the outer finally, once the connection is back in the pool.
                 # Endpoint runs are chargeable for billing but exempt from the read budget (see
                 # QueryRunner._call_with_rate_limits), so they are not debited either.
-                if tags.chargeable and tags.team_id and tags.product != Product.ENDPOINTS:
+                if tags.chargeable and tags.team_id and tags.feature != Feature.ENDPOINT_EXECUTION:
                     chargeable_query_info = _chargeable_query_info(client, query_info_before)
             if (
                 "INSERT INTO" in prepared_sql

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -216,7 +216,7 @@ def resolve_kill_switch_level(team_id: Optional[int]) -> KillSwitchLevel:
     return level
 
 
-def _meter_chargeable_query(team_id: str, query_info: Any) -> None:
+def _meter_budgeted_query(team_id: str, query_info: Any) -> None:
     # Runs after the pooled connection is released, and must never raise: a metering failure
     # is an error counter, not a failed query.
     try:
@@ -228,7 +228,7 @@ def _meter_chargeable_query(team_id: str, query_info: Any) -> None:
         capture_exception(e)
 
 
-def _chargeable_query_info(client: Any, query_info_before: Any) -> Optional[Any]:
+def _query_info_to_meter(client: Any, query_info_before: Any) -> Optional[Any]:
     """The query info to meter for the query that just ran on `client`, or None.
 
     The driver only creates a new query info once the connection is established, so the identity
@@ -534,7 +534,7 @@ def sync_execute(
         else:
             settings["use_hedged_requests"] = "1" if get_hedged_app_queries_enabled() else "0"
     start_time = perf_counter()
-    chargeable_query_info: Optional[Any] = None
+    budgeted_query_info: Optional[Any] = None
 
     try:
         QUERY_STARTED_COUNTER.labels(
@@ -560,8 +560,8 @@ def sync_execute(
                 # A query killed mid-scan (timeout, memory limit) has already cost the read, so
                 # keep the progress the server reported before it died. The Redis write happens
                 # in the outer finally, once the connection is back in the pool.
-                if tags.chargeable and tags.team_id and not tags.api_queries_budget_exempt:
-                    chargeable_query_info = _chargeable_query_info(client, query_info_before)
+                if tags.api_queries_budgeted and tags.team_id:
+                    budgeted_query_info = _query_info_to_meter(client, query_info_before)
             if (
                 "INSERT INTO" in prepared_sql
                 and hasattr(client, "last_query")
@@ -584,8 +584,8 @@ def sync_execute(
         raise err from e
     finally:
         execution_time = perf_counter() - start_time
-        if chargeable_query_info is not None:
-            _meter_chargeable_query(str(tags.team_id), chargeable_query_info)
+        if budgeted_query_info is not None:
+            _meter_budgeted_query(str(tags.team_id), budgeted_query_info)
 
         QUERY_FINISHED_COUNTER.labels(
             team_id=str(team_id or ""),

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -560,7 +560,9 @@ def sync_execute(
                 # A query killed mid-scan (timeout, memory limit) has already cost the read, so
                 # keep the progress the server reported before it died. The Redis write happens
                 # in the outer finally, once the connection is back in the pool.
-                if tags.chargeable and tags.team_id:
+                # Endpoint runs are chargeable for billing but exempt from the read budget (see
+                # QueryRunner._call_with_rate_limits), so they are not debited either.
+                if tags.chargeable and tags.team_id and tags.product != Product.ENDPOINTS:
                     chargeable_query_info = _chargeable_query_info(client, query_info_before)
             if (
                 "INSERT INTO" in prepared_sql

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -420,6 +420,7 @@ class QueryTags(BaseModel):
     exported_asset_id: Optional[int] = None
     export_format: Optional[str] = None
     chargeable: Optional[int] = None
+    api_queries_budget_exempt: Optional[bool] = None  # server-set only; request tags cannot reach it
     request_name: Optional[str] = None
     name: Optional[str] = None
     endpoint_version: Optional[int] = None  # Endpoints, the product

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -420,7 +420,7 @@ class QueryTags(BaseModel):
     exported_asset_id: Optional[int] = None
     export_format: Optional[str] = None
     chargeable: Optional[int] = None
-    api_queries_budget_exempt: Optional[bool] = None  # server-set only; request tags cannot reach it
+    api_queries_budgeted: Optional[bool] = None  # server-set only; request tags cannot reach it
     request_name: Optional[str] = None
     name: Optional[str] = None
     endpoint_version: Optional[int] = None  # Endpoints, the product

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -2075,11 +2075,9 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
 
         if self.is_query_service:
             tag_queries(chargeable=1)
-            # Materialized endpoint runs read a precomputed table on the endpoints workload, so
-            # they do not draw from the read budget. Inline endpoint runs cost the same bytes as
-            # /query and stay budgeted. Keyed on the workload tag, which only the endpoint run
-            # view sets; the product tag is caller-supplied via query.tags.productKey.
-            if not is_materialized_endpoint:
+            # Only server code sets api_queries_budget_exempt (materialized endpoint runs and data
+            # catalog metric runs); the product tag is caller-supplied via query.tags.productKey.
+            if not get_query_tag_value("api_queries_budget_exempt"):
                 self._enforce_api_queries_budget()
 
         with (

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -129,7 +129,7 @@ from posthog.clickhouse.client.limit import (
     get_materialized_endpoints_rate_limiter,
     get_org_app_concurrency_limit,
 )
-from posthog.clickhouse.query_tagging import Feature, get_query_tag_value, is_api_key_access_method, tag_queries
+from posthog.clickhouse.query_tagging import get_query_tag_value, is_api_key_access_method, tag_queries
 from posthog.constants import AvailableFeature
 from posthog.dataclasses import frozen
 from posthog.errors import QueryErrorCategory, classify_query_error, clickhouse_error_type
@@ -2075,11 +2075,11 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
 
         if self.is_query_service:
             tag_queries(chargeable=1)
-            # Endpoints are billed as API queries but keep their own throttles and mostly serve
-            # cached or materialized results, so they do not draw from the read budget. Keyed on
-            # the feature tag, which only the endpoint run view sets; the product tag is
-            # caller-supplied via query.tags.productKey, so it cannot gate an exemption.
-            if get_query_tag_value("feature") != Feature.ENDPOINT_EXECUTION:
+            # Materialized endpoint runs read a precomputed table on the endpoints workload, so
+            # they do not draw from the read budget. Inline endpoint runs cost the same bytes as
+            # /query and stay budgeted. Keyed on the workload tag, which only the endpoint run
+            # view sets; the product tag is caller-supplied via query.tags.productKey.
+            if not is_materialized_endpoint:
                 self._enforce_api_queries_budget()
 
         with (

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -2075,10 +2075,10 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
 
         if self.is_query_service:
             tag_queries(chargeable=1)
-            # Only server code sets api_queries_budget_exempt (materialized endpoint runs and data
-            # catalog metric runs); the product tag is caller-supplied via query.tags.productKey.
-            if not get_query_tag_value("api_queries_budget_exempt"):
-                self._enforce_api_queries_budget()
+        # Only the /query view and the inline endpoint run set api_queries_budgeted; the product
+        # tag is caller-supplied via query.tags.productKey, so it cannot opt a query in or out.
+        if get_query_tag_value("api_queries_budgeted"):
+            self._enforce_api_queries_budget()
 
         with (
             get_materialized_endpoints_rate_limiter().run(

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -129,7 +129,7 @@ from posthog.clickhouse.client.limit import (
     get_materialized_endpoints_rate_limiter,
     get_org_app_concurrency_limit,
 )
-from posthog.clickhouse.query_tagging import get_query_tag_value, is_api_key_access_method, tag_queries
+from posthog.clickhouse.query_tagging import Product, get_query_tag_value, is_api_key_access_method, tag_queries
 from posthog.constants import AvailableFeature
 from posthog.dataclasses import frozen
 from posthog.errors import QueryErrorCategory, classify_query_error, clickhouse_error_type
@@ -2075,7 +2075,10 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
 
         if self.is_query_service:
             tag_queries(chargeable=1)
-            self._enforce_api_queries_budget()
+            # Endpoints are billed as API queries but keep their own throttles and mostly serve
+            # cached or materialized results, so they do not draw from the read budget.
+            if get_query_tag_value("product") != Product.ENDPOINTS:
+                self._enforce_api_queries_budget()
 
         with (
             get_materialized_endpoints_rate_limiter().run(

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -129,7 +129,7 @@ from posthog.clickhouse.client.limit import (
     get_materialized_endpoints_rate_limiter,
     get_org_app_concurrency_limit,
 )
-from posthog.clickhouse.query_tagging import Product, get_query_tag_value, is_api_key_access_method, tag_queries
+from posthog.clickhouse.query_tagging import Feature, get_query_tag_value, is_api_key_access_method, tag_queries
 from posthog.constants import AvailableFeature
 from posthog.dataclasses import frozen
 from posthog.errors import QueryErrorCategory, classify_query_error, clickhouse_error_type
@@ -2076,8 +2076,10 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         if self.is_query_service:
             tag_queries(chargeable=1)
             # Endpoints are billed as API queries but keep their own throttles and mostly serve
-            # cached or materialized results, so they do not draw from the read budget.
-            if get_query_tag_value("product") != Product.ENDPOINTS:
+            # cached or materialized results, so they do not draw from the read budget. Keyed on
+            # the feature tag, which only the endpoint run view sets; the product tag is
+            # caller-supplied via query.tags.productKey, so it cannot gate an exemption.
+            if get_query_tag_value("feature") != Feature.ENDPOINT_EXECUTION:
                 self._enforce_api_queries_budget()
 
         with (

--- a/posthog/hogql_queries/test/test_api_queries_budget.py
+++ b/posthog/hogql_queries/test/test_api_queries_budget.py
@@ -9,7 +9,7 @@ from parameterized import parameterized
 from posthog.schema import HogQLQuery
 
 from posthog.api_queries_budget import budget_spec_for, debit, refill_and_read
-from posthog.clickhouse.query_tagging import Product, reset_query_tags, tag_queries
+from posthog.clickhouse.query_tagging import Feature, Product, reset_query_tags, tag_queries
 from posthog.exceptions import APIQueriesBudgetExceeded
 from posthog.hogql_queries.hogql_query_runner import HogQLQueryRunner
 from posthog.hogql_queries.query_runner import (
@@ -99,7 +99,7 @@ class TestApiQueriesBudgetEnforcement(BaseTest):
     def test_call_with_rate_limits_does_not_enforce_the_budget_for_endpoint_runs(self):
         self._drain()
         runner = self._runner(is_query_service=True)
-        tag_queries(product=Product.ENDPOINTS)
+        tag_queries(feature=Feature.ENDPOINT_EXECUTION)
         try:
             with (
                 patch("posthog.hogql_queries.query_runner._api_queries_budget_enforcement_enabled", return_value=True),
@@ -109,6 +109,20 @@ class TestApiQueriesBudgetEnforcement(BaseTest):
         finally:
             reset_query_tags()
         assert result == "stub result"
+
+    def test_call_with_rate_limits_ignores_a_caller_supplied_endpoints_product_tag(self):
+        self._drain()
+        runner = self._runner(is_query_service=True)
+        tag_queries(product=Product.ENDPOINTS)
+        try:
+            with (
+                patch("posthog.hogql_queries.query_runner._api_queries_budget_enforcement_enabled", return_value=True),
+                patch.object(runner, "calculate", return_value="stub result"),
+                pytest.raises(APIQueriesBudgetExceeded),
+            ):
+                runner._call_with_rate_limits(dashboard_id=None)
+        finally:
+            reset_query_tags()
 
     def test_concurrency_limit_ignores_billing_quota_limited_teams(self):
         # get_api_queries_concurrency_limit reads the plain `posthog.settings` module

--- a/posthog/hogql_queries/test/test_api_queries_budget.py
+++ b/posthog/hogql_queries/test/test_api_queries_budget.py
@@ -9,6 +9,7 @@ from parameterized import parameterized
 from posthog.schema import HogQLQuery
 
 from posthog.api_queries_budget import budget_spec_for, debit, refill_and_read
+from posthog.clickhouse.client.connection import Workload
 from posthog.clickhouse.query_tagging import Feature, Product, reset_query_tags, tag_queries
 from posthog.exceptions import APIQueriesBudgetExceeded
 from posthog.hogql_queries.hogql_query_runner import HogQLQueryRunner
@@ -96,10 +97,10 @@ class TestApiQueriesBudgetEnforcement(BaseTest):
                 result, _duration_ms = runner._call_with_rate_limits(dashboard_id=None)
                 assert result == "stub result"
 
-    def test_call_with_rate_limits_does_not_enforce_the_budget_for_endpoint_runs(self):
+    def test_call_with_rate_limits_does_not_enforce_the_budget_for_materialized_endpoint_runs(self):
         self._drain()
         runner = self._runner(is_query_service=True)
-        tag_queries(feature=Feature.ENDPOINT_EXECUTION)
+        tag_queries(workload=Workload.ENDPOINTS, feature=Feature.ENDPOINT_EXECUTION)
         try:
             with (
                 patch("posthog.hogql_queries.query_runner._api_queries_budget_enforcement_enabled", return_value=True),
@@ -110,10 +111,16 @@ class TestApiQueriesBudgetEnforcement(BaseTest):
             reset_query_tags()
         assert result == "stub result"
 
-    def test_call_with_rate_limits_ignores_a_caller_supplied_endpoints_product_tag(self):
+    @parameterized.expand(
+        [
+            ("inline_endpoint_run", {"feature": Feature.ENDPOINT_EXECUTION}),
+            ("caller_supplied_endpoints_product_tag", {"product": Product.ENDPOINTS}),
+        ]
+    )
+    def test_call_with_rate_limits_still_enforces_the_budget(self, _name, tags):
         self._drain()
         runner = self._runner(is_query_service=True)
-        tag_queries(product=Product.ENDPOINTS)
+        tag_queries(**tags)
         try:
             with (
                 patch("posthog.hogql_queries.query_runner._api_queries_budget_enforcement_enabled", return_value=True),

--- a/posthog/hogql_queries/test/test_api_queries_budget.py
+++ b/posthog/hogql_queries/test/test_api_queries_budget.py
@@ -9,7 +9,7 @@ from parameterized import parameterized
 from posthog.schema import HogQLQuery
 
 from posthog.api_queries_budget import budget_spec_for, debit, refill_and_read
-from posthog.clickhouse.query_tagging import Feature, Product, reset_query_tags, tag_queries
+from posthog.clickhouse.query_tagging import Product, reset_query_tags, tag_queries
 from posthog.exceptions import APIQueriesBudgetExceeded
 from posthog.hogql_queries.hogql_query_runner import HogQLQueryRunner
 from posthog.hogql_queries.query_runner import (
@@ -81,46 +81,28 @@ class TestApiQueriesBudgetEnforcement(BaseTest):
         ):
             self._runner()._enforce_api_queries_budget()
 
-    @parameterized.expand([("api_key_query_refused", True), ("app_query_admitted", False)])
-    def test_call_with_rate_limits_enforces_the_budget_for_api_key_queries_only(self, _name, is_query_service):
+    @parameterized.expand([("api_key_query_unbudgeted", True), ("app_query", False)])
+    def test_call_with_rate_limits_admits_unbudgeted_queries(self, _name, is_query_service):
         self._drain()
         runner = self._runner(is_query_service=is_query_service)
         with (
             patch("posthog.hogql_queries.query_runner._api_queries_budget_enforcement_enabled", return_value=True),
             patch.object(runner, "calculate", return_value="stub result"),
         ):
-            if is_query_service:
-                with pytest.raises(APIQueriesBudgetExceeded):
-                    runner._call_with_rate_limits(dashboard_id=None)
-            else:
-                result, _duration_ms = runner._call_with_rate_limits(dashboard_id=None)
-                assert result == "stub result"
-
-    def test_call_with_rate_limits_does_not_enforce_the_budget_for_exempt_runs(self):
-        self._drain()
-        runner = self._runner(is_query_service=True)
-        tag_queries(api_queries_budget_exempt=True)
-        try:
-            with (
-                patch("posthog.hogql_queries.query_runner._api_queries_budget_enforcement_enabled", return_value=True),
-                patch.object(runner, "calculate", return_value="stub result"),
-            ):
-                result, _duration_ms = runner._call_with_rate_limits(dashboard_id=None)
-        finally:
-            reset_query_tags()
+            result, _duration_ms = runner._call_with_rate_limits(dashboard_id=None)
         assert result == "stub result"
 
     @parameterized.expand(
         [
-            ("inline_endpoint_run", {"feature": Feature.ENDPOINT_EXECUTION}),
+            ("budgeted", {}),
             ("caller_supplied_endpoints_product_tag", {"product": Product.ENDPOINTS}),
             ("caller_supplied_data_catalog_product_tag", {"product": Product.DATA_CATALOG}),
         ]
     )
-    def test_call_with_rate_limits_still_enforces_the_budget(self, _name, tags):
+    def test_call_with_rate_limits_enforces_the_budget_for_budgeted_queries(self, _name, tags):
         self._drain()
         runner = self._runner(is_query_service=True)
-        tag_queries(**tags)
+        tag_queries(api_queries_budgeted=True, **tags)
         try:
             with (
                 patch("posthog.hogql_queries.query_runner._api_queries_budget_enforcement_enabled", return_value=True),

--- a/posthog/hogql_queries/test/test_api_queries_budget.py
+++ b/posthog/hogql_queries/test/test_api_queries_budget.py
@@ -9,7 +9,6 @@ from parameterized import parameterized
 from posthog.schema import HogQLQuery
 
 from posthog.api_queries_budget import budget_spec_for, debit, refill_and_read
-from posthog.clickhouse.client.connection import Workload
 from posthog.clickhouse.query_tagging import Feature, Product, reset_query_tags, tag_queries
 from posthog.exceptions import APIQueriesBudgetExceeded
 from posthog.hogql_queries.hogql_query_runner import HogQLQueryRunner
@@ -97,10 +96,10 @@ class TestApiQueriesBudgetEnforcement(BaseTest):
                 result, _duration_ms = runner._call_with_rate_limits(dashboard_id=None)
                 assert result == "stub result"
 
-    def test_call_with_rate_limits_does_not_enforce_the_budget_for_materialized_endpoint_runs(self):
+    def test_call_with_rate_limits_does_not_enforce_the_budget_for_exempt_runs(self):
         self._drain()
         runner = self._runner(is_query_service=True)
-        tag_queries(workload=Workload.ENDPOINTS, feature=Feature.ENDPOINT_EXECUTION)
+        tag_queries(api_queries_budget_exempt=True)
         try:
             with (
                 patch("posthog.hogql_queries.query_runner._api_queries_budget_enforcement_enabled", return_value=True),
@@ -115,6 +114,7 @@ class TestApiQueriesBudgetEnforcement(BaseTest):
         [
             ("inline_endpoint_run", {"feature": Feature.ENDPOINT_EXECUTION}),
             ("caller_supplied_endpoints_product_tag", {"product": Product.ENDPOINTS}),
+            ("caller_supplied_data_catalog_product_tag", {"product": Product.DATA_CATALOG}),
         ]
     )
     def test_call_with_rate_limits_still_enforces_the_budget(self, _name, tags):

--- a/posthog/hogql_queries/test/test_api_queries_budget.py
+++ b/posthog/hogql_queries/test/test_api_queries_budget.py
@@ -9,6 +9,7 @@ from parameterized import parameterized
 from posthog.schema import HogQLQuery
 
 from posthog.api_queries_budget import budget_spec_for, debit, refill_and_read
+from posthog.clickhouse.query_tagging import Product, reset_query_tags, tag_queries
 from posthog.exceptions import APIQueriesBudgetExceeded
 from posthog.hogql_queries.hogql_query_runner import HogQLQueryRunner
 from posthog.hogql_queries.query_runner import (
@@ -94,6 +95,20 @@ class TestApiQueriesBudgetEnforcement(BaseTest):
             else:
                 result, _duration_ms = runner._call_with_rate_limits(dashboard_id=None)
                 assert result == "stub result"
+
+    def test_call_with_rate_limits_does_not_enforce_the_budget_for_endpoint_runs(self):
+        self._drain()
+        runner = self._runner(is_query_service=True)
+        tag_queries(product=Product.ENDPOINTS)
+        try:
+            with (
+                patch("posthog.hogql_queries.query_runner._api_queries_budget_enforcement_enabled", return_value=True),
+                patch.object(runner, "calculate", return_value="stub result"),
+            ):
+                result, _duration_ms = runner._call_with_rate_limits(dashboard_id=None)
+        finally:
+            reset_query_tags()
+        assert result == "stub result"
 
     def test_concurrency_limit_ignores_billing_quota_limited_teams(self):
         # get_api_queries_concurrency_limit reads the plain `posthog.settings` module

--- a/posthog/test/test_api_queries_budget.py
+++ b/posthog/test/test_api_queries_budget.py
@@ -21,7 +21,7 @@ from posthog.api_queries_budget import (
     seconds_until_positive,
 )
 from posthog.clickhouse.client import sync_execute
-from posthog.clickhouse.query_tagging import Product, reset_query_tags, tag_queries
+from posthog.clickhouse.query_tagging import Feature, Product, reset_query_tags, tag_queries
 
 SPEC = BudgetSpec(bytes_per_hour=3600.0, capacity_bytes=7200.0)
 
@@ -124,13 +124,22 @@ class TestChargeableQueryMetering(ClickhouseTestMixin, BaseTest):
         sync_execute(self.BOUNDED_QUERY)
         assert get_request_query_cost() is None
 
-    def test_endpoint_query_is_chargeable_but_not_metered(self):
-        tag_queries(chargeable=1, team_id=self.team.pk, product=Product.ENDPOINTS)
+    def test_endpoint_run_is_chargeable_but_not_metered(self):
+        tag_queries(chargeable=1, team_id=self.team.pk, feature=Feature.ENDPOINT_EXECUTION)
         try:
             sync_execute(self.BOUNDED_QUERY)
         finally:
             reset_query_tags()
         assert get_request_query_cost() is None
+
+    def test_caller_supplied_endpoints_product_tag_is_still_metered(self):
+        tag_queries(chargeable=1, team_id=self.team.pk, product=Product.ENDPOINTS)
+        try:
+            sync_execute(self.BOUNDED_QUERY)
+        finally:
+            reset_query_tags()
+        cost = get_request_query_cost()
+        assert cost is not None and cost.bytes_read > 0
 
 
 class QueryDied(Exception):

--- a/posthog/test/test_api_queries_budget.py
+++ b/posthog/test/test_api_queries_budget.py
@@ -21,6 +21,7 @@ from posthog.api_queries_budget import (
     seconds_until_positive,
 )
 from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.client.connection import Workload
 from posthog.clickhouse.query_tagging import Feature, Product, reset_query_tags, tag_queries
 
 SPEC = BudgetSpec(bytes_per_hour=3600.0, capacity_bytes=7200.0)
@@ -124,16 +125,22 @@ class TestChargeableQueryMetering(ClickhouseTestMixin, BaseTest):
         sync_execute(self.BOUNDED_QUERY)
         assert get_request_query_cost() is None
 
-    def test_endpoint_run_is_chargeable_but_not_metered(self):
-        tag_queries(chargeable=1, team_id=self.team.pk, feature=Feature.ENDPOINT_EXECUTION)
+    def test_materialized_endpoint_run_is_chargeable_but_not_metered(self):
+        tag_queries(chargeable=1, team_id=self.team.pk, workload=Workload.ENDPOINTS, feature=Feature.ENDPOINT_EXECUTION)
         try:
             sync_execute(self.BOUNDED_QUERY)
         finally:
             reset_query_tags()
         assert get_request_query_cost() is None
 
-    def test_caller_supplied_endpoints_product_tag_is_still_metered(self):
-        tag_queries(chargeable=1, team_id=self.team.pk, product=Product.ENDPOINTS)
+    @parameterized.expand(
+        [
+            ("inline_endpoint_run", {"feature": Feature.ENDPOINT_EXECUTION}),
+            ("caller_supplied_endpoints_product_tag", {"product": Product.ENDPOINTS}),
+        ]
+    )
+    def test_chargeable_query_is_still_metered(self, _name, tags):
+        tag_queries(chargeable=1, team_id=self.team.pk, **tags)
         try:
             sync_execute(self.BOUNDED_QUERY)
         finally:

--- a/posthog/test/test_api_queries_budget.py
+++ b/posthog/test/test_api_queries_budget.py
@@ -21,7 +21,7 @@ from posthog.api_queries_budget import (
     seconds_until_positive,
 )
 from posthog.clickhouse.client import sync_execute
-from posthog.clickhouse.query_tagging import Feature, Product, reset_query_tags, tag_queries
+from posthog.clickhouse.query_tagging import Product, reset_query_tags, tag_queries
 
 SPEC = BudgetSpec(bytes_per_hour=3600.0, capacity_bytes=7200.0)
 
@@ -99,7 +99,7 @@ class TestRequestQueryCost(SimpleTestCase):
         assert get_request_query_cost() is None
 
 
-class TestChargeableQueryMetering(ClickhouseTestMixin, BaseTest):
+class TestBudgetedQueryMetering(ClickhouseTestMixin, BaseTest):
     # LIMIT applies to the aggregate's single output row, not to system.numbers itself,
     # so bound the scan inside a subquery or the read never terminates.
     BOUNDED_QUERY = "SELECT sum(number) FROM (SELECT number FROM system.numbers LIMIT 10000)"
@@ -108,10 +108,10 @@ class TestChargeableQueryMetering(ClickhouseTestMixin, BaseTest):
         super().setUp()
         reset_request_query_cost()
 
-    def test_chargeable_query_debits_the_team_budget(self):
+    def test_budgeted_query_debits_the_team_budget(self):
         spec = budget_spec_for(self.organization)
         refill_and_read(str(self.team.pk), spec)
-        tag_queries(chargeable=1, team_id=self.team.pk)
+        tag_queries(api_queries_budgeted=True, team_id=self.team.pk)
         try:
             sync_execute(self.BOUNDED_QUERY)
         finally:
@@ -124,8 +124,8 @@ class TestChargeableQueryMetering(ClickhouseTestMixin, BaseTest):
         sync_execute(self.BOUNDED_QUERY)
         assert get_request_query_cost() is None
 
-    def test_exempt_run_is_chargeable_but_not_metered(self):
-        tag_queries(chargeable=1, team_id=self.team.pk, api_queries_budget_exempt=True)
+    def test_chargeable_but_unbudgeted_query_is_not_metered(self):
+        tag_queries(chargeable=1, team_id=self.team.pk)
         try:
             sync_execute(self.BOUNDED_QUERY)
         finally:
@@ -134,13 +134,12 @@ class TestChargeableQueryMetering(ClickhouseTestMixin, BaseTest):
 
     @parameterized.expand(
         [
-            ("inline_endpoint_run", {"feature": Feature.ENDPOINT_EXECUTION}),
             ("caller_supplied_endpoints_product_tag", {"product": Product.ENDPOINTS}),
             ("caller_supplied_data_catalog_product_tag", {"product": Product.DATA_CATALOG}),
         ]
     )
-    def test_chargeable_query_is_still_metered(self, _name, tags):
-        tag_queries(chargeable=1, team_id=self.team.pk, **tags)
+    def test_caller_supplied_tags_do_not_change_metering(self, _name, tags):
+        tag_queries(api_queries_budgeted=True, team_id=self.team.pk, **tags)
         try:
             sync_execute(self.BOUNDED_QUERY)
         finally:
@@ -161,7 +160,7 @@ class TestFailedQueryMetering(BaseTest):
         fake_client.execute.side_effect = QueryDied("network down before connecting")
         pool = MagicMock()
         pool.__enter__.return_value = fake_client
-        tag_queries(chargeable=1, team_id=self.team.pk)
+        tag_queries(api_queries_budgeted=True, team_id=self.team.pk)
         try:
             with patch("posthog.clickhouse.client.execute.get_client_from_pool", return_value=pool):
                 with pytest.raises(QueryDied):

--- a/posthog/test/test_api_queries_budget.py
+++ b/posthog/test/test_api_queries_budget.py
@@ -21,7 +21,6 @@ from posthog.api_queries_budget import (
     seconds_until_positive,
 )
 from posthog.clickhouse.client import sync_execute
-from posthog.clickhouse.client.connection import Workload
 from posthog.clickhouse.query_tagging import Feature, Product, reset_query_tags, tag_queries
 
 SPEC = BudgetSpec(bytes_per_hour=3600.0, capacity_bytes=7200.0)
@@ -125,8 +124,8 @@ class TestChargeableQueryMetering(ClickhouseTestMixin, BaseTest):
         sync_execute(self.BOUNDED_QUERY)
         assert get_request_query_cost() is None
 
-    def test_materialized_endpoint_run_is_chargeable_but_not_metered(self):
-        tag_queries(chargeable=1, team_id=self.team.pk, workload=Workload.ENDPOINTS, feature=Feature.ENDPOINT_EXECUTION)
+    def test_exempt_run_is_chargeable_but_not_metered(self):
+        tag_queries(chargeable=1, team_id=self.team.pk, api_queries_budget_exempt=True)
         try:
             sync_execute(self.BOUNDED_QUERY)
         finally:
@@ -137,6 +136,7 @@ class TestChargeableQueryMetering(ClickhouseTestMixin, BaseTest):
         [
             ("inline_endpoint_run", {"feature": Feature.ENDPOINT_EXECUTION}),
             ("caller_supplied_endpoints_product_tag", {"product": Product.ENDPOINTS}),
+            ("caller_supplied_data_catalog_product_tag", {"product": Product.DATA_CATALOG}),
         ]
     )
     def test_chargeable_query_is_still_metered(self, _name, tags):

--- a/posthog/test/test_api_queries_budget.py
+++ b/posthog/test/test_api_queries_budget.py
@@ -21,7 +21,7 @@ from posthog.api_queries_budget import (
     seconds_until_positive,
 )
 from posthog.clickhouse.client import sync_execute
-from posthog.clickhouse.query_tagging import reset_query_tags, tag_queries
+from posthog.clickhouse.query_tagging import Product, reset_query_tags, tag_queries
 
 SPEC = BudgetSpec(bytes_per_hour=3600.0, capacity_bytes=7200.0)
 
@@ -122,6 +122,14 @@ class TestChargeableQueryMetering(ClickhouseTestMixin, BaseTest):
 
     def test_untagged_query_is_not_metered(self):
         sync_execute(self.BOUNDED_QUERY)
+        assert get_request_query_cost() is None
+
+    def test_endpoint_query_is_chargeable_but_not_metered(self):
+        tag_queries(chargeable=1, team_id=self.team.pk, product=Product.ENDPOINTS)
+        try:
+            sync_execute(self.BOUNDED_QUERY)
+        finally:
+            reset_query_tags()
         assert get_request_query_cost() is None
 
 

--- a/products/data_catalog/backend/logic/execution.py
+++ b/products/data_catalog/backend/logic/execution.py
@@ -95,7 +95,7 @@ def run_metric(
         )
         started_at = time.monotonic()
         try:
-            with tags_context(product=Product.DATA_CATALOG, feature=Feature.QUERY, api_queries_budget_exempt=True):
+            with tags_context(product=Product.DATA_CATALOG, feature=Feature.QUERY):
                 raw = process_query_dict(
                     team,
                     query,

--- a/products/data_catalog/backend/logic/execution.py
+++ b/products/data_catalog/backend/logic/execution.py
@@ -95,7 +95,7 @@ def run_metric(
         )
         started_at = time.monotonic()
         try:
-            with tags_context(product=Product.DATA_CATALOG, feature=Feature.QUERY):
+            with tags_context(product=Product.DATA_CATALOG, feature=Feature.QUERY, api_queries_budget_exempt=True):
                 raw = process_query_dict(
                     team,
                     query,

--- a/products/data_catalog/backend/tests/test_execution.py
+++ b/products/data_catalog/backend/tests/test_execution.py
@@ -227,14 +227,12 @@ class TestMetricRunTagging(APIBaseTest):
         def capture(*args: object, **kwargs: object) -> dict:
             tags = get_query_tags()
             captured["product"], captured["feature"] = tags.product, tags.feature
-            captured["exempt"] = tags.api_queries_budget_exempt
             return dict(_OK_PAYLOAD)
 
         with patch(_PROCESS_QUERY, side_effect=capture):
             run_metric(team=self.team, metric=metric, user=self.user)
 
         assert (captured["product"], captured["feature"]) == (Product.DATA_CATALOG, Feature.QUERY)
-        assert captured["exempt"] is True
 
     @parameterized.expand(
         [

--- a/products/data_catalog/backend/tests/test_execution.py
+++ b/products/data_catalog/backend/tests/test_execution.py
@@ -227,12 +227,14 @@ class TestMetricRunTagging(APIBaseTest):
         def capture(*args: object, **kwargs: object) -> dict:
             tags = get_query_tags()
             captured["product"], captured["feature"] = tags.product, tags.feature
+            captured["exempt"] = tags.api_queries_budget_exempt
             return dict(_OK_PAYLOAD)
 
         with patch(_PROCESS_QUERY, side_effect=capture):
             run_metric(team=self.team, metric=metric, user=self.user)
 
         assert (captured["product"], captured["feature"]) == (Product.DATA_CATALOG, Feature.QUERY)
+        assert captured["exempt"] is True
 
     @parameterized.expand(
         [

--- a/products/endpoints/backend/logic/execution.py
+++ b/products/endpoints/backend/logic/execution.py
@@ -804,6 +804,7 @@ class EndpointExecutionService(PydanticModelMixin):
                 workload=Workload.ENDPOINTS,
                 warehouse_query=True,
                 endpoint_version=version.version,
+                api_queries_budget_exempt=True,
             )
 
             # Compute dynamic cache TTL: time remaining until data_freshness window expires

--- a/products/endpoints/backend/logic/execution.py
+++ b/products/endpoints/backend/logic/execution.py
@@ -804,7 +804,6 @@ class EndpointExecutionService(PydanticModelMixin):
                 workload=Workload.ENDPOINTS,
                 warehouse_query=True,
                 endpoint_version=version.version,
-                api_queries_budget_exempt=True,
             )
 
             # Compute dynamic cache TTL: time remaining until data_freshness window expires
@@ -945,6 +944,8 @@ class EndpointExecutionService(PydanticModelMixin):
         offset: int | None = None,
     ) -> Response:
         """Execute query directly against ClickHouse."""
+        if is_api_key_access_method(get_query_tag_value("access_method")):
+            tag_queries(api_queries_budgeted=True)
         strategy: EndpointQueryStrategy | None = None
         try:
             strategy = strategy_for(endpoint, version, self.team)


### PR DESCRIPTION
## Problem

The hourly read budget (PR 95375) is gated on `is_query_service`, a flag that endpoint runs and data catalog metric runs also set for billing and the concurrency limiter. So they got budgeted by accident: a materialized endpoint reads a precomputed table, yet it can 429 because someone on the same team polled `/query`. Any new surface that sets `is_query_service` would inherit the budget the same way.

## Changes

- The budget is now opt-in through a server-set `api_queries_budgeted` query tag.
- Only two places set it: the `/query` view for personal API key requests, and the inline  endpoint run for any API key.
- The runner checks the budget and the ClickHouse client debits the bucket only when the tag is set, so `is_query_service` goes back to meaning billing and the concurrency limiter.
- Request tags can't reach the new tag, so callers can't opt in or out.
- Materialized endpoint runs and data catalog metric runs end up unbudgeted without any code of their own.

## How did you test this code?

- `pytest posthog/hogql_queries/test/test_api_queries_budget.py posthog/test/test_api_queries_budget.py`: tagged queries are refused and debited, including with a caller-supplied `product` tag; untagged `is_query_service` queries are admitted and not debited.
- The `/query` cost-header tests and the endpoint execution tests still pass.
- End to end on a local `runserver` with a 20 KB budget: a personal API key `/query` and an inline endpoint run each debited 16,000 bytes and were admission-checked (counters and the observe log line); a data catalog metric run and a session `/query` touched neither the bucket nor the counters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RubgfyZjB81BshzwWn7Unr



