### PR TITLE
chore(replay-vision): retain signal evidence in private evals

### DIFF
--- a/docs/internal/replay-vision-evaluation-evidence.md
+++ b/docs/internal/replay-vision-evaluation-evidence.md
@@ -1,0 +1,13 @@
+# Replay Vision evaluation evidence
+
+Successful scanner quality evaluations retain every structured finding in `signals`, alongside `signals_count`.
+An empty result retains `signals: []`.
+The output preserves each finding's type, time range, URL, description, and confidence for review against the recording.
+
+Primary verdict agreement, signal counts, and model confidence do not measure recommendation precision.
+The suite does not score each finding's evidence or usefulness.
+Review the findings against the recording before using them to assess recommendations.
+
+Signal payloads can contain session content.
+Keep them private and out of public CI summaries, commits, and pull requests.
+See the [evaluation README](../../products/replay_vision/evals/README.md) for run instructions and data handling restrictions.

--- a/products/replay_vision/evals/README.md
+++ b/products/replay_vision/evals/README.md
@@ -53,6 +53,13 @@ Use `--trials N` for variance on Gemini nondeterminism and `--eval <case-substri
 
 `output_stability` and `labeled_outcome` deliberately pull in opposite directions, so read them as a pair: a prompt change that only adds churn shows up as `labeled_outcome` flat or up while `output_stability` drops.
 
+Primary verdict agreement and signal counts do not measure recommendation precision.
+The label scorer compares primary outcomes; it does not check each signal's evidence or usefulness.
+Model confidence does not establish whether a signal supports a useful recommendation.
+Successful scans retain the complete structured `signals` list in the private per-case output alongside `signals_count`; no findings produces `signals: []`.
+Compare each finding's type, time range, URL, description, and confidence with the recording before using it as recommendation evidence.
+This suite does not calculate recommendation precision.
+
 ## Running it on a GitHub runner
 
 `.github/workflows/ci-replay-vision-evals.yml` runs the same loop on an ephemeral runner, on manual dispatch only, with `per_type` and `trials` as inputs (GitHub only offers the dispatch once the workflow is on master).
@@ -70,6 +77,7 @@ The dataset contains real session recordings and event data.
 - Keep it in a local or internal location only; never commit it, upload it, or reference its contents in PRs.
 - A dataset expires 30 days after its last collection: the suite refuses to run it, because the consent verification (and the recordings themselves) can lapse after collection. Re-running collect.py re-verifies consent and refreshes the manifest.
 - The suite is `OneShotPrivateEval`, so per-case logs stay in the local `eval_harness/logs/` directory and nothing goes to Braintrust.
+- The retained `signals` can contain session content. Keep these payloads private; never include them in public CI summaries, commits, or pull requests.
 - Dataset-derived content still leaves the machine on three paths. Two reach a model provider: the Gemini scans, which are the same provider call production already makes through `run_scan`, and the `summary_alignment` judge, which sends the recorded and fresh summaries to `gpt-5.4`. The third is the harness's `$ai_evaluation` capture, which stays inside PostHog.
 - The judge calls the OpenAI API directly with `OPENAI_API_KEY`. It does not go through the internal LLM gateway, which a one-shot suite never starts, so nothing sits in front of the provider on that path.
 - That capture posts every run's scores to project 2, keyed `<scanner_type>-<observation_id>`, with the scanner prompt as `$ai_input` and the recorded and fresh outcomes as `$ai_expected`/`$ai_output`. The scores land in that project's offline experiments view, which is where to compare runs over time.

--- a/products/replay_vision/evals/eval_scanner_quality.py
+++ b/products/replay_vision/evals/eval_scanner_quality.py
@@ -177,6 +177,7 @@ async def _scan_task(
         "error": None,
         "scanner_type": golden.scanner_type,
         "signals_count": len(result.signals),
+        "signals": [signal.model_dump(mode="json") for signal in result.signals],
         "primary": primary,
         "last_message": primary or "",
     }

--- a/products/replay_vision/evals/test/test_eval_scanner_quality.py
+++ b/products/replay_vision/evals/test/test_eval_scanner_quality.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import time
 import random
 import asyncio
@@ -8,12 +9,18 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
 
+from google.genai import types as genai_types
+
+from products.posthog_ai.eval_harness.harness.context import EvalContext
 from products.posthog_ai.eval_harness.scorers.contract import Score, Scorer
 from products.replay_vision.backend.temporal.activities.call_scanner_provider import apply_known_freeform_tags
 from products.replay_vision.backend.temporal.scanners import ClassifierScanner
-from products.replay_vision.backend.temporal.types import ScannerSnapshot
-from products.replay_vision.evals import collector
+from products.replay_vision.backend.temporal.scanners.base import SignalFinding
+from products.replay_vision.backend.temporal.scanners.monitor import MonitorOutput
+from products.replay_vision.backend.temporal.types import ScannerCallOutput, ScannerLlmInputs, ScannerSnapshot
+from products.replay_vision.evals import collector, eval_scanner_quality
 from products.replay_vision.evals.collector import (
     _VideoAsset,
     asset_is_recorded_video,
@@ -169,6 +176,70 @@ def test_scan_completed_fails_on_schema_breakage() -> None:
     failed = _eval(ScanCompleted(), {"model_output": None, "error": "required step rejected"}, {})
     assert failed.score == 0.0
     assert "rejected" in failed.metadata["reason"]
+
+
+@pytest.mark.parametrize(
+    "signals",
+    [
+        [],
+        [
+            {
+                "problem_type": "design_flaw",
+                "start_time": 7,
+                "end_time": 11,
+                "url": "https://example.com/library",
+                "description": "The navigation panel overlaps the book list.",
+                "confidence": 0.8,
+            },
+            {
+                "problem_type": "crash",
+                "start_time": 23,
+                "end_time": 29,
+                "url": "https://example.com/reader",
+                "description": "The reader shows an error screen after the book opens.",
+                "confidence": 0.95,
+            },
+        ],
+    ],
+    ids=["empty", "multiple_findings"],
+)
+def test_scan_task_retains_structured_signals(signals: list[dict[str, str | int | float]], tmp_path: Path) -> None:
+    golden = _golden("monitor", True, {"verdict": "yes"})
+    golden = golden.model_copy(update={"snapshot": golden.snapshot.model_copy(update={"emits_signals": True})})
+    scan_output = ScannerCallOutput(
+        model_output=MonitorOutput(verdict="yes", reasoning="The book list is covered.", confidence=0.9),
+        signals=[SignalFinding.model_validate(signal) for signal in signals],
+    )
+    with (
+        patch.object(GoldenCase, "load_inputs", return_value=MagicMock(spec=ScannerLlmInputs)),
+        patch.object(eval_scanner_quality, "gemini_api_key", return_value="fake-eval-api-key"),
+        patch.object(eval_scanner_quality, "RawGenAIClient"),
+        patch.object(
+            eval_scanner_quality,
+            "_upload_video",
+            return_value=genai_types.File(
+                name="files/eval-video", uri="https://example.com/video.mp4", mime_type="video/mp4"
+            ),
+        ),
+        patch.object(eval_scanner_quality, "_delete_file_quiet"),
+        patch.object(eval_scanner_quality, "run_scan", new=AsyncMock(return_value=scan_output)),
+    ):
+        output = asyncio.run(
+            eval_scanner_quality._scan_task(
+                tmp_path, {golden.case_id: golden}, build_case(golden), MagicMock(spec=EvalContext)
+            )
+        )
+
+    assert json.loads(json.dumps(output)) == {
+        "exit_code": 0,
+        "model_output": scan_output.model_output.model_dump(mode="json"),
+        "error": None,
+        "scanner_type": "monitor",
+        "signals_count": len(signals),
+        "signals": signals,
+        "primary": "Verdict: yes",
+        "last_message": "Verdict: yes",
+    }
 
 
 def test_summary_alignment_prepare_gates_on_reference() -> None:


### PR DESCRIPTION


## Problem

Signal counts and monitor verdicts do not let reviewers check individual recommendations against recordings.

## Changes

- Retain complete structured findings in private evaluation output.
- Preserve an empty list when no findings exist.
- Document that verdict agreement and confidence do not measure recommendation precision.
- Keep production behavior unchanged.

## How did you test this code?

- Local evaluation tests cover empty and multiple findings through the scan task with mocked external services.
- Preflight and commit-hook checks pass.
- No live model evaluation ran.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The evaluation README and `docs/internal/replay-vision-evaluation-evidence.md` explain evidence review and private data handling.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex with worker agents. Skills: `writing-tests`, `writing-user-facing-copy`, `writing-pr-descriptions`, and `running-ci-preflight`.
No frontend changes.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for reviewing Replay Vision evaluation results, including the limitations of aggregate scorer agreement and confidence metrics.
  - Documented that successful scans retain structured findings for manual comparison.
  - Added privacy guidance for handling retained signals, which may contain session content.

- **Tests**
  - Expanded evaluation coverage for empty and multiple scan findings, verification states, and preservation of result metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->