### PR TITLE
fix(warehouse-sources): stop retrying TiDB Cloud access-denied errors

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -209,6 +209,19 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             # source — so the user fixes credentials instead of the generic "check connection
             # details" message sending them to check the host/port.
             "Access denied for user": _INVALID_CREDENTIALS_ERROR,
+            # TiDB Cloud's own ER_ACCESS_DENIED_ERROR (also 1105) wording, distinct from the
+            # standard MySQL "Access denied for user" text above: it points the user at TiDB
+            # Cloud's docs on the cluster-tier username prefix a Serverless cluster requires
+            # (e.g. `<prefix>.root`). Same root cause — wrong credentials, or a username missing
+            # that prefix — so it's non-retryable for the same reason, but needs its own key since
+            # neither existing "Access denied" phrase appears in it. Match the stable sentence,
+            # excluding TiDB's own docs URL that follows it.
+            "Access denied. Please check your user name and password": (
+                "TiDB Cloud rejected the username or password. If you're connecting to a TiDB "
+                "Cloud Serverless cluster, make sure your username includes the required cluster "
+                "prefix (see TiDB Cloud's connection docs). Otherwise check the user and password "
+                "for this source and try again."
+            ),
             # MySQL/MariaDB error 1049 (ER_BAD_DB_ERROR): the configured database doesn't exist on
             # the server — it was renamed or dropped after the source was set up, or the connection
             # was reconfigured to point at a different server. `validate_credentials` already

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -1982,6 +1982,22 @@ class TestMySQLSourceNonRetryableErrors:
         assert friendly is not None, f"Connect failure should surface a friendly message: {error_msg}"
         assert "SSH tunnel" in friendly
 
+    def test_tidb_cloud_access_denied_surfaces_actionable_message(self, source):
+        # TiDB Cloud's ER_ACCESS_DENIED_ERROR wording doesn't contain the standard MySQL
+        # "Access denied for user" phrase, so without its own entry this credentials failure
+        # would retry forever instead of surfacing the cluster-tier username prefix guidance.
+        error_msg = (
+            "(1105, 'Access denied. Please check your user name and password. See "
+            "https://docs.pingcap.com/tidbcloud/select-cluster-tier#user-name-prefix')"
+        )
+        non_retryable = source.get_non_retryable_errors()
+        friendly = next(
+            (message for pattern, message in non_retryable.items() if pattern in error_msg),
+            None,
+        )
+        assert friendly is not None, f"TiDB Cloud access-denied error should be non-retryable: {error_msg}"
+        assert "TiDB Cloud" in friendly
+
     @pytest.mark.parametrize(
         "error_msg",
         [


### PR DESCRIPTION
## Problem

A MySQL source connecting to TiDB Cloud with the wrong username or password keeps retrying instead of stopping and telling the customer to check their credentials.

TiDB Cloud's access-denied error (MySQL error 1105) uses its own wording:

```
(1105, 'Access denied. Please check your user name and password. See https://docs.pingcap.com/tidbcloud/select-cluster-tier#user-name-prefix')
```

That text doesn't contain the standard MySQL `"Access denied for user"` phrase the source already treats as non-retryable, so this credentials failure fell through and kept retrying, surfacing as [error tracking noise](https://us.posthog.com/project/2/error_tracking/01a08e08-596b-7af2-9d80-a473de24c8fd).

## Changes

- `MySQLSource.get_non_retryable_errors` gets a new entry matching TiDB Cloud's stable access-denied sentence, pointing the customer at TiDB Cloud's cluster-tier username-prefix requirement instead of retrying forever.

## How did you test this code?

Added `test_tidb_cloud_access_denied_surfaces_actionable_message`, extending `TestMySQLSourceNonRetryableErrors` next to the existing connect-failure case. It asserts the TiDB Cloud message is classified non-retryable and its friendly message mentions TiDB Cloud, guarding against this credentials error silently retrying again.

Ran locally: `pytest products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py` (303 passed) and `ruff check` on the two changed files (clean).

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triggered by an error tracking webhook for the linked issue; no human directed this specific change.
- Tools: Claude Code, using the PostHog MCP error-tracking tools to confirm the stack trace and a sample event.
- Skills invoked: `/triaging-error-issues`, `/investigating-error-issue`, `/writing-tests`, `/writing-pr-descriptions`.
- Searched open PRs (by keyword and by the automation's own `posthog/` branches) for a duplicate fix; found none for this error.
- No customer data, tickets, or internal threads were used — the change is derived entirely from the public error message text and the existing `get_non_retryable_errors` pattern in this file.