### PR TITLE
fix(persons): anchor "View events" to the event it was opened from

### DIFF
--- a/frontend/src/lib/components/NotFound/index.tsx
+++ b/frontend/src/lib/components/NotFound/index.tsx
@@ -15,13 +15,13 @@ import { preflightLogic } from 'lib/logic/preflightLogic'
 import { cn } from 'lib/utils/css-classes'
 import { getAppContext } from 'lib/utils/getAppContext'
 import { capitalizeFirstLetter } from 'lib/utils/strings'
-import { getDefaultEventsSceneQuery } from 'scenes/activity/explore/defaults'
+import { getPersonEventsSceneQuery } from 'scenes/activity/explore/defaults'
 import { useNotebookNode } from 'scenes/notebooks/Nodes/NotebookNodeContext'
 import { urls } from 'scenes/urls'
 
 import { adminLoginAs } from '~/layout/navigation/ImpersonationNotice/adminLoginAs'
 import { ImpersonationReasonModal } from '~/layout/navigation/ImpersonationNotice/ImpersonationReasonModal'
-import { ActivityTab, PropertyFilterType, PropertyOperator, UserBasicType } from '~/types'
+import { ActivityTab, UserBasicType } from '~/types'
 
 import { ScrollableShadows } from '../ScrollableShadows/ScrollableShadows'
 import { supportLogic } from '../Support/supportLogic'
@@ -118,16 +118,7 @@ export function NotFound({ object, caption, meta, className, style }: NotFoundPr
                             combineUrl(
                                 urls.activity(ActivityTab.ExploreEvents),
                                 {},
-                                {
-                                    q: getDefaultEventsSceneQuery([
-                                        {
-                                            type: PropertyFilterType.EventMetadata,
-                                            key: 'distinct_id',
-                                            value: meta.urlId,
-                                            operator: PropertyOperator.Exact,
-                                        },
-                                    ]),
-                                }
+                                { q: getPersonEventsSceneQuery(meta.urlId) }
                             ).url
                         }
                     >

--- a/frontend/src/lib/components/NotFound/index.tsx
+++ b/frontend/src/lib/components/NotFound/index.tsx
@@ -108,7 +108,7 @@ export function NotFound({ object, caption, meta, className, style }: NotFoundPr
                     </LemonButton>
                 </div>
             )}
-            {object === 'Person' && meta?.urlId && (
+            {object.toLowerCase() === 'person' && meta?.urlId && (
                 <div className="flex justify-center mt-4 w-fit">
                     <LemonButton
                         type="secondary"

--- a/frontend/src/queries/nodes/DataTable/renderColumn.test.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumn.test.tsx
@@ -1,0 +1,29 @@
+import { PersonDisplayProps } from 'scenes/persons/PersonDisplay'
+
+import { DataTableNode, NodeKind } from '~/queries/schema/schema-general'
+import { setLatestVersionsOnQuery } from '~/queries/utils'
+
+import { renderColumn } from './renderColumn'
+import { defaultDataTableColumns } from './utils'
+
+const select = defaultDataTableColumns(NodeKind.EventsQuery)
+const eventsTable = setLatestVersionsOnQuery({
+    kind: NodeKind.DataTableNode,
+    source: { kind: NodeKind.EventsQuery, select },
+}) as DataTableNode
+
+const TIMESTAMP = '2026-09-07T09:00:00Z'
+
+function personColumnProps(key: string, value: unknown): PersonDisplayProps {
+    const row = select.map((column) => (column === '*' ? { timestamp: TIMESTAMP } : null))
+    const element = renderColumn(key, value, row, 0, 1, eventsTable)
+    return (element as JSX.Element).props
+}
+
+describe('renderColumn', () => {
+    it('passes the row timestamp to the person column, so its popover links to events around that event', () => {
+        const value = { distinct_id: 'the-distinct-id', display_name: 'the-distinct-id' }
+
+        expect(personColumnProps('person_display_name -- Person', value).eventTimestamp).toBe(TIMESTAMP)
+    })
+})

--- a/frontend/src/queries/nodes/DataTable/renderColumn.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumn.tsx
@@ -336,9 +336,6 @@ export function renderColumn(
         if (isEventsQuery(query.source)) {
             displayProps.person = value.distinct_id ? (value as EventsQueryPersonColumn) : value
             displayProps.noPopover = false // If we are in an events list, the popover experience is better
-            const resultRow = record as any[]
-            const eventRecord = query.source.select.includes('*') ? resultRow[query.source.select.indexOf('*')] : null
-            displayProps.eventTimestamp = eventRecord?.timestamp
         }
 
         if (isPersonsNode(query.source) && personRecord.distinct_ids) {
@@ -362,6 +359,8 @@ export function renderColumn(
     } else if (key === 'person_display_name') {
         // Hide the popover on people list only
         const noPopover = isActorsQuery(query.source)
+        const eventsSelect = isEventsQuery(query.source) ? query.source.select : null
+        const eventRecord = eventsSelect?.includes('*') ? (record as any[])[eventsSelect.indexOf('*')] : null
         const displayProps: PersonDisplayProps = {
             withIcon: true,
             // `properties: {}` marks this row as an identified profile so PersonDisplay still renders the link;
@@ -369,6 +368,7 @@ export function renderColumn(
             person: { id: value.id, distinct_id: value.distinct_id, properties: {} },
             displayName: value.display_name,
             noPopover,
+            eventTimestamp: eventRecord?.timestamp,
         }
         return <PersonDisplay {...displayProps} />
     } else if (key === 'group' && typeof value === 'object') {

--- a/frontend/src/queries/nodes/DataTable/renderColumn.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumn.tsx
@@ -336,6 +336,9 @@ export function renderColumn(
         if (isEventsQuery(query.source)) {
             displayProps.person = value.distinct_id ? (value as EventsQueryPersonColumn) : value
             displayProps.noPopover = false // If we are in an events list, the popover experience is better
+            const resultRow = record as any[]
+            const eventRecord = query.source.select.includes('*') ? resultRow[query.source.select.indexOf('*')] : null
+            displayProps.eventTimestamp = eventRecord?.timestamp
         }
 
         if (isPersonsNode(query.source) && personRecord.distinct_ids) {

--- a/frontend/src/scenes/activity/explore/defaults.test.ts
+++ b/frontend/src/scenes/activity/explore/defaults.test.ts
@@ -1,6 +1,7 @@
-import { NodeKind } from '~/queries/schema/schema-general'
+import { EventsQuery, NodeKind } from '~/queries/schema/schema-general'
+import { PropertyFilterType, PropertyOperator } from '~/types'
 
-import { getDefaultEventsSceneQuery, getDefaultSessionsSceneQuery } from './defaults'
+import { getDefaultEventsSceneQuery, getDefaultSessionsSceneQuery, getPersonEventsSceneQuery } from './defaults'
 
 describe('activity explore defaults', () => {
     test.each([
@@ -10,5 +11,29 @@ describe('activity explore defaults', () => {
         const query = getQuery()
         expect(query.source.kind).toBe(kind)
         expect(query.source).toMatchObject({ after: '-1h' })
+    })
+
+    it('centers a person events query on the event it was opened from', () => {
+        const source = getPersonEventsSceneQuery('the-distinct-id', '2026-09-07T09:00:00Z').source as EventsQuery
+
+        expect(source).toMatchObject({ after: '2026-09-07T08:00:00.000Z', before: '2026-09-07T10:00:00.000Z' })
+        expect(source.properties).toEqual([
+            {
+                type: PropertyFilterType.EventMetadata,
+                key: 'distinct_id',
+                value: 'the-distinct-id',
+                operator: PropertyOperator.Exact,
+            },
+        ])
+    })
+
+    test.each([
+        ['no anchor', undefined],
+        ['an unparseable anchor', 'yesterday-ish'],
+    ])('widens a person events query past the scene default given %s', (_, anchor) => {
+        const source = getPersonEventsSceneQuery('the-distinct-id', anchor).source as EventsQuery
+
+        expect(source.after).toBe('-7d')
+        expect(source.before).toBeUndefined()
     })
 })

--- a/frontend/src/scenes/activity/explore/defaults.ts
+++ b/frontend/src/scenes/activity/explore/defaults.ts
@@ -1,6 +1,8 @@
+import { dayjs } from 'lib/dayjs'
+
 import { defaultDataTableColumns } from '~/queries/nodes/DataTable/utils'
-import { DataTableNode, NodeKind } from '~/queries/schema/schema-general'
-import { AnyPropertyFilter, TeamPublicType, TeamType } from '~/types'
+import { DataTableNode, EventsQuery, NodeKind } from '~/queries/schema/schema-general'
+import { AnyPropertyFilter, PropertyFilterType, PropertyOperator, TeamPublicType, TeamType } from '~/types'
 
 export const getDefaultEventsSceneQuery = (properties?: AnyPropertyFilter[]): DataTableNode => ({
     kind: NodeKind.DataTableNode,
@@ -16,6 +18,43 @@ export const getDefaultEventsSceneQuery = (properties?: AnyPropertyFilter[]): Da
     showSavedQueries: true,
     showPersistentColumnConfigurator: true,
 })
+
+/** Hours either side of a known event when deep-linking to the moment it happened. */
+const EVENTS_AROUND_TIMESTAMP_HOURS = 1
+/** Lookback for a person's events when we know who to look at but not when. */
+const PERSON_EVENTS_FALLBACK_AFTER = '-7d'
+
+/**
+ * Events scene query for a single distinct ID.
+ *
+ * The scene's own `-1h` default is meant for live traffic, so it leaves these links empty for anything but a
+ * person who is active right now. Pass `aroundTimestamp` (e.g. the timestamp of the survey response or event the
+ * link sits on) to center the window on that moment instead; without one we fall back to a wider lookback.
+ */
+export const getPersonEventsSceneQuery = (
+    distinctId: string | undefined,
+    aroundTimestamp?: string | null
+): DataTableNode => {
+    const query = getDefaultEventsSceneQuery([
+        {
+            type: PropertyFilterType.EventMetadata,
+            key: 'distinct_id',
+            value: distinctId,
+            operator: PropertyOperator.Exact,
+        },
+    ])
+    const source = query.source as EventsQuery
+    const anchor = aroundTimestamp ? dayjs(aroundTimestamp) : null
+
+    if (anchor?.isValid()) {
+        source.after = anchor.subtract(EVENTS_AROUND_TIMESTAMP_HOURS, 'hour').toISOString()
+        source.before = anchor.add(EVENTS_AROUND_TIMESTAMP_HOURS, 'hour').toISOString()
+    } else {
+        source.after = PERSON_EVENTS_FALLBACK_AFTER
+    }
+
+    return query
+}
 
 export function applyTestAccountFilter<T extends DataTableNode>(
     base: T,

--- a/frontend/src/scenes/persons/PersonDisplay.tsx
+++ b/frontend/src/scenes/persons/PersonDisplay.tsx
@@ -41,6 +41,8 @@ export interface PersonDisplayProps {
     className?: string
     /** Use muted/secondary text color instead of default */
     muted?: boolean
+    /** Timestamp of the event this person is shown for, so the popover can link to events around that moment. */
+    eventTimestamp?: string | null
 }
 
 export function PersonIcon({
@@ -94,6 +96,7 @@ export function PersonDisplay({
     inline,
     className,
     muted,
+    eventTimestamp,
 }: PersonDisplayProps): JSX.Element {
     const display = displayName || asDisplay(person, maxLength)
     const [visible, setVisible] = useState(false)
@@ -202,6 +205,7 @@ export function PersonDisplay({
                     <PersonPreview
                         distinctId={person?.distinct_id || person?.distinct_ids?.[0]}
                         personId={person?.id}
+                        eventTimestamp={eventTimestamp}
                         onClose={() => setVisible(false)}
                     />
                 ) : null

--- a/frontend/src/scenes/persons/PersonPreview.tsx
+++ b/frontend/src/scenes/persons/PersonPreview.tsx
@@ -10,12 +10,12 @@ import { IconOpenInNew } from 'lib/lemon-ui/icons'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
 import { Spinner } from 'lib/lemon-ui/Spinner'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { getDefaultEventsSceneQuery } from 'scenes/activity/explore/defaults'
+import { getPersonEventsSceneQuery } from 'scenes/activity/explore/defaults'
 import { NotebookSelectButton } from 'scenes/notebooks/NotebookSelectButton/NotebookSelectButton'
 import { NotebookNodeType } from 'scenes/notebooks/types'
 import { urls } from 'scenes/urls'
 
-import { ActivityTab, PropertyDefinitionType, PropertyFilterType, PropertyOperator } from '~/types'
+import { ActivityTab, PropertyDefinitionType } from '~/types'
 
 import { ComposeTicketButton } from 'products/conversations/frontend/components/ComposeTicket'
 
@@ -25,6 +25,8 @@ import { personLogic } from './personLogic'
 export type PersonPreviewProps = {
     distinctId?: string
     personId?: string
+    /** Timestamp of the event this preview was opened from, used to anchor the "View events" link. */
+    eventTimestamp?: string | null
     onClose?: () => void
 }
 
@@ -46,14 +48,7 @@ function PersonPreviewInner(props: PersonPreviewProps): JSX.Element | null {
 
     // NOTE: This can happen if the Person was deleted or the events associated with the distinct_id had person processing disabled
     if (!person) {
-        const eventsQuery = getDefaultEventsSceneQuery([
-            {
-                type: PropertyFilterType.EventMetadata,
-                key: 'distinct_id',
-                value: props.distinctId,
-                operator: PropertyOperator.Exact,
-            },
-        ])
+        const eventsQuery = getPersonEventsSceneQuery(props.distinctId, props.eventTimestamp)
         const eventsUrl = combineUrl(urls.activity(ActivityTab.ExploreEvents), {}, { q: eventsQuery }).url
         return (
             <div className="p-2 max-w-160">

--- a/frontend/src/scenes/surveys/components/question-visualizations/VirtualizedResponseList.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/VirtualizedResponseList.tsx
@@ -41,6 +41,7 @@ function ResponseListItem({ response }: { response: OpenQuestionResponseData }):
                         withIcon="xs"
                         noEllipsis={false}
                         noLink={!response.distinctId}
+                        eventTimestamp={response.timestamp}
                         muted
                     />
                 </div>
@@ -81,6 +82,7 @@ function ResponseListItem({ response }: { response: OpenQuestionResponseData }):
                             withIcon
                             noEllipsis={false}
                             noLink={!response.distinctId}
+                            eventTimestamp={response.timestamp}
                         />
                         <div className="flex items-center gap-2">
                             <ViewRecordingButton

--- a/frontend/src/scenes/surveys/hooks/useSurveyResponseColumns.tsx
+++ b/frontend/src/scenes/surveys/hooks/useSurveyResponseColumns.tsx
@@ -56,7 +56,10 @@ export function useSurveyResponseColumns(): Record<string, QueryContextColumn> {
             },
             respondent: {
                 title: 'Person',
-                render: ({ record }) => <PersonDisplay person={(record as EventType[])[0].person} />,
+                render: ({ record }) => {
+                    const event = (record as EventType[])[0]
+                    return <PersonDisplay person={event.person} eventTimestamp={event.timestamp} />
+                },
             },
             actions: {
                 title: ' ',


### PR DESCRIPTION
## Problem

Anyone opening "View events" from a survey response — or from any person popover — lands on an empty events table and has to widen the date filter by hand before they see anything.

`PersonPreview` built that link with `getDefaultEventsSceneQuery()`, whose `after: '-1h'` default exists for browsing live traffic. Scoped to a single `distinct_id`, an hour window is empty unless that person happens to be active right now. Survey responses are the worst case: they are read days after they came in, and the respondents often have no person profile, which is exactly the branch that renders this button.

A Replay Vision scanner caught it: a user reviewing survey responses clicked "View events", hit the empty state, switched the filter to "Last 7 days", went back, clicked "View events" on the next response, and hit the same empty state again.

## Changes

- "View events" on a survey response now opens the events around when that response came in, so the table has rows on arrival. Same for the person popover on any events table row.
- Without a timestamp to anchor to — the person-not-found page — the link falls back to a 7 day lookback instead of 1 hour. That page's button also never rendered: it was gated on `object === 'Person'` while its only caller passes `object="person"`. Now compared case-insensitively.
- New `getPersonEventsSceneQuery(distinctId, aroundTimestamp?)` in `scenes/activity/explore/defaults.ts` holds both behaviours and the `distinct_id` filter the three call sites used to build inline. It centers on the anchor ±1 hour when one is given.
- `PersonDisplay` and `PersonPreview` take an optional `eventTimestamp` and thread it through. Mechanical: the scene's own `-1h` default is untouched, and callers that pass no timestamp keep the same filter shape.

> [!NOTE]
> The events table's person cell renders through the `person_display_name` branch of `renderColumn`, not the `person` one — `defaultDataTableEventColumns` selects `person_display_name -- Person`. The `person` branch is dead for that key regardless: `productColumnRenderers` is consulted first and AI observability registers `person` globally. Worth knowing before adding anything else to that branch.

## How did you test this code?

Automated, run locally:

- `frontend/src/scenes/activity/explore/defaults.test.ts` — three added cases. They catch a regression no existing test did: routing a person-scoped link back through the scene's `-1h` default, and dropping the timestamp anchor so the window stops following the event.
- `frontend/src/queries/nodes/DataTable/renderColumn.test.tsx` — new. Catches the timestamp being wired into a person renderer the default events table does not use, which is the bug review found in the first commit.
- `jest src/scenes/activity src/scenes/persons src/queries/nodes/DataTable src/lib/components/NotFound src/scenes/surveys` — 42 suites, 706 passed.
- `pnpm --filter=@posthog/frontend typescript:check` and `pnpm --filter=@posthog/frontend fix` both clean.

Not done: no manual pass in a running app, so the rendered popover and the resulting events table were not clicked through. There are no visual changes to screenshot — only the date range inside the link's `#q=` payload changes.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by the PostHog Slack app (Claude Opus 5) from a Replay Vision observation a person passed over. The session read the observation, then confirmed the surface from the recording's own events rather than trusting the scanner's prose — the emitted `#q=` payload showed `after: "-1h"` plus an `event_metadata`/`distinct_id` filter, which pins it to `PersonPreview`'s no-profile branch and rules out the other "View events" buttons in the app.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, and the repo PR template.
- CodeRabbit CLI pass: paused, so this opened without a local review pass.
- Second commit answers a PostHog Review pass, which found both that the events-table anchor sat on the wrong renderer and that the person-not-found button never rendered. Verifying the first one turned up the extra detail that its `person` branch is globally shadowed, so that assignment was removed rather than duplicated.
- Decisions: the scanner suggested anchoring only the survey link. The fix generalises one step, because the same helper covers the events data table for free, and the no-anchor fallback fixes the person-not-found page where no timestamp exists. It stops short of changing the events scene default, which is correct for its own purpose.
- No duplicate: `gh pr list --state open --search` over this behaviour returned nothing related.
- Public artifact: nothing here carries session-private material. The observation's own text is not quoted, and no customer, project, or person from the recording is named.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C07QD3LT8U9/p1789074239905579)*

