### PR TITLE
feat(warehouse-sources): promote the Webflow source to GA

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/webflow/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/webflow/source.py
@@ -242,7 +242,7 @@ Grant the read scopes for the resources you want to sync:
 """,
             iconPath="/static/services/webflow.png",
             docsUrl="https://posthog.com/docs/cdp/sources/webflow",
-            releaseStatus=ReleaseStatus.ALPHA,
+            releaseStatus=ReleaseStatus.GA,
             fields=cast(
                 list[FieldType],
                 [


### PR DESCRIPTION
## Problem

People connecting Webflow in the data warehouse wizard see an "Alpha" label on the source. That label tells them the connector is new and lightly tested, which no longer matches how it behaves. The source has been live for over three months and its imports are not failing.

## Changes

- The Webflow source now shows as GA in the source catalog instead of Alpha.
- Nothing else changes: `releaseStatus` is a label on an already-visible source, so schemas, transport, webhooks, and sync logic are untouched.
- No gating to remove. Webflow carries no `unreleasedSource` flag and no `featureFlag`, so the one-line status change is the whole promotion.

Promotion criteria, measured over a 7-day window:

| Criterion | Threshold | Webflow |
| --- | --- | --- |
| Adoption | 100+ teams **or** 3+ months live | live 3.1 months |
| Import error rate | < 2.5% | 0.0% |

## How did you test this code?

Ran `pytest products/warehouse_sources/backend/temporal/data_imports/sources/webflow/tests/` — 79 passed. Also ran the cross-source invariant suites that read every registered source's config (`test_source_categories.py`, `test_source_versions.py`) plus the rest of the sources package, all passing. No test asserted the old alpha value, so none needed updating.

No new tests. A test that reads `releaseStatus` back out of `get_source_config` restates the declaration it is checking and cannot fail independently of it.

No manual verification against a live Webflow account was done.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The posthog.com Webflow doc does not state a release stage.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Claude Opus 5 via PostHog Desktop, from an automated sweep that promotes warehouse sources once they clear the adoption and error-rate bars.

Skills invoked: `/implementing-warehouse-sources` for the release-status conventions (it specifies the `ReleaseStatus` enum over a string literal, and separates `releaseStatus` as a soft label from `unreleasedSource` as a visibility gate), and `/writing-pr-descriptions` for this body.

- **No duplicate:** searched open PRs for the source name, "releaseStatus", and "promote", and listed the maintainer's own open PRs. Nothing addresses the Webflow promotion.
- **Patch coverage:** the changed line is a config value covered by the existing source-config tests.
- **CodeRabbit CLI pass:** paused, so this PR opened without a local pass.
- **Public artifact:** the diff and this description contain only repository content and the two aggregate promotion metrics quoted above.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
