### PR TITLE
fix(desktop): keep the update banner reachable without the sidebar

### DIFF
--- a/products/desktop/apps/code/src/renderer/platform-adapters/updates.ts
+++ b/products/desktop/apps/code/src/renderer/platform-adapters/updates.ts
@@ -7,6 +7,7 @@ import {
 } from "@posthog/core/updates/updateStore";
 import { resolveService } from "@posthog/di/container";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
+import { useUpdateModalStore } from "@posthog/ui/features/updates/updateModalStore";
 import {
   UPDATES_CLIENT,
   type UpdatesClient,
@@ -71,6 +72,9 @@ client.onStatus({
       }
       if (outcome.toast) {
         showToast(outcome.toast);
+      }
+      if (outcome.openUpdateModal) {
+        useUpdateModalStore.getState().open();
       }
     }
   },

--- a/products/desktop/docs/UPDATES.md
+++ b/products/desktop/docs/UPDATES.md
@@ -27,6 +27,14 @@ GitHub Releases in `PostHog/posthog` remain the human-facing changelog and downl
 
 Remote announcements can drive this flow: a `required-update` announcement blocks apps below a version and reuses the updater; where the updater is unavailable it degrades to a manual download link. See [ANNOUNCEMENTS.md](./ANNOUNCEMENTS.md).
 
+## In-app update surfaces
+
+- The sidebar footer shows the update banner while the sidebar is on screen. It covers the available, downloading, ready and installing states.
+- The title bar shows a compact chip for the same states while the sidebar is collapsed, peeked away or absent, so only one copy is on screen at a time.
+- Both surfaces open the update modal, which shows the release notes and holds the Download and Restart actions. The sidebar card also has its own Restart button for a staged update.
+- "Check for Updates..." in the app menu runs a check. It shows a toast when the app is up to date or the check fails, and opens the update modal when the check finds an available, downloading or staged update.
+- The modal is mounted in the app shell above the router, so it also opens from the sign-in, access and consent screens.
+
 ## How it works
 
 1. A base tag like `desktop-v0.15` marks the start of a minor version.

--- a/products/desktop/packages/core/src/updates/updateStore.test.ts
+++ b/products/desktop/packages/core/src/updates/updateStore.test.ts
@@ -147,6 +147,17 @@ describe("resolveMenuCheckFromStatus", () => {
   it("keeps pending while still checking", () => {
     expect(resolveMenuCheckFromStatus({ checking: true }, true)).toBeNull();
   });
+
+  it.each([
+    ["available", { checking: false, available: true }],
+    ["downloading", { checking: true, downloading: true }],
+    ["staged", { checking: false, updateReady: true }],
+  ])("opens the update modal on an %s result", (_label, payload) => {
+    expect(resolveMenuCheckFromStatus(payload, true)).toEqual({
+      clearPending: true,
+      openUpdateModal: true,
+    });
+  });
 });
 
 describe("resolveMenuCheckResult", () => {

--- a/products/desktop/packages/core/src/updates/updateStore.ts
+++ b/products/desktop/packages/core/src/updates/updateStore.ts
@@ -147,6 +147,7 @@ export interface MenuCheckToast {
 export interface MenuCheckOutcome {
   toast?: MenuCheckToast;
   clearPending: boolean;
+  openUpdateModal?: boolean;
 }
 
 export function resolveMenuCheckFromStatus(
@@ -173,6 +174,10 @@ export function resolveMenuCheckFromStatus(
         description: payload.error,
       },
     };
+  }
+
+  if (payload.available || payload.downloading || payload.updateReady) {
+    return { clearPending: true, openUpdateModal: true };
   }
 
   if (payload.checking === false) {

--- a/products/desktop/packages/ui/src/features/sidebar/components/UpdateBanner.stories.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/UpdateBanner.stories.tsx
@@ -4,18 +4,33 @@ import {
 } from "@posthog/core/updates/updateStore";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { UpdateBanner } from "@posthog/ui/features/sidebar/components/UpdateBanner";
-import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
+import { useEffect } from "react";
 
-function seedStore(status: UpdateUiStatus): void {
-  useSettingsStore.setState({ dismissibleUpdateBanners: false });
-  updateStore.setState({
-    status,
-    isEnabled: true,
-    version: status === "available" ? null : "0.24.1",
-    availableVersion: "0.24.1",
-    downloadPercent: 42,
-    downloadSizeBytes: 180 * 1024 * 1024,
-  });
+function withUpdateState(status: UpdateUiStatus): Decorator {
+  return function WithUpdateState(Story) {
+    useEffect(() => {
+      const previousUpdate = updateStore.getState();
+      const previousDismissible =
+        useSettingsStore.getState().dismissibleUpdateBanners;
+      useSettingsStore.setState({ dismissibleUpdateBanners: false });
+      updateStore.setState({
+        status,
+        isEnabled: true,
+        version: status === "available" ? null : "0.24.1",
+        availableVersion: "0.24.1",
+        downloadPercent: 42,
+        downloadSizeBytes: 180 * 1024 * 1024,
+      });
+      return () => {
+        updateStore.setState(previousUpdate);
+        useSettingsStore.setState({
+          dismissibleUpdateBanners: previousDismissible,
+        });
+      };
+    }, [status]);
+    return <Story />;
+  };
 }
 
 const meta = {
@@ -28,38 +43,32 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const InSidebar: Story = {
-  render: (args) => {
-    seedStore("ready");
-    return (
-      <div className="flex h-[320px] w-[280px] flex-col justify-end bg-chrome">
-        <UpdateBanner {...args} />
-      </div>
-    );
-  },
+  decorators: [withUpdateState("ready")],
+  render: (args) => (
+    <div className="flex h-[320px] w-[280px] flex-col justify-end bg-chrome">
+      <UpdateBanner {...args} />
+    </div>
+  ),
 };
 
 export const InTitleBar: Story = {
   args: { variant: "compact" },
-  render: (args) => {
-    seedStore("ready");
-    return (
-      <div className="flex h-[38px] w-[720px] items-center bg-chrome px-3">
-        <span className="text-[13px] text-muted-foreground">Tabs</span>
-        <div className="ml-auto flex items-center pr-2">
-          <UpdateBanner {...args} />
-        </div>
+  decorators: [withUpdateState("ready")],
+  render: (args) => (
+    <div className="flex h-[38px] w-[720px] items-center bg-chrome px-3">
+      <span className="text-[13px] text-muted-foreground">Tabs</span>
+      <div className="ml-auto flex items-center pr-2">
+        <UpdateBanner {...args} />
       </div>
-    );
-  },
+    </div>
+  ),
 };
 
 export const Downloading: Story = {
-  render: (args) => {
-    seedStore("downloading");
-    return (
-      <div className="flex w-[280px] flex-col bg-chrome">
-        <UpdateBanner {...args} />
-      </div>
-    );
-  },
+  decorators: [withUpdateState("downloading")],
+  render: (args) => (
+    <div className="flex w-[280px] flex-col bg-chrome">
+      <UpdateBanner {...args} />
+    </div>
+  ),
 };

--- a/products/desktop/packages/ui/src/features/sidebar/components/UpdateBanner.stories.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/UpdateBanner.stories.tsx
@@ -1,0 +1,65 @@
+import {
+  type UpdateUiStatus,
+  updateStore,
+} from "@posthog/core/updates/updateStore";
+import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
+import { UpdateBanner } from "@posthog/ui/features/sidebar/components/UpdateBanner";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+function seedStore(status: UpdateUiStatus): void {
+  useSettingsStore.setState({ dismissibleUpdateBanners: false });
+  updateStore.setState({
+    status,
+    isEnabled: true,
+    version: status === "available" ? null : "0.24.1",
+    availableVersion: "0.24.1",
+    downloadPercent: 42,
+    downloadSizeBytes: 180 * 1024 * 1024,
+  });
+}
+
+const meta = {
+  title: "Sidebar/UpdateBanner",
+  component: UpdateBanner,
+} satisfies Meta<typeof UpdateBanner>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const InSidebar: Story = {
+  render: (args) => {
+    seedStore("ready");
+    return (
+      <div className="flex h-[320px] w-[280px] flex-col justify-end bg-chrome">
+        <UpdateBanner {...args} />
+      </div>
+    );
+  },
+};
+
+export const InTitleBar: Story = {
+  args: { variant: "compact" },
+  render: (args) => {
+    seedStore("ready");
+    return (
+      <div className="flex h-[38px] w-[720px] items-center bg-chrome px-3">
+        <span className="text-[13px] text-muted-foreground">Tabs</span>
+        <div className="ml-auto flex items-center pr-2">
+          <UpdateBanner {...args} />
+        </div>
+      </div>
+    );
+  },
+};
+
+export const Downloading: Story = {
+  render: (args) => {
+    seedStore("downloading");
+    return (
+      <div className="flex w-[280px] flex-col bg-chrome">
+        <UpdateBanner {...args} />
+      </div>
+    );
+  },
+};

--- a/products/desktop/packages/ui/src/features/sidebar/components/UpdateBanner.test.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/UpdateBanner.test.tsx
@@ -49,7 +49,7 @@ function renderBanner(variant?: "sidebar" | "compact") {
 
 const VARIANTS = [
   { variant: "sidebar", readyText: "1.2.3 ready" },
-  { variant: "compact", readyText: "1.2.3 ready — Restart" },
+  { variant: "compact", readyText: "1.2.3 ready" },
 ] as const;
 
 function dismissButton() {

--- a/products/desktop/packages/ui/src/features/sidebar/components/UpdateBanner.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/UpdateBanner.tsx
@@ -102,12 +102,10 @@ export function UpdateBanner({ variant = "sidebar" }: UpdateBannerProps) {
                 <button
                   type="button"
                   className="flex items-center gap-1.5 rounded-2 border border-(--green-a5) bg-(--green-a3) px-2.5 py-1 font-medium text-(--green-11) text-[13px] transition-colors hover:bg-(--green-a4)"
-                  onClick={() => void installUpdate()}
+                  onClick={openModal}
                 >
                   <Gift size={14} weight="duotone" />
-                  <span>
-                    {version ? `${version} ready` : "Update ready"} — Restart
-                  </span>
+                  <span>{version ? `${version} ready` : "Update ready"}</span>
                 </button>
                 {canDismiss && (
                   <DismissButton onClick={() => dismissBanner(dismissKey)} />

--- a/products/desktop/packages/ui/src/features/sidebar/components/UpdateBanner.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/UpdateBanner.tsx
@@ -1,42 +1,62 @@
 import { ArrowsClockwise, Gift, X } from "@phosphor-icons/react";
+import { updateStore } from "@posthog/core/updates/updateStore";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { useUpdateBannerStore } from "@posthog/ui/features/updates/updateBannerStore";
 import { useUpdateModalStore } from "@posthog/ui/features/updates/updateModalStore";
 import {
+  useHasActiveUpdate,
   useInstallUpdate,
   useUpdateView,
 } from "@posthog/ui/features/updates/updateStore";
 import { Spin, Spinner } from "@posthog/ui/primitives/Spinner";
 import { Box } from "@radix-ui/themes";
 import { AnimatePresence, motion } from "framer-motion";
+import { useStore } from "zustand";
 
 interface UpdateBannerProps {
   variant?: "sidebar" | "compact";
 }
 
-export function UpdateBanner({ variant = "sidebar" }: UpdateBannerProps) {
-  const { status, version, availableVersion, downloadPercent, isEnabled } =
-    useUpdateView();
-  const installUpdate = useInstallUpdate();
-  const openModal = useUpdateModalStore((state) => state.open);
+function dismissKeyFor(
+  version: string | null,
+  availableVersion: string | null,
+): string {
+  return version ?? availableVersion ?? "unknown";
+}
+
+// Primitive selectors only, so download progress does not re-render the app shell.
+export function useUpdateBannerVisible(): boolean {
+  const hasActiveUpdate = useHasActiveUpdate();
+  const isEnabled = useStore(updateStore, (state) => state.isEnabled);
+  const dismissKey = useStore(updateStore, (state) =>
+    dismissKeyFor(state.version, state.availableVersion),
+  );
   const canDismiss = useSettingsStore(
     (state) => state.dismissibleUpdateBanners,
   );
   const dismissedVersion = useUpdateBannerStore(
     (state) => state.dismissedVersion,
   );
+
+  return (
+    isEnabled &&
+    hasActiveUpdate &&
+    !(canDismiss && dismissedVersion === dismissKey)
+  );
+}
+
+export function UpdateBanner({ variant = "sidebar" }: UpdateBannerProps) {
+  const { status, version, availableVersion, downloadPercent } =
+    useUpdateView();
+  const installUpdate = useInstallUpdate();
+  const openModal = useUpdateModalStore((state) => state.open);
+  const canDismiss = useSettingsStore(
+    (state) => state.dismissibleUpdateBanners,
+  );
   const dismissBanner = useUpdateBannerStore((state) => state.dismiss);
 
-  const dismissKey = version ?? availableVersion ?? "unknown";
-  const isDismissed = canDismiss && dismissedVersion === dismissKey;
-
-  const isVisible =
-    isEnabled &&
-    !isDismissed &&
-    (status === "available" ||
-      status === "downloading" ||
-      status === "ready" ||
-      status === "installing");
+  const dismissKey = dismissKeyFor(version, availableVersion);
+  const isVisible = useUpdateBannerVisible();
 
   const percent = Math.round(downloadPercent ?? 0);
 

--- a/products/desktop/packages/ui/src/router/routes/__root.tsx
+++ b/products/desktop/packages/ui/src/router/routes/__root.tsx
@@ -48,6 +48,10 @@ import { useIntegrations } from "@posthog/ui/features/integrations/useIntegratio
 import { useLoopDeepLink } from "@posthog/ui/features/loops/hooks/useLoopDeepLink";
 import { useScoutDeepLink } from "@posthog/ui/features/scouts/hooks/useScoutDeepLink";
 import { useSetupDiscovery } from "@posthog/ui/features/setup/useSetupDiscovery";
+import {
+  UpdateBanner,
+  useUpdateBannerVisible,
+} from "@posthog/ui/features/sidebar/components/UpdateBanner";
 import { NAV_RAIL_WIDTH } from "@posthog/ui/features/sidebar/constants";
 import {
   beginSidebarPeek,
@@ -61,7 +65,6 @@ import { ExistingWorktreeDialog } from "@posthog/ui/features/task-detail/compone
 import { RemoteBranchCheckoutDialog } from "@posthog/ui/features/task-detail/components/RemoteBranchCheckoutDialog";
 import { useTasks } from "@posthog/ui/features/tasks/useTasks";
 import { TourOverlay } from "@posthog/ui/features/tour/components/TourOverlay";
-import { UpdateAvailableModal } from "@posthog/ui/features/updates/UpdateAvailableModal";
 import { WhatsNewModal } from "@posthog/ui/features/updates/WhatsNewModal";
 import { useWorkspaces } from "@posthog/ui/features/workspace/useWorkspace";
 import { AnimatedLogo } from "@posthog/ui/primitives/AnimatedLogo";
@@ -219,6 +222,9 @@ function RootLayout() {
 
   const toggleSidebar = useSidebarStore((s) => s.toggle);
   const sidebarPeek = useSidebarPeekStore((s) => s.peek);
+  const updateBannerVisible = useUpdateBannerVisible();
+  const showTitleBarUpdate =
+    updateBannerVisible && !sidebarDocked && !sidebarPeek;
   // Toggling makes any hover-peek redundant (opening replaces the overlay;
   // closing must not leave it lingering under the pointer).
   const handleToggleSidebar = (): void => {
@@ -348,7 +354,7 @@ function RootLayout() {
                 aria-label="Toggle sidebar"
                 onClick={handleToggleSidebar}
                 onMouseEnter={() => {
-                  if (!sidebarOpen) beginSidebarPeek();
+                  if (!sidebarOpen && hasSidebar) beginSidebarPeek();
                 }}
               >
                 {sidebarOpen ? (
@@ -386,6 +392,11 @@ function RootLayout() {
               also the only global owner of Cmd+W, so the fallback has to hold
               that key wherever the strip isn't mounted. */}
           <BrowserTabStrip />
+          {showTitleBarUpdate && (
+            <div className="no-drag ml-auto flex items-center pr-2">
+              <UpdateBanner variant="compact" />
+            </div>
+          )}
           {/* Gated so an empty right-side group can't claim a no-drag rect
               in the title bar for nothing — every pixel without controls
               should drag the window. */}
@@ -493,7 +504,6 @@ function RootLayout() {
         <TourOverlay />
         {billingEnabled && <UsageLimitModal />}
         <AnnouncementsHost />
-        <UpdateAvailableModal />
         <WhatsNewModal />
         <RemoteBranchCheckoutDialog />
         <FeedbackModal

--- a/products/desktop/packages/ui/src/shell/App.tsx
+++ b/products/desktop/packages/ui/src/shell/App.tsx
@@ -28,6 +28,7 @@ import { useOnboardingStore } from "@posthog/ui/features/onboarding/onboardingSt
 import { SettingsDialog } from "@posthog/ui/features/settings/SettingsDialog";
 import { UpdateBanner } from "@posthog/ui/features/sidebar/components/UpdateBanner";
 import { PendingPromptRecovery } from "@posthog/ui/features/task-detail/components/PendingPromptRecovery";
+import { UpdateAvailableModal } from "@posthog/ui/features/updates/UpdateAvailableModal";
 import { router } from "@posthog/ui/router/router";
 import { AppLoadingScreen } from "@posthog/ui/shell/AppLoadingScreen";
 import {
@@ -336,6 +337,7 @@ function App({ devToolbar }: AppProps) {
             <ScopeReauthPrompt />
             <AddDirectoryDialog />
             <ErrorDetailsDialog />
+            <UpdateAvailableModal />
           </div>
           {devToolbar}
         </div>


### PR DESCRIPTION
## Problem

- A Desktop user with the sidebar collapsed has no way to reach a staged update. The sidebar footer is the only surface that draws the update banner, so with that column collapsed, or on a rail destination that has no list, the install has no entry point.
- "Check for Updates..." finishes silently when an update is already available or staged, so the menu offers no way in either.

## Changes

- The title bar shows the compact update banner whenever the sidebar is not docked or peeked. The sidebar footer keeps its banner while the column is on screen, so only one copy shows at a time.
- The compact chip for a staged update reads "0.62.0 ready" and opens the update modal, where the Restart action lives. It no longer restarts the app on click, which matches the available chip and the sidebar card.
- "Check for Updates..." opens the update modal when the check lands on an available, downloading or staged update.
- The update modal now mounts in the app shell above the router. A menu check from the sign-in, access or consent screen shows the dialog instead of setting state that nothing renders until the main app mounts.
- Hovering the sidebar toggle on a destination with no sidebar no longer starts a peek. A peek that never ended there hid the title bar banner and left the scrim up.
- Mechanical: `useUpdateBannerVisible` is extracted from the banner so the title bar can gate its no-drag slot on it, `dismissKeyFor` replaces a duplicated expression, and the banner gets Storybook stories that seed the stores in a decorator and restore them on unmount.

Title bar with the sidebar collapsed and an update staged, before:

![Title bar with the sidebar collapsed, before](https://raw.githubusercontent.com/PostHog/pr-assets/0f92169fa95fd8f4676adc11c0385ce675c0e40e/2026/09/72637529-c608-4017-af22-8a915cdbcf50.png)

After:

![Title bar with the sidebar collapsed, after](https://raw.githubusercontent.com/PostHog/pr-assets/91a5bab41a8618b239dcfa3885581d6b7f413e5a/2026/09/172f4c7e-41c5-465a-a03e-48cbc9ea49d4.png)

The modal opened from the title bar chip:

![Update modal opened from the title bar chip](https://raw.githubusercontent.com/PostHog/pr-assets/ed0ee0d2ba003c7f7868b2139397e3546425b1f2/2026/09/e4be464b-eb4d-4429-9891-a5fdb6fc88c4.png)

## How did you test this code?

- Ran the dev app with the sidebar collapsed. A dev build has no updater, so the update state was seeded into the renderer store. The screenshots above come from that run, and the modal opened from the title bar chip.
- New `updateStore.test.ts` cases: a menu check that lands on an available, downloading or staged result asks for the modal. No existing case covered a check that finds an update, which is why the menu item could finish silently.
- `UpdateBanner.test.tsx` now expects the compact ready chip to read "1.2.3 ready".
- Not run: a packaged build against a live update feed. Not checked: the menu path on the sign-in and consent screens, because the menu item is hidden in dev builds.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`products/desktop/docs/UPDATES.md` gains a section on the in-app update surfaces: the sidebar banner, the title bar chip, the modal and the menu check.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tools: Claude Code. Skills invoked: `/posthog-desktop`, `/writing-pr-descriptions`, `/writing-code-comments`, `/writing-user-facing-copy`, `/writing-tests`, `/reviewing-with-coderabbit`. The CodeRabbit pass is paused, so this opened without a local pass.
- The modal mount move and the peek guard were added after a review of an earlier draft found the stale-peek and unmounted-modal cases. The narrow-window squeeze of the tab strip on Windows at the 800px minimum is known and left for a follow-up.
- `useUpdateBannerVisible` reads three stores to derive one boolean. That follows `useRailSurface`, which derives its values from the channels layout flag and the route in the same way.
