### PR TITLE
feat(signals): stamp uses_self_driving organization group property

### DIFF
--- a/products/signals/backend/receivers.py
+++ b/products/signals/backend/receivers.py
@@ -8,6 +8,7 @@ import json
 from datetime import datetime, timedelta
 from typing import Any
 
+from django.core.cache import cache
 from django.db import transaction
 from django.db.models import QuerySet
 from django.db.models.signals import post_delete, post_save, pre_save
@@ -18,6 +19,7 @@ import structlog
 import posthoganalytics
 
 from posthog.event_usage import groups
+from posthog.models import Team
 
 from products.signals.backend.implementation_pr import PrCloseReason
 from products.signals.backend.models import SignalReport, SignalReportArtefact
@@ -643,6 +645,53 @@ _SNAPSHOT_ARTEFACT_FIELDS = [
     (SignalReportArtefact.ArtefactType.DISMISSAL, "reason", "dismissal_reason"),
     (SignalReportArtefact.ArtefactType.DISMISSAL, "corrected_repository", "dismissal_corrected_repository"),
 ]
+
+
+# One `uses_self_driving` stamp per team per day is enough, because the property is a durable
+# marker. The throttle keeps busy report pipelines from queueing a group_identify on every save.
+_USES_SELF_DRIVING_STAMP_TTL_SECONDS = 24 * 60 * 60
+
+
+@receiver(post_save, sender=SignalReport)
+def stamp_organization_uses_self_driving(
+    sender: type[SignalReport],
+    instance: SignalReport,
+    created: bool,
+    **kwargs: Any,
+) -> None:
+    """Set `uses_self_driving: true` on the internal `organization` group once a team has a
+    user-visible report (`first_visible_at` is set, so the inbox lists it).
+
+    Internal feature flags target this group property to opt every self-driving organization
+    into a rollout (e.g. `phai-sandbox-mode`, which the inbox's report-to-AI-sidebar flow
+    requires) instead of a manual per-organization condition on each flag.
+    """
+    if instance.first_visible_at is None:
+        return
+    team_id = instance.team_id
+
+    def _stamp() -> None:
+        try:
+            if not cache.add(
+                f"signals_uses_self_driving_stamped/{team_id}",
+                True,
+                _USES_SELF_DRIVING_STAMP_TTL_SECONDS,
+            ):
+                return
+            organization_id = Team.objects.filter(id=team_id).values_list("organization_id", flat=True).first()
+            if organization_id is None:
+                return
+            posthoganalytics.group_identify(
+                "organization",
+                str(organization_id),
+                properties={"uses_self_driving": True},
+            )
+        except Exception:
+            # Analytics must never break the save that triggered it.
+            logger.exception("Failed to stamp uses_self_driving group property", team_id=team_id)
+
+    # After commit, so a rolled-back save never marks the organization.
+    transaction.on_commit(_stamp)
 
 
 def _is_dismissal_transition(previous_status: str, new_status: str) -> bool:

--- a/products/signals/backend/test/test_uses_self_driving_group_property.py
+++ b/products/signals/backend/test/test_uses_self_driving_group_property.py
@@ -1,0 +1,41 @@
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from django.core.cache import cache
+
+from products.signals.backend.models import SignalReport
+
+
+class TestStampOrganizationUsesSelfDriving(BaseTest):
+    def setUp(self):
+        super().setUp()
+        cache.delete(f"signals_uses_self_driving_stamped/{self.team.id}")
+
+    def test_stamps_once_when_a_report_first_becomes_visible(self):
+        with patch("products.signals.backend.receivers.posthoganalytics.group_identify") as mock_group_identify:
+            with self.captureOnCommitCallbacks(execute=True):
+                report = SignalReport.objects.create(
+                    team=self.team,
+                    status=SignalReport.Status.POTENTIAL,
+                    title="Test report",
+                    summary="Test summary",
+                )
+                report.save(update_fields=report.transition_to(SignalReport.Status.CANDIDATE))
+                report.save(
+                    update_fields=report.transition_to(SignalReport.Status.IN_PROGRESS, signals_at_run_increment=3)
+                )
+            assert mock_group_identify.call_count == 0
+
+            with self.captureOnCommitCallbacks(execute=True):
+                report.save(
+                    update_fields=report.transition_to(
+                        SignalReport.Status.READY, title="Test report", summary="Test summary"
+                    )
+                )
+            assert mock_group_identify.call_count == 1
+            assert mock_group_identify.call_args.args == ("organization", str(self.team.organization_id))
+            assert mock_group_identify.call_args.kwargs["properties"] == {"uses_self_driving": True}
+
+            with self.captureOnCommitCallbacks(execute=True):
+                report.save(update_fields=report.transition_to(SignalReport.Status.RESOLVED))
+            assert mock_group_identify.call_count == 1


### PR DESCRIPTION
## Problem

- A self-driving customer who clicks Implement or Ask AI on an inbox report gets the AI sidebar experience ([#98565](https://github.com/PostHog/posthog/pull/98565)) only when the `phai-sandbox-mode` flag is on for them.
- The flag enrolls customer organizations through a manual id list, so each new self-driving organization waits for a flag edit.

## Changes

- A new `SignalReport` post_save receiver sets `uses_self_driving: true` on the internal `organization` group when a team's report first becomes user-visible (`first_visible_at`).
- One release condition on that group property then enrolls every self-driving organization in `phai-sandbox-mode` automatically. That condition is a flag-side follow-up in the internal project, not part of this diff.
- A cache throttle limits the stamp to one write per team per day.
- The stamp runs after commit and never raises, following `capture_status_change_analytics` in the same file.
- An alternative, an OR of "team uses self-driving" inside `has_sandbox_mode_feature_flag`, was rejected: `ee` must not import `products.signals`, and the flag has many independent frontend consumers.
- Nothing user-visible changes in this PR by itself.

## How did you test this code?

- `test_uses_self_driving_group_property.py` guards the regression where flag targeting silently stops enrolling new organizations: no stamp before a report is visible, one stamp with the right group key and property on first visibility, no second stamp inside the throttle window. No existing test exercises this receiver.
- The new test, `test_status_change_telemetry.py`, and `test_daily_limit.py` pass in the cloud sandbox. Not run: the wider backend suite, which CI covers.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude in a PostHog Desktop cloud task; the PostHog MCP inspected the flag's current release conditions.
- Skills read: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- Duplicate search for "phai-sandbox-mode" and "uses_self_driving" found no open PR with this change.
- CodeRabbit local pass is paused, so the PR opened without one.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
