### PR TITLE
chore(ruff): pin target-version to py313

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -328,6 +328,9 @@ profile = "black"
 
 [tool.ruff]
 line-length = 120
+# Pinned apart from requires-python. Raising it to py314 makes ruff format drop the parentheses
+# in `except (A, B):` (PEP 758) across the repo, and makes UP037 flag every quoted annotation.
+target-version = "py313"
 force-exclude = true
 exclude = [
     ".git",


### PR DESCRIPTION
## Problem

- The interpreter bump in [bump to 3.14.7](https://github.com/PostHog/posthog/pull/94402) also reformats 654 files and fails the CI format check.
- ruff reads its target from `requires-python`. At py314, `ruff format` drops the parentheses in `except (A, B):` (PEP 758).

## Changes

- `[tool.ruff]` sets `target-version = "py313"`, so the ruff target no longer follows `requires-python`. Nothing changes on master today.
- Code with 3.14-only syntax, such as `except A, B:`, fails `ruff check` until the target moves.
- A follow-up raises the target and applies the reformat and the UP037 fixes.

## How did you test this code?

ruff 0.15.20, with `requires-python` set to 3.14.7 locally:

| ruff target | `ruff format --check .` |
| --- | --- |
| py314 | 654 files would change |
| py313 (this pin) | 0 files would change |

- `ruff check .` passes with the pin.
- `except ValueError, TypeError:` fails with "Multiple exception types must be parenthesized on Python 3.13".

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code. Skills: `/writing-pr-descriptions`, `/writing-code-comments`, `/reviewing-with-coderabbit`.
- The CodeRabbit pass is paused, so the PR opened without a local pass.
- Split out of [bump to 3.14.7](https://github.com/PostHog/posthog/pull/94402) so the cutover layer stays small.

https://claude.ai/code/session_018GcySHcU5S9WncgqkWuCGd
