### PR TITLE
chore(flags): point mcp merge helper at its backend drift guard

### DIFF
--- a/services/mcp/src/tools/featureFlags/preserveGroupTargeting.ts
+++ b/services/mcp/src/tools/featureFlags/preserveGroupTargeting.ts
@@ -122,6 +122,7 @@ function mergeProperty(
     if (!isPresentType(out.type) && existingProp && isPresentType(existingProp.type)) {
         // Leaving the type unset makes the API report the property the agent actually
         // sent. Restoring `group` here would name fields the agent never sent.
+        // `!== 'group'` relies on the same complement rule. See mergeConditionGroup.
         if (canCarryGroupTargeting || existingProp.type !== 'group') {
             out.type = existingProp.type
         }
@@ -161,6 +162,10 @@ function mergeConditionGroup(
     // One explicit person, cohort, or flag property stops this set from keeping or
     // gaining group targeting. An explicit incoming group index still wins, and the API
     // then reports the contradiction in the agent's own payload.
+    // `!== 'group'` is the complement of PERSON_AGGREGATED_PROPERTY_TYPES in
+    // filters_validation.py. It holds only while 'group' is the sole type outside that
+    // tuple. A Python test asserts that:
+    // products/feature_flags/backend/test/test_filters_validation.py
     const hasExplicitNonGroupProperty =
         Array.isArray(incoming.properties) &&
         incoming.properties.some((p) => isPresentType(p?.type) && p.type !== 'group')


### PR DESCRIPTION
## Problem

An engineer reading the MCP feature-flag merge helper cannot tell that two of its checks restate a backend rule.

- The helper decides person aggregation from the complement of `group`, at two sites.
- That matches `PERSON_AGGREGATED_PROPERTY_TYPES` only while `group` is the sole type outside it.
- #98620 asserts that invariant in Python, and its failure message names the helper.
- A grep from the helper for that guard test finds nothing.

## Changes

- `mergeConditionGroup` now names `PERSON_AGGREGATED_PROPERTY_TYPES` as the rule its check stands in for.
- The guard test's full path sits on its own comment line, so a grep for that test lands here.
- `mergeProperty` points back at `mergeConditionGroup` instead of restating the rule.
- The whole diff is five comment lines and no code, so merge behavior stays byte-identical.

The helper arrived in #78678. The guard test arrived in #98620.

## How did you test this code?

- No new tests. The diff changes no executable line.
- `pnpm --dir services/mcp exec vitest run tests/unit/preserve-group-targeting.test.ts` passes unchanged.
- `pnpm --dir services/mcp lint` is clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No behavior, API, or setting changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code from a plan file, as the second half of a two-PR split. #98620 landed the Python assertion. This half waited for #78678, because `preserveGroupTargeting.ts` did not exist on master before that.

- Skills invoked: `/writing-code-comments`, `/writing-pr-descriptions`, `/reviewing-with-coderabbit`.
- The CodeRabbit CLI pass is paused, so this PR opened without a local pass.
- No duplicate: `gh pr list --state open --search` over "preserveGroupTargeting drift guard" and "group-targeting merge" returned no PR touching this file.
- Patch coverage: the diff adds comments only, so no line is coverable.
- Public artifact: nothing in this PR carries material from the agent session that is not already in this repository.

https://claude.ai/code/session_01VTnux4RFNnBTih9FXQrAQ7
