### PR TITLE
fix(signals): remove report card selection checkboxes

### DIFF
--- a/docs/internal/inbox-report-selection.md
+++ b/docs/internal/inbox-report-selection.md
@@ -1,0 +1,10 @@
+# Inbox report selection
+
+Report cards on the self-driving inbox Reports page do not show selection checkboxes, including on hover or when selected.
+Selected cards keep their accent outline.
+
+Use Cmd+click on macOS or Ctrl+click to select or deselect a report.
+Use Shift+click to select a range of reports.
+Press and hold also selects a report.
+Once a selection exists, a plain click selects or deselects a report instead of opening it.
+Selection cannot change while a bulk action runs, and resolved reports cannot be selected.

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -7805,9 +7805,9 @@ snapshots:
     scenes-app-inbox-scene--self-driving-onboarding--light:
         hash: v1.k794b7964.5268ad52b39cdc5bb1d699e6a1a839a552ce397134d6773714e1f5a2d95994b6.hgkYOJDE9ZNZ0mMtcj9cpcDCtmas-opelntO_tyQ9Ig
     scenes-app-inbox-scene--self-driving-paused--dark:
-        hash: v1.k794b7964.6f6de2a01c5398c97c8ddd0281400631d6ba29d103597b77105c801643a409bc.-TaozrVEIt_uo8VyQ6nVEBHm963WvHGLzUHxi8wp26Y
+        hash: v1.k794b7964.e7554de0d4e364453bf8c253190dc430a6e832643a10b71400975a07deeb98f3.yz3-YvCb9lv0mdTvRxSy2THCdsNFkxwOX5h2bcpWAKo
     scenes-app-inbox-scene--self-driving-paused--light:
-        hash: v1.k794b7964.9efe93134b008b672d863eea64d6df50e116fc062382640487cf7abe064da8a3.4iJCYRKBIvpPuk4gUo05pIcps0bn_D2Kc7i2UpldvYw
+        hash: v1.k794b7964.9b6321c99a8afe06a23169859a20b6d9bbb17001a045e81bf5aac7f0ce41c3a1.w9WGbvl3PBCA5r-R-eQGHObp1gJhb-IAUjQEdkVZbH4
     scenes-app-inbox-scene--self-driving-verdict-pending--dark:
         hash: v1.k794b7964.3d6c42afbe79033f9c7dad5ca09eb0e34d874aa4c73837d6d6f91fefe37b10df.MxJN_DArFyn1VpR8nheZ1FLPtFcbL2StXF9tha9Tk4o
     scenes-app-inbox-scene--self-driving-verdict-pending--light:
@@ -8089,9 +8089,9 @@ snapshots:
     scenes-app-inbox-tabs--pull-requests-legacy--light:
         hash: v1.k794b7964.d66d0f73814191c857a64891ddd73dbbca609b40f71b80b5a97b95b1d0ed5d0d.coTm8czKJGGrvOoP28HGqgyV0I1HTpvp14uWHt7b4dQ
     scenes-app-inbox-tabs--reports--dark:
-        hash: v1.k794b7964.b1db9bb0142b3483849bfe5e58d3f28f30ebff35b182334908744be186401445.nbPIXcHKsEmF7_o13nUuwjXNdkI5MZ05uaU6kCMQHGc
+        hash: v1.k794b7964.fe27a895558915d24de4ef9f9511479ebcd0782da864a5d1b85f81b5263327a3.wCHia_XS0ZgsPveDc9FPERSvKwbu8uzGer6NY7jUvG8
     scenes-app-inbox-tabs--reports--light:
-        hash: v1.k794b7964.52016d79921c15036bc3c37a8184e6e077b5b2e2069ec1cafb9c5dd9bf38c52b.vPZ1XXLbha6Uiwe2_OE-EO_sr__aY8etd3z2Zq-QzVA
+        hash: v1.k794b7964.3de600060cd59ed20fe68fe175911b3ca30a42e434c72258b6e45054d3777e6b.RJUlFpkeZ-ZdCFpGYrESLRPVmSAfz8PBUJTRJ50nhVw
     scenes-app-inbox-tabs--reports-empty--dark:
         hash: v1.k794b7964.a84b301c5e7b2f3b614ae70fd79cb33521d4702790bdfe4a4dcad0816a78152e.y29PsyMQdbg-pSBHIijqi2DdHAXSdJTGVyGKvsnPn1E
     scenes-app-inbox-tabs--reports-empty--light:
@@ -8101,9 +8101,9 @@ snapshots:
     scenes-app-inbox-tabs--reports-legacy--light:
         hash: v1.k794b7964.7864bdacc54e80bd704a403fb813da48779160b95ad014df7bbae8a84a5d24a3.7J1YPQyUSF6iat2oGdHpGn1E3Ml0eTRtyb64GwDL334
     scenes-app-inbox-tabs--reports-state-filtered--dark:
-        hash: v1.k794b7964.812a63c8b33d45d4e64a37d04674608b0a2fea71f272bdc9dcc038f1fe89962a.qAteZLOJc-E4Y-DaNkuLqAP_0VEWRoggMCwkHZucrT8
+        hash: v1.k794b7964.ef6044e404e08f120db2abcbf5275cc4274e095dc75d20ea9385e9bf0a61e996.WIJHi0FEecMWzGEWzZmTLWdZ8QrkMgs2cwpnHFIb8vY
     scenes-app-inbox-tabs--reports-state-filtered--light:
-        hash: v1.k794b7964.b1d639cf97e75540e32017e881a0e28c78b5fa25bdb0d9b5cb177810af01c308.LpK3TIDfV6ChorAgMDxdv4wso9VdLAuRgV7tiyDKo8k
+        hash: v1.k794b7964.a8c338c26cc0037d244e1932a7600df596bbc3aef58604a77a4f36f447b37760.R0uj_FJJ6_i534cJJGyBcv4mR26wX9nhPl7oX7z-Le8
     scenes-app-inbox-tabs--runs--dark:
         hash: v1.k794b7964.4ece3bdc6be5207a77eafc6d9005ce3a065539767d7a4da5f3f2f5f913bb3567.Wu4dnjXImAjEXPa2f8AdBAeJIwpnA-ak02ZeHI87kBo
     scenes-app-inbox-tabs--runs--light:

--- a/products/signals/frontend/inbox/components/cards/InboxCards.stories.tsx
+++ b/products/signals/frontend/inbox/components/cards/InboxCards.stories.tsx
@@ -25,7 +25,7 @@ export const ReportCards: Story = {
     render: () => (
         <Stack>
             {reportTabReports.map((r) => (
-                <ReportCard key={r.id} report={r} />
+                <ReportCard key={r.id} report={r} selectable />
             ))}
         </Stack>
     ),

--- a/products/signals/frontend/inbox/components/cards/ReportCard.test.tsx
+++ b/products/signals/frontend/inbox/components/cards/ReportCard.test.tsx
@@ -154,8 +154,12 @@ describe('ReportCard', () => {
         expect(logic.values.selectedReportIds).toEqual([])
     })
 
-    it('selects from the gutter checkbox', () => {
-        fireEvent.click(screen.getByLabelText('Select report: Report r-1'))
+    it('does not show a checkbox on hover or when selected', () => {
+        fireEvent.mouseEnter(cardLink())
+        expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+
+        fireEvent.click(cardLink(), { metaKey: true })
+        expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
 
         expect(logic.values.selectedReportIds).toEqual(['r-1'])
     })
@@ -164,7 +168,9 @@ describe('ReportCard', () => {
         cleanup()
         render(<ReportCard report={makeReport('r-2', { status: SignalReportStatus.RESOLVED })} selectable />)
 
-        expect(screen.queryByLabelText('Select report: Report r-2')).not.toBeInTheDocument()
+        fireEvent.click(screen.getByText('Report r-2').closest('a') as HTMLElement, { metaKey: true })
+
+        expect(logic.values.selectedReportIds).toEqual([])
     })
 
     it('locks the selection while a bulk action is running', () => {
@@ -174,9 +180,7 @@ describe('ReportCard', () => {
             logic.actions.bulkDismiss({ reason: 'other', note: '', correctedRepository: null })
         })
 
-        const checkbox = screen.getByLabelText('Select report: Report r-1')
-        expect(checkbox).toBeDisabled()
-        fireEvent.click(checkbox)
+        fireEvent.click(cardLink(), { metaKey: true })
         expect(logic.values.selectedReportIds).toEqual(['r-1'])
         setState.mockRestore()
     })

--- a/products/signals/frontend/inbox/components/cards/ReportCard.tsx
+++ b/products/signals/frontend/inbox/components/cards/ReportCard.tsx
@@ -3,7 +3,7 @@ import { useValues } from 'kea'
 import { router } from 'kea-router'
 
 import { IconHide, IconUndo } from '@posthog/icons'
-import { LemonButton, LemonCheckbox, LemonTag, Link, Tooltip } from '@posthog/lemon-ui'
+import { LemonButton, LemonTag, Link, Tooltip } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
@@ -132,7 +132,7 @@ export function ReportCard({
     /** Onboarding sample: render as a static card with no detail link and no focusable actions, so its
      * placeholder report id can never be opened (it 404s). */
     preview?: boolean
-    /** Offer multi-select on this row: the gutter checkbox, press and hold, and modifier clicks. */
+    /** Offer multi-select on this row: press and hold and modifier clicks. */
     selectable?: boolean
 }): JSX.Element {
     // Keyed on status, not the section: the legacy Archive tab lists dismissed and resolved rows
@@ -159,14 +159,10 @@ export function ReportCard({
         redesign ? 'reports' : INBOX_SECTION_LEGACY_TAB[sectionKey]
     )
 
-    const {
-        isSelected,
-        selectionMode,
-        isHolding,
-        selectionDisabled,
-        toggle: toggleSelection,
-        cardHandlers,
-    } = useReportCardSelection(report.id, selectable && !preview && !isResolved)
+    const { isSelected, isHolding, cardHandlers } = useReportCardSelection(
+        report.id,
+        selectable && !preview && !isResolved
+    )
 
     const { isDismissing, onDismissClick } = useReportDismiss({
         reportId: report.id,
@@ -298,22 +294,6 @@ export function ReportCard({
             )}
         >
             <div className="relative flex min-w-0 flex-1">
-                {selectable && !preview && !isResolved && (
-                    <div
-                        className={clsx(
-                            'mr-3 flex shrink-0 items-start pt-0.5 transition-opacity',
-                            selectionMode ? 'opacity-100' : 'opacity-0 group-hover:opacity-100 focus-within:opacity-100'
-                        )}
-                    >
-                        <LemonCheckbox
-                            checked={isSelected}
-                            disabledReason={selectionDisabled ? 'Wait for the bulk action to finish' : undefined}
-                            onChange={() => toggleSelection('checkbox')}
-                            label={<span className="sr-only">Select report: {cardTitle}</span>}
-                            data-attr="inbox-report-select"
-                        />
-                    </div>
-                )}
                 {hasPr && prNumber != null ? (
                     <div className="absolute right-0 top-0 z-10">
                         <PrBadge

--- a/products/signals/frontend/inbox/components/cards/useReportCardSelection.ts
+++ b/products/signals/frontend/inbox/components/cards/useReportCardSelection.ts
@@ -12,7 +12,7 @@ import {
 
 export interface ReportCardSelection {
     isSelected: boolean
-    /** True once anything is selected: every card then shows its checkbox and toggles on click. */
+    /** True once anything is selected: every card then toggles on click. */
     selectionMode: boolean
     /** Set while a hold is running, so the card suppresses text selection under the finger. */
     isHolding: boolean


### PR DESCRIPTION
## Problem

Report cards show a selection checkbox on hover, which adds a separate control and reserves space beside the content.

**Why:** Keep report rows clear while retaining selection through modifier clicks.

## Changes

Remove the checkbox and its gutter. Keep Shift+click, Cmd/Ctrl+click, press-and-hold selection, and the selected outline unchanged.

After, with the report card hovered and unselected (Storybook sample data):

![Report card after the change, hovered and unselected](https://raw.githubusercontent.com/PostHog/pr-assets/1d28ec886069a3dd7db691c1e8d72554b401be02/2026/09/478decf6-1762-439f-8c1a-f15455c8d4ee.png)

## How did you test this code?

- Ran the ReportCard and reportSelection Jest suites. Updated existing cases to check checkbox absence and selection restrictions through modifier clicks.
- Ran frontend formatting and CI preflight with no blocking failures.
- The full frontend type check stopped with exit 137 due to memory exhaustion.
- Rendered the report card in Storybook with the inbox redesign enabled. Confirmed hover shows no checkbox and captured the unselected state. Full-page browser verification remains incomplete.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Added `docs/internal/inbox-report-selection.md` with the retained selection behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

The PostHog Slack app made this change. Used the writing-ui-components, writing-tests, writing-user-facing-copy, writing-pr-descriptions, and running-ci-preflight skills. No local CodeRabbit pass ran because it is paused.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1789085091118989?thread_ts=1789085091.118989&cid=C09SK2PAGKF)*

