### PR TITLE
fix(clickhouse): squash person_id on flag_evaluations after a merge

### DIFF
--- a/docs/internal/clickhouse-deletion-coverage.md
+++ b/docs/internal/clickhouse-deletion-coverage.md
@@ -81,7 +81,7 @@ ClickHouse has no S3 dictionary source, but that source runs its query locally, 
 The same staging carries the person-overrides squash, which is not a deletion but has the identical problem.
 `squash_person_overrides` rewrites `person_id` on every table in `SQUASH_TARGETS` — `sharded_events`, `sharded_events_json` and `sharded_flag_evaluations` — through a mutation that joins a snapshot dictionary, then deletes the overrides it just applied.
 Skipping one of those tables is worse than under-deleting: the overrides that record the correct `person_id` are gone in the next op, so the divergence is permanent.
-`SQUASH_TARGETS` is deliberately its own list rather than `PERSONAL_DATA_TARGETS`, so registering a table for deletion does not silently enrol it in the squash as well.
+`SQUASH_TARGETS` is deliberately its own list rather than `PERSONAL_DATA_TARGETS`, so registering a table for deletion does not silently enroll it in the squash as well.
 `posthog/dags/common/staged_dictionary.py` holds the piece both jobs share.
 
 ## Covered tables
@@ -172,10 +172,10 @@ The fix would belong to the producer, not the scanner.
 Keeping the fork downstream of person resolution is the contract, tracked on #81002.
 
 Write-time parity is not sufficient on its own, because a later merge moves the person the sweep looks for.
-`squash_person_overrides` rewrote `person_id` on `EVENTS_TARGETS` only, so after person A merged into B the events rows carried B while the flag-evaluation rows still carried A.
-A deletion of B is queued under B's uuid, so it missed those rows, and they survived with their event `properties` and their stale `person_id` until the TTL dropped the part.
-`sharded_flag_evaluations` is now a squash target as well as a deletion target: it is in `SQUASH_TARGETS` in `posthog/dags/person_overrides.py`, and `person_id` is not in its sort key, so it takes the same `ALTER UPDATE` the events tables take.
-Rows a merge stranded before that landed cannot be reconciled, because the squash deletes the overrides that recorded the mapping right after applying them; they age out with their partition.
+After person A merges into B, a deletion of B is queued under B's uuid, so any row still carrying A matches nothing and survives with its event `properties` and its stale `person_id` until the TTL drops the part.
+`sharded_flag_evaluations` is a squash target as well as a deletion target for that reason: it is in `SQUASH_TARGETS` in `posthog/dags/person_overrides.py`, and `person_id` is not in its sort key, so it takes the same `ALTER UPDATE` the events tables take.
+A table missing from `SQUASH_TARGETS` strands its rows permanently, because the squash deletes the overrides that recorded the mapping right after applying them.
+Rows a merge stranded before `sharded_flag_evaluations` joined the list age out with their partition.
 
 ## Related, and deliberately unchanged
 
@@ -188,5 +188,8 @@ Rows a merge stranded before that landed cannot be reconciled, because the squas
 Register it in `PERSONAL_DATA_TARGETS`, with capability flags reflecting what its schema can actually take and what the sweep code actually implements: `accepts_property_rewrite` needs the rewrite machinery to reach the table, not just assignable columns; `stores_person_properties` needs the table's `person_properties` column to actually hold reachable data, not just exist in the schema; see `FLAG_EVALUATIONS` for a table where those diverged.
 If it is not going to be swept, add it to `TTL_ONLY_TABLES` with the window you are accepting.
 If its storage lives on a cluster other than the one the deletion jobs connect to, give it a `cluster_setting` naming that cluster and mark it `optional`; see "Reach" and "Dispatching" above for which sweeps then reach it and which refuse.
+If a merge can move the `person_id` it stamps, add it to `SQUASH_TARGETS` in `posthog/dags/person_overrides.py` as well; registering it for deletion does not enroll it.
+The squash applies an `ALTER UPDATE`, so the column has to sit outside the table's sort key; see the person_id parity section above.
 
-`posthog/clickhouse/test/test_deletion_coverage.py` fails on any storage table that declares `person_properties` and appears in neither list, so the decision has to be made rather than skipped.
+`posthog/clickhouse/test/test_deletion_coverage.py` fails on any storage table that declares `person_properties` and appears in neither deletion list, so that decision has to be made rather than skipped.
+Nothing yet forces the `SQUASH_TARGETS` decision.

--- a/docs/internal/clickhouse-deletion-coverage.md
+++ b/docs/internal/clickhouse-deletion-coverage.md
@@ -79,8 +79,9 @@ ClickHouse has no S3 dictionary source, but that source runs its query locally, 
 - Retention belongs to the bucket lifecycle policy, set through `DICTIONARY_STAGING_S3_*`. Nothing deletes the objects.
 
 The same staging carries the person-overrides squash, which is not a deletion but has the identical problem.
-`squash_person_overrides` rewrites `person_id` on `sharded_events` and `sharded_events_json` through a mutation that joins a snapshot dictionary, then deletes the overrides it just applied.
-Skipping the second table there is worse than under-deleting: the overrides that record the correct `person_id` are gone in the next op, so the divergence is permanent.
+`squash_person_overrides` rewrites `person_id` on every table in `SQUASH_TARGETS` — `sharded_events`, `sharded_events_json` and `sharded_flag_evaluations` — through a mutation that joins a snapshot dictionary, then deletes the overrides it just applied.
+Skipping one of those tables is worse than under-deleting: the overrides that record the correct `person_id` are gone in the next op, so the divergence is permanent.
+`SQUASH_TARGETS` is deliberately its own list rather than `PERSONAL_DATA_TARGETS`, so registering a table for deletion does not silently enrol it in the squash as well.
 `posthog/dags/common/staged_dictionary.py` holds the piece both jobs share.
 
 ## Covered tables
@@ -171,10 +172,10 @@ The fix would belong to the producer, not the scanner.
 Keeping the fork downstream of person resolution is the contract, tracked on #81002.
 
 Write-time parity is not sufficient on its own, because a later merge moves the person the sweep looks for.
-`squash_person_overrides` rewrites `person_id` on `EVENTS_TARGETS` only, so after person A merges into B the events rows carry B while the flag-evaluation rows still carry A.
-A deletion of B is queued under B's uuid, so it misses those rows and they survive, with their event `properties` and their stale `person_id`, until the TTL drops the part.
-The squash deletes the overrides right after applying them, so nothing can reconcile the divergence afterwards.
-Extending the squash to `FLAG_EVALUATIONS` is the fix, and it belongs to `posthog/dags/person_overrides.py` rather than to this table. Tracked on #93035.
+`squash_person_overrides` rewrote `person_id` on `EVENTS_TARGETS` only, so after person A merged into B the events rows carried B while the flag-evaluation rows still carried A.
+A deletion of B is queued under B's uuid, so it missed those rows, and they survived with their event `properties` and their stale `person_id` until the TTL dropped the part.
+`sharded_flag_evaluations` is now a squash target as well as a deletion target: it is in `SQUASH_TARGETS` in `posthog/dags/person_overrides.py`, and `person_id` is not in its sort key, so it takes the same `ALTER UPDATE` the events tables take.
+Rows a merge stranded before that landed cannot be reconciled, because the squash deletes the overrides that recorded the mapping right after applying them; they age out with their partition.
 
 ## Related, and deliberately unchanged
 

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -797,6 +797,16 @@ class MutationWaiters:
             waiter.wait(client)
 
 
+def wait_for_mutations_on_shards(cluster: ClickhouseCluster, shard_mutations: Mapping[int, MutationWaiter]) -> None:
+    """Block until every mutation in ``shard_mutations`` is complete on all hosts within its shard."""
+    # during periods of elevated replication lag, it may take some time for mutations to become available on
+    # the shards, so give them a little bit of breathing room with retries
+    retry_policy = RetryPolicy(max_attempts=3, delay=10.0, exceptions=(MutationNotFound,))
+    cluster.map_all_hosts_in_shards(
+        {shard_num: retry_policy(waiter) for shard_num, waiter in shard_mutations.items()}
+    ).result()
+
+
 class MutationCapacityTimeout(Exception):
     """Raised when another mutation held the table past a runner's ``capacity_timeout``."""
 
@@ -988,10 +998,14 @@ class MutationRunner(abc.ABC):
             command: mutation_id for command, (mutation_id,) in zip(command_list, mutations) if mutation_id is not None
         }
 
-    def run_on_shards(self, cluster: ClickhouseCluster, shards: Iterable[int] | None = None) -> None:
+    def enqueue_on_shards(
+        self, cluster: ClickhouseCluster, shards: Iterable[int] | None = None
+    ) -> dict[int, MutationWaiter]:
         """
-        Enqueue (or find) this mutation on one host in each shard, and then block until the mutation is complete on all
-        hosts within the affected shards.
+        Enqueue (or find) this mutation on one host in each shard, without waiting for it to complete.
+
+        A caller running mutations on several tables enqueues all of them before waiting on any, so the total wait is
+        the longest one rather than their sum. Pair with ``wait_for_mutations_on_shards``.
         """
         if shards is not None:
             shard_host_mutation_waiters = cluster.map_any_host_in_shards(dict.fromkeys(shards, self))
@@ -1006,13 +1020,14 @@ class MutationRunner(abc.ABC):
             if host.shard_num is not None
         }
         assert len(shard_mutations) == len(shard_host_mutation_waiters)
+        return shard_mutations
 
-        # during periods of elevated replication lag, it may take some time for mutations to become available on
-        # the shards, so give them a little bit of breathing room with retries
-        retry_policy = RetryPolicy(max_attempts=3, delay=10.0, exceptions=(MutationNotFound,))
-        cluster.map_all_hosts_in_shards(
-            {shard_num: retry_policy(waiter) for shard_num, waiter in shard_mutations.items()}
-        ).result()
+    def run_on_shards(self, cluster: ClickhouseCluster, shards: Iterable[int] | None = None) -> None:
+        """
+        Enqueue (or find) this mutation on one host in each shard, and then block until the mutation is complete on all
+        hosts within the affected shards.
+        """
+        wait_for_mutations_on_shards(cluster, self.enqueue_on_shards(cluster, shards))
 
 
 @dataclass

--- a/posthog/dags/common/overrides_manager.py
+++ b/posthog/dags/common/overrides_manager.py
@@ -153,18 +153,17 @@ class OverridesSnapshotDictionary(ABC, Generic[TOverridesSnapshotTable]):
 
     @property
     @abstractmethod
-    def update_table(self):
-        raise NotImplementedError()
-
-    @property
-    @abstractmethod
     def update_commands(self):
         raise NotImplementedError()
 
-    @property
-    def update_mutation_runner(self) -> AlterTableMutationRunner:
+    def update_mutation_runner_for(self, table: str) -> AlterTableMutationRunner:
+        """The rewrite this snapshot applies, aimed at one target's storage table.
+
+        A squash rewrites every table that stamps the overridden column, so the table is an
+        argument rather than a property of the snapshot.
+        """
         return AlterTableMutationRunner(
-            table=self.update_table,
+            table=table,
             commands=self.update_commands,
             parameters={"name": self.qualified_name},
         )

--- a/posthog/dags/person_overrides.py
+++ b/posthog/dags/person_overrides.py
@@ -17,8 +17,15 @@ from posthog.dags.common.staged_dictionary import (
     load_and_verify_on_every_cluster,
 )
 from posthog.dataclasses import frozen
-from posthog.models.deletion_targets import EVENTS_JSON, EVENTS_TARGETS, placement_for, sweep_clusters
+from posthog.models.deletion_targets import (
+    EVENTS_JSON,
+    FLAG_EVALUATIONS,
+    PERSONAL_DATA_TARGETS,
+    placement_for,
+    sweep_clusters,
+)
 from posthog.models.event.sql import EVENTS_DATA_TABLE, EVENTS_JSON_DATA_TABLE
+from posthog.models.flag_evaluations.sql import FLAG_EVALUATIONS_DATA_TABLE
 from posthog.models.person.sql import PERSON_DISTINCT_ID_OVERRIDES_TABLE
 
 
@@ -27,7 +34,7 @@ def _squash_clusters(cluster: ClickhouseCluster) -> list[ClickhouseCluster]:
 
     The rewrite joins the snapshot dictionary, so the dictionary has to exist on each of them.
     """
-    return sweep_clusters(cluster, EVENTS_TARGETS)
+    return sweep_clusters(cluster, PERSONAL_DATA_TARGETS)
 
 
 @dataclass
@@ -39,13 +46,11 @@ class PersonOverridesSnapshotTable(OverridesSnapshotTable):
         return f"person_distinct_id_overrides_snapshot_{self.id.hex}"
 
     def create(self, client: Client) -> None:
-        client.execute(
-            f"""
+        client.execute(f"""
             CREATE TABLE IF NOT EXISTS {self.qualified_name} (team_id Int64, distinct_id String, person_id UUID, version Int64)
             ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/{self.qualified_name}', '{{replica}}-{{shard}}', version)
             ORDER BY (team_id, distinct_id)
-            """
-        )
+            """)
 
     def populate(self, client: Client, timestamp: str, limit: int | None = None) -> None:
         # NOTE: this is theoretically subject to replication lag and accuracy of this result is not a guarantee
@@ -122,12 +127,10 @@ class PersonOverridesSnapshotDictionary(OverridesSnapshotDictionary):
         )
 
     def get_checksum(self, client: Client):
-        results = client.execute(
-            f"""
+        results = client.execute(f"""
              SELECT groupBitXor(row_checksum) AS table_checksum
              FROM (SELECT cityHash64(*) AS row_checksum FROM {self.qualified_name} ORDER BY team_id, distinct_id)
-             """
-        )
+             """)
         [[checksum]] = results
         return checksum
 
@@ -147,6 +150,16 @@ class PersonOverridesSnapshotDictionary(OverridesSnapshotDictionary):
         rewritten or person_id diverges between them while they coexist."""
         return AlterTableMutationRunner(
             table=EVENTS_JSON_DATA_TABLE,
+            commands=self.update_commands,
+            parameters={"name": self.qualified_name},
+        )
+
+    @property
+    def flag_evaluations_update_mutation_runner(self) -> AlterTableMutationRunner:
+        """The same person_id squash applied to the flag_evaluations table — both tables must be
+        rewritten or person_id diverges between them while they coexist."""
+        return AlterTableMutationRunner(
+            table=FLAG_EVALUATIONS_DATA_TABLE,
             commands=self.update_commands,
             parameters={"name": self.qualified_name},
         )
@@ -297,6 +310,11 @@ def run_person_id_update_mutations(
     placement = placement_for(cluster, EVENTS_JSON)
     if placement is not None:
         dictionary.events_json_update_mutation_runner.run_on_shards(placement.cluster)
+
+    flag_evaluations_placement = placement_for(cluster, FLAG_EVALUATIONS)
+    if flag_evaluations_placement is not None:
+        dictionary.flag_evaluations_update_mutation_runner.run_on_shards(flag_evaluations_placement.cluster)
+
     return dictionary
 
 

--- a/posthog/dags/person_overrides.py
+++ b/posthog/dags/person_overrides.py
@@ -8,7 +8,12 @@ import pydantic
 from clickhouse_driver import Client
 
 from posthog import settings
-from posthog.clickhouse.cluster import AlterTableMutationRunner, ClickhouseCluster, MutationWaiter
+from posthog.clickhouse.cluster import (
+    AlterTableMutationRunner,
+    ClickhouseCluster,
+    MutationWaiter,
+    wait_for_mutations_on_shards,
+)
 from posthog.dags.common import JobOwners
 from posthog.dags.common.overrides_manager import OverridesSnapshotDictionary, OverridesSnapshotTable
 from posthog.dags.common.staged_dictionary import (
@@ -17,16 +22,18 @@ from posthog.dags.common.staged_dictionary import (
     load_and_verify_on_every_cluster,
 )
 from posthog.dataclasses import frozen
-from posthog.models.deletion_targets import (
-    EVENTS_JSON,
-    FLAG_EVALUATIONS,
-    PERSONAL_DATA_TARGETS,
-    placement_for,
-    sweep_clusters,
-)
-from posthog.models.event.sql import EVENTS_DATA_TABLE, EVENTS_JSON_DATA_TABLE
-from posthog.models.flag_evaluations.sql import FLAG_EVALUATIONS_DATA_TABLE
+from posthog.models.deletion_targets import EVENTS_TARGETS, FLAG_EVALUATIONS, resolve_placements, sweep_clusters
+from posthog.models.event.sql import EVENTS_DATA_TABLE
 from posthog.models.person.sql import PERSON_DISTINCT_ID_OVERRIDES_TABLE
+
+# Every table the squash rewrites person_id on. sharded_flag_evaluations is not an events table,
+# but it stamps rows with the same person_id, and a person deletion matches the deleted person's
+# uuid against that column. A row a merge left on the absorbed person therefore matches nothing and
+# survives until its partition ages out, so the squash has to move it too.
+#
+# Deliberately not PERSONAL_DATA_TARGETS: registering a table for deletion should not silently make
+# it a squash target as well.
+SQUASH_TARGETS = (*EVENTS_TARGETS, FLAG_EVALUATIONS)
 
 
 def _squash_clusters(cluster: ClickhouseCluster) -> list[ClickhouseCluster]:
@@ -34,7 +41,7 @@ def _squash_clusters(cluster: ClickhouseCluster) -> list[ClickhouseCluster]:
 
     The rewrite joins the snapshot dictionary, so the dictionary has to exist on each of them.
     """
-    return sweep_clusters(cluster, PERSONAL_DATA_TARGETS)
+    return sweep_clusters(cluster, SQUASH_TARGETS)
 
 
 @dataclass
@@ -46,11 +53,13 @@ class PersonOverridesSnapshotTable(OverridesSnapshotTable):
         return f"person_distinct_id_overrides_snapshot_{self.id.hex}"
 
     def create(self, client: Client) -> None:
-        client.execute(f"""
+        client.execute(
+            f"""
             CREATE TABLE IF NOT EXISTS {self.qualified_name} (team_id Int64, distinct_id String, person_id UUID, version Int64)
             ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/{self.qualified_name}', '{{replica}}-{{shard}}', version)
             ORDER BY (team_id, distinct_id)
-            """)
+            """
+        )
 
     def populate(self, client: Client, timestamp: str, limit: int | None = None) -> None:
         # NOTE: this is theoretically subject to replication lag and accuracy of this result is not a guarantee
@@ -127,10 +136,12 @@ class PersonOverridesSnapshotDictionary(OverridesSnapshotDictionary):
         )
 
     def get_checksum(self, client: Client):
-        results = client.execute(f"""
+        results = client.execute(
+            f"""
              SELECT groupBitXor(row_checksum) AS table_checksum
              FROM (SELECT cityHash64(*) AS row_checksum FROM {self.qualified_name} ORDER BY team_id, distinct_id)
-             """)
+             """
+        )
         [[checksum]] = results
         return checksum
 
@@ -144,22 +155,10 @@ class PersonOverridesSnapshotDictionary(OverridesSnapshotDictionary):
             "UPDATE person_id = dictGet(%(name)s, 'person_id', (team_id, distinct_id)) WHERE dictHas(%(name)s, (team_id, distinct_id))"
         }
 
-    @property
-    def events_json_update_mutation_runner(self) -> AlterTableMutationRunner:
-        """The same person_id squash applied to the native-JSON events table — both tables must be
-        rewritten or person_id diverges between them while they coexist."""
+    def update_mutation_runner_for(self, table: str) -> AlterTableMutationRunner:
+        """The person_id squash applied to one squash target's storage table."""
         return AlterTableMutationRunner(
-            table=EVENTS_JSON_DATA_TABLE,
-            commands=self.update_commands,
-            parameters={"name": self.qualified_name},
-        )
-
-    @property
-    def flag_evaluations_update_mutation_runner(self) -> AlterTableMutationRunner:
-        """The same person_id squash applied to the flag_evaluations table — both tables must be
-        rewritten or person_id diverges between them while they coexist."""
-        return AlterTableMutationRunner(
-            table=FLAG_EVALUATIONS_DATA_TABLE,
+            table=table,
             commands=self.update_commands,
             parameters={"name": self.qualified_name},
         )
@@ -302,19 +301,24 @@ def run_person_id_update_mutations(
     cluster: dagster.ResourceParam[ClickhouseCluster],
     dictionary: PersonOverridesSnapshotDictionary,
 ) -> PersonOverridesSnapshotDictionary:
-    dictionary.update_mutation_runner.run_on_shards(cluster)
+    """Rewrite person_id on every squash target, each on the cluster whose shards carry it.
 
-    # sharded_events_json may be stored on another cluster, whose shards only its own handle
-    # enumerates. Skipping it would leave those rows on a person_id this run just squashed away,
-    # and the overrides that record the correct one are deleted immediately after.
-    placement = placement_for(cluster, EVENTS_JSON)
-    if placement is not None:
-        dictionary.events_json_update_mutation_runner.run_on_shards(placement.cluster)
+    A target's storage table can sit on a cluster whose shards only its own handle enumerates, so
+    the dispatch follows the resolved placement rather than the handle in hand. Skipping one would
+    leave its rows on a person_id this run squashed away, and the overrides that record the correct
+    one are deleted in the very next op.
 
-    flag_evaluations_placement = placement_for(cluster, FLAG_EVALUATIONS)
-    if flag_evaluations_placement is not None:
-        dictionary.flag_evaluations_update_mutation_runner.run_on_shards(flag_evaluations_placement.cluster)
+    Every mutation is enqueued before any of them is waited on. They run on separate tables, so
+    waiting on each in turn would cost the sum of their durations instead of the longest one. The
+    op still returns only once all of them are complete, which is what the overrides delete needs.
+    """
+    enqueued = []
+    for placement in resolve_placements(cluster, SQUASH_TARGETS):
+        runner = dictionary.update_mutation_runner_for(placement.target.data_table)
+        enqueued.append((placement.cluster, runner.enqueue_on_shards(placement.cluster)))
 
+    for handle, shard_mutations in enqueued:
+        wait_for_mutations_on_shards(handle, shard_mutations)
     return dictionary
 
 

--- a/posthog/dags/person_overrides.py
+++ b/posthog/dags/person_overrides.py
@@ -8,12 +8,7 @@ import pydantic
 from clickhouse_driver import Client
 
 from posthog import settings
-from posthog.clickhouse.cluster import (
-    AlterTableMutationRunner,
-    ClickhouseCluster,
-    MutationWaiter,
-    wait_for_mutations_on_shards,
-)
+from posthog.clickhouse.cluster import ClickhouseCluster, MutationWaiter, wait_for_mutations_on_shards
 from posthog.dags.common import JobOwners
 from posthog.dags.common.overrides_manager import OverridesSnapshotDictionary, OverridesSnapshotTable
 from posthog.dags.common.staged_dictionary import (
@@ -23,7 +18,6 @@ from posthog.dags.common.staged_dictionary import (
 )
 from posthog.dataclasses import frozen
 from posthog.models.deletion_targets import EVENTS_TARGETS, FLAG_EVALUATIONS, resolve_placements, sweep_clusters
-from posthog.models.event.sql import EVENTS_DATA_TABLE
 from posthog.models.person.sql import PERSON_DISTINCT_ID_OVERRIDES_TABLE
 
 # Every table the squash rewrites person_id on. sharded_flag_evaluations is not an events table,
@@ -146,22 +140,10 @@ class PersonOverridesSnapshotDictionary(OverridesSnapshotDictionary):
         return checksum
 
     @property
-    def update_table(self):
-        return EVENTS_DATA_TABLE()
-
-    @property
     def update_commands(self):
         return {
             "UPDATE person_id = dictGet(%(name)s, 'person_id', (team_id, distinct_id)) WHERE dictHas(%(name)s, (team_id, distinct_id))"
         }
-
-    def update_mutation_runner_for(self, table: str) -> AlterTableMutationRunner:
-        """The person_id squash applied to one squash target's storage table."""
-        return AlterTableMutationRunner(
-            table=table,
-            commands=self.update_commands,
-            parameters={"name": self.qualified_name},
-        )
 
     @property
     def overrides_table(self):
@@ -307,16 +289,14 @@ def run_person_id_update_mutations(
     the dispatch follows the resolved placement rather than the handle in hand. Skipping one would
     leave its rows on a person_id this run squashed away, and the overrides that record the correct
     one are deleted in the very next op.
-
-    Every mutation is enqueued before any of them is waited on. They run on separate tables, so
-    waiting on each in turn would cost the sum of their durations instead of the longest one. The
-    op still returns only once all of them are complete, which is what the overrides delete needs.
     """
-    enqueued = []
+    enqueued: list[tuple[ClickhouseCluster, dict[int, MutationWaiter]]] = []
     for placement in resolve_placements(cluster, SQUASH_TARGETS):
         runner = dictionary.update_mutation_runner_for(placement.target.data_table)
         enqueued.append((placement.cluster, runner.enqueue_on_shards(placement.cluster)))
 
+    # Every mutation is already in flight, so these waits overlap and cost the longest rather than
+    # their sum. The capacity wait inside enqueue_on_shards is still per table and serial.
     for handle, shard_mutations in enqueued:
         wait_for_mutations_on_shards(handle, shard_mutations)
     return dictionary

--- a/posthog/dags/tests/test_person_overrides.py
+++ b/posthog/dags/tests/test_person_overrides.py
@@ -24,7 +24,7 @@ from posthog.dags.person_overrides import (
     squash_person_overrides,
     wait_for_overrides_delete_mutations,
 )
-from posthog.models.deletion_targets import EVENTS_JSON, TargetPlacement
+from posthog.models.deletion_targets import EVENTS_JSON, FLAG_EVALUATIONS, TargetPlacement
 
 
 def test_full_job(cluster: ClickhouseCluster):
@@ -52,8 +52,18 @@ def test_full_job(cluster: ClickhouseCluster):
                 ("c", UUID(int=0), timestamp - timedelta(hours=12), 1),  # 0: {"a", "c"}
                 ("e", UUID(int=3), timestamp - timedelta(hours=6), 1),  # 3: {"d", "e"}
                 ("d", UUID(int=1), timestamp - timedelta(hours=5), 1),  # 1: {"b", "d"}
-                ("e", UUID(int=1), timestamp - timedelta(hours=5), 2),  # 1: {"b", "d", "e"}
-                ("z", UUID(int=0), timestamp + timedelta(hours=1), 1),  # arrived after timestamp, ignored this run
+                (
+                    "e",
+                    UUID(int=1),
+                    timestamp - timedelta(hours=5),
+                    2,
+                ),  # 1: {"b", "d", "e"}
+                (
+                    "z",
+                    UUID(int=0),
+                    timestamp + timedelta(hours=1),
+                    1,
+                ),  # arrived after timestamp, ignored this run
             ],
         )
 
@@ -80,7 +90,12 @@ def test_full_job(cluster: ClickhouseCluster):
         UUID(int=4): {"e"},
         UUID(int=100): {"z"},
     }
-    assert cluster.any_host(get_distinct_ids_with_overrides).result() == {"c", "d", "e", "z"}
+    assert cluster.any_host(get_distinct_ids_with_overrides).result() == {
+        "c",
+        "d",
+        "e",
+        "z",
+    }
 
     # run with limit
     limited_run_result = squash_person_overrides.execute_in_process(
@@ -161,14 +176,19 @@ def _create_snapshot_with(cluster: ClickhouseCluster, rows: list[tuple]) -> Pers
     cluster.any_host(table.create).result()
 
     def insert(client: Client) -> None:
-        client.execute(f"INSERT INTO {table.qualified_name} (team_id, distinct_id, person_id, version) VALUES", rows)
+        client.execute(
+            f"INSERT INTO {table.qualified_name} (team_id, distinct_id, person_id, version) VALUES",
+            rows,
+        )
 
     cluster.any_host(insert).result()
     return PersonOverridesSnapshotDictionary(source=table)
 
 
 @pytest.mark.django_db
-def test_a_staged_snapshot_dictionary_holds_the_same_rows_as_the_snapshot_table(cluster: ClickhouseCluster):
+def test_a_staged_snapshot_dictionary_holds_the_same_rows_as_the_snapshot_table(
+    cluster: ClickhouseCluster,
+):
     # A cluster that shares no Keeper with the job's own never receives the replicated snapshot
     # table, so it builds the dictionary from a staged object. The squash is gated on both sides
     # checksumming alike, which only means something if every column round-trips exactly. This one
@@ -193,7 +213,9 @@ def test_a_staged_snapshot_dictionary_holds_the_same_rows_as_the_snapshot_table(
 
 
 @pytest.mark.django_db
-def test_run_person_id_update_mutations_rewrites_events_json_on_its_own_cluster(cluster: ClickhouseCluster):
+def test_run_person_id_update_mutations_rewrites_events_json_on_its_own_cluster(
+    cluster: ClickhouseCluster,
+):
     # sharded_events_json may sit on a cluster whose shards only its own handle enumerates. Running
     # its rewrite over the job's handle would skip those rows, and the overrides that record the
     # correct person_id are deleted in the very next op, so the divergence would be permanent.
@@ -206,7 +228,37 @@ def test_run_person_id_update_mutations_rewrites_events_json_on_its_own_cluster(
             return_value=TargetPlacement(target=EVENTS_JSON, cluster=sibling),
         ),
         patch.object(
-            type(dictionary.events_json_update_mutation_runner), "run_on_shards", autospec=True
+            type(dictionary.events_json_update_mutation_runner),
+            "run_on_shards",
+            autospec=True,
+        ) as run_on_shards,
+    ):
+        run_person_id_update_mutations(cluster, dictionary)
+
+    dispatched = [call.args[1] for call in run_on_shards.call_args_list]
+    assert sibling in dispatched
+    cluster.any_host(dictionary.source.drop).result()
+
+
+@pytest.mark.django_db
+def test_run_person_id_update_mutations_dispatches_flag_evaluations_to_correct_cluster(
+    cluster: ClickhouseCluster,
+):
+    # sharded_flag_evaluations may sit on a cluster whose shards only its own handle enumerates. Running
+    # its rewrite over the job's handle would skip those rows, and the overrides that record the
+    # correct person_id are deleted in the very next op, so the divergence would be permanent.
+    dictionary = _create_snapshot_with(cluster, [(1, "a", UUID(int=7), 3)])
+    sibling = cluster.sibling(django_settings.CLICKHOUSE_SINGLE_SHARD_CLUSTER)
+
+    with (
+        patch(
+            "posthog.dags.person_overrides.placement_for",
+            return_value=TargetPlacement(target=FLAG_EVALUATIONS, cluster=sibling),
+        ),
+        patch.object(
+            type(dictionary.flag_evaluations_update_mutation_runner),
+            "run_on_shards",
+            autospec=True,
         ) as run_on_shards,
     ):
         run_person_id_update_mutations(cluster, dictionary)

--- a/posthog/dags/tests/test_person_overrides.py
+++ b/posthog/dags/tests/test_person_overrides.py
@@ -4,7 +4,7 @@ from functools import partial
 from uuid import UUID
 
 import pytest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from django.conf import settings as django_settings
 
@@ -236,19 +236,14 @@ def _create_snapshot_with(cluster: ClickhouseCluster, rows: list[tuple]) -> Pers
     cluster.any_host(table.create).result()
 
     def insert(client: Client) -> None:
-        client.execute(
-            f"INSERT INTO {table.qualified_name} (team_id, distinct_id, person_id, version) VALUES",
-            rows,
-        )
+        client.execute(f"INSERT INTO {table.qualified_name} (team_id, distinct_id, person_id, version) VALUES", rows)
 
     cluster.any_host(insert).result()
     return PersonOverridesSnapshotDictionary(source=table)
 
 
 @pytest.mark.django_db
-def test_a_staged_snapshot_dictionary_holds_the_same_rows_as_the_snapshot_table(
-    cluster: ClickhouseCluster,
-):
+def test_a_staged_snapshot_dictionary_holds_the_same_rows_as_the_snapshot_table(cluster: ClickhouseCluster):
     # A cluster that shares no Keeper with the job's own never receives the replicated snapshot
     # table, so it builds the dictionary from a staged object. The squash is gated on both sides
     # checksumming alike, which only means something if every column round-trips exactly. This one
@@ -273,9 +268,7 @@ def test_a_staged_snapshot_dictionary_holds_the_same_rows_as_the_snapshot_table(
 
 
 @pytest.mark.django_db
-def test_run_person_id_update_mutations_rewrites_each_target_on_its_own_cluster(
-    cluster: ClickhouseCluster,
-):
+def test_run_person_id_update_mutations_rewrites_each_target_on_its_own_cluster(cluster: ClickhouseCluster):
     # sharded_events_json and sharded_flag_evaluations may each sit on a cluster whose shards only
     # its own handle enumerates. Running one of those rewrites over the job's handle would skip its
     # rows, and the overrides that record the correct person_id are deleted in the very next op, so
@@ -288,22 +281,17 @@ def test_run_person_id_update_mutations_rewrites_each_target_on_its_own_cluster(
         TargetPlacement(target=EVENTS_JSON, cluster=sibling),
         TargetPlacement(target=FLAG_EVALUATIONS, cluster=sibling),
     ]
-    phases: list[str] = []
-
-    def enqueue(runner: AlterTableMutationRunner, handle: ClickhouseCluster) -> dict:
-        phases.append("enqueue")
-        return {}
+    calls = Mock()
 
     with (
         patch("posthog.dags.person_overrides.resolve_placements", return_value=placements),
         patch.object(
-            AlterTableMutationRunner, "enqueue_on_shards", autospec=True, side_effect=enqueue
+            AlterTableMutationRunner, "enqueue_on_shards", autospec=True, return_value={}
         ) as enqueue_on_shards,
-        patch(
-            "posthog.dags.person_overrides.wait_for_mutations_on_shards",
-            side_effect=lambda handle, shard_mutations: phases.append("wait"),
-        ),
+        patch("posthog.dags.person_overrides.wait_for_mutations_on_shards") as wait_for_mutations,
     ):
+        calls.attach_mock(enqueue_on_shards, "enqueue")
+        calls.attach_mock(wait_for_mutations, "wait")
         run_person_id_update_mutations(cluster, dictionary)
 
     assert {call.args[0].table: call.args[1] for call in enqueue_on_shards.call_args_list} == {
@@ -311,7 +299,7 @@ def test_run_person_id_update_mutations_rewrites_each_target_on_its_own_cluster(
         EVENTS_JSON_DATA_TABLE: sibling,
         FLAG_EVALUATIONS_DATA_TABLE: sibling,
     }
-    # Waiting on each mutation as it is enqueued would cost the sum of their durations rather than
-    # the longest one, which is the whole reason the op enqueues in one pass.
-    assert phases == ["enqueue"] * 3 + ["wait"] * 3
+    # Waiting on each mutation as it is enqueued would cost the sum of their completion times
+    # rather than the longest, which is the whole reason the op enqueues in one pass.
+    assert [name for name, *_ in calls.mock_calls] == ["enqueue"] * 3 + ["wait"] * 3
     cluster.any_host(dictionary.source.drop).result()

--- a/posthog/dags/tests/test_person_overrides.py
+++ b/posthog/dags/tests/test_person_overrides.py
@@ -27,7 +27,7 @@ from posthog.dags.person_overrides import (
 )
 from posthog.dags.tests.conftest import insert_flag_evaluations
 from posthog.models.async_deletion import AsyncDeletion, DeletionType
-from posthog.models.deletion_targets import EVENTS, EVENTS_JSON, FLAG_EVALUATIONS, TargetPlacement
+from posthog.models.deletion_targets import EVENTS, EVENTS_JSON, EVENTS_TARGETS, FLAG_EVALUATIONS, TargetPlacement
 from posthog.models.event.sql import EVENTS_DATA_TABLE, EVENTS_JSON_DATA_TABLE
 from posthog.models.flag_evaluations.sql import FLAG_EVALUATIONS_DATA_TABLE
 
@@ -284,7 +284,7 @@ def test_run_person_id_update_mutations_rewrites_each_target_on_its_own_cluster(
     calls = Mock()
 
     with (
-        patch("posthog.dags.person_overrides.resolve_placements", return_value=placements),
+        patch("posthog.dags.person_overrides.resolve_placements", return_value=placements) as resolve_placements,
         patch.object(
             AlterTableMutationRunner, "enqueue_on_shards", autospec=True, return_value={}
         ) as enqueue_on_shards,
@@ -294,6 +294,9 @@ def test_run_person_id_update_mutations_rewrites_each_target_on_its_own_cluster(
         calls.attach_mock(wait_for_mutations, "wait")
         run_person_id_update_mutations(cluster, dictionary)
 
+    # This assertion names the targets literally instead of reusing SQUASH_TARGETS.
+    # The constant would still match after someone drops FLAG_EVALUATIONS from its definition.
+    resolve_placements.assert_called_once_with(cluster, (*EVENTS_TARGETS, FLAG_EVALUATIONS))
     assert {call.args[0].table: call.args[1] for call in enqueue_on_shards.call_args_list} == {
         EVENTS_DATA_TABLE(): cluster,
         EVENTS_JSON_DATA_TABLE: sibling,

--- a/posthog/dags/tests/test_person_overrides.py
+++ b/posthog/dags/tests/test_person_overrides.py
@@ -11,7 +11,8 @@ from django.conf import settings as django_settings
 import dagster
 from clickhouse_driver import Client
 
-from posthog.clickhouse.cluster import ClickhouseCluster
+from posthog.clickhouse.cluster import AlterTableMutationRunner, ClickhouseCluster
+from posthog.dags.deletes import deletes_job
 from posthog.dags.person_overrides import (
     GetExistingDictionaryConfig,
     PersonOverridesSnapshotDictionary,
@@ -24,7 +25,11 @@ from posthog.dags.person_overrides import (
     squash_person_overrides,
     wait_for_overrides_delete_mutations,
 )
-from posthog.models.deletion_targets import EVENTS_JSON, FLAG_EVALUATIONS, TargetPlacement
+from posthog.dags.tests.conftest import insert_flag_evaluations
+from posthog.models.async_deletion import AsyncDeletion, DeletionType
+from posthog.models.deletion_targets import EVENTS, EVENTS_JSON, FLAG_EVALUATIONS, TargetPlacement
+from posthog.models.event.sql import EVENTS_DATA_TABLE, EVENTS_JSON_DATA_TABLE
+from posthog.models.flag_evaluations.sql import FLAG_EVALUATIONS_DATA_TABLE
 
 
 def test_full_job(cluster: ClickhouseCluster):
@@ -52,18 +57,8 @@ def test_full_job(cluster: ClickhouseCluster):
                 ("c", UUID(int=0), timestamp - timedelta(hours=12), 1),  # 0: {"a", "c"}
                 ("e", UUID(int=3), timestamp - timedelta(hours=6), 1),  # 3: {"d", "e"}
                 ("d", UUID(int=1), timestamp - timedelta(hours=5), 1),  # 1: {"b", "d"}
-                (
-                    "e",
-                    UUID(int=1),
-                    timestamp - timedelta(hours=5),
-                    2,
-                ),  # 1: {"b", "d", "e"}
-                (
-                    "z",
-                    UUID(int=0),
-                    timestamp + timedelta(hours=1),
-                    1,
-                ),  # arrived after timestamp, ignored this run
+                ("e", UUID(int=1), timestamp - timedelta(hours=5), 2),  # 1: {"b", "d", "e"}
+                ("z", UUID(int=0), timestamp + timedelta(hours=1), 1),  # arrived after timestamp, ignored this run
             ],
         )
 
@@ -90,12 +85,7 @@ def test_full_job(cluster: ClickhouseCluster):
         UUID(int=4): {"e"},
         UUID(int=100): {"z"},
     }
-    assert cluster.any_host(get_distinct_ids_with_overrides).result() == {
-        "c",
-        "d",
-        "e",
-        "z",
-    }
+    assert cluster.any_host(get_distinct_ids_with_overrides).result() == {"c", "d", "e", "z"}
 
     # run with limit
     limited_run_result = squash_person_overrides.execute_in_process(
@@ -136,6 +126,76 @@ def test_full_job(cluster: ClickhouseCluster):
         UUID(int=100): {"z"},
     }
     assert cluster.any_host(get_distinct_ids_with_overrides).result() == {"z"}
+
+
+@pytest.mark.django_db
+def test_a_person_deletion_after_a_merge_reaches_flag_evaluations(cluster: ClickhouseCluster):
+    # A merge moves a distinct_id's rows onto the surviving person, and a deletion of that person
+    # names only the surviving uuid. The squash is what makes the two agree, so a table it skips
+    # keeps the absorbed uuid and the sweep never matches those rows, permanently, because the
+    # override that recorded the mapping is deleted in the same squash run. This runs both dags
+    # because the regression lives at the seam between them, which neither dag's own test covers.
+    timestamp = (datetime.now() + timedelta(days=31)).replace(microsecond=0)
+    team_id = 4242
+    absorbed_person, surviving_person = UUID(int=9001), UUID(int=9002)
+    row_uuid = UUID(int=9003)
+
+    cluster.any_host(
+        partial(
+            insert_flag_evaluations,
+            [(team_id, "merged", absorbed_person, row_uuid, timestamp - timedelta(hours=2))],
+        )
+    ).result()
+
+    def insert_override(client: Client) -> None:
+        client.execute(
+            "INSERT INTO person_distinct_id_overrides (team_id, distinct_id, person_id, _timestamp, version) VALUES",
+            [(team_id, "merged", surviving_person, timestamp - timedelta(hours=1), 1)],
+        )
+
+    cluster.any_host(insert_override).result()
+
+    def surviving_flag_evaluation_person_ids(client: Client) -> set[UUID]:
+        # _row_exists = 1 drops rows a lightweight delete already hid; without it a swept row
+        # still reads back until its part merges.
+        rows = client.execute(
+            "SELECT person_id FROM flag_evaluations WHERE uuid = %(uuid)s AND _row_exists = 1",
+            {"uuid": row_uuid},
+        )
+        return {person_id for [person_id] in rows}
+
+    squash_person_overrides.execute_in_process(
+        run_config=dagster.RunConfig(
+            {populate_snapshot_table.name: PopulateSnapshotTableConfig(timestamp=timestamp.isoformat())}
+        ),
+        resources={"cluster": cluster},
+    )
+
+    assert cluster.any_host(surviving_flag_evaluation_person_ids).result() == {surviving_person}
+
+    deletion = AsyncDeletion.objects.create(
+        team_id=team_id, deletion_type=DeletionType.Person, key=str(surviving_person)
+    )
+    deletion.created_at = timestamp
+    deletion.save()
+
+    # A person sweep only picks up requests made before the oldest surviving override, and the
+    # squash consumed the only one this test wrote. An empty overrides table pins that watermark at
+    # the epoch, so give the sweep an unrelated later override, which is what production always has.
+    def insert_later_override(client: Client) -> None:
+        client.execute(
+            "INSERT INTO person_distinct_id_overrides (team_id, distinct_id, person_id, _timestamp, version) VALUES",
+            [(team_id, "unrelated", UUID(int=9004), timestamp + timedelta(hours=1), 1)],
+        )
+
+    cluster.any_host(insert_later_override).result()
+
+    deletes_job.execute_in_process(
+        run_config={"ops": {"create_pending_deletions_table": {"config": {"team_id": team_id}}}},
+        resources={"cluster": cluster},
+    )
+
+    assert cluster.any_host(surviving_flag_evaluation_person_ids).result() == set()
 
 
 def test_cleanup_job(cluster: ClickhouseCluster) -> None:
@@ -213,56 +273,45 @@ def test_a_staged_snapshot_dictionary_holds_the_same_rows_as_the_snapshot_table(
 
 
 @pytest.mark.django_db
-def test_run_person_id_update_mutations_rewrites_events_json_on_its_own_cluster(
+def test_run_person_id_update_mutations_rewrites_each_target_on_its_own_cluster(
     cluster: ClickhouseCluster,
 ):
-    # sharded_events_json may sit on a cluster whose shards only its own handle enumerates. Running
-    # its rewrite over the job's handle would skip those rows, and the overrides that record the
-    # correct person_id are deleted in the very next op, so the divergence would be permanent.
+    # sharded_events_json and sharded_flag_evaluations may each sit on a cluster whose shards only
+    # its own handle enumerates. Running one of those rewrites over the job's handle would skip its
+    # rows, and the overrides that record the correct person_id are deleted in the very next op, so
+    # the divergence would be permanent. The assertion is keyed by table because a weaker one --
+    # that some mutation reached the sibling -- still passes when a target is dropped entirely.
     dictionary = _create_snapshot_with(cluster, [(1, "a", UUID(int=7), 3)])
     sibling = cluster.sibling(django_settings.CLICKHOUSE_SINGLE_SHARD_CLUSTER)
+    placements = [
+        TargetPlacement(target=EVENTS, cluster=cluster),
+        TargetPlacement(target=EVENTS_JSON, cluster=sibling),
+        TargetPlacement(target=FLAG_EVALUATIONS, cluster=sibling),
+    ]
+    phases: list[str] = []
+
+    def enqueue(runner: AlterTableMutationRunner, handle: ClickhouseCluster) -> dict:
+        phases.append("enqueue")
+        return {}
 
     with (
-        patch(
-            "posthog.dags.person_overrides.placement_for",
-            return_value=TargetPlacement(target=EVENTS_JSON, cluster=sibling),
-        ),
+        patch("posthog.dags.person_overrides.resolve_placements", return_value=placements),
         patch.object(
-            type(dictionary.events_json_update_mutation_runner),
-            "run_on_shards",
-            autospec=True,
-        ) as run_on_shards,
+            AlterTableMutationRunner, "enqueue_on_shards", autospec=True, side_effect=enqueue
+        ) as enqueue_on_shards,
+        patch(
+            "posthog.dags.person_overrides.wait_for_mutations_on_shards",
+            side_effect=lambda handle, shard_mutations: phases.append("wait"),
+        ),
     ):
         run_person_id_update_mutations(cluster, dictionary)
 
-    dispatched = [call.args[1] for call in run_on_shards.call_args_list]
-    assert sibling in dispatched
-    cluster.any_host(dictionary.source.drop).result()
-
-
-@pytest.mark.django_db
-def test_run_person_id_update_mutations_dispatches_flag_evaluations_to_correct_cluster(
-    cluster: ClickhouseCluster,
-):
-    # sharded_flag_evaluations may sit on a cluster whose shards only its own handle enumerates. Running
-    # its rewrite over the job's handle would skip those rows, and the overrides that record the
-    # correct person_id are deleted in the very next op, so the divergence would be permanent.
-    dictionary = _create_snapshot_with(cluster, [(1, "a", UUID(int=7), 3)])
-    sibling = cluster.sibling(django_settings.CLICKHOUSE_SINGLE_SHARD_CLUSTER)
-
-    with (
-        patch(
-            "posthog.dags.person_overrides.placement_for",
-            return_value=TargetPlacement(target=FLAG_EVALUATIONS, cluster=sibling),
-        ),
-        patch.object(
-            type(dictionary.flag_evaluations_update_mutation_runner),
-            "run_on_shards",
-            autospec=True,
-        ) as run_on_shards,
-    ):
-        run_person_id_update_mutations(cluster, dictionary)
-
-    dispatched = [call.args[1] for call in run_on_shards.call_args_list]
-    assert sibling in dispatched
+    assert {call.args[0].table: call.args[1] for call in enqueue_on_shards.call_args_list} == {
+        EVENTS_DATA_TABLE(): cluster,
+        EVENTS_JSON_DATA_TABLE: sibling,
+        FLAG_EVALUATIONS_DATA_TABLE: sibling,
+    }
+    # Waiting on each mutation as it is enqueued would cost the sum of their durations rather than
+    # the longest one, which is the whole reason the op enqueues in one pass.
+    assert phases == ["enqueue"] * 3 + ["wait"] * 3
     cluster.any_host(dictionary.source.drop).result()

--- a/posthog/dags/tests/test_person_overrides.py
+++ b/posthog/dags/tests/test_person_overrides.py
@@ -4,7 +4,7 @@ from functools import partial
 from uuid import UUID
 
 import pytest
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 from django.conf import settings as django_settings
 
@@ -27,7 +27,7 @@ from posthog.dags.person_overrides import (
 )
 from posthog.dags.tests.conftest import insert_flag_evaluations
 from posthog.models.async_deletion import AsyncDeletion, DeletionType
-from posthog.models.deletion_targets import EVENTS, EVENTS_JSON, EVENTS_TARGETS, FLAG_EVALUATIONS, TargetPlacement
+from posthog.models.deletion_targets import EVENTS, EVENTS_JSON, FLAG_EVALUATIONS, TargetPlacement
 from posthog.models.event.sql import EVENTS_DATA_TABLE, EVENTS_JSON_DATA_TABLE
 from posthog.models.flag_evaluations.sql import FLAG_EVALUATIONS_DATA_TABLE
 
@@ -135,6 +135,7 @@ def test_a_person_deletion_after_a_merge_reaches_flag_evaluations(cluster: Click
     # keeps the absorbed uuid and the sweep never matches those rows, permanently, because the
     # override that recorded the mapping is deleted in the same squash run. This runs both dags
     # because the regression lives at the seam between them, which neither dag's own test covers.
+    # nosemgrep: test-datetime-now-without-freeze (every timestamp here is an offset from this base, so no assertion reads a day bucket)
     timestamp = (datetime.now() + timedelta(days=31)).replace(microsecond=0)
     team_id = 4242
     absorbed_person, surviving_person = UUID(int=9001), UUID(int=9002)
@@ -282,11 +283,19 @@ def test_run_person_id_update_mutations_rewrites_each_target_on_its_own_cluster(
         TargetPlacement(target=FLAG_EVALUATIONS, cluster=sibling),
     ]
     calls = Mock()
+    enqueued = {
+        EVENTS_DATA_TABLE(): {0: Mock()},
+        EVENTS_JSON_DATA_TABLE: {0: Mock()},
+        FLAG_EVALUATIONS_DATA_TABLE: {0: Mock()},
+    }
 
     with (
         patch("posthog.dags.person_overrides.resolve_placements", return_value=placements) as resolve_placements,
         patch.object(
-            AlterTableMutationRunner, "enqueue_on_shards", autospec=True, return_value={}
+            AlterTableMutationRunner,
+            "enqueue_on_shards",
+            autospec=True,
+            side_effect=lambda runner, handle, shards=None: enqueued[runner.table],
         ) as enqueue_on_shards,
         patch("posthog.dags.person_overrides.wait_for_mutations_on_shards") as wait_for_mutations,
     ):
@@ -294,14 +303,24 @@ def test_run_person_id_update_mutations_rewrites_each_target_on_its_own_cluster(
         calls.attach_mock(wait_for_mutations, "wait")
         run_person_id_update_mutations(cluster, dictionary)
 
-    # This assertion names the targets literally instead of reusing SQUASH_TARGETS.
-    # The constant would still match after someone drops FLAG_EVALUATIONS from its definition.
-    resolve_placements.assert_called_once_with(cluster, (*EVENTS_TARGETS, FLAG_EVALUATIONS))
-    assert {call.args[0].table: call.args[1] for call in enqueue_on_shards.call_args_list} == {
+    # This assertion names the targets literally instead of reusing SQUASH_TARGETS or EVENTS_TARGETS.
+    # Either constant would still match after someone drops a target from its definition.
+    resolve_placements.assert_called_once_with(cluster, (EVENTS, EVENTS_JSON, FLAG_EVALUATIONS))
+    assert {enqueue.args[0].table: enqueue.args[1] for enqueue in enqueue_on_shards.call_args_list} == {
         EVENTS_DATA_TABLE(): cluster,
         EVENTS_JSON_DATA_TABLE: sibling,
         FLAG_EVALUATIONS_DATA_TABLE: sibling,
     }
+    # Each wait has to receive the mutations its own enqueue returned. A wait handed an empty set
+    # returns at once, and the next op deletes the overrides that record the mapping.
+    wait_for_mutations.assert_has_calls(
+        [
+            call(cluster, enqueued[EVENTS_DATA_TABLE()]),
+            call(sibling, enqueued[EVENTS_JSON_DATA_TABLE]),
+            call(sibling, enqueued[FLAG_EVALUATIONS_DATA_TABLE]),
+        ],
+        any_order=True,
+    )
     # Waiting on each mutation as it is enqueued would cost the sum of their completion times
     # rather than the longest, which is the whole reason the op enqueues in one pass.
     assert [name for name, *_ in calls.mock_calls] == ["enqueue"] * 3 + ["wait"] * 3


### PR DESCRIPTION
## Problem

A customer who merges two people and later deletes the survivor still has the absorbed person's flag-evaluation history sitting in `flag_evaluations`, full event `properties` and all, until the partition ages out.

`squash_person_overrides` rewrote `person_id` on the events tables only. A person deletion matches the deleted person's uuid against the stored `person_id`, so rows a merge left stamped with the absorbed person match nothing and survive the sweep. The squash deletes the overrides that record the mapping in the very next op, so nothing can reconcile the divergence afterwards.

This matters now rather than later because #92995 exposes `posthog.flag_evaluations` as a HogQL table, which turns those rows from storage the customer cannot see into rows they can query.

Closes #93035

## Changes

- Deleting a person who was previously merged into another now removes their `flag_evaluations` rows, matching the behavior events already had.
- `sharded_flag_evaluations` joins the squash's target list. The dispatch loops over `resolve_placements(cluster, SQUASH_TARGETS)` instead of a hand-written `placement_for` branch per table, so a target added to the list cannot go unrewritten the way this one did.
- `SQUASH_TARGETS` is deliberately its own list rather than `PERSONAL_DATA_TARGETS`. Registering a table for deletion stays a separate decision from enrolling it in the squash.
- The squash's completion waits now overlap. `MutationRunner.run_on_shards` splits into `enqueue_on_shards` plus a shared `wait_for_mutations_on_shards`, and every mutation is enqueued before any is waited on, so once they are in flight the op costs the longest rather than their sum. The capacity wait inside each enqueue is still per table and serial; see the follow-ups below. `run_on_shards` keeps its previous contract for its other caller in `posthog/temporal/backfill_materialized_property/`.
- Mechanical: parameterizing the runner by table left the singular form dead, so `OverridesSnapshotDictionary.update_mutation_runner` and the abstract `update_table` are gone and `update_mutation_runner_for` moved onto the base class. The base abstraction previously obliged every subclass to name one canonical squash table, which is false once a squash rewrites three.

The riskiest part is the `posthog/clickhouse/cluster.py` split, because `run_on_shards` is shared. The rest is confined to the squash dag, its base class, and its tests.

> [!NOTE]
> #92995 landed first, and its version of the "Producer prerequisite: person_id parity" section documents this gap as still open. This branch is rebased onto that master and reconciles the paragraph: it keeps #92995's clearer "A merges into B" explanation and corrects it to say the squash now covers the table.

## How did you test this code?

Verified locally:

- `pytest posthog/dags/tests/test_person_overrides.py` — 5 passed, run again after the cleanup commit.
- `uv run mypy --cache-fine-grained .` — `Success: no issues found in 20312 source files`, run repo-wide the way CI does, once before and once after the cleanup commit. Worth noting for anyone reproducing: the first two attempts were killed by the OOM killer at ~8.8 GB RSS while the dev stack held memory; it passes with the stack stopped.
- `hogli ci:preflight --strict` — 0 failures.

Those runs happened before this branch was rebased onto current master to take #92995. The rebase changed only the coverage doc, in the paragraph described above.

What the new tests catch:

- `test_a_person_deletion_after_a_merge_reaches_flag_evaluations` runs merge → squash → delete through both dags and asserts the row is gone. That seam is the regression this PR fixes and neither dag's own tests covered it. On an earlier shape of this change the same test failed on `master` (the row survived with the absorbed uuid) and passed with the fix; it has not been re-run against `master` in its current form.
- `test_run_person_id_update_mutations_rewrites_each_target_on_its_own_cluster` replaces two prior dispatch tests. It asserts the whole table-to-cluster mapping, because the previous form (`sibling in dispatched`) passed even with a target dropped from the dispatch entirely.

Not verified:

- The CodeRabbit CLI is not installed in this environment, so this PR opens without a local review pass. No agent review was substituted for it.
- No manual or UI testing. This change has no user-visible surface beyond the deletion behavior itself.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`docs/internal/clickhouse-deletion-coverage.md` is updated here: the squash paragraph names `SQUASH_TARGETS` and all three tables, and the person_id parity section records why write-time parity is not sufficient once a merge has moved a `distinct_id`, including that rows stranded before this landed cannot be reconciled and age out with their partition.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: Claude Code (PostHog Desktop task).
- Skills invoked: `/writing-tests`, `/simplify`. `writing-pr-descriptions` and `reviewing-with-coderabbit` are not registered with the skill runner in this environment, so both were read from `.agents/skills/` and followed.
- The first commit carries the original fix, authored by vmaineng in #95459 and brought over so the review could be addressed on top of it rather than alongside it. The signed-commit tooling here creates commits server-side as the authenticated user, so their authorship survives as attribution rather than as a commit author field.
- `/simplify` ran four review agents over the diff. Three independently found that parameterizing the runner had orphaned the base class's singular form; that is the third commit, which removes 33 net lines. It also corrected two claims that were overstated: the batching wording above, and an earlier commit message that said it had reverted unrelated reformatting when four hunks remained.
- Two findings from `/simplify` were deliberately kept out of this diff and ship in #98865, stacked on top of it: the `accepts_person_id_rewrite` capability field and its invariant tests, which catch the *next* table rather than this one, and adopting the extracted wait helper in `posthog/dags/deletes.py` so it gains the `MutationNotFound` retry it was missing. Both change shared modules and read better as their own review.
- Test data (uuids, distinct_ids, team id) is invented. No customer or session material is in the code, tests, or this description.

**Definition of done:**

- No duplicate: #95459 is the origin of the first commit, not a competing PR — it is superseded by this one and should be closed in its favor. No other open PR addresses #93035 (`gh pr list --state open --search "flag_evaluations squash"`).
- Patch coverage: check the "🧪 Backend test coverage" comment once CI reports.
- Public artifact: nothing here carries material from the agent session that was not already in this repository or on the linked issue and PR.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
