### PR TITLE
feat(persons): record the duration of the distinct-id move in a merge

### DIFF
--- a/nodejs/src/common/persons/repositories/postgres-person-repository.ts
+++ b/nodejs/src/common/persons/repositories/postgres-person-repository.ts
@@ -14,6 +14,8 @@ import { PersonUpdate } from '~/common/persons/person-update-batch'
 import { CreatePersonResult, MoveDistinctIdsResult, PersonPropertiesSize } from '~/common/utils/db/db'
 import {
     moveDistinctIdsCountHistogram,
+    moveDistinctIdsDurationHistogram,
+    movedRowsBand,
     personPropertiesSizeHistogram,
     personUpdateVersionMismatchCounter,
 } from '~/common/utils/db/metrics'
@@ -1629,6 +1631,7 @@ export class PostgresPersonRepository
         tx?: TransactionClient
     ): Promise<MoveDistinctIdsResult> {
         let movedDistinctIdResult: QueryResult<any> | null = null
+        const stopMoveTimer = moveDistinctIdsDurationHistogram.startTimer()
         try {
             const hasLimit = limit !== undefined
             const query = hasLimit
@@ -1682,14 +1685,17 @@ export class PostgresPersonRepository
                 })
                 // Track 0 moved IDs for failed merges
                 moveDistinctIdsCountHistogram.observe(0)
+                stopMoveTimer({ rows: '0' })
                 return {
                     success: false,
                     error: 'TargetNotFound',
                 }
             }
 
+            stopMoveTimer({ rows: 'error' })
             throw error
         }
+        stopMoveTimer({ rows: movedRowsBand(movedDistinctIdResult.rows.length) })
 
         // this is caused by a race condition where the _source_ person was deleted after fetching but
         // before the update query ran and will trigger a retry with updated persons
@@ -1762,6 +1768,7 @@ export class PostgresPersonRepository
         const sourceIds = sources.map((source) => source.id).sort((a, b) => (BigInt(a) < BigInt(b) ? -1 : 1))
 
         let movedDistinctIdResult: QueryResult<any> | null = null
+        const stopMoveTimer = moveDistinctIdsDurationHistogram.startTimer()
         try {
             movedDistinctIdResult = await this.postgres.query(
                 tx ?? PostgresUse.PERSONS_WRITE,
@@ -1787,14 +1794,17 @@ export class PostgresPersonRepository
                     person_id: target.id,
                 })
                 moveDistinctIdsCountHistogram.observe(0)
+                stopMoveTimer({ rows: '0' })
                 return {
                     success: false,
                     error: 'TargetNotFound',
                 }
             }
 
+            stopMoveTimer({ rows: 'error' })
             throw error
         }
+        stopMoveTimer({ rows: movedRowsBand(movedDistinctIdResult.rows.length) })
 
         // Unlike the single-source variant, zero moved rows for a source is not
         // a failure here: a concurrently completed merge may have already moved

--- a/nodejs/src/common/utils/db/metrics.test.ts
+++ b/nodejs/src/common/utils/db/metrics.test.ts
@@ -1,0 +1,20 @@
+import { movedRowsBand } from './metrics'
+
+describe('movedRowsBand', () => {
+    it.each([
+        [0, '0'],
+        [1, '1'],
+        [2, '2-10'],
+        [10, '2-10'],
+        [11, '11-100'],
+        [100, '11-100'],
+        [101, '101-1000'],
+        [1000, '101-1000'],
+        [1001, '1001-10000'],
+        [10000, '1001-10000'],
+        [10001, '10001+'],
+        [500000, '10001+'],
+    ])('maps %i moved rows to band %s', (count, band) => {
+        expect(movedRowsBand(count)).toBe(band)
+    })
+})

--- a/nodejs/src/common/utils/db/metrics.ts
+++ b/nodejs/src/common/utils/db/metrics.ts
@@ -24,6 +24,31 @@ export const moveDistinctIdsCountHistogram = new Histogram({
     ],
 })
 
+export const moveDistinctIdsDurationHistogram = new Histogram({
+    name: 'move_distinct_ids_duration_seconds',
+    help: 'Wall time of the UPDATE that moves distinct IDs in a merge, by number of rows moved',
+    labelNames: ['rows'],
+    buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60],
+})
+
+const MOVED_ROWS_BANDS: [number, string][] = [
+    [0, '0'],
+    [1, '1'],
+    [10, '2-10'],
+    [100, '11-100'],
+    [1000, '101-1000'],
+    [10000, '1001-10000'],
+]
+
+export function movedRowsBand(count: number): string {
+    for (const [upperBound, band] of MOVED_ROWS_BANDS) {
+        if (count <= upperBound) {
+            return band
+        }
+    }
+    return '10001+'
+}
+
 export const personPropertiesSizeHistogram = new Histogram({
     name: 'person_properties_size',
     help: 'histogram of compressed person JSONB bytes retrieved in Person DB calls',


### PR DESCRIPTION
## Problem

- Nobody can tell how many distinct-id moves in a merge take longer than a second, or what the fleet-wide p99 of that UPDATE is.
- Every query records `instrumented_fn_duration_ms`, a per-pod lifetime Summary. It has no buckets, so it cannot be thresholded, windowed to a day, or merged across pods.
- `move_distinct_ids_count` records how many rows a move touched, but not how long it took. A move that hits the statement timeout never reaches it.

## Changes

- Operators can now read the daily count of moves over any latency threshold, and the p99 per moved-row band, from the new `move_distinct_ids_duration_seconds` histogram.
- The histogram times only the UPDATE that reassigns rows to the target person, in both the single-source and the folded merge paths. The Kafka produce and the rest of the merge transaction stay out.
- The `rows` label bands the moved-row count: 0, 1, 2-10, 11-100, 101-1000, 1001-10000, 10001+. A query that throws records under `error`, so a timed-out move is counted.
- Buckets run from 5 ms to 60 s with 1 s as a boundary. Cardinality is 8 bands times 14 buckets per pod.
- Nothing user-visible changes.

Once deployed, the two questions this answers:

```promql
# moves over 1 s per day, by row band
sum by (rows) (increase(move_distinct_ids_duration_seconds_bucket{le="+Inf"}[1d]) - ignoring(le) increase(move_distinct_ids_duration_seconds_bucket{le="1"}[1d]))

# fleet-wide daily p99 per row band
histogram_quantile(0.99, sum by (le, rows) (rate(move_distinct_ids_duration_seconds_bucket[1d])))
```

The obvious alternative, turning the per-query Summary into a Histogram for every query tag, was rejected. It multiplies series by the bucket count across every tag, and no generic wrapper can attach the row band, which is the split that matters here.

## How did you test this code?

- `movedRowsBand` has an `it.each` test over each band edge. It catches an edge moved so that 100 or 10000 lands in the neighboring band, which would misfile data silently. No existing test covered the metrics module.
- Not run: the Postgres-backed repository suites. The call sites are a timer start and stop around existing queries, with no change to the queries themselves.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`. No CodeRabbit local pass, which is paused. The change started as a question about how many wide merges cross one second; the existing Summary and row-count histogram could only bound it, so this histogram was added to measure it directly. No open PR adds merge latency buckets.

https://claude.ai/code/session_01Bg8t24xC1Xk2dRvBbf2Q21
