### PR TITLE
fix(warehouse-sources): make a repointed table visible again

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_sync.py
@@ -278,6 +278,14 @@ async def validate_schema_and_update_table(
                     _refresh_cumulative_row_count(table, logger, f"{_schema_name} ({_schema_id})")
                 else:
                     table.row_count = row_count
+                updated_fields = ["format", "url_pattern", "queryable_folder", "row_count"]
+                if table.deleted:
+                    # Deleting a schema's data unlinks the table too, so a table this schema still
+                    # points at is not one anybody chose to delete. Repointing it at fresh files while
+                    # leaving it hidden serves nothing and no later run resolves that on its own.
+                    table.deleted = False
+                    table.deleted_at = None
+                    updated_fields += ["deleted", "deleted_at"]
                 # get_count() above can retry against a degraded ClickHouse cluster for minutes, long
                 # enough for the pooled Postgres connection to be recycled underneath us. Retry once
                 # on a fresh connection rather than let this escape as error-tracking noise.
@@ -285,7 +293,7 @@ async def validate_schema_and_update_table(
                 # request input, so this sync is a trusted writer of a credential-less table's URL.
                 retry_on_db_connection_drop(
                     lambda: table.save(
-                        update_fields=["format", "url_pattern", "queryable_folder", "row_count"],
+                        update_fields=updated_fields,
                         internally_computed_url_pattern=True,
                     )
                 )

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/test_pipeline_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/test_pipeline_sync.py
@@ -5,6 +5,7 @@ from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, patch
 
 from django.db import OperationalError, transaction
+from django.utils import timezone
 
 from asgiref.sync import async_to_sync
 from clickhouse_driver.errors import ServerException
@@ -379,12 +380,16 @@ class TestValidateSchemaAndUpdateTable:
         schema.save()
         return table
 
-    def test_zero_reported_row_count_still_repoints_existing_table(self, team):
-        # The v3 load consumer can report row_count 0 on a redelivered final batch after a real write.
-        # An existing table must then be repointed at the freshly published files, not stranded on the
-        # previous queryable_folder - stranding it serves stale data under a green sync.
+    # The v3 load consumer can report row_count 0 on a redelivered final batch after a real write.
+    # An existing table must then be repointed at the freshly published files, not stranded on the
+    # previous queryable_folder - stranding it serves stale data under a green sync. A table left
+    # soft-deleted while still linked has to come back too, or the sync maintains a hidden table.
+    @pytest.mark.parametrize("table_soft_deleted", [False, True])
+    def test_zero_reported_row_count_still_repoints_existing_table(self, team, table_soft_deleted: bool):
         schema, job = self._schema_and_job(team)
         table = self._linked_table(team, schema, job, queryable_folder="s3://bucket/orders_v1")
+        if table_soft_deleted:
+            DataWarehouseTable.objects.filter(id=table.id).update(deleted=True, deleted_at=timezone.now())
 
         with (
             patch.object(DataWarehouseTable, "get_columns", return_value={}),
@@ -403,6 +408,8 @@ class TestValidateSchemaAndUpdateTable:
         assert table.queryable_folder == "s3://bucket/orders_v2"
         # A reported 0 must not zero a table that was just republished.
         assert table.row_count == 150
+        assert table.deleted is False
+        assert table.deleted_at is None
 
     # Published files at zero rows mean a resumed or redelivered run counted only its own attempt.
     # Trusting row_count there left the data in S3 with no table to query it through.


### PR DESCRIPTION
## Problem

- A customer enables a schema, watches rows sync against it, and the source page still reports that no table exists.
- Deleting a schema's data soft-deletes its table and clears `table_id` in one save. When only the first half lands, the schema still points at a table that is soft-deleted.
- Both schema serializers return `table: null` for that state (`external_data_schema.py:621` and `:1446`), and `DataWarehouseTableQuerySet.queryable()` excludes the row from HogQL.
- Every run repoints that table at its freshly published files, so the table holds current data and stays hidden. Nothing in the sync resolves it.

## Changes

- A run that repoints a table now clears `deleted` and `deleted_at` with the repoint, so the table returns to the source page and to HogQL on the next sync.
- The flag is cleared only for a table the schema still links to. Deleting a schema's data unlinks the table, so an intentional delete is never undone.
- Direct-query sources already clear both fields when they re-expose a table (`direct_snowflake.py:70`, `direct_redshift.py:74`). This brings the Delta path in line with them.
- Nothing user-visible changes for a schema whose table is live.

## How did you test this code?

- `test_zero_reported_row_count_still_repoints_existing_table` now runs for a live table and a soft-deleted one. The soft-deleted case fails on the unfixed code with `assert True is False` on `table.deleted`, which is the regression that leaves a repointed table hidden. No existing test set a table's `deleted` flag.
- Ran `test_pipeline_sync.py` against an isolated Postgres database.
- Not checked: no run against a real source, and no verification in a deployed environment.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 5) in PostHog Desktop, directed by @danielcarletti.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/improving-drf-endpoints`.
- The CodeRabbit local pass is paused, so this PR opened without one.
- No duplicate: `gh pr list --state open --search "soft-deleted table repoint warehouse"` returned nothing covering this.
- The work started from a support investigation. Nothing from that session reaches the diff: the test builds its own source, schema, table and job through the existing fixtures.
- The rejected alternative was to resolve `schema.table` through a manager that excludes deleted rows, so the sync would build a fresh table instead. That leaves a dangling `table_id`, and it drops the row history and the access controls attached to the old table id.
- #98817 fixes the write path that produces this split state.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

