### PR TITLE
fix(mcp): include CSP _meta on UI app entries in resources/list

### DIFF
--- a/services/mcp/src/hono/resource-catalog.ts
+++ b/services/mcp/src/hono/resource-catalog.ts
@@ -185,6 +185,7 @@ export class ResourceCatalog {
                 uri: app.uri,
                 mimeType: RESOURCE_MIME_TYPE,
                 description: app.description,
+                _meta: meta,
             })
             this.uiAppReadEntries.set(app.uri, {
                 uri: app.uri,

--- a/services/mcp/tests/hono/resource-catalog.test.ts
+++ b/services/mcp/tests/hono/resource-catalog.test.ts
@@ -143,6 +143,22 @@ describe('ResourceCatalog', () => {
             expect(mockManifestEntriesSet).toHaveBeenCalledWith(2)
         })
 
+        it('lists UI app resources with the same CSP _meta the read entry carries', async () => {
+            vi.mocked(fetchAndExtractEntries).mockResolvedValue([])
+            vi.mocked(getPromptsFromManifest).mockResolvedValue([])
+
+            const catalog = new ResourceCatalog(mockEnv, redis)
+            await catalog.warmup()
+
+            const uri = 'ui://posthog/query-results.html'
+            const listed = catalog.getResourcesList().resources.find((r) => r.uri === uri)
+            const read = await catalog.readResource({ uri })
+
+            const readMeta = read.contents[0]?._meta as { 'openai/widgetCSP': { resource_domains: string[] } }
+            expect(listed?._meta).toEqual(readMeta)
+            expect(readMeta['openai/widgetCSP'].resource_domains).toEqual(['https://apps.test'])
+        })
+
         it('pre-merges resource list so getResourcesList returns a stable array', async () => {
             vi.mocked(fetchAndExtractEntries).mockResolvedValue([makeEntry('a')])
             vi.mocked(getPromptsFromManifest).mockResolvedValue([])


### PR DESCRIPTION
## Problem

- PostHog widgets render blank in ChatGPT: the iframe CSP only allows the connector origin, so the widget's JS and CSS on `mcp.us.posthog.com` are blocked.
- The MCP server declares the CSP (`ui.csp` and `openai/widgetCSP`) only on the `resources/read` entry. The `resources/list` entry for the same UI app carries no `_meta`.
- Whether ChatGPT builds the CSP from the list entry is unconfirmed. Claude reads it from `resources/read` and renders correctly.

## Changes

- `resources/list` entries for UI apps now carry the same `_meta` as the `resources/read` entry. Any host that reads CSP from the list now sees the declared domains.
- No change for hosts that read CSP from `resources/read`. Nothing is removed.

## How did you test this code?

- Added a case to the `ResourceCatalog` listing tests asserting the list entry's `_meta` equals the read entry's and carries the configured resource domain. Without the fix it fails on `_meta` being undefined. No existing test covered list-entry metadata on the Hono path.
- Not run: ChatGPT itself. Published plugins cannot be tested from a dev-mode connector, so the effect on ChatGPT is only observable after deploy.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5.1) in a terminal session. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`. No open PR fixes this (searched `gh pr list --state open --search "mcp resources list _meta csp widget"`). Opened without a CodeRabbit local pass. Origin context: bug report to OpenAI in the shared Slack channel; nothing from that thread is quoted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
