### PR TITLE
fix(desktop): show full pull request references

### DIFF
--- a/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.stories.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.stories.tsx
@@ -1,4 +1,8 @@
-import { GithubRefChip } from "@posthog/ui/features/editor/components/GithubRefChip";
+import { GitPullRequestIcon } from "@phosphor-icons/react";
+import {
+  GithubRefChip,
+  GithubRefChipLink,
+} from "@posthog/ui/features/editor/components/GithubRefChip";
 import {
   PrRefChip,
   type PrRefDetails,
@@ -23,6 +27,39 @@ export const WithoutLiveDetails: Story = {
       >
         example-org/example-repo#101
       </GithubRefChip>
+    </div>
+  ),
+};
+
+const NINE_DIGIT_PULL_REQUEST = "#123456789";
+
+export const PullRequestNumberWidth: Story = {
+  render: () => (
+    <div className="flex flex-col items-start gap-4 text-[13px]">
+      <div className="flex flex-col gap-1">
+        <span className="text-(--gray-11)">Before</span>
+        <div className="w-[6ch]">
+          <GithubRefChipLink
+            href="https://github.com/example-org/example-repo/pull/123456789"
+            icon={GitPullRequestIcon}
+            preservePrNumber={false}
+          >
+            {NINE_DIGIT_PULL_REQUEST}
+          </GithubRefChipLink>
+        </div>
+      </div>
+      <div className="flex flex-col gap-1">
+        <span className="text-(--gray-11)">After</span>
+        <div className="w-[6ch]">
+          <GithubRefChipLink
+            href="https://github.com/example-org/example-repo/pull/123456789"
+            icon={GitPullRequestIcon}
+            preservePrNumber
+          >
+            {NINE_DIGIT_PULL_REQUEST}
+          </GithubRefChipLink>
+        </div>
+      </div>
     </div>
   ),
 };

--- a/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.stories.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.stories.tsx
@@ -29,7 +29,7 @@ export const WithoutLiveDetails: Story = {
 
 const LIFECYCLE_CASES: { number: number; details: PrRefDetails }[] = [
   {
-    number: 101,
+    number: 123456789,
     details: {
       state: "open",
       merged: false,

--- a/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.stories.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.stories.tsx
@@ -31,14 +31,14 @@ export const WithoutLiveDetails: Story = {
   ),
 };
 
-const NINE_DIGIT_PULL_REQUEST = "#123456789";
+const NINE_DIGIT_PULL_REQUEST = "example-org/example-repo#123456789";
 
 export const PullRequestNumberWidth: Story = {
   render: () => (
     <div className="flex flex-col items-start gap-4 text-[13px]">
       <div className="flex flex-col gap-1">
         <span className="text-(--gray-11)">Before</span>
-        <div className="w-[6ch]">
+        <div className="w-[22ch]">
           <GithubRefChipLink
             href="https://github.com/example-org/example-repo/pull/123456789"
             icon={GitPullRequestIcon}
@@ -50,7 +50,7 @@ export const PullRequestNumberWidth: Story = {
       </div>
       <div className="flex flex-col gap-1">
         <span className="text-(--gray-11)">After</span>
-        <div className="w-[6ch]">
+        <div className="w-[22ch]">
           <GithubRefChipLink
             href="https://github.com/example-org/example-repo/pull/123456789"
             icon={GitPullRequestIcon}

--- a/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.test.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.test.tsx
@@ -7,14 +7,44 @@ describe("GithubRefChip", () => {
     const href = "https://github.com/PostHog/posthog/pull/23985";
     const { container } = render(
       <GithubRefChip href={href} kind="pr">
-        #123456789
+        PostHog/posthog#23985
       </GithubRefChip>,
     );
 
     const carrier = container.querySelector(`[${GITHUB_REF_URL_ATTR}]`);
     expect(carrier).not.toBeNull();
     expect(carrier?.getAttribute(GITHUB_REF_URL_ATTR)).toBe(href);
-    expect(screen.getByText("#123456789")).toHaveClass("min-w-[10ch]");
+  });
+
+  it("truncates a pull request label from the start so its number survives", () => {
+    render(
+      <GithubRefChip
+        href="https://github.com/PostHog/posthog/pull/123456789"
+        kind="pr"
+      >
+        PostHog/posthog#123456789
+      </GithubRefChip>,
+    );
+
+    const label = screen.getByText("PostHog/posthog#123456789");
+    expect(label).toHaveAttribute("dir", "ltr");
+    expect(label.parentElement).toHaveAttribute("dir", "rtl");
+    expect(label.parentElement).toHaveClass("truncate");
+  });
+
+  it("leaves a label that puts its number first alone", () => {
+    render(
+      <GithubRefChip
+        href="https://github.com/PostHog/posthog/pull/42"
+        kind="pr"
+      >
+        #42 - Fix the sign-up redirect
+      </GithubRefChip>,
+    );
+
+    expect(
+      screen.getByText("#42 - Fix the sign-up redirect"),
+    ).not.toHaveAttribute("dir");
   });
 
   it("lets a nested right-click target resolve the URL via closest()", () => {

--- a/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.test.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.test.tsx
@@ -7,13 +7,14 @@ describe("GithubRefChip", () => {
     const href = "https://github.com/PostHog/posthog/pull/23985";
     const { container } = render(
       <GithubRefChip href={href} kind="pr">
-        PostHog/posthog#23985
+        #123456789
       </GithubRefChip>,
     );
 
     const carrier = container.querySelector(`[${GITHUB_REF_URL_ATTR}]`);
     expect(carrier).not.toBeNull();
     expect(carrier?.getAttribute(GITHUB_REF_URL_ATTR)).toBe(href);
+    expect(screen.getByText("#123456789")).toHaveClass("min-w-[10ch]");
   });
 
   it("lets a nested right-click target resolve the URL via closest()", () => {

--- a/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.tsx
@@ -18,6 +18,7 @@ interface GithubRefChipLinkProps
   /** Names the icon for screen readers. Omit when the icon says nothing extra. */
   iconLabel?: string;
   toneClass?: string;
+  preservePrNumber?: boolean;
   children: ReactNode;
 }
 
@@ -32,7 +33,15 @@ export const GithubRefChipLink = forwardRef<
   HTMLButtonElement,
   GithubRefChipLinkProps
 >(function GithubRefChipLink(
-  { href, icon: RefIcon, iconLabel, toneClass, children, ...buttonProps },
+  {
+    href,
+    icon: RefIcon,
+    iconLabel,
+    toneClass,
+    preservePrNumber,
+    children,
+    ...buttonProps
+  },
   ref,
 ) {
   return (
@@ -71,6 +80,7 @@ export const GithubRefChipLink = forwardRef<
         // chip edge in a narrow panel instead of truncating.
         className={cn(
           "inline-block max-w-[min(16rem,calc(100%-1rem))] truncate align-top",
+          preservePrNumber && "min-w-[10ch]",
           toneClass,
         )}
       >
@@ -98,6 +108,7 @@ export function GithubRefChip({
     <GithubRefChipLink
       href={href}
       icon={kind === "pr" ? GitPullRequestIcon : GithubLogoIcon}
+      preservePrNumber={kind === "pr"}
     >
       {children}
     </GithubRefChipLink>

--- a/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.tsx
@@ -18,8 +18,18 @@ interface GithubRefChipLinkProps
   /** Names the icon for screen readers. Omit when the icon says nothing extra. */
   iconLabel?: string;
   toneClass?: string;
+  /** Keeps a trailing `#number` visible when the label truncates. */
   preservePrNumber?: boolean;
   children: ReactNode;
+}
+
+/**
+ * Truncation removes the end of a label, which for `owner/repo#number` is the
+ * number that tells two pull requests apart. Only labels that end in a number
+ * qualify: `#12 - Title` already keeps its number at the front.
+ */
+function endsWithRefNumber(label: ReactNode): boolean {
+  return typeof label === "string" && /#\d+$/.test(label);
 }
 
 /**
@@ -44,6 +54,11 @@ export const GithubRefChipLink = forwardRef<
   },
   ref,
 ) {
+  // A right-to-left box puts the ellipsis at the start, so the trailing number
+  // survives truncation. The inner isolate keeps the text itself left-to-right.
+  // The label stays one text node on purpose: a number in its own flex item
+  // puts a line break into copied text.
+  const ellipsisAtStart = preservePrNumber && endsWithRefNumber(children);
   return (
     <Button
       ref={ref}
@@ -80,11 +95,11 @@ export const GithubRefChipLink = forwardRef<
         // chip edge in a narrow panel instead of truncating.
         className={cn(
           "inline-block max-w-[min(16rem,calc(100%-1rem))] truncate align-top",
-          preservePrNumber && "min-w-[10ch]",
           toneClass,
         )}
+        dir={ellipsisAtStart ? "rtl" : undefined}
       >
-        {children}
+        {ellipsisAtStart ? <span dir="ltr">{children}</span> : children}
       </span>
     </Button>
   );

--- a/products/desktop/packages/ui/src/features/editor/components/PrRefChip.test.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/PrRefChip.test.tsx
@@ -37,6 +37,9 @@ describe("PrRefChip", () => {
     expect(
       await screen.findByText("Show pull request status in sessions"),
     ).toBeInTheDocument();
+    expect(
+      document.querySelector('[data-slot="tooltip-content"]'),
+    ).toHaveTextContent("PostHog/posthog#23985");
     expect(screen.getByText("Created by @octocat")).toBeInTheDocument();
     expect(screen.getByText("CI passed")).toBeInTheDocument();
   });

--- a/products/desktop/packages/ui/src/features/editor/components/PrRefChip.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/PrRefChip.tsx
@@ -84,6 +84,7 @@ export function PrRefChip({
         {/* The tooltip surface is inverted, so its contents inherit that color
             rather than the page foreground/muted tokens. */}
         <div className="flex min-w-0 flex-col gap-1.5 text-start">
+          <span className="font-mono text-current/70">{children}</span>
           <div className="flex items-center gap-1.5 font-medium">
             <StatusIcon
               size={12}

--- a/products/desktop/packages/ui/src/features/editor/components/PrRefChip.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/PrRefChip.tsx
@@ -75,6 +75,7 @@ export function PrRefChip({
             icon={StatusIcon}
             iconLabel={iconLabel}
             toneClass={toneClass}
+            preservePrNumber
           >
             {children}
           </GithubRefChipLink>


### PR DESCRIPTION
## Problem

- Desktop users cannot tell pull requests apart when a narrow chat view truncates a chip label and the ellipsis removes the trailing `#number`.

## Changes

- Pull request chips whose label ends in a number now truncate from the start, so the number always stays visible.
- The label sits in a right-to-left box with a left-to-right isolate inside, which moves the ellipsis to the start without reordering the text.
- The label stays one text node, so copied chat text and screen readers get the full reference unchanged.
- Labels that put the number first, such as `#12 - Title`, keep the normal end truncation.
- The hover card continues to show the full repository and pull request reference.
- The Storybook state compares the old and new truncation of a nine-digit `owner/repo#number` label in the same narrow container.

Rejected alternatives: a minimum width on the whole label (the first version of this PR) cannot stop the ellipsis from removing the number of an `owner/repo#number` label. Splitting the number into its own flex item keeps it visible but puts a line break into copied text.

Before and after, in a 22-character container. This replaces the earlier screenshot, which showed a number-only label:

![story-width](https://raw.githubusercontent.com/PostHog/pr-assets/be3fb5dc650388520ede6767a9460b1bfed38aad/2026/09/0b95ca2d-5e17-4e93-a65e-bda32f593cb0.png)

## How did you test this code?

- Added a case that a pull request label ending in a number renders inside the start-truncating box, and one that a `#12 - Title` label does not. Both guard the two ways this fix can silently regress.
- Rendered the comparison story in headless Chromium and checked that selecting a chip copies the label as one unbroken line.
- Not run: the Storybook visual test runner.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No docs update is needed for this small UI fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- PostHog Slack app authored the first version with `/posthog-desktop`, `/storybook-stories`, `/writing-user-facing-copy`, and `/writing-pr-descriptions`.
- Claude Code addressed the Codex review with `/review-triage`, `/paul-pair`, `/writing-code-comments`, `/writing-tests`, and `/writing-pr-descriptions`, replacing the minimum-width approach with start truncation.
- The open-PR search found no duplicate. The PR opened without a local CodeRabbit pass.
- The screenshot uses a synthetic Storybook fixture. No private session data is in this PR.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1789072104577159?thread_ts=1789072104.577159&cid=C0ACRAMJUAG)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
