### PR TITLE
fix(replay-vision): validate signal timestamp evidence

### DIFF
--- a/docs/internal/replay-vision-signal-evidence.md
+++ b/docs/internal/replay-vision-signal-evidence.md
@@ -1,0 +1,16 @@
+# Replay Vision signal timestamps
+
+New signals responses require nonnegative whole-second timestamps with `start_time <= end_time`.
+Each finding must end at or before the recording duration. A duration of 10.9 seconds permits `REC_T 10`, but not `REC_T 11`.
+Equal start and end times are valid, including zero in a recording shorter than one second.
+
+A nonempty response fails validation when the recording duration is missing, nonfinite, zero, or negative.
+An empty signals list is valid regardless of duration.
+
+If any finding fails validation, the provider gets one correction request for the signals response.
+For timestamps past the duration, the request says to use visible timestamps or omit the finding, without clamping timestamps.
+For an unavailable duration, the request says to return an empty signals list.
+If the second response also fails, the signals step contributes no findings. The main scanner output is preserved.
+
+Time ordering is validated on `SignalsResponse`, not the shared `SignalFinding` payload.
+Stored `ScannerCallOutput` payloads can still load legacy findings whose end time precedes their start time.

--- a/products/replay_vision/backend/temporal/activities/call_scanner_provider.py
+++ b/products/replay_vision/backend/temporal/activities/call_scanner_provider.py
@@ -7,12 +7,13 @@ Each step validates its own output and re-prompts once on failure; required step
 """
 
 import re
+import math
 import time
 import asyncio
 import functools
 from collections import Counter
 from collections.abc import Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import timedelta
 from typing import Any, TypeVar
 from uuid import UUID, uuid4
@@ -44,6 +45,7 @@ from products.replay_vision.backend.temporal.gemini import classify_gemini_error
 from products.replay_vision.backend.temporal.metrics import record_mission_pass, record_provider_call
 from products.replay_vision.backend.temporal.scanners import scanner_from_snapshot
 from products.replay_vision.backend.temporal.scanners.base import (
+    STEP_SIGNALS,
     TIMESTAMP_CITATION_RE,
     BaseScanner,
     BaseScannerOutput,
@@ -51,6 +53,7 @@ from products.replay_vision.backend.temporal.scanners.base import (
     MissionStep,
     Segment,
     SignalFinding,
+    SignalsResponse,
     TextSegment,
 )
 from products.replay_vision.backend.temporal.scanners.classifier import ClassifierScanner
@@ -384,11 +387,22 @@ async def _run_mission(
         return dispatch_events_tool(call, events_index)
 
     cache = await _maybe_create_video_cache(cache_client, model, video_part, preamble_text)
+    steps = [
+        replace(
+            step,
+            validate=functools.partial(
+                _validate_signal_timestamps, duration_seconds=llm_inputs.metadata.duration_seconds
+            ),
+        )
+        if step.name == STEP_SIGNALS
+        else step
+        for step in scanner.mission_steps()
+    ]
     run = functools.partial(
         _run_steps,
         client=client,
         model=model,
-        steps=scanner.mission_steps(),
+        steps=steps,
         video_part=video_part,
         preamble_text=preamble_text,
         dispatch=dispatch,
@@ -403,6 +417,19 @@ async def _run_mission(
             await _delete_video_cache(cache_client, cache.name)
 
     return scanner.assemble(step_outputs)
+
+
+def _validate_signal_timestamps(output: BaseModel, *, duration_seconds: float | None) -> str | None:
+    if not isinstance(output, SignalsResponse) or not output.signals:
+        return None
+    if duration_seconds is None or not math.isfinite(duration_seconds) or duration_seconds <= 0:
+        return "Recording duration is unavailable. Return an empty signals list."
+    if any(signal.end_time > duration_seconds for signal in output.signals):
+        return (
+            f"Signal timestamps must not exceed REC_T {math.floor(duration_seconds)}. "
+            "Use timestamps visible in the recording, or omit the finding. Do not clamp timestamps."
+        )
+    return None
 
 
 async def _run_mission_attempts(*, run: Any, cache: Any | None, model: str) -> dict[str, BaseModel]:

--- a/products/replay_vision/backend/temporal/scanners/base.py
+++ b/products/replay_vision/backend/temporal/scanners/base.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Annotated, Any, ClassVar, Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from posthog.dataclasses import frozen
 
@@ -95,6 +95,12 @@ class SignalsResponse(BaseModel, frozen=True):
             "reveals. Usually empty: most sessions show nothing video-only. List each issue separately."
         ),
     )
+
+    @model_validator(mode="after")
+    def _validate_time_ranges(self) -> "SignalsResponse":
+        if any(signal.end_time < signal.start_time for signal in self.signals):
+            raise ValueError("end_time must be greater than or equal to start_time")
+        return self
 
 
 @dataclass(frozen=True)

--- a/products/replay_vision/backend/tests/test_call_scanner_provider.py
+++ b/products/replay_vision/backend/tests/test_call_scanner_provider.py
@@ -7,6 +7,7 @@ import httpx
 from google.genai.errors import APIError
 from pydantic import BaseModel
 
+from products.replay_vision.backend.models.replay_scanner import ScannerType
 from products.replay_vision.backend.temporal.activities.call_scanner_provider import (
     _maybe_create_video_cache,
     _run_mission,
@@ -16,7 +17,9 @@ from products.replay_vision.backend.temporal.activities.call_scanner_provider im
     _step_config,
 )
 from products.replay_vision.backend.temporal.errors import FailureKind, ScannerFailureError
-from products.replay_vision.backend.temporal.scanners.base import MissionStep
+from products.replay_vision.backend.temporal.scanners.base import MissionStep, SignalFinding, SignalsResponse
+from products.replay_vision.backend.temporal.scanners.monitor import MonitorLlmResponse, MonitorOutput, MonitorScanner
+from products.replay_vision.backend.temporal.types import ScannerSnapshot
 
 _LABELS = {"provider": "gemini", "model": "gemini-3-flash-preview", "scanner_type": "monitor"}
 # The driver treats the video part opaquely (just appended to the conversation), so a sentinel is fine.
@@ -240,6 +243,77 @@ async def test_non_required_step_failure_is_skipped_not_raised() -> None:
     out = await _run(client, steps)
     assert "core" in out
     assert "side" not in out
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "duration_seconds,end_times,expected_end",
+    [
+        (10.9, [10], 10),
+        (10.0, [10], 10),
+        (0.9, [0], 0),
+        (10.9, [11, 11], None),
+        (10.9, [11, 10], 10),
+        (None, [0, 0], None),
+        (0.0, [0, 0], None),
+        (-1.0, [0, 0], None),
+        (float("nan"), [0, 0], None),
+        (float("inf"), [0, 0], None),
+        (None, [None], None),
+    ],
+)
+async def test_signal_timestamps_use_recording_duration(
+    duration_seconds: float | None, end_times: list[int | None], expected_end: int | None
+) -> None:
+    scanner = MonitorScanner(prompt="Did the dialog block input?", emits_signals=True)
+    snapshot = ScannerSnapshot(
+        name="monitor",
+        scanner_type=ScannerType.MONITOR,
+        scanner_version=1,
+        model="gemini-3-flash-preview",
+        provider="gemini",
+        emits_signals=True,
+        scanner_config={"prompt": scanner.prompt},
+    )
+    signal = SignalFinding(
+        problem_type="bug",
+        start_time=0,
+        end_time=0,
+        url="https://example.com/editor",
+        description="A blank dialog covers the editor and prevents input.",
+        confidence=0.9,
+    )
+    core = MonitorLlmResponse(verdict="yes", reasoning="The dialog blocked input.", confidence=0.9)
+    client = _FakeClient(
+        [_Resp(text=core.model_dump_json())]
+        + [
+            _Resp(
+                text=SignalsResponse(
+                    signals=[] if end_time is None else [signal.model_copy(update={"end_time": end_time})]
+                ).model_dump_json()
+            )
+            for end_time in end_times
+        ]
+    )
+    module = "products.replay_vision.backend.temporal.activities.call_scanner_provider"
+    with (
+        patch(f"{module}.genai.AsyncClient", return_value=client),
+        patch(f"{module}.GoogleGenAIClient"),
+        patch(f"{module}.build_events_index", return_value={}),
+        patch(f"{module}._maybe_create_video_cache", new=AsyncMock(return_value=None)),
+    ):
+        finalized, signals = await _run_mission(
+            scanner=scanner,
+            snapshot=snapshot,
+            video_part=_VIDEO,
+            preamble_text="PRE",
+            team_id=1,
+            llm_inputs=MagicMock(metadata=MagicMock(duration_seconds=duration_seconds)),
+            trace_id="trace-1",
+        )
+    assert cast(MonitorOutput, finalized).verdict == "yes"
+    assert signals == ([] if expected_end is None else [signal.model_copy(update={"end_time": expected_end})])
+    assert len(client.models.calls) == 1 + len(end_times)
 
 
 @pytest.mark.asyncio

--- a/products/replay_vision/backend/tests/test_scanners.py
+++ b/products/replay_vision/backend/tests/test_scanners.py
@@ -19,7 +19,7 @@ from products.replay_vision.backend.temporal.scanners import (
 )
 from products.replay_vision.backend.temporal.scanners.base import BaseScanner, SignalFinding, SignalsResponse
 from products.replay_vision.backend.temporal.scanners.summarizer import summary_embedding_text
-from products.replay_vision.backend.temporal.types import EventTable
+from products.replay_vision.backend.temporal.types import EventTable, ScannerCallOutput
 
 
 def _build_replay_scanner(**overrides) -> ReplayScanner:
@@ -830,18 +830,35 @@ class TestSignalSideMission:
         )
         assert scanner.mission_steps()[-1].name == "signals"
 
-    def test_signals_parse_and_assemble_alongside_output(self) -> None:
+    @pytest.mark.parametrize("start_time, end_time", [(0, 0), (72, 72), (72, 78)])
+    def test_signals_parse_and_assemble_alongside_output(self, start_time: int, end_time: int) -> None:
         scanner = scanner_from_db(_build_replay_scanner(emits_signals=True))
-        signals_resp = SignalsResponse.model_validate(
-            {"signals": [{**self._VALID_SIGNAL}, {**self._VALID_SIGNAL, "url": "/two"}]}
-        )
+        signal = {**self._VALID_SIGNAL, "start_time": start_time, "end_time": end_time}
+        signals_resp = SignalsResponse.model_validate({"signals": [signal, {**self._VALID_SIGNAL, "url": "/two"}]})
         core = MonitorLlmResponse(verdict="yes", reasoning="r", confidence=0.9)
         out, signals = scanner.assemble({"core": core, "signals": signals_resp})
         assert isinstance(out, MonitorOutput)
         assert [isinstance(s, SignalFinding) for s in signals] == [True, True]
         assert signals[0].problem_type == "bug"
-        assert signals[0].start_time == 72
+        assert signals[0].start_time == start_time
+        assert signals[0].end_time == end_time
         assert signals[1].url == "/two"
+
+    @pytest.mark.parametrize("start_time, end_time", [(-1, 0), (0, -1), (72, 71)])
+    def test_signals_reject_invalid_time_ranges(self, start_time: int, end_time: int) -> None:
+        signal = {**self._VALID_SIGNAL, "start_time": start_time, "end_time": end_time}
+        with pytest.raises(ValidationError):
+            SignalsResponse.model_validate({"signals": [signal]})
+
+    def test_historical_activity_output_keeps_legacy_signal_times(self) -> None:
+        output = ScannerCallOutput.model_validate(
+            {
+                "model_output": MonitorOutput(verdict="yes", reasoning="r", confidence=0.9).model_dump(),
+                "signals": [{**self._VALID_SIGNAL, "start_time": 78, "end_time": 72}],
+            }
+        )
+        assert output.signals[0].start_time == 78
+        assert output.signals[0].end_time == 72
 
     def test_signals_default_empty_when_step_absent(self) -> None:
         # A signals turn that failed validation is absent; the output still assembles with no findings.


### PR DESCRIPTION


## Problem

Replay Vision can return findings whose time range is reversed or extends beyond the recording.

## Changes

- Reject invalid time ranges in new model responses.
- Request corrected evidence once, then omit findings if validation still fails.
- Withhold findings when recording duration is unavailable.
- Preserve the main scanner result and compatibility with stored activity payloads.

## How did you test this code?

- Local provider and scanner tests cover bounds, retries, missing duration, and legacy payloads.
- Preflight and commit-hook checks pass.
- Live recordings and model quality were not evaluated.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`docs/internal/replay-vision-signal-evidence.md` describes validation and compatibility.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex with worker agents. Skills: `writing-tests`, `writing-user-facing-copy`, `writing-pr-descriptions`, and `running-ci-preflight`.
Open-PR searches found no equivalent timestamp validation change.
No frontend changes.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*