### PR TITLE
feat(flags): read the usage tab from flag_evaluations behind a flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -339,6 +339,8 @@ export const FEATURE_FLAGS = {
     FEATURE_FLAG_REQUEST_USAGE: 'feature-flag-request-usage', // owner: #team-feature-flags
     FIELD_NOTES: 'field-notes', // owner: @adamleith
     FLAG_EVALUATION_TAGS: 'flag-evaluation-tags', // owner: @dmarticus #team-feature-flags
+    FLAG_EVALUATIONS_HOGQL_TABLE: 'flag-evaluations-hogql-table', // owner: #team-feature-flags, also read by the backend to expose posthog.flag_evaluations
+    FLAG_EVALUATIONS_USAGE_TAB: 'flag-evaluations-usage-tab', // owner: #team-feature-flags, reads the Usage tab from flag_evaluations instead of events
     FLAGGED_FEATURE_INDICATOR: 'flagged-feature-indicator', // owner: @benjackwhite
     FLAT_NAV: 'flat-nav', // owner: @rafaeelaudibert #team-growth multivariate=control,test, swaps the tree-based Browse tab for the flat sidebar, see FlatNavBrowse.tsx
     GITHUB_FIRST_SELF_DRIVING_ONBOARDING: 'github-first-self-driving-onboarding', // owner: #team-self-driving

--- a/frontend/src/scenes/feature-flags/FeatureFlagUsageMetrics.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagUsageMetrics.tsx
@@ -4,20 +4,27 @@ import { QueryCard } from 'lib/components/Cards/InsightCard/QueryCard'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 
 import { featureFlagUsageLogic } from './featureFlagUsageLogic'
+import { FLAG_EVALUATIONS_RETENTION_DAYS } from './featureFlagUsageQueries'
 
 export function FeatureFlagUsageMetrics({ id }: { id: number }): JSX.Element {
     const logic = featureFlagUsageLogic({ id })
-    const { dateRange, usageCharts } = useValues(logic)
+    const { dateRange, dateOptions, readsFlagEvaluationsTable, usageCharts } = useValues(logic)
     const { setDates } = useActions(logic)
 
     return (
         <div className="flex flex-col gap-4" data-attr="feature-flag-usage-inline">
-            <div>
+            <div className="flex flex-wrap items-center gap-2">
                 <DateFilter
                     dateFrom={dateRange.date_from ?? null}
                     dateTo={dateRange.date_to ?? null}
+                    dateOptions={dateOptions}
                     onChange={(fromDate, toDate) => setDates(fromDate, toDate)}
                 />
+                {readsFlagEvaluationsTable && (
+                    <span className="text-secondary text-xs">
+                        Flag evaluations are kept for {FLAG_EVALUATIONS_RETENTION_DAYS} days.
+                    </span>
+                )}
             </div>
             <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
                 {usageCharts.map((chart) => (

--- a/frontend/src/scenes/feature-flags/featureFlagUsageLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagUsageLogic.test.ts
@@ -4,14 +4,23 @@ import { expectLogic } from 'kea-test-utils'
 import { urls } from 'scenes/urls'
 
 import { useMocks } from '~/mocks/jest'
+import { NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import { FeatureFlagType } from '~/types'
 
 import { NEW_FLAG, featureFlagLogic } from './featureFlagLogic'
 import { featureFlagUsageLogic } from './featureFlagUsageLogic'
-import { DEFAULT_USAGE_DATE_RANGE } from './featureFlagUsageQueries'
+import { DEFAULT_USAGE_DATE_RANGE, FlagUsageQuery } from './featureFlagUsageQueries'
 
 const FLAG_ID = 1
+
+// No feature flag is enabled in these tests, so every chart reads the events table.
+function trendsSource(query: FlagUsageQuery): TrendsQuery {
+    if (query.kind !== NodeKind.InsightVizNode) {
+        throw new Error(`Expected an events-table trend, got ${query.kind}`)
+    }
+    return query.source
+}
 
 function flag(overrides: Partial<FeatureFlagType> = {}): FeatureFlagType {
     return {
@@ -56,8 +65,8 @@ describe('featureFlagUsageLogic', () => {
 
         expect(logic.values.usageCharts).toHaveLength(4)
         for (const chart of logic.values.usageCharts) {
-            expect(chart.query.source.dateRange).toEqual({ date_from: '-24h', date_to: null })
-            expect(chart.query.source.interval).toEqual('hour')
+            expect(trendsSource(chart.query).dateRange).toEqual({ date_from: '-24h', date_to: null })
+            expect(trendsSource(chart.query).interval).toEqual('hour')
         }
     })
 
@@ -65,7 +74,9 @@ describe('featureFlagUsageLogic', () => {
         featureFlagLogic({ id: FLAG_ID }).actions.loadFeatureFlagSuccess(flag({ key: 'renamed-feature' }))
 
         for (const chart of logic.values.usageCharts) {
-            expect(chart.query.source.properties).toEqual([expect.objectContaining({ value: 'renamed-feature' })])
+            expect(trendsSource(chart.query).properties).toEqual([
+                expect.objectContaining({ value: 'renamed-feature' }),
+            ])
         }
     })
 

--- a/frontend/src/scenes/feature-flags/featureFlagUsageLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagUsageLogic.ts
@@ -1,6 +1,8 @@
 import { LogicWrapper, MakeLogicType, actions, connect, kea, key, path, props, reducers, selectors } from 'kea'
 import { actionToUrl, router, urlToAction } from 'kea-router'
 
+import { FEATURE_FLAGS } from 'lib/constants'
+import { FeatureFlagsSet, featureFlagLogic as enabledFeaturesLogic } from 'lib/logic/featureFlagLogic'
 import { urls } from 'scenes/urls'
 
 import { Noun, groupsModel } from '~/models/groupsModel'
@@ -15,6 +17,8 @@ import {
     buildEnrichedUsageCharts,
     buildFlagCalledTotalVolumeChart,
     buildFlagCalledUniqueCallersChart,
+    buildFlagEvaluationsTotalVolumeChart,
+    buildFlagEvaluationsUniqueCallersChart,
 } from './featureFlagUsageQueries'
 
 // The Usage tab only renders for persisted flags, so unlike featureFlagLogic this
@@ -27,10 +31,12 @@ export interface FeatureFlagUsageLogicProps {
 export interface featureFlagUsageLogicValues {
     featureFlag: FeatureFlagType // featureFlagLogic
     aggregationLabel: (groupTypeIndex: number | null | undefined, deferToUserWording?: boolean) => Noun // groupsModel
+    featureFlags: FeatureFlagsSet // enabledFeaturesLogic
     aggregationGroupTypeIndex: number | null | undefined
     dateRange: DateRange
     flagKey: string
     hasEnrichedAnalytics: boolean | undefined
+    readsFlagEvaluationsTable: boolean
     usageCharts: FlagUsageChart[]
 }
 
@@ -52,11 +58,13 @@ export interface featureFlagUsageLogicMeta {
         flagKey: (featureFlag: FeatureFlagType) => string
         aggregationGroupTypeIndex: (featureFlag: FeatureFlagType) => number | null | undefined
         hasEnrichedAnalytics: (featureFlag: FeatureFlagType) => boolean | undefined
+        readsFlagEvaluationsTable: (featureFlags: FeatureFlagsSet) => boolean
         usageCharts: (
             flagKey: string,
             aggregationGroupTypeIndex: number | null | undefined,
             hasEnrichedAnalytics: boolean | undefined,
             dateRange: DateRange,
+            readsFlagEvaluationsTable: boolean,
             aggregationLabel: (groupTypeIndex: number | null | undefined, deferToUserWording?: boolean) => Noun // groupsModel
         ) => FlagUsageChart[]
     }
@@ -74,7 +82,14 @@ export const featureFlagUsageLogic: LogicWrapper<featureFlagUsageLogicType> = ke
     key(({ id }) => id),
     path((key) => ['scenes', 'feature-flags', 'featureFlagUsageLogic', key]),
     connect((props: FeatureFlagUsageLogicProps) => ({
-        values: [featureFlagLogic(props), ['featureFlag'], groupsModel, ['aggregationLabel']],
+        values: [
+            featureFlagLogic(props),
+            ['featureFlag'],
+            groupsModel,
+            ['aggregationLabel'],
+            enabledFeaturesLogic,
+            ['featureFlags'],
+        ],
     })),
     actions({
         setDates: (dateFrom: string | null, dateTo: string | null) => ({ dateFrom, dateTo }),
@@ -100,13 +115,30 @@ export const featureFlagUsageLogic: LogicWrapper<featureFlagUsageLogicType> = ke
             (s) => [s.featureFlag],
             (featureFlag: FeatureFlagType): boolean | undefined => featureFlag.has_enriched_analytics,
         ],
+        // Both flags are keyed by organization. The usage-tab flag alone is not enough: the
+        // flag_evaluations table is removed from the HogQL catalog of an organization that does not
+        // hold flag-evaluations-hogql-table, and a query against it fails to resolve there.
+        readsFlagEvaluationsTable: [
+            (s) => [s.featureFlags],
+            (featureFlags: FeatureFlagsSet): boolean =>
+                !!featureFlags[FEATURE_FLAGS.FLAG_EVALUATIONS_USAGE_TAB] &&
+                !!featureFlags[FEATURE_FLAGS.FLAG_EVALUATIONS_HOGQL_TABLE],
+        ],
         usageCharts: [
-            (s) => [s.flagKey, s.aggregationGroupTypeIndex, s.hasEnrichedAnalytics, s.dateRange, s.aggregationLabel],
+            (s) => [
+                s.flagKey,
+                s.aggregationGroupTypeIndex,
+                s.hasEnrichedAnalytics,
+                s.dateRange,
+                s.readsFlagEvaluationsTable,
+                s.aggregationLabel,
+            ],
             (
                 flagKey: string,
                 aggregationGroupTypeIndex: number | null | undefined,
                 hasEnrichedAnalytics: boolean | undefined,
                 dateRange: DateRange,
+                readsFlagEvaluationsTable: boolean,
                 aggregationLabel: (groupTypeIndex: number | null | undefined, deferToUserWording?: boolean) => Noun
             ): FlagUsageChart[] => {
                 const options: FlagUsageQueryOptions = {
@@ -115,7 +147,11 @@ export const featureFlagUsageLogic: LogicWrapper<featureFlagUsageLogicType> = ke
                     callerNoun: aggregationLabel(aggregationGroupTypeIndex, true),
                     dateRange,
                 }
-                const charts = [buildFlagCalledTotalVolumeChart(options), buildFlagCalledUniqueCallersChart(options)]
+                // The enriched-analytics charts stay on the events table either way: $feature_view
+                // and $feature_interaction are not flag evaluations, so that table does not hold them.
+                const charts = readsFlagEvaluationsTable
+                    ? [buildFlagEvaluationsTotalVolumeChart(options), buildFlagEvaluationsUniqueCallersChart(options)]
+                    : [buildFlagCalledTotalVolumeChart(options), buildFlagCalledUniqueCallersChart(options)]
                 if (hasEnrichedAnalytics) {
                     charts.push(...buildEnrichedUsageCharts(options))
                 }

--- a/frontend/src/scenes/feature-flags/featureFlagUsageLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagUsageLogic.ts
@@ -7,7 +7,7 @@ import { urls } from 'scenes/urls'
 
 import { Noun, groupsModel } from '~/models/groupsModel'
 import { DateRange } from '~/queries/schema/schema-general'
-import { FeatureFlagType } from '~/types'
+import { DateMappingOption, FeatureFlagType } from '~/types'
 
 import { featureFlagLogic } from './featureFlagLogic'
 import {
@@ -19,6 +19,8 @@ import {
     buildFlagCalledUniqueCallersChart,
     buildFlagEvaluationsTotalVolumeChart,
     buildFlagEvaluationsUniqueCallersChart,
+    clampToFlagEvaluationsRetention,
+    flagEvaluationsDateOptions,
 } from './featureFlagUsageQueries'
 
 // The Usage tab only renders for persisted flags, so unlike featureFlagLogic this
@@ -33,7 +35,9 @@ export interface featureFlagUsageLogicValues {
     aggregationLabel: (groupTypeIndex: number | null | undefined, deferToUserWording?: boolean) => Noun // groupsModel
     featureFlags: FeatureFlagsSet // enabledFeaturesLogic
     aggregationGroupTypeIndex: number | null | undefined
+    selectedDateRange: DateRange
     dateRange: DateRange
+    dateOptions: DateMappingOption[] | undefined
     flagKey: string
     hasEnrichedAnalytics: boolean | undefined
     readsFlagEvaluationsTable: boolean
@@ -59,6 +63,8 @@ export interface featureFlagUsageLogicMeta {
         aggregationGroupTypeIndex: (featureFlag: FeatureFlagType) => number | null | undefined
         hasEnrichedAnalytics: (featureFlag: FeatureFlagType) => boolean | undefined
         readsFlagEvaluationsTable: (featureFlags: FeatureFlagsSet) => boolean
+        dateRange: (selectedDateRange: DateRange, readsFlagEvaluationsTable: boolean) => DateRange
+        dateOptions: (readsFlagEvaluationsTable: boolean) => DateMappingOption[] | undefined
         usageCharts: (
             flagKey: string,
             aggregationGroupTypeIndex: number | null | undefined,
@@ -95,7 +101,7 @@ export const featureFlagUsageLogic: LogicWrapper<featureFlagUsageLogicType> = ke
         setDates: (dateFrom: string | null, dateTo: string | null) => ({ dateFrom, dateTo }),
     }),
     reducers({
-        dateRange: [
+        selectedDateRange: [
             DEFAULT_USAGE_DATE_RANGE,
             {
                 setDates: (_, { dateFrom, dateTo }) => ({ date_from: dateFrom, date_to: dateTo }),
@@ -124,6 +130,19 @@ export const featureFlagUsageLogic: LogicWrapper<featureFlagUsageLogicType> = ke
                 !!featureFlags[FEATURE_FLAGS.FLAG_EVALUATIONS_USAGE_TAB] &&
                 !!featureFlags[FEATURE_FLAGS.FLAG_EVALUATIONS_HOGQL_TABLE],
         ],
+        // flag_evaluations holds 90 days, so a longer range would quietly show fewer rows than the
+        // same range on the events table. The clamp covers the date picker, a link someone shares,
+        // and a range typed into the URL alike.
+        dateRange: [
+            (s) => [s.selectedDateRange, s.readsFlagEvaluationsTable],
+            (selectedDateRange: DateRange, readsFlagEvaluationsTable: boolean): DateRange =>
+                readsFlagEvaluationsTable ? clampToFlagEvaluationsRetention(selectedDateRange) : selectedDateRange,
+        ],
+        dateOptions: [
+            (s) => [s.readsFlagEvaluationsTable],
+            (readsFlagEvaluationsTable: boolean): DateMappingOption[] | undefined =>
+                readsFlagEvaluationsTable ? flagEvaluationsDateOptions() : undefined,
+        ],
         usageCharts: [
             (s) => [
                 s.flagKey,
@@ -149,7 +168,7 @@ export const featureFlagUsageLogic: LogicWrapper<featureFlagUsageLogicType> = ke
                 }
                 // The enriched-analytics charts stay on the events table either way: $feature_view
                 // and $feature_interaction are not flag evaluations, so that table does not hold them.
-                const charts = readsFlagEvaluationsTable
+                const charts: FlagUsageChart[] = readsFlagEvaluationsTable
                     ? [buildFlagEvaluationsTotalVolumeChart(options), buildFlagEvaluationsUniqueCallersChart(options)]
                     : [buildFlagCalledTotalVolumeChart(options), buildFlagCalledUniqueCallersChart(options)]
                 if (hasEnrichedAnalytics) {

--- a/frontend/src/scenes/feature-flags/featureFlagUsageQueries.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagUsageQueries.test.ts
@@ -1,5 +1,7 @@
+import { dateMapping } from 'lib/utils/dateFilters'
+
 import { Noun } from '~/models/groupsModel'
-import { DataVisualizationNode, DateRange } from '~/queries/schema/schema-general'
+import { DataVisualizationNode, DateRange, InsightVizNode, TrendsQuery } from '~/queries/schema/schema-general'
 
 import {
     buildEnrichedUsageCharts,
@@ -7,9 +9,13 @@ import {
     buildFlagCalledUniqueCallersChart,
     buildFlagEvaluationsTotalVolumeChart,
     buildFlagEvaluationsUniqueCallersChart,
+    clampToFlagEvaluationsRetention,
+    flagEvaluationsDateOptions,
     FlagUsageChart,
     FlagUsageQueryOptions,
 } from './featureFlagUsageQueries'
+
+type TrendsUsageChart = FlagUsageChart<InsightVizNode<TrendsQuery>>
 
 const dateRange: DateRange = { date_from: '-30d', date_to: null }
 const userNoun: Noun = { singular: 'user', plural: 'users' }
@@ -30,12 +36,12 @@ const groupFlagOptions: FlagUsageQueryOptions = {
 
 describe('featureFlagUsageQueries', () => {
     it.each([
-        ['buildFlagCalledTotalVolumeChart', (): FlagUsageChart => buildFlagCalledTotalVolumeChart(personFlagOptions)],
+        ['buildFlagCalledTotalVolumeChart', (): TrendsUsageChart => buildFlagCalledTotalVolumeChart(personFlagOptions)],
         [
             'buildFlagCalledUniqueCallersChart',
-            (): FlagUsageChart => buildFlagCalledUniqueCallersChart(personFlagOptions),
+            (): TrendsUsageChart => buildFlagCalledUniqueCallersChart(personFlagOptions),
         ],
-        ['buildEnrichedUsageCharts', (): FlagUsageChart => buildEnrichedUsageCharts(personFlagOptions)[0]],
+        ['buildEnrichedUsageCharts', (): TrendsUsageChart => buildEnrichedUsageCharts(personFlagOptions)[0]],
     ])('%s builds an unsaved TrendsQuery with the shared envelope', (_name, build) => {
         const { query } = build()
 
@@ -79,11 +85,11 @@ describe('featureFlagUsageQueries', () => {
     it.each([
         [
             'buildFlagCalledTotalVolumeChart',
-            (options: FlagUsageQueryOptions): FlagUsageChart => buildFlagCalledTotalVolumeChart(options),
+            (options: FlagUsageQueryOptions): TrendsUsageChart => buildFlagCalledTotalVolumeChart(options),
         ],
         [
             'buildFlagCalledUniqueCallersChart',
-            (options: FlagUsageQueryOptions): FlagUsageChart => buildFlagCalledUniqueCallersChart(options),
+            (options: FlagUsageQueryOptions): TrendsUsageChart => buildFlagCalledUniqueCallersChart(options),
         ],
     ])('%s filters on $feature_flag, adding a $group_N is_set filter only for group flags', (_name, build) => {
         expect(build(personFlagOptions).query.source.properties).toEqual([
@@ -190,6 +196,41 @@ describe('featureFlagUsageQueries', () => {
             expect(query.source.query.includes("`$group_0` != ''")).toEqual(expectsGroupFilter)
         }
     )
+
+    it.each([
+        [
+            'a range inside the window is left alone',
+            { date_from: '-30d', date_to: null },
+            { date_from: '-30d', date_to: null },
+        ],
+        ['the window itself is left alone', { date_from: '-90d', date_to: null }, { date_from: '-90d', date_to: null }],
+        ['a longer range is pulled back', { date_from: '-180d', date_to: null }, { date_from: '-90d', date_to: null }],
+        ['all time is pulled back', { date_from: 'all', date_to: null }, { date_from: '-90d', date_to: null }],
+        ['a missing start is pulled back', { date_from: null, date_to: null }, { date_from: '-90d', date_to: null }],
+        [
+            'a range that ends before the window runs to now instead of backwards',
+            { date_from: '-200d', date_to: '-150d' },
+            { date_from: '-90d', date_to: null },
+        ],
+        [
+            'an end inside the window is kept',
+            { date_from: '-200d', date_to: '-10d' },
+            { date_from: '-90d', date_to: '-10d' },
+        ],
+    ])('clampToFlagEvaluationsRetention: %s', (_name, dateRange, expected) => {
+        expect(clampToFlagEvaluationsRetention(dateRange)).toEqual(expected)
+    })
+
+    it('flagEvaluationsDateOptions offers no preset older than the retention window', () => {
+        const keys = flagEvaluationsDateOptions().map((option) => option.key)
+
+        expect(keys).toContain('Last 90 days')
+        expect(keys).toContain('Last 30 days')
+        expect(keys).not.toContain('Last 180 days')
+        expect(keys).not.toContain('All time')
+        // The custom entry carries no range of its own, so it must survive the filter.
+        expect(keys).toContain(dateMapping[0].key)
+    })
 
     it('buildEnrichedUsageCharts filters on the bare feature_flag property key with no breakdown', () => {
         // A wrong property key here silently produces an empty chart, so pin the exact key.

--- a/frontend/src/scenes/feature-flags/featureFlagUsageQueries.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagUsageQueries.test.ts
@@ -1,10 +1,12 @@
 import { Noun } from '~/models/groupsModel'
-import { DateRange } from '~/queries/schema/schema-general'
+import { DataVisualizationNode, DateRange } from '~/queries/schema/schema-general'
 
 import {
     buildEnrichedUsageCharts,
     buildFlagCalledTotalVolumeChart,
     buildFlagCalledUniqueCallersChart,
+    buildFlagEvaluationsTotalVolumeChart,
+    buildFlagEvaluationsUniqueCallersChart,
     FlagUsageChart,
     FlagUsageQueryOptions,
 } from './featureFlagUsageQueries'
@@ -135,6 +137,59 @@ describe('featureFlagUsageQueries', () => {
             },
         ])
     })
+
+    it.each([
+        [
+            'buildFlagEvaluationsTotalVolumeChart',
+            (options: FlagUsageQueryOptions): FlagUsageChart<DataVisualizationNode> =>
+                buildFlagEvaluationsTotalVolumeChart(options),
+        ],
+        [
+            'buildFlagEvaluationsUniqueCallersChart',
+            (options: FlagUsageQueryOptions): FlagUsageChart<DataVisualizationNode> =>
+                buildFlagEvaluationsUniqueCallersChart(options),
+        ],
+    ])('%s reads flag_evaluations with the flag key and date range bound as parameters', (_name, build) => {
+        const { query } = build(personFlagOptions)
+
+        expect(query.kind).toEqual('DataVisualizationNode')
+        expect(query.source.kind).toEqual('HogQLQuery')
+        expect(query.source.query).toContain('FROM posthog.flag_evaluations')
+        // An inlined flag key would be a HogQL injection, and a missing date filter would scan
+        // the whole retention window whatever range the tab shows.
+        expect(query.source.query).toContain('flag_key = {flag_key}')
+        expect(query.source.query).toContain('{filters(timestamp AS timestamp)}')
+        expect(query.source.values?.flag_key).toEqual('alpha-feature')
+        expect(query.source.filters).toEqual({ dateRange })
+    })
+
+    it('buildFlagEvaluationsTotalVolumeChart breaks the line graph down by response over the date range interval', () => {
+        const { query } = buildFlagEvaluationsTotalVolumeChart({
+            ...personFlagOptions,
+            dateRange: { date_from: '-24h', date_to: null },
+        })
+
+        expect(query.display).toEqual('ActionsLineGraph')
+        expect(query.source.query).toContain("dateTrunc('hour', timestamp) AS period")
+        expect(query.chartSettings).toEqual({
+            xAxis: { column: 'period' },
+            yAxis: [{ column: 'total' }],
+            seriesBreakdownColumn: 'variant',
+        })
+    })
+
+    it.each([
+        ['person flag', personFlagOptions, 'uniq(person_id)', false],
+        ['group flag', groupFlagOptions, 'uniq(`$group_0`)', true],
+    ])(
+        'buildFlagEvaluationsUniqueCallersChart counts the callers of a %s',
+        (_name, options, expectedAggregation, expectsGroupFilter) => {
+            const { query } = buildFlagEvaluationsUniqueCallersChart(options)
+
+            expect(query.source.query).toContain(expectedAggregation)
+            expect(query.source.query.includes("`$group_0` != ''")).toEqual(expectsGroupFilter)
+        }
+    )
 
     it('buildEnrichedUsageCharts filters on the bare feature_flag property key with no breakdown', () => {
         // A wrong property key here silently produces an empty chart, so pin the exact key.

--- a/frontend/src/scenes/feature-flags/featureFlagUsageQueries.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagUsageQueries.ts
@@ -8,7 +8,8 @@
 //
 // The buildFlagEvaluations* builders answer the same two questions from the flag_evaluations table
 // instead of the events table, for the organizations that read flag evaluations from there.
-import { getDefaultInterval } from 'lib/utils/dateFilters'
+import { dayjs } from 'lib/dayjs'
+import { dateMapping, dateStringToDayJs, getDefaultInterval } from 'lib/utils/dateFilters'
 
 import { Noun } from '~/models/groupsModel'
 import {
@@ -26,6 +27,7 @@ import {
     AnyPropertyFilter,
     BaseMathType,
     ChartDisplayType,
+    DateMappingOption,
     GroupMathType,
     GroupTypeIndex,
     PropertyFilterType,
@@ -186,6 +188,47 @@ function enrichedSeries(event: '$feature_view' | '$feature_interaction', seriesL
 // table, so the `posthog.` prefix is part of the name. An organization without the
 // flag-evaluations-hogql-table flag has no such table, and these queries fail to resolve for it.
 const FLAG_EVALUATIONS_TABLE = 'posthog.flag_evaluations'
+
+/** How long a row stays in flag_evaluations. The events table keeps $feature_flag_called forever. */
+export const FLAG_EVALUATIONS_RETENTION_DAYS = 90
+
+/** Start of the oldest day the table still holds. */
+function earliestRetainedDay(): dayjs.Dayjs {
+    return dayjs().startOf('day').subtract(FLAG_EVALUATIONS_RETENTION_DAYS, 'day')
+}
+
+/**
+ * Pulls a date range back inside the retention window. A range that reaches further would show
+ * fewer rows than the same range on the events table, with nothing on the chart to say why.
+ */
+export function clampToFlagEvaluationsRetention(dateRange: DateRange): DateRange {
+    const earliest = earliestRetainedDay()
+    const dateFrom = dateStringToDayJs(dateRange.date_from ?? null)
+    // A null start is "all time", which reaches further than any retained day.
+    if (dateFrom && !dateFrom.isBefore(earliest)) {
+        return dateRange
+    }
+    const dateTo = dateStringToDayJs(dateRange.date_to ?? null)
+    return {
+        date_from: `-${FLAG_EVALUATIONS_RETENTION_DAYS}d`,
+        // A range that ended before the window holds nothing, and the clamped start would sit
+        // after its end. Run to now instead of showing a backwards range.
+        date_to: dateTo?.isBefore(earliest) ? null : (dateRange.date_to ?? null),
+    }
+}
+
+/** The presets that stay inside the retention window, plus the custom-range entry. */
+export function flagEvaluationsDateOptions(): DateMappingOption[] {
+    const earliest = earliestRetainedDay()
+    return dateMapping.filter(({ values }) => {
+        const dateFrom = values[0]
+        if (dateFrom === undefined) {
+            return true
+        }
+        const parsed = dateStringToDayJs(dateFrom)
+        return !!parsed && !parsed.isBefore(earliest)
+    })
+}
 
 function flagEvaluationsConditions({ aggregationGroupTypeIndex }: FlagUsageQueryOptions): string {
     // `{filters(... AS timestamp)}` binds the tab's date range to this table's own timestamp column.

--- a/frontend/src/scenes/feature-flags/featureFlagUsageQueries.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagUsageQueries.ts
@@ -5,10 +5,15 @@
 // Titles differ on purpose: update_feature_flag_dashboard looks tiles up by name, so the Python
 // names are pinned, while these use sentence case. The interval here follows the user's date range
 // rather than the template's fixed "day".
+//
+// The buildFlagEvaluations* builders answer the same two questions from the flag_evaluations table
+// instead of the events table, for the organizations that read flag evaluations from there.
 import { getDefaultInterval } from 'lib/utils/dateFilters'
 
 import { Noun } from '~/models/groupsModel'
 import {
+    ChartSettings,
+    DataVisualizationNode,
     DateRange,
     EventsNode,
     InsightVizNode,
@@ -37,11 +42,13 @@ export interface FlagUsageQueryOptions {
 
 export const DEFAULT_USAGE_DATE_RANGE: DateRange = { date_from: '-30d', date_to: null }
 
-export interface FlagUsageChart {
+export type FlagUsageQuery = InsightVizNode<TrendsQuery> | DataVisualizationNode
+
+export interface FlagUsageChart<Q extends FlagUsageQuery = FlagUsageQuery> {
     key: string
     title: string
     description: string
-    query: InsightVizNode<TrendsQuery>
+    query: Q
 }
 
 function flagCalledProperties({ flagKey, aggregationGroupTypeIndex }: FlagUsageQueryOptions): AnyPropertyFilter[] {
@@ -83,7 +90,9 @@ function buildUsageQuery(
     })
 }
 
-export function buildFlagCalledTotalVolumeChart(options: FlagUsageQueryOptions): FlagUsageChart {
+export function buildFlagCalledTotalVolumeChart(
+    options: FlagUsageQueryOptions
+): FlagUsageChart<InsightVizNode<TrendsQuery>> {
     return {
         key: 'total-volume',
         title: 'Feature flag called total volume',
@@ -100,7 +109,9 @@ export function buildFlagCalledTotalVolumeChart(options: FlagUsageQueryOptions):
     }
 }
 
-export function buildFlagCalledUniqueCallersChart(options: FlagUsageQueryOptions): FlagUsageChart {
+export function buildFlagCalledUniqueCallersChart(
+    options: FlagUsageQueryOptions
+): FlagUsageChart<InsightVizNode<TrendsQuery>> {
     const mathProperties: Pick<EventsNode, 'math' | 'math_group_type_index'> =
         options.aggregationGroupTypeIndex != null
             ? {
@@ -133,7 +144,7 @@ export function buildFlagCalledUniqueCallersChart(options: FlagUsageQueryOptions
 
 export function buildEnrichedUsageCharts(
     options: Pick<FlagUsageQueryOptions, 'flagKey' | 'dateRange'>
-): FlagUsageChart[] {
+): FlagUsageChart<InsightVizNode<TrendsQuery>>[] {
     return [
         {
             key: 'feature-view',
@@ -169,6 +180,98 @@ function enrichedSeries(event: '$feature_view' | '$feature_interaction', seriesL
         { kind: NodeKind.EventsNode, event, name: `${seriesLabel} - Total` },
         { kind: NodeKind.EventsNode, event, name: `${seriesLabel} - Unique users`, math: BaseMathType.UniqueUsers },
     ]
+}
+
+// The dedicated flag-evaluation table, which only holds $feature_flag_called. It is not a root
+// table, so the `posthog.` prefix is part of the name. An organization without the
+// flag-evaluations-hogql-table flag has no such table, and these queries fail to resolve for it.
+const FLAG_EVALUATIONS_TABLE = 'posthog.flag_evaluations'
+
+function flagEvaluationsConditions({ aggregationGroupTypeIndex }: FlagUsageQueryOptions): string {
+    // `{filters(... AS timestamp)}` binds the tab's date range to this table's own timestamp column.
+    // The bare `{filters}` placeholder only knows a fixed set of tables, and this is not one of them.
+    const conditions = ['flag_key = {flag_key}', '{filters(timestamp AS timestamp)}']
+    if (aggregationGroupTypeIndex != null) {
+        // The group columns are non-nullable and hold an empty string when the evaluation
+        // carried no group, so this is the equivalent of the events path's is_set filter.
+        conditions.push(`\`$group_${aggregationGroupTypeIndex}\` != ''`)
+    }
+    return conditions.join('\n    AND ')
+}
+
+function buildFlagEvaluationsQuery(
+    options: FlagUsageQueryOptions,
+    query: string,
+    display: ChartDisplayType,
+    chartSettings?: ChartSettings
+): DataVisualizationNode {
+    const { dateRange, flagKey } = options
+    return setLatestVersionsOnQuery({
+        kind: NodeKind.DataVisualizationNode,
+        source: {
+            kind: NodeKind.HogQLQuery,
+            query,
+            filters: { dateRange },
+            values: { flag_key: flagKey },
+        },
+        display,
+        chartSettings,
+    })
+}
+
+export function buildFlagEvaluationsTotalVolumeChart(
+    options: FlagUsageQueryOptions
+): FlagUsageChart<DataVisualizationNode> {
+    // dateTrunc needs a literal unit, so the interval is written into the query rather than
+    // passed as a value. getDefaultInterval only returns members of IntervalType.
+    const interval = getDefaultInterval(options.dateRange.date_from ?? null, options.dateRange.date_to ?? null)
+    return {
+        key: 'total-volume',
+        title: 'Feature flag called total volume',
+        description: `Shows the number of total calls made on feature flag with key: ${options.flagKey}`,
+        query: buildFlagEvaluationsQuery(
+            options,
+            `SELECT
+    dateTrunc('${interval}', timestamp) AS period,
+    response AS variant,
+    count() AS total
+FROM ${FLAG_EVALUATIONS_TABLE}
+WHERE ${flagEvaluationsConditions(options)}
+GROUP BY period, variant
+ORDER BY period`,
+            ChartDisplayType.ActionsLineGraph,
+            {
+                xAxis: { column: 'period' },
+                yAxis: [{ column: 'total' }],
+                seriesBreakdownColumn: 'variant',
+            }
+        ),
+    }
+}
+
+export function buildFlagEvaluationsUniqueCallersChart(
+    options: FlagUsageQueryOptions
+): FlagUsageChart<DataVisualizationNode> {
+    const { aggregationGroupTypeIndex, callerNoun, flagKey } = options
+    // The row keeps the person it was attributed to when the flag was evaluated, and a later
+    // identify or merge does not rewrite it, so this count can be higher than the events one.
+    const caller = aggregationGroupTypeIndex != null ? `\`$group_${aggregationGroupTypeIndex}\`` : 'person_id'
+    return {
+        key: 'unique-callers',
+        title: `Feature flag calls made by unique ${callerNoun.plural} per variant`,
+        description: `Shows the number of unique ${callerNoun.singular} calls made on feature flag per variant with key: ${flagKey}`,
+        query: buildFlagEvaluationsQuery(
+            options,
+            `SELECT
+    response AS \`Variant\`,
+    uniq(${caller}) AS \`Unique callers\`
+FROM ${FLAG_EVALUATIONS_TABLE}
+WHERE ${flagEvaluationsConditions(options)}
+GROUP BY \`Variant\`
+ORDER BY \`Unique callers\` DESC`,
+            ChartDisplayType.ActionsTable
+        ),
+    }
 }
 
 // Enriched analytics events carry the flag key in the bare `feature_flag` property,


### PR DESCRIPTION
## Problem

A person on a feature flag's Usage tab still reads both charts from the events table, even when their project's flag evaluations are also written to the dedicated `flag_evaluations` table. We need a way to read that tab from the new table before it becomes the only place the data lives.

Refs #88126

## Changes

- The two flag-called charts ("total volume" and "unique callers per variant") query `posthog.flag_evaluations` with HogQL when the organization holds **both** `flag-evaluations-usage-tab` and `flag-evaluations-hogql-table`. The charts look the same: a line graph broken down by response, and a table of unique callers per variant. Every other organization keeps today's events-table trends.
- The second flag is not redundant. An organization without `flag-evaluations-hogql-table` has no `flag_evaluations` node in its HogQL catalog, so a query naming the table fails to resolve rather than falling back.
- The two enriched-analytics charts stay on the events table. `$feature_view` and `$feature_interaction` are not flag evaluations, so the new table does not hold them.

- When the tab reads `flag_evaluations`, the date picker offers no preset older than 90 days, and a longer range is pulled back to the last 90 days whether it comes from the picker or from the URL. A line next to the picker states the limit. The events path keeps every preset.

One behavior difference to know about before widening the flag: the unique-caller count uses the person the row was attributed to at evaluation time. A later identify or merge does not rewrite it, so the count can be higher than the events one, which follows merges.

### On the eventual cutoff

The plan is that organizations created after a cutoff date read only `flag_evaluations`. A feature flag cannot express that: the gate evaluates locally and sends only the organization id, so a condition on a creation date cannot evaluate and reads false for everyone. A setting that holds the date works, but the date should be read once when a team is created and the result stored on `TeamFeatureFlagsConfig`, not compared on every read. Moving the date must not change where a project's existing rows live, ingestion is keyed by team rather than organization, and a stored value can be overridden for one project. At that point the frontend should read one server-computed source value and the client flags here go away.

## How did you test this code?

Automated, run by me:

- `jest frontend/src/scenes/feature-flags/featureFlagUsage*` - 35 passed. New cases pin the table name, the parameterized flag key, the bound date-range placeholder, the chart axes and breakdown column, the per-caller aggregation for person and group flags, and the retention clamp (including a range that ends before the window, which would otherwise produce a start after its end). Without them an inlined flag key, a dropped date filter, or a group flag counting persons all pass silently.
- `tsgo --noEmit` over the frontend: no errors in the files this PR touches. The run is not clean overall in my sandbox, because several products fail to resolve the quill packages, which are not built here.
- `pnpm --filter=@posthog/frontend fix`.

Not done: I did not render the tab or run the query against ClickHouse, so the HogQL is unverified end to end. The query shape follows existing precedent for the column-bound `{filters(... AS timestamp)}` placeholder and for backticked `$group_N` columns on this table.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by Claude Opus 5 in PostHog Desktop. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.
- CodeRabbit CLI pass: paused, so this PR opened without a local pass.
- No duplicate: `gh pr list --state open --search` for flag-evaluations usage-tab work found nothing.
- Decisions along the way: a server-computed source field on the feature flag API was considered and dropped for now, because it costs an OpenAPI regeneration and the cutoff it would serve is not built yet. The reasoning above is recorded in the context wiki as `decisions/2026-09-11-flag-evaluations-usage-tab-source.md`.
- Public artifact: nothing here carries non-public material from the session.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

