### PR TITLE
fix(warehouse-sources): recognize MariaDB's host-not-allowed wording as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -306,8 +306,11 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             # PostHog's connecting host, so the handshake is rejected before any credentials are
             # checked. Only a DB admin can fix this server-side (GRANT for the host, or allow our
             # egress / SSH-tunnel host) — retrying connects from the same host fails identically.
-            # Match the stable tail phrase, not the volatile host in the message prefix.
-            "is not allowed to connect to this MySQL server": "Your MySQL/MariaDB server isn't allowing connections from PostHog's host (error 1130). Ask your database admin to grant access for the connecting host (or allow our IP / SSH-tunnel host), then retry the sync.",
+            # Match the stable tail phrase, not the volatile host in the message prefix, and not the
+            # vendor name that follows it: MariaDB renders this same error as "...this MariaDB
+            # server", not "...this MySQL server", so anchoring on the vendor name missed every
+            # MariaDB server.
+            "is not allowed to connect to this": "Your MySQL/MariaDB server isn't allowing connections from PostHog's host (error 1130). Ask your database admin to grant access for the connecting host (or allow our IP / SSH-tunnel host), then retry the sync.",
             # MySQL/MariaDB error 1226 (ER_USER_LIMIT_REACHED): the connecting user account has a
             # `MAX_CONNECTIONS_PER_HOUR` resource limit set (via `CREATE USER`/`GRANT ... WITH
             # MAX_CONNECTIONS_PER_HOUR`), and this hour's quota is used up. The counter only resets

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -2154,6 +2154,13 @@ class TestMySQLSourceNonRetryableErrors:
             ),
             # Temporal-wrapped str(e.cause) form — different host, same stable phrase.
             "OperationalError: (1130, \"Host '10.0.1.5' is not allowed to connect to this MySQL server\")",
+            # MariaDB renders the same error naming itself, not "MySQL server".
+            str(
+                pymysql.err.OperationalError(
+                    1130,
+                    "Host 'ec2-203-0-113-42.compute-1.amazonaws.com' is not allowed to connect to this MariaDB server",
+                )
+            ),
         ],
     )
     def test_host_not_privileged_is_non_retryable(self, source, error_msg):


### PR DESCRIPTION
## Problem

A MariaDB source rejected with error 1130 (host not allowed to connect) keeps retrying and reopening an [error tracking issue](https://us.posthog.com/project/2/error_tracking/01a08e13-7048-78b2-955c-1816215fb9f7), instead of failing once with actionable guidance.

`MySQLSource.get_non_retryable_errors` matched only the phrase "...is not allowed to connect to this MySQL server". MariaDB renders the identical error naming itself instead: "...this MariaDB server". The classifier never recognized that wording, even though this source explicitly supports MariaDB.

## Changes

- Broadened the 1130 match to "is not allowed to connect to this", the vendor-agnostic phrase shared by both the MySQL and MariaDB wordings.
- Added a MariaDB-worded case to the existing non-retryable parametrized test.

## How did you test this code?

Extended `test_host_not_privileged_is_non_retryable` in `test_mysql.py` with a MariaDB-worded case, guarding the exact gap this PR closes.

<details>
<summary>Local run</summary>

```
uv run pytest products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py -q
303 passed
uv run ruff check ... && uv run ruff format --check ...
All checks passed / already formatted
```

</details>

Not run: no live MariaDB server, no sync executed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Written by Claude Code while triaging an error tracking issue on PostHog's own project.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- Duplicate search: checked open PRs by exception type, "MariaDB", "is not allowed to connect", and the module path, plus every currently-open PR from this maintainer. None address this pattern gap.
- Public artifact: the work drew on an error tracking issue on PostHog's own project. The host in the new test case is invented (RFC 5737 TEST-NET-3), not the real one from the report.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*