### PR TITLE
chore(flags): point mcp merge helper at its backend drift guard

### DIFF
--- a/services/mcp/src/tools/featureFlags/preserveGroupTargeting.ts
+++ b/services/mcp/src/tools/featureFlags/preserveGroupTargeting.ts
@@ -122,6 +122,8 @@ function mergeProperty(
     if (!isPresentType(out.type) && existingProp && isPresentType(existingProp.type)) {
         // Leaving the type unset makes the API report the property the agent actually
         // sent. Restoring `group` here would name fields the agent never sent.
+        // `!== 'group'` stands for the complement of PERSON_AGGREGATED_PROPERTY_TYPES.
+        // mergeConditionGroup documents the invariant.
         if (canCarryGroupTargeting || existingProp.type !== 'group') {
             out.type = existingProp.type
         }
@@ -161,6 +163,9 @@ function mergeConditionGroup(
     // One explicit person, cohort, or flag property stops this set from keeping or
     // gaining group targeting. An explicit incoming group index still wins, and the API
     // then reports the contradiction in the agent's own payload.
+    // `!== 'group'` is the complement of PERSON_AGGREGATED_PROPERTY_TYPES in filters_validation.py
+    // and holds only while 'group' is the sole type outside it. Asserted by
+    // products/feature_flags/backend/test/test_filters_validation.py.
     const hasExplicitNonGroupProperty =
         Array.isArray(incoming.properties) &&
         incoming.properties.some((p) => isPresentType(p?.type) && p.type !== 'group')


### PR DESCRIPTION
## Problem

PR #98620 added a backend test guarding an invariant the MCP merge helper's `type !== 'group'` checks rely on. Nothing in that TypeScript file pointed back at the test.

## Changes

- Adds a comment above each `!== 'group'` check in `preserveGroupTargeting.ts`, naming `PERSON_AGGREGATED_PROPERTY_TYPES` and the test that guards it.
- No behavior changes: the merge helper's code paths are untouched, verified by stripping comments from both versions and diffing.

## How did you test this code?

Ran the existing `preserve-group-targeting.test.ts` suite (20 tests, unchanged) and `pnpm --dir services/mcp lint`, both clean.

`pnpm --filter=@posthog/mcp run typecheck` fails in this environment, but only on missing `@posthog/quill` module resolution in files this PR does not touch. Confirmed pre-existing: the same failures appear with this change stashed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Comment-only change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: Claude Code, [session](https://claude.ai/code/session_011dok7EVgJedxkdHVfEtfr5).
- Skills invoked: `/writing-code-comments` before adding the comments, a `code-reviewer` subagent before committing, `/create-pr`, `/writing-pr-descriptions`, and `/reviewing-with-coderabbit` for this PR.
- The CodeRabbit rollout is paused repo-wide, so this PR opened without a local CodeRabbit pass.
- The `code-reviewer` subagent verified both cited paths and names against the actual files, confirmed the comments pass the `/writing-code-comments` gate, and found one style nit: a semicolon joining two facts, and a missing antecedent for `mergeConditionGroup` when a reader lands in `mergeProperty` first. Fixed in the commit.
- No duplicate: searched open PRs for this change and found none.
- Patch coverage: comment-only change, nothing to cover.
- This closes the loop opened by #98620 and #78678: the guard test and the code it protects now point at each other.
- Public artifact: everything here comes from reading this repository's own code. No customer or internal-only material.
