### PR TITLE
fix(toolbar): update CSP eval allowlist for hedgehog-mode 0.0.57

### DIFF
--- a/frontend/bin/check-toolbar-csp-eval.mjs
+++ b/frontend/bin/check-toolbar-csp-eval.mjs
@@ -26,8 +26,8 @@ const ALLOWED_VIOLATIONS = {
     'new Function()': {
         loader: 0,
         eager: 1, // toolbarLogic's deliberate CSP support probe
-        total: 5, // + pixi.js via @posthog/hedgehog-mode (4), in the lazy hedgehog chunks
-        source: 'toolbarLogic CSP probe (1, eager) + pixi.js via @posthog/hedgehog-mode (4, lazy)',
+        total: 6, // + pixi.js via @posthog/hedgehog-mode (5), in the lazy hedgehog chunks
+        source: 'toolbarLogic CSP probe (1, eager) + pixi.js via @posthog/hedgehog-mode (5, lazy)',
     },
 }
 


### PR DESCRIPTION
## Problem

Master's Frontend CI fails on the "Check toolbar for CSP eval violations" step: the check finds six `new Function()` occurrences in the toolbar outputs, and the allowlist expects five. Every open PR inherits the failure, because the bundle-size job runs this check against a rebuild of the base branch.

The sixth occurrence came from the `@posthog/hedgehog-mode` 0.0.57 bump ([#98641](https://github.com/PostHog/posthog/pull/98641)). The bump moved pixi.js shader-codegen across the lazy chunks, so the deferred count went from four to five.

## Changes

- Update `ALLOWED_VIOLATIONS` in `frontend/bin/check-toolbar-csp-eval.mjs`: total five to six, with the pixi.js note four to five. This is the update the check itself prescribes for a dependency bump.
- The loader budget stays at zero and the eager budget stays at one, so no new code runs before user interaction. All five deferred occurrences sit in the lazy hedgehog/pixi chunks (verified by inspecting each flagged chunk; the occurrences are pixi.js WebGL uniform-sync generators).

## How did you test this code?

- Built the toolbar on latest master and ran `pnpm --filter=@posthog/frontend check-toolbar-csp-eval`: it reproduces the failure with six found, five expected.
- Re-ran the check with this change: it passes.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code from a PostHog Desktop task, while diagnosing a red CI run on [#98820](https://github.com/PostHog/posthog/pull/98820). No duplicate: open-PR searches for the CSP check and for hedgehog found no existing fix, and the check script has not changed since July.
- CodeRabbit CLI pass: paused, so the PR opened without a local pass.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
