### PR TITLE
feat(desktop): sign windows builds with azure artifact signing

### DIFF
--- a/.github/scripts/desktop/verify-windows-signatures.ps1
+++ b/.github/scripts/desktop/verify-windows-signatures.ps1
@@ -1,0 +1,30 @@
+# Fails unless every Windows artifact carries a valid Authenticode signature
+# whose subject satisfies the publisherName electron-builder wrote into
+# app-update.yml, which is the value electron-updater enforces on updates.
+param(
+  [Parameter(Mandatory = $true)] [string] $OutDir
+)
+$ErrorActionPreference = "Stop"
+
+$updateConfig = Join-Path $OutDir "win-unpacked/resources/app-update.yml"
+$publisherLine = Select-String -LiteralPath $updateConfig -Pattern '^\s*-\s*["'']?(CN=.+?)["'']?\s*$' | Select-Object -First 1
+if (-not $publisherLine) {
+  throw "FAIL: no publisherName in $updateConfig, the build was packaged without Azure signing"
+}
+$expected = [System.Security.Cryptography.X509Certificates.X500DistinguishedName]::new($publisherLine.Matches[0].Groups[1].Value)
+$expectedParts = $expected.Format($true).Trim() -split "\r?\n"
+
+$files = @(Get-ChildItem -LiteralPath $OutDir -File -Filter "*.exe")
+$files += Get-Item -LiteralPath (Join-Path $OutDir "win-unpacked/PostHog.exe")
+foreach ($file in $files) {
+  $signature = Get-AuthenticodeSignature -LiteralPath $file.FullName
+  if ($signature.Status -ne "Valid") {
+    throw "FAIL: $($file.Name) signature status is $($signature.Status)"
+  }
+  $actualParts = $signature.SignerCertificate.SubjectName.Format($true).Trim() -split "\r?\n"
+  $missing = $expectedParts | Where-Object { $actualParts -notcontains $_ }
+  if ($missing) {
+    throw "FAIL: $($file.Name) is signed by '$($signature.SignerCertificate.Subject)', app-update.yml expects '$($expected.Name)'"
+  }
+  Write-Output "OK: $($file.Name) signed by $($signature.SignerCertificate.Subject)"
+}

--- a/.github/workflows/desktop-build-test.yml
+++ b/.github/workflows/desktop-build-test.yml
@@ -332,7 +332,7 @@ jobs:
               if: github.event_name == 'workflow_dispatch'
               shell: pwsh
               run: |
-                  & "$env:GITHUB_WORKSPACE/.github/scripts/desktop/verify-windows-signatures.ps1" -OutDir out
+                  & "$env:GITHUB_WORKSPACE/.github/scripts/desktop/verify-windows-signatures.ps1" -OutDir apps/code/out
 
             - name: Upload artifacts
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/desktop-build-test.yml
+++ b/.github/workflows/desktop-build-test.yml
@@ -253,9 +253,12 @@ jobs:
             VITE_POSTHOG_API_HOST: ${{ vars.VITE_POSTHOG_API_HOST }}
             VITE_POSTHOG_UI_HOST: ${{ vars.VITE_POSTHOG_UI_HOST }}
             VITE_POSTHOG_BUILD_CHANNEL: test
-            AZURE_TENANT_ID: ${{ secrets.DESKTOP_AZURE_CODESIGN_TENANT_ID }}
-            AZURE_CLIENT_ID: ${{ secrets.DESKTOP_AZURE_CODESIGN_CLIENT_ID }}
-            AZURE_CLIENT_SECRET: ${{ secrets.DESKTOP_AZURE_CODESIGN_CLIENT_SECRET }}
+            # Signing credentials reach manual runs only. A label persists across
+            # later pushes, so a labeled PR build would hand the production
+            # signing secret to code nobody re-approved.
+            AZURE_TENANT_ID: ${{ github.event_name == 'workflow_dispatch' && secrets.DESKTOP_AZURE_CODESIGN_TENANT_ID || '' }}
+            AZURE_CLIENT_ID: ${{ github.event_name == 'workflow_dispatch' && secrets.DESKTOP_AZURE_CODESIGN_CLIENT_ID || '' }}
+            AZURE_CLIENT_SECRET: ${{ github.event_name == 'workflow_dispatch' && secrets.DESKTOP_AZURE_CODESIGN_CLIENT_SECRET || '' }}
         steps:
             - name: Checkout
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -324,18 +327,12 @@ jobs:
                     exit 1
                   }
                   echo "OK: renderer bundle"
-                  if ($env:AZURE_CLIENT_ID) {
-                    $signed = @(Get-ChildItem "out" -File -Filter "*.exe")
-                    $signed += Get-Item "out/win-unpacked/PostHog.exe"
-                    foreach ($f in $signed) {
-                      $sig = Get-AuthenticodeSignature -LiteralPath $f.FullName
-                      if ($sig.Status -ne "Valid") {
-                        Write-Error "FAIL: $($f.Name) signature status is $($sig.Status)"
-                        exit 1
-                      }
-                      echo "OK: $($f.Name) signed by $($sig.SignerCertificate.Subject)"
-                    }
-                  }
+
+            - name: Verify signatures
+              if: github.event_name == 'workflow_dispatch'
+              shell: pwsh
+              run: |
+                  & "$env:GITHUB_WORKSPACE/.github/scripts/desktop/verify-windows-signatures.ps1" -OutDir out
 
             - name: Upload artifacts
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/desktop-build-test.yml
+++ b/.github/workflows/desktop-build-test.yml
@@ -253,6 +253,9 @@ jobs:
             VITE_POSTHOG_API_HOST: ${{ vars.VITE_POSTHOG_API_HOST }}
             VITE_POSTHOG_UI_HOST: ${{ vars.VITE_POSTHOG_UI_HOST }}
             VITE_POSTHOG_BUILD_CHANNEL: test
+            AZURE_TENANT_ID: ${{ secrets.DESKTOP_AZURE_CODESIGN_TENANT_ID }}
+            AZURE_CLIENT_ID: ${{ secrets.DESKTOP_AZURE_CODESIGN_CLIENT_ID }}
+            AZURE_CLIENT_SECRET: ${{ secrets.DESKTOP_AZURE_CODESIGN_CLIENT_SECRET }}
         steps:
             - name: Checkout
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -321,6 +324,18 @@ jobs:
                     exit 1
                   }
                   echo "OK: renderer bundle"
+                  if ($env:AZURE_CLIENT_ID) {
+                    $signed = @(Get-ChildItem "out" -File -Filter "*.exe")
+                    $signed += Get-Item "out/win-unpacked/PostHog.exe"
+                    foreach ($f in $signed) {
+                      $sig = Get-AuthenticodeSignature -LiteralPath $f.FullName
+                      if ($sig.Status -ne "Valid") {
+                        Write-Error "FAIL: $($f.Name) signature status is $($sig.Status)"
+                        exit 1
+                      }
+                      echo "OK: $($f.Name) signed by $($sig.SignerCertificate.Subject)"
+                    }
+                  }
 
             - name: Upload artifacts
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -331,6 +331,9 @@ jobs:
             POSTHOG_SOURCEMAP_API_KEY: ${{ secrets.DESKTOP_POSTHOG_SOURCEMAP_API_KEY }}
             POSTHOG_ENV_ID: ${{ vars.DESKTOP_POSTHOG_ENV_ID }}
             POSTHOG_HOST: ${{ secrets.DESKTOP_POSTHOG_HOST }}
+            AZURE_TENANT_ID: ${{ secrets.DESKTOP_AZURE_CODESIGN_TENANT_ID }}
+            AZURE_CLIENT_ID: ${{ secrets.DESKTOP_AZURE_CODESIGN_CLIENT_ID }}
+            AZURE_CLIENT_SECRET: ${{ secrets.DESKTOP_AZURE_CODESIGN_CLIENT_SECRET }}
         steps:
             - name: Get app token
               id: app-token
@@ -428,6 +431,18 @@ jobs:
                       exit 1
                     }
                     echo "OK: codex-acp/$f"
+                  }
+                  if ($env:AZURE_CLIENT_ID) {
+                    $signed = @(Get-ChildItem "apps/code/out" -File -Filter "*.exe")
+                    $signed += Get-Item "apps/code/out/win-unpacked/PostHog.exe"
+                    foreach ($f in $signed) {
+                      $sig = Get-AuthenticodeSignature -LiteralPath $f.FullName
+                      if ($sig.Status -ne "Valid") {
+                        Write-Error "FAIL: $($f.Name) signature status is $($sig.Status)"
+                        exit 1
+                      }
+                      echo "OK: $($f.Name) signed by $($sig.SignerCertificate.Subject)"
+                    }
                   }
 
             - name: Upload release artifacts

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -432,18 +432,13 @@ jobs:
                     }
                     echo "OK: codex-acp/$f"
                   }
-                  if ($env:AZURE_CLIENT_ID) {
-                    $signed = @(Get-ChildItem "apps/code/out" -File -Filter "*.exe")
-                    $signed += Get-Item "apps/code/out/win-unpacked/PostHog.exe"
-                    foreach ($f in $signed) {
-                      $sig = Get-AuthenticodeSignature -LiteralPath $f.FullName
-                      if ($sig.Status -ne "Valid") {
-                        Write-Error "FAIL: $($f.Name) signature status is $($sig.Status)"
-                        exit 1
-                      }
-                      echo "OK: $($f.Name) signed by $($sig.SignerCertificate.Subject)"
-                    }
-                  }
+
+            # Runs unconditionally: a release with the secrets missing or
+            # misnamed must fail here, before the upload steps.
+            - name: Verify signatures
+              shell: pwsh
+              run: |
+                  & "$env:GITHUB_WORKSPACE/.github/scripts/desktop/verify-windows-signatures.ps1" -OutDir apps/code/out
 
             - name: Upload release artifacts
               shell: pwsh

--- a/products/desktop/apps/code/README.md
+++ b/products/desktop/apps/code/README.md
@@ -158,7 +158,7 @@ export AZURE_CLIENT_ID="xxx"
 export AZURE_CLIENT_SECRET="xxx"
 ```
 
-They authenticate an Entra app registration that holds the `Artifact Signing Certificate Profile Signer` role on the `posthog-desktop` account (West US 2, certificate profile `posthog-desktop-public`). CI reads them from the `DESKTOP_AZURE_CODESIGN_*` repository secrets. Without them the build packages unsigned, which is what fork PRs and local builds get.
+They authenticate an Entra app registration that holds the `Artifact Signing Certificate Profile Signer` role on the `posthog-desktop` account (West US 2, certificate profile `posthog-desktop-public`). CI reads them from the `DESKTOP_AZURE_CODESIGN_*` repository secrets. Without them the build packages unsigned, which is what pull request builds, fork PRs and local builds get. A manual run of the `desktop-build-test` workflow signs and verifies the result, which is how to check the pipeline before a release.
 
 electron-builder installs the `TrustedSigning` PowerShell module on the build machine and signs every executable through it, so signing only runs on Windows. Nothing is downloaded: Microsoft issues a short-lived certificate inside the service and returns only the signature.
 

--- a/products/desktop/apps/code/README.md
+++ b/products/desktop/apps/code/README.md
@@ -148,6 +148,22 @@ Set `SKIP_NOTARIZE=1` if you need to generate signed artifacts without submittin
 SKIP_NOTARIZE=1 pnpm run make
 ```
 
+### Windows code signing
+
+Windows builds are signed through Azure Artifact Signing when these environment variables are present:
+
+```bash
+export AZURE_TENANT_ID="xxx"
+export AZURE_CLIENT_ID="xxx"
+export AZURE_CLIENT_SECRET="xxx"
+```
+
+They authenticate an Entra app registration that holds the `Artifact Signing Certificate Profile Signer` role on the `posthog-desktop` account (West US 2, certificate profile `posthog-desktop-public`). CI reads them from the `DESKTOP_AZURE_CODESIGN_*` repository secrets. Without them the build packages unsigned, which is what fork PRs and local builds get.
+
+electron-builder installs the `TrustedSigning` PowerShell module on the build machine and signs every executable through it, so signing only runs on Windows. Nothing is downloaded: Microsoft issues a short-lived certificate inside the service and returns only the signature.
+
+The certificate subject is set as `publisherName` in `electron-builder.ts` and baked into `app-update.yml`. electron-updater rejects an update whose signature does not match it, so keep it identical to the certificate profile's subject in Azure.
+
 ## Workspace Configuration (posthog-code.json)
 
 PostHog supports per-repository configuration through a `posthog-code.json` file. This lets you define scripts that run automatically when workspaces are created or destroyed.

--- a/products/desktop/apps/code/codesign.env.example
+++ b/products/desktop/apps/code/codesign.env.example
@@ -8,3 +8,9 @@ APPLE_TEAM_ID="TEAMID"
 
 APPLE_CODESIGN_CERT_BASE64="xxx"
 APPLE_CODESIGN_CERT_PASSWORD="xxx"
+
+# Azure Artifact Signing (Windows), app registration with the
+# "Artifact Signing Certificate Profile Signer" role
+AZURE_TENANT_ID="xxx"
+AZURE_CLIENT_ID="xxx"
+AZURE_CLIENT_SECRET="xxx"

--- a/products/desktop/apps/code/electron-builder.ts
+++ b/products/desktop/apps/code/electron-builder.ts
@@ -8,6 +8,13 @@ const require = createRequire(import.meta.url);
 const skipNotarize =
   process.env.SKIP_NOTARIZE === "1" || !process.env.APPLE_TEAM_ID;
 
+// Fork PRs and local builds have no Azure credentials, so they package
+// unsigned instead of failing inside Invoke-TrustedSigning.
+const signWindowsWithAzure =
+  !!process.env.AZURE_TENANT_ID &&
+  !!process.env.AZURE_CLIENT_ID &&
+  !!process.env.AZURE_CLIENT_SECRET;
+
 // A test build installs beside a release build, so it must not claim the
 // release deep-link scheme: the OS would route one of the two builds'
 // callbacks to the wrong app.
@@ -116,6 +123,20 @@ const config: Configuration = {
     // electron-builder generates the multi-size .ico from this 1024px PNG; a real
     // .ico must be >=256px and the committed app-icon.ico is only 32px.
     icon: "build/app-icon.png",
+    ...(signWindowsWithAzure
+      ? {
+          azureSignOptions: {
+            // electron-updater compares this against the certificate subject
+            // before installing an update, so it must match the Azure
+            // certificate profile exactly.
+            publisherName:
+              "CN=PostHog Inc., O=PostHog Inc., L=San Francisco, S=California, C=US",
+            endpoint: "https://wus2.codesigning.azure.net",
+            codeSigningAccountName: "posthog-desktop",
+            certificateProfileName: "posthog-desktop-public",
+          },
+        }
+      : {}),
   },
 
   nsis: {

--- a/products/desktop/docs/UPDATES.md
+++ b/products/desktop/docs/UPDATES.md
@@ -22,6 +22,7 @@ GitHub Releases in `PostHog/posthog` remain the human-facing changelog and downl
 **macOS**: DMG + zip artifacts are uploaded; the merged `latest-mac.yml` covers both arm64 and x64 so the correct build is selected per architecture.
 
 **Windows**: A single NSIS installer is shipped and updated through electron-updater via `latest.yml`. The legacy Squirrel.Windows installer is no longer built; anyone still on an old Squirrel install must reinstall once via the NSIS installer to keep receiving updates.
+Release builds are signed through Azure Artifact Signing, and the certificate subject ships in `app-update.yml` as `publisherName`, so electron-updater rejects a downloaded installer that is not signed by the same publisher.
 
 **Linux**: No auto-update. AppImage, deb and rpm packages are manual downloads from the GitHub Release, also mirrored to the S3 feed.
 


### PR DESCRIPTION
## Problem

Windows builds ship unsigned, so every install and update shows the SmartScreen "unknown publisher" warning and managed machines block the app.

## Changes

electron-builder now signs Windows builds through Azure Artifact Signing (account `posthog-desktop`, profile `posthog-desktop-public`). Microsoft holds the certificate, nothing is stored in CI.

Signing needs the three `DESKTOP_AZURE_CODESIGN_*` secrets. The release job always gets them and fails before upload if any artifact is unsigned or signed by a subject that does not satisfy the `publisherName` electron-updater will enforce. Pull request builds never see the secrets and package unsigned; a manual run of `desktop-build-test` signs and verifies, which is how to test the pipeline before a release.

Signed installs verify that updates come from the same publisher before installing them.

## How did you test this code?

Workflow linters, Biome and typecheck pass. A manual dispatch of `desktop-build-test` on this branch signed all 16 executables and passed the signature check: [run 34547391965](https://github.com/PostHog/posthog/actions/runs/34547391965). The downloaded installer also verifies with osslsigncode against Microsoft's identity verification root.
