### PR TITLE
fix(warehouse-sources): write only the fields a schema PATCH supplies

### DIFF
--- a/products/warehouse_sources/backend/presentation/views/external_data_schema.py
+++ b/products/warehouse_sources/backend/presentation/views/external_data_schema.py
@@ -679,7 +679,7 @@ class ExternalDataSchemaSerializer(UserAccessControlSerializerMixin, serializers
         validated_data: dict[str, Any],
         original_sync_type_config: dict[str, Any],
     ) -> ExternalDataSchema:
-        """Persist the update, writing only the fields this request changed onto a freshly-locked row.
+        """Persist the update onto a freshly-locked row, writing only the fields this request changed.
 
         super().update() does a full-instance save: every column goes back to the value it held in the
         copy loaded at the start of the request. A PATCH that carries one field therefore reverts every
@@ -702,12 +702,14 @@ class ExternalDataSchemaSerializer(UserAccessControlSerializerMixin, serializers
             merged.update(changed)
             for key in removed:
                 merged.pop(key, None)
-            instance.sync_type_config = merged
             validated_data["sync_type_config"] = merged
+            # Apply to the locked row rather than the request's copy. The copy still holds whatever
+            # the other writer replaced, and activity logging diffs the stored row against the
+            # instance it saves, so saving the copy logs a reversal that never reached the database.
             for attr, value in validated_data.items():
-                setattr(instance, attr, value)
-            instance.save(update_fields=_concrete_field_names(validated_data))
-            return instance
+                setattr(locked, attr, value)
+            locked.save(update_fields=_concrete_field_names(validated_data))
+            return locked
 
     def update(self, instance: ExternalDataSchema, validated_data: dict[str, Any]) -> ExternalDataSchema:
         data = self.initial_data if isinstance(self.initial_data, dict) else {}

--- a/products/warehouse_sources/backend/presentation/views/external_data_schema.py
+++ b/products/warehouse_sources/backend/presentation/views/external_data_schema.py
@@ -138,6 +138,15 @@ def _cdc_table_mode_change_needs_resnapshot(old_mode: str | None, new_mode: str 
     return bool(new_targets - old_targets)
 
 
+def _concrete_field_names(validated_data: dict[str, Any]) -> list[str]:
+    """The schema columns this payload writes, for a save() that leaves every other column alone.
+
+    updated_at is auto_now, and Django only refreshes an auto_now field named in update_fields.
+    """
+    columns = {field.name for field in ExternalDataSchema._meta.concrete_fields}
+    return [*(key for key in validated_data if key in columns), "updated_at"]
+
+
 def _reset_cdc_for_full_resnapshot(instance: ExternalDataSchema) -> None:
     """Cancel any running workflow and reset schema state so the next run does a full snapshot.
 
@@ -670,13 +679,15 @@ class ExternalDataSchemaSerializer(UserAccessControlSerializerMixin, serializers
         validated_data: dict[str, Any],
         original_sync_type_config: dict[str, Any],
     ) -> ExternalDataSchema:
-        """Persist the update, replaying only the sync_type_config keys this request changed onto a
-        freshly-locked copy of the row.
+        """Persist the update, writing only the fields this request changed onto a freshly-locked row.
 
-        super().update() does a full-instance save that rewrites sync_type_config wholesale from the
-        copy loaded at the start of the request, so without this it would revert any key a concurrent
-        CDC extract activity (cdc_last_log_position, cdc_deferred_runs, cdc_mode) committed in between.
-        The lock is held across the save so nothing interleaves.
+        super().update() does a full-instance save: every column goes back to the value it held in the
+        copy loaded at the start of the request. A PATCH that carries one field therefore reverts every
+        field anything else wrote in between — a concurrent CDC extract activity's sync_type_config keys
+        (cdc_last_log_position, cdc_deferred_runs, cdc_mode), or the table_id, status, last_synced_at
+        and initial_sync_complete that `delete_table()` clears. sync_type_config additionally merges,
+        because two writers own different keys of the same column. The lock is held across the save so
+        nothing interleaves.
         """
         intended = instance.sync_type_config or {}
         changed = {
@@ -693,7 +704,10 @@ class ExternalDataSchemaSerializer(UserAccessControlSerializerMixin, serializers
                 merged.pop(key, None)
             instance.sync_type_config = merged
             validated_data["sync_type_config"] = merged
-            return super().update(instance, validated_data)
+            for attr, value in validated_data.items():
+                setattr(instance, attr, value)
+            instance.save(update_fields=_concrete_field_names(validated_data))
+            return instance
 
     def update(self, instance: ExternalDataSchema, validated_data: dict[str, Any]) -> ExternalDataSchema:
         data = self.initial_data if isinstance(self.initial_data, dict) else {}
@@ -1086,7 +1100,7 @@ class ExternalDataSchemaSerializer(UserAccessControlSerializerMixin, serializers
             sync_type is None and instance.sync_type == ExternalDataSchema.SyncType.CDC
         )
         if is_cdc and source_type_supports_cdc(source.source_type):
-            self._handle_cdc_publication_change(instance, source, should_sync, sync_type)
+            self._handle_cdc_publication_change(instance, source, should_sync, sync_type, validated_data)
 
         if trigger_refresh:
             instance.sync_type_config.update({"reset_pipeline": True})
@@ -1359,6 +1373,7 @@ class ExternalDataSchemaSerializer(UserAccessControlSerializerMixin, serializers
         source: ExternalDataSource,
         should_sync: bool | None,
         sync_type: str | None,
+        validated_data: dict[str, Any],
     ) -> None:
         """Add/remove the table from the CDC capture set when a schema is toggled or set to CDC."""
         adapter = get_cdc_adapter(source)
@@ -1388,10 +1403,12 @@ class ExternalDataSchemaSerializer(UserAccessControlSerializerMixin, serializers
             if should_sync is True and not newly_set_to_cdc:
                 # Mutate in memory only — the locked terminal save in `update()` (which calls this)
                 # persists both fields, merging cdc_mode onto the freshly-read config so a concurrent
-                # CDC extract activity's writes survive. A separate save here would clobber them.
+                # CDC extract activity's writes survive. A separate save here would clobber them. It
+                # writes only the columns validated_data names, hence the flag going in there too.
                 instance.sync_type_config["cdc_mode"] = "snapshot"
                 instance.sync_type_config["reset_pipeline"] = True
                 instance.initial_sync_complete = False
+                validated_data["initial_sync_complete"] = False
 
         # Remove table from capture set when toggling sync off
         elif should_sync is False and instance.should_sync:

--- a/products/warehouse_sources/backend/tests/api/test_external_data_schema.py
+++ b/products/warehouse_sources/backend/tests/api/test_external_data_schema.py
@@ -3353,9 +3353,9 @@ class TestExternalDataSchemaSerializerValidation(APIBaseTest):
         assert self.schema.sync_type == ExternalDataSchema.SyncType.INCREMENTAL
 
 
-class TestSyncTypeConfigLostUpdateProtection(APIBaseTest):
-    """The serializer's full-instance save must not revert a sync_type_config key that a concurrent
-    CDC extract activity committed after the request loaded the row."""
+class TestSerializerLostUpdateProtection(APIBaseTest):
+    """A PATCH must not revert what another writer committed after the request loaded the row —
+    a sync_type_config key from a CDC extract activity, or the link fields "Delete data" clears."""
 
     def setUp(self):
         super().setUp()
@@ -3447,6 +3447,41 @@ class TestSyncTypeConfigLostUpdateProtection(APIBaseTest):
         # The user's key change landed AND the concurrent position (a key the request didn't touch) survived.
         assert self.schema.cdc_table_mode == "both"
         assert self.schema.sync_type_config["cdc_last_log_position"] == "0/900"
+
+    def test_patch_does_not_revert_a_concurrent_delete_data(self):
+        from products.warehouse_sources.backend.presentation.views.external_data_schema import (
+            ExternalDataSchemaSerializer,
+        )
+
+        table = DataWarehouseTable.objects.create(
+            team=self.team, name="orders", format="Parquet", external_data_source=self.source
+        )
+        self.schema.table = table
+        self.schema.initial_sync_complete = True
+        self.schema.save()
+
+        instance = ExternalDataSchema.objects.get(id=self.schema.id)  # in-memory copy, still linked
+
+        with mock.patch("products.data_warehouse.backend.facade.api.get_s3_client"):
+            ExternalDataSchema.objects.get(id=self.schema.id).delete_table()
+
+        serializer = ExternalDataSchemaSerializer(
+            instance,
+            data={"should_sync": False},
+            partial=True,
+            context={"team_id": self.team.pk, "post_commit_actions": []},
+        )
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+        self.schema.refresh_from_db()
+        table.refresh_from_db()
+        assert self.schema.should_sync is False
+        assert self.schema.table_id is None
+        assert self.schema.status is None
+        assert self.schema.last_synced_at is None
+        assert self.schema.initial_sync_complete is False
+        assert table.deleted is True
 
 
 class TestAvailableColumnsAcrossSqlSources(APIBaseTest):

--- a/products/warehouse_sources/backend/tests/api/test_external_data_schema.py
+++ b/products/warehouse_sources/backend/tests/api/test_external_data_schema.py
@@ -3472,10 +3472,12 @@ class TestSerializerLostUpdateProtection(APIBaseTest):
             context={"team_id": self.team.pk, "post_commit_actions": []},
         )
         serializer.is_valid(raise_exception=True)
-        serializer.save()
+        saved = serializer.save()
 
         self.schema.refresh_from_db()
         table.refresh_from_db()
+        assert saved.table_id is None
+        assert saved.initial_sync_complete is False
         assert self.schema.should_sync is False
         assert self.schema.table_id is None
         assert self.schema.status is None


### PR DESCRIPTION
## Problem

- A customer deletes a schema's data, disables the schema, and later re-enables it. The schema then syncs into a table that no longer appears anywhere.
- The schema serializer ends in DRF's full-instance save, so every column is written back from the copy loaded at the start of the request.
- A PATCH that carries one field therefore reverts whatever another writer committed in between. `delete_table()` clears `table_id`, `status`, `last_synced_at` and `initial_sync_complete`; an overlapping PATCH puts all four back.
- The schema is then linked to a table that stays soft-deleted, which the API and HogQL both hide. The sync keeps that table current, and the customer sees nothing.
- `sync_type_config` already had a hand-written merge for this exact hazard. Every other column was unprotected.

## Changes

- The terminal save now uses `update_fields` scoped to the columns the payload names, so a PATCH cannot touch a column it did not carry.
- The CDC re-snapshot branch set `initial_sync_complete` on the instance alone and relied on the full save to persist it, so it now declares that field too.
- Nothing changes for a request that runs on its own. The difference shows only when two writers overlap.

## How did you test this code?

- `TestSyncTypeConfigLostUpdateProtection` becomes `TestSerializerLostUpdateProtection`, because the class now guards the whole row rather than one column.
- The new case runs a real `delete_table()` between the serializer loading the row and saving it, then asserts the four cleared fields stay cleared. On the unfixed code it fails with `assert UUID(...) is None` on `table_id`, which is the customer symptom. The two existing cases cover `sync_type_config` only.
- Ran `test_external_data_schema.py` against an isolated Postgres database with a local Temporal server.
- Not checked: no run against a real source, and no verification in a deployed environment.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 5) in PostHog Desktop, directed by @danielcarletti.
- Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-pr-descriptions`.
- The CodeRabbit local pass is paused, so this PR opened without one.
- No duplicate: `gh pr list --state open --search "warehouse_sources schema patch update_fields"` returned nothing covering this.
- The work started from a support investigation, and the audit trail on one schema is what identified the write path. Nothing from that session reaches the diff: the test builds its own source, schema and table through the existing fixtures.
- A narrower fix would extend the existing merge to the four link fields by name. Scoping the save to the payload was chosen instead, because the same hazard applies to every column and a per-field list goes stale as fields are added.
- #98816 restores the tables this write path already left hidden.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

