### PR TITLE
feat(replay-vision): emit an observation event on the failure path

### DIFF
--- a/products/replay_vision/backend/api/backfills.py
+++ b/products/replay_vision/backend/api/backfills.py
@@ -239,10 +239,10 @@ class ReplayScannerBackfillViewSet(
     def _unobserved_count(self, scanner: ReplayScanner, window_start: datetime, window_end: datetime) -> int:
         """Upper bound on what a backfill over this window would scan, rejecting when it is zero.
 
-        An upper bound rather than exact: the exclusion reads `$recording_observed`, which only exists
-        for observations that succeeded and managed to publish, so sessions already tried and found
-        ineligible or failed still count here. They cannot produce a second observation, so the real
-        spend lands under the quote.
+        An upper bound rather than exact: the exclusion reads succeeded `$recording_observed` rows,
+        and only those that managed to publish, so sessions already tried and found ineligible or
+        failed still count here. They cannot produce a second observation, so the real spend lands
+        under the quote.
 
         Distinguishes "nothing here matches the scanner" from "everything here is already done"; the
         second count only runs on the rejection path, so the happy path stays at one ClickHouse query.

--- a/products/replay_vision/backend/queries/scanner_candidate_query.py
+++ b/products/replay_vision/backend/queries/scanner_candidate_query.py
@@ -24,6 +24,7 @@ from posthog.session_recordings.queries.session_recording_list_from_query import
 )
 from posthog.session_recordings.queries.sub_queries.group_key_resolver import GROUP_KEY_RESOLUTION_QUERY_TYPE
 
+from products.replay_vision.backend.models.replay_observation import ObservationStatus
 from products.replay_vision.backend.models.replay_scanner import SETTLE_INTERVAL, SamplingMode
 from products.replay_vision.backend.session_limits import (
     MAX_ACTIVE_SECONDS_FOR_VIDEO_SCANNER_S,
@@ -72,7 +73,8 @@ DEFAULT_CANDIDATE_LIMIT = 5_000
 CANDIDATE_SCAN_LIMIT = 2_000
 DEFAULT_MAX_EXECUTION_SECONDS = 180
 
-# Emitted by `emit_observation_event_activity` once an observation succeeds.
+# Emitted by `emit_observation_event_activity` once an observation reaches a terminal state;
+# `properties.status` says which one.
 OBSERVATION_EVENT_NAME = "$recording_observed"
 
 # Calibrated from the prod score distribution: focused keeps roughly the top 25% of sessions, balanced the top 65%.
@@ -689,9 +691,13 @@ class WindowedCandidateQuery:
 
         Reads the event rather than shipping observation ids over from Postgres, so the exclusion is
         a plain ClickHouse join with no cross-database list and no size ceiling. The trade-off is that
-        the event is only emitted on the success path, and fail-soft even there, so ineligible,
-        failed, and in-flight observations stay in the count. Those cannot produce a second
-        observation (the unique constraint blocks it), which is why the total is an upper bound.
+        only succeeded rows are read, and fail-soft even there, so ineligible, failed, and in-flight
+        observations stay in the count. Those cannot produce a second observation (the unique
+        constraint blocks it), which is why the total is an upper bound.
+
+        Terminal non-success outcomes emit the same event, so the status filter below holds the
+        selected set to exactly what it was before they did. It must stay: a backfill retakes a
+        failed observation, so pruning on a failed row would quote less work than the backfill runs.
         """
         observed = ast.SelectQuery(
             select=[ast.Field(chain=["properties", "session_id"])],
@@ -707,6 +713,13 @@ class WindowedCandidateQuery:
                         op=ast.CompareOperationOp.Eq,
                         left=ast.Field(chain=["properties", "scanner_id"]),
                         right=ast.Constant(value=scanner_id),
+                    ),
+                    # Rows emitted before the event carried a status have none; `NOT IN` keeps them,
+                    # which is what holds the pre-existing selection fixed.
+                    ast.CompareOperation(
+                        op=ast.CompareOperationOp.NotIn,
+                        left=ast.Field(chain=["properties", "status"]),
+                        right=ast.Constant(value=[ObservationStatus.FAILED.value, ObservationStatus.INELIGIBLE.value]),
                     ),
                     # An observation is always emitted after its session ended, so the window's own
                     # lower bound prunes partitions without ever excluding a relevant event.

--- a/products/replay_vision/backend/temporal/activities/emit_observation_event.py
+++ b/products/replay_vision/backend/temporal/activities/emit_observation_event.py
@@ -1,4 +1,4 @@
-"""Emit the `$recording_observed` event with the scanner output to the customer's events table."""
+"""Emit the `$recording_observed` event with the scan outcome to the customer's events table."""
 
 from datetime import UTC, datetime
 
@@ -26,7 +26,12 @@ _EVENT_SOURCE = "replay_vision"
 @activity.defn
 @track_activity(side_effect="event")
 async def emit_observation_event_activity(inputs: EmitObservationEventInputs) -> None:
-    """Capture the `$recording_observed` event into the customer's events table; dedup-keyed by observation_id."""
+    """Capture the `$recording_observed` event into the customer's events table; dedup-keyed by observation_id.
+
+    Runs on every terminal outcome, not just success: `status` and `error_kind` are what make failure
+    rate queryable per `triggered_by`, and they are the only view of an inline scan, which belongs to
+    no saved scanner and so appears on no scanner page.
+    """
     await database_sync_to_async(_emit_event, thread_sensitive=False)(inputs)
 
 
@@ -68,8 +73,10 @@ def _emit_event(inputs: EmitObservationEventInputs) -> None:
         # Priced at emit time, so it can drift from quota.py's repriced-at-current-rates totals.
         "credits": observation_credits_for_model(snapshot.model),
         "emits_signals": snapshot.emits_signals,
+        "status": str(observation.status),
+        **_failure_properties(observation),
         # Flatten scanner output so HogQL can query individual fields without a JSON extract.
-        **inputs.model_output.to_event_properties(),
+        **(inputs.model_output.to_event_properties() if inputs.model_output is not None else {}),
         **_group_properties(team, observation),
     }
     distinct_id = (
@@ -91,6 +98,13 @@ def _emit_event(inputs: EmitObservationEventInputs) -> None:
         event_uuid=str(observation.id),
     )
     result.raise_for_status()
+
+
+def _failure_properties(observation: ReplayObservation) -> dict:
+    """The kind half of `error_reason` only; the message half quotes provider ids and other internals."""
+    if not observation.error_reason:
+        return {}
+    return {"error_kind": observation.error_reason.split(":", 1)[0]}
 
 
 def _group_properties(team: Team, observation: ReplayObservation) -> dict:

--- a/products/replay_vision/backend/temporal/types.py
+++ b/products/replay_vision/backend/temporal/types.py
@@ -292,4 +292,5 @@ class EmitObservationEventInputs(BaseModel, frozen=True):
     """Payload for the `$recording_observed` capture."""
 
     observation_id: UUID
-    model_output: AnyScannerOutput
+    # None on terminal non-success statuses: there is no model output, the event carries the outcome alone.
+    model_output: AnyScannerOutput | None = None

--- a/products/replay_vision/backend/temporal/workflow.py
+++ b/products/replay_vision/backend/temporal/workflow.py
@@ -385,6 +385,7 @@ class ApplyScannerWorkflow(PostHogWorkflow):
                     or FailureKind.INTERNAL_ERROR.value
                 )
                 await self._mark_failed(observation_id, scanner_type, failure_kind, _root_cause_message(e))
+            await self._emit_terminal_event(observation_id)
             raise
         finally:
             if uploaded is not None:
@@ -526,6 +527,23 @@ class ApplyScannerWorkflow(PostHogWorkflow):
             schedule_to_close_timeout=_STATE_ACTIVITY_SCHEDULE_TO_CLOSE,
             retry_policy=_STATE_ACTIVITY_RETRY,
         )
+
+    async def _emit_terminal_event(self, observation_id: UUID) -> None:
+        """Emit `$recording_observed` for a failed or ineligible outcome, fail-soft as on the success path.
+
+        Without it the events table only ever sees the scans that worked, so no query can report a
+        failure rate, and an inline scan — which belongs to no saved scanner — leaves no trace at all.
+        """
+        try:
+            await wf.execute_activity(
+                emit_observation_event_activity,
+                EmitObservationEventInputs(observation_id=observation_id),
+                start_to_close_timeout=dt.timedelta(seconds=30),
+                schedule_to_close_timeout=_STATE_ACTIVITY_SCHEDULE_TO_CLOSE,
+                retry_policy=_STATE_ACTIVITY_RETRY,
+            )
+        except Exception:
+            wf.logger.exception("Event emission failed for terminal observation %s", observation_id)
 
     async def _apply_scanner_side_effects(
         self,

--- a/products/replay_vision/backend/tests/test_backfills.py
+++ b/products/replay_vision/backend/tests/test_backfills.py
@@ -249,8 +249,8 @@ class TestCreateObservationForBackfill:
     @pytest.mark.parametrize(
         "seeded_status,expect_retaken",
         [
-            # A failed scan emits no $recording_observed event, so the creation-time count quotes that session
-            # as work. Leaving the row alone would report progress for a scan that never re-ran.
+            # A failed scan is not excluded from the creation-time count, which quotes that session as
+            # work. Leaving the row alone would report progress for a scan that never re-ran.
             (ObservationStatus.FAILED, True),
             # A succeeded session is already billed; retaking it would scan and charge twice.
             (ObservationStatus.SUCCEEDED, False),

--- a/products/replay_vision/backend/tests/test_scanner_candidate_query.py
+++ b/products/replay_vision/backend/tests/test_scanner_candidate_query.py
@@ -820,6 +820,43 @@ class TestWindowedCandidateQueryAgainstClickHouse(ClickhouseTestMixin):
         )
 
     @pytest.mark.django_db
+    def test_exclusion_reads_succeeded_observations_only(self, team) -> None:
+        # Every terminal outcome emits `$recording_observed` now. A backfill retakes a failed
+        # observation, so pruning on a failed row would quote less work than the backfill runs.
+        window_end = _NOW - dt.timedelta(hours=1)
+        window_start = window_end - dt.timedelta(days=1)
+        observed_at = window_end - dt.timedelta(minutes=30)
+        for session_id, status in (("ok-sess", "succeeded"), ("failed-sess", "failed"), ("inelig-sess", "ineligible")):
+            end = window_end - dt.timedelta(hours=2)
+            self._produce(team.id, session_id, end - dt.timedelta(minutes=10), end)
+            _create_event(
+                team=team,
+                event="$recording_observed",
+                distinct_id="d1",
+                timestamp=observed_at,
+                properties={"session_id": session_id, "scanner_id": "scanner-1", "status": status},
+            )
+        # A row from before the event carried a status: it must keep pruning its session.
+        legacy_end = window_end - dt.timedelta(hours=2)
+        self._produce(team.id, "legacy-sess", legacy_end - dt.timedelta(minutes=10), legacy_end)
+        _create_event(
+            team=team,
+            event="$recording_observed",
+            distinct_id="d1",
+            timestamp=observed_at,
+            properties={"session_id": "legacy-sess", "scanner_id": "scanner-1"},
+        )
+
+        candidates = self._query(
+            team=team,
+            window_start=window_start,
+            window_end=window_end,
+            exclude_observed_by_scanner="scanner-1",
+        ).run()
+
+        assert sorted(c.session_id for c in candidates) == ["failed-sess", "inelig-sess"]
+
+    @pytest.mark.django_db
     def test_rejects_inverted_window(self, team) -> None:
         with pytest.raises(ValueError, match="window_start must be before window_end"):
             self._query(team=team, window_start=_NOW, window_end=_NOW - dt.timedelta(days=1))

--- a/products/replay_vision/backend/tests/test_sweep.py
+++ b/products/replay_vision/backend/tests/test_sweep.py
@@ -657,8 +657,8 @@ class TestFindScannerCandidatesActivity:
         assert MockDeep.call_args.kwargs["candidate_limit"] == expected_deep_limit
 
     def test_deep_pass_excludes_sessions_with_terminal_observations(self) -> None:
-        # The $recording_observed event only lands on success, so excluding on it would hand these
-        # sessions back on every tick and the walk would never move past them.
+        # The deep pass excludes on the Postgres rows, not on $recording_observed, so a terminal
+        # observation of any status moves the walk past its session.
         scanner = _make_scanner(deep_swept_through=dt.datetime.now(dt.UTC) - _PAST_DEEP_INTERVAL)
         for session_id, status in (("failed-sess", ObservationStatus.FAILED), ("ok-sess", ObservationStatus.SUCCEEDED)):
             ReplayObservation.objects.create(

--- a/products/replay_vision/backend/tests/test_temporal.py
+++ b/products/replay_vision/backend/tests/test_temporal.py
@@ -1500,6 +1500,85 @@ class TestEmitObservationEventActivity:
         assert properties["$group_0"] == "acme-inc"
         assert "$groups" not in properties
 
+    def test_failed_observation_emits_its_outcome_with_no_model_output(self) -> None:
+        # Without this row the events table only ever holds the scans that worked, so no query can
+        # report a failure rate, per trigger or otherwise.
+        scanner = _make_scanner()
+        observation = _make_observation(
+            scanner,
+            status=ObservationStatus.FAILED,
+            error_reason="provider_rejected:Gemini file files/abc123 reached non-ACTIVE state 'FAILED'",
+            completed_at=timezone.now(),
+        )
+
+        with patch(
+            "products.replay_vision.backend.temporal.activities.emit_observation_event.capture_internal"
+        ) as capture:
+            _emit_event(EmitObservationEventInputs(observation_id=observation.id))
+
+        properties = capture.call_args.kwargs["properties"]
+        assert properties["status"] == ObservationStatus.FAILED
+        assert properties["error_kind"] == "provider_rejected"
+        assert properties["triggered_by"] == ObservationTrigger.ON_DEMAND
+        assert not [key for key in properties if key.startswith("scanner_output_")]
+
+    def test_the_message_half_of_the_reason_stays_out_of_the_event(self) -> None:
+        # `error_reason` quotes provider file ids and other internals; the kind is the whole
+        # aggregation axis, so only the kind is published.
+        scanner = _make_scanner()
+        observation = _make_observation(
+            scanner,
+            status=ObservationStatus.FAILED,
+            error_reason="provider_rejected:Gemini file files/abc123 reached non-ACTIVE state 'FAILED'",
+            completed_at=timezone.now(),
+        )
+
+        with patch(
+            "products.replay_vision.backend.temporal.activities.emit_observation_event.capture_internal"
+        ) as capture:
+            _emit_event(EmitObservationEventInputs(observation_id=observation.id))
+
+        assert "files/abc123" not in str(capture.call_args.kwargs["properties"])
+
+    def test_ineligible_observation_emits_its_kind(self) -> None:
+        # Ineligible is a normal outcome, and telling it apart from a failure is what stops a healthy
+        # scanner reading as a broken one.
+        scanner = _make_scanner()
+        observation = _make_observation(
+            scanner,
+            status=ObservationStatus.INELIGIBLE,
+            error_reason="too_long:4004.2s of active interaction; max is 3600s",
+            completed_at=timezone.now(),
+        )
+
+        with patch(
+            "products.replay_vision.backend.temporal.activities.emit_observation_event.capture_internal"
+        ) as capture:
+            _emit_event(EmitObservationEventInputs(observation_id=observation.id))
+
+        properties = capture.call_args.kwargs["properties"]
+        assert properties["status"] == ObservationStatus.INELIGIBLE
+        assert properties["error_kind"] == "too_long"
+
+    def test_succeeded_observation_carries_its_status_and_no_error_kind(self) -> None:
+        scanner = _make_scanner()
+        observation = _make_observation(scanner, status=ObservationStatus.SUCCEEDED, completed_at=timezone.now())
+
+        with patch(
+            "products.replay_vision.backend.temporal.activities.emit_observation_event.capture_internal"
+        ) as capture:
+            _emit_event(
+                EmitObservationEventInputs(
+                    observation_id=observation.id,
+                    model_output=MonitorOutput(verdict="yes", reasoning="ok", confidence=0.9),
+                )
+            )
+
+        properties = capture.call_args.kwargs["properties"]
+        assert properties["status"] == ObservationStatus.SUCCEEDED
+        assert "error_kind" not in properties
+        assert properties["scanner_output_verdict"] == "yes"
+
 
 def _counter_value(metric_name: str, **labels: str) -> float:
     return REGISTRY.get_sample_value(metric_name, labels) or 0.0
@@ -2537,7 +2616,7 @@ async def test_apply_scanner_workflow_marks_failed_when_fetch_raises() -> None:
     assert mark_observation_failed_activity in called
     assert mocks.child_calls == []
 
-    failed_input = mocks.activity_calls[-1][1]
+    failed_input = next(arg for fn, arg in mocks.activity_calls if fn is mark_observation_failed_activity)
     assert failed_input.observation_id == new_observation_id
     assert "no events" in failed_input.error_reason.lower()
 
@@ -2591,7 +2670,8 @@ async def test_apply_scanner_workflow_splits_rasterizer_failures_by_cause(
     other = mark_observation_failed_activity if expect_ineligible else mark_observation_ineligible_activity
     assert terminal in called
     assert other not in called
-    assert mocks.activity_calls[-1][1].error_reason.startswith(f"{expected_kind}:")
+    terminal_input = next(arg for fn, arg in mocks.activity_calls if fn is terminal)
+    assert terminal_input.error_reason.startswith(f"{expected_kind}:")
     # The video is never uploaded when the render fails, so there is nothing to bill or clean up.
     assert upload_video_to_gemini_activity not in called
 
@@ -2643,7 +2723,8 @@ async def test_apply_scanner_workflow_classifies_rasterizer_dependency_failure_b
     called = {fn for fn, _ in mocks.activity_calls}
     assert mark_observation_failed_activity in called
     assert mark_observation_ineligible_activity not in called
-    assert mocks.activity_calls[-1][1].error_reason == expected_reason
+    failed_input = next(arg for fn, arg in mocks.activity_calls if fn is mark_observation_failed_activity)
+    assert failed_input.error_reason == expected_reason
 
     if expected_kind is FailureKind.INFRA_TRANSIENT:
         # `from None` keeps the volatile cause out of the chain error tracking serializes, so the outage
@@ -2765,6 +2846,54 @@ async def test_apply_scanner_workflow_marks_failed_when_mark_running_fails() -> 
 
     failed_input = next(arg for fn, arg in mocks.activity_calls if fn is mark_observation_failed_activity)
     assert failed_input.observation_id == new_observation_id
+
+
+@pytest.mark.asyncio
+async def test_apply_scanner_workflow_emits_the_event_for_a_failed_observation() -> None:
+    # The failure path published nothing before, which is why an inline scan that only ever failed
+    # left no trace anywhere: it belongs to no saved scanner, so no scanner page shows it either.
+    new_observation_id = uuid.uuid4()
+    mocks = _WorkflowMocks(
+        activity_results={
+            create_observation_activity: CreateObservationOutput(
+                observation_id=new_observation_id, was_created=True, scanner_type=ScannerType.MONITOR
+            ),
+            ensure_session_asset_activity: EnsureSessionAssetOutput(asset_id=42),
+        },
+        activity_errors={upload_video_to_gemini_activity: ApplicationError("provider rejected", non_retryable=True)},
+    )
+
+    with pytest.raises(ApplicationError, match="provider rejected"):
+        await _run_workflow(_build_inputs(session_id="sess-failed"), mocks)
+
+    called = {fn for fn, _ in mocks.activity_calls}
+    assert mark_observation_failed_activity in called
+    emit_input = next(arg for fn, arg in mocks.activity_calls if fn is emit_observation_event_activity)
+    assert emit_input.observation_id == new_observation_id
+    # The event is read back from the row the mark activity wrote, so the payload carries no output.
+    assert emit_input.model_output is None
+
+
+@pytest.mark.asyncio
+async def test_apply_scanner_workflow_keeps_its_own_failure_when_the_terminal_event_fails() -> None:
+    # Emission is advisory on this path too: an events outage must not replace the reason the scan failed.
+    mocks = _WorkflowMocks(
+        activity_results={
+            create_observation_activity: CreateObservationOutput(
+                observation_id=uuid.uuid4(), was_created=True, scanner_type=ScannerType.MONITOR
+            ),
+            ensure_session_asset_activity: EnsureSessionAssetOutput(asset_id=42),
+        },
+        activity_errors={
+            upload_video_to_gemini_activity: ApplicationError("provider rejected", non_retryable=True),
+            emit_observation_event_activity: RuntimeError("kafka down"),
+        },
+    )
+
+    with pytest.raises(ApplicationError, match="provider rejected"):
+        await _run_workflow(_build_inputs(session_id="sess-failed-flaky"), mocks)
+
+    assert mark_observation_failed_activity in {fn for fn, _ in mocks.activity_calls}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Anyone reading Replay Vision fleet health today can see only the scans that worked. `$recording_observed` was emitted on the success path alone, so the events table holds no denominator: no query can report a failure rate, split it by `triggered_by`, or say whether the on-demand path a customer hits from "Scan this recording" fails more often than a scheduled sweep. It does — noticeably so, on the fleet this was checked against — and nothing in the product surfaced it.

An inline scan is invisible twice over. It mints a hidden scanner keyed by a fingerprint of its config, which the scanner list never returns, so its observations appear on no scanner page; and with no event on failure, an inline scan that only ever fails leaves no trace anywhere.

## Changes

- Every terminal outcome now emits `$recording_observed`, not just success. The event carries `status` (`succeeded` / `failed` / `ineligible`) and, on the two non-success statuses, `error_kind` — the kind half of `error_reason` (`provider_rejected`, `too_long`, ...). Failure rate per `triggered_by`, per scanner, per error kind is now a plain HogQL query, and an inline scan shows up in it like any other.
- Only the kind is published. The message half of `error_reason` quotes provider file ids and other internals, so it stays in the API where the scanner page already reads it.
- Emission is fail-soft on this path too, as it already was on the success path: an events outage must not replace the reason the scan failed.
- The sweep's candidate exclusion reads this same event, so it now filters to succeeded rows and selects exactly the set it selected before. That filter is load-bearing rather than defensive: a backfill retakes a failed observation, so pruning a session on a failed row would quote less work than the backfill goes on to run. Widening the exclusion is a separate change to sweep behaviour and is deliberately not in this PR.
- Mechanical: three assertions in `test_temporal.py` read the terminal activity's input positionally as the last call. The terminal event now follows it, so they look the call up by activity instead.

Not covered: an observation the reaper marks `orphaned` never reaches this code, because its workflow died. That row still has no event.

## How did you test this code?

Automated only — no manual scan was run against the provider.

New tests, and the regression each catches that no existing test did:

- `TestEmitObservationEventActivity` — a failed and an ineligible observation emit with `status` + `error_kind` and no `scanner_output_*` keys; the message half of `error_reason` never reaches the payload; a succeeded row still carries its status and no `error_kind`. Previously the activity could not be called without a model output at all.
- `test_apply_scanner_workflow_emits_the_event_for_a_failed_observation` and `..._keeps_its_own_failure_when_the_terminal_event_fails` — the failure path emits, with no model output in the payload, and an emission outage does not replace the workflow's own error.
- `test_exclusion_reads_succeeded_observations_only` (ClickHouse-backed) — failed and ineligible rows do not prune their session, and a row written before the event carried a status still does. Verified non-vacuous: it fails when the status filter is removed.

Ran locally against a local Postgres + ClickHouse: `test_temporal.py`, `test_scanner_candidate_query.py`, `test_sweep.py`, `test_backfills.py` (400 passed), plus `mypy` and `ruff` over the changed modules.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow, API, or setting changes. The event gains two properties.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by the PostHog Slack app (Opus 5) from a Slack thread where someone reported a deterministic on-demand scan failure and asked whether the failure rate could be split by `triggered_by` across the fleet. It could not be — that gap is what this PR closes. Skills invoked: `exploring-replay-vision-observations`.
- No duplicate: `gh pr list --state open --search` over the replay-vision observation and event paths found nothing covering this. #98760 is adjacent and complementary — it reclassifies the provider-side upload failure so it retries; this PR makes the outcome visible whichever way that classification lands.
- Decisions along the way: the first shape published the whole `error_reason`, which leaks provider file ids into a customer's events table, so only the kind is emitted. The sweep exclusion was the other open question — the cheap reading is that failed rows should now prune too, but a backfill retakes them, so the exclusion is pinned to succeeded rows and a test holds it there.
- The CodeRabbit CLI pass is paused, so this PR opens without a local pass.
- Public artifact: the thread behind this work names a customer project's sessions and quotes fleet figures. None of it is in the diff, the fixtures, the commit message, or this description; the test fixtures are invented and the one rate claim above is qualitative.

---

*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C03PB072FMJ/p1789074822747469?thread_ts=1789074822.747469&cid=C03PB072FMJ)*
