### PR TITLE
fix(data-warehouse): say no source exists yet on the credential handoff screen

### DIFF
--- a/products/data_warehouse/frontend/scenes/SourceConnectScene/SourceConnectScene.tsx
+++ b/products/data_warehouse/frontend/scenes/SourceConnectScene/SourceConnectScene.tsx
@@ -57,10 +57,11 @@ export function SourceConnectScene(): JSX.Element {
             <div className="max-w-200">
                 {storedCredential ? (
                     <LemonBanner type="success">
-                        <p className="font-semibold mb-1">{sourceLabel} credentials saved — you can close this tab.</p>
+                        <p className="font-semibold mb-1">{sourceLabel} credentials saved. You can close this tab.</p>
                         <p className="m-0 text-sm">
-                            Return to your chat and let the assistant know you're done; it will finish setting up the
-                            source. Credential id: <code>{storedCredential.credential_id}</code>.
+                            The source doesn't exist yet, so it won't show in your sources list. Return to your chat and
+                            let the assistant know you're done, and it will finish the setup. Credential id:{' '}
+                            <code>{storedCredential.credential_id}</code>.
                         </p>
                     </LemonBanner>
                 ) : (


### PR DESCRIPTION
## Problem

Someone who saves credentials on the assistant handoff screen goes looking for the source in Data management, does not find it, and starts the connection over. Session recordings of the new-source flow show this: a long wait after the success banner, then a hunt through the managed sources list, then a return to the connector.

- The banner reads "credentials saved, you can close this tab" and says the assistant will finish setting up the source.
- That reads as "setup is running in the background", so people expect the source to appear.
- Saving credentials only stores them. No source row exists until the assistant creates one.

## Changes

- The banner now says the source does not exist yet and will not show in the sources list, before it says what to do next.
- The headline drops the em dash for a full stop, per the copy rules in CLAUDE.md.
- The credential id stays where it was.

Copy only, in one JSX block. No logic changed.

|         | Body text |
| ------- | --------- |
| Before  | Return to your chat and let the assistant know you're done; it will finish setting up the source. |
| After   | The source doesn't exist yet, so it won't show in your sources list. Return to your chat and let the assistant know you're done, and it will finish the setup. |

## How did you test this code?

- Ran oxfmt and oxlint over the changed file. Both clean.
- No test added: the change is static banner copy, and a test asserting the string catches no regression a reader would not.
- Not run: the app itself. This sandbox has no running stack, so the rendered banner went unverified. The block is a two-paragraph `LemonBanner` and the diff does not touch layout.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude Opus 5 in a PostHog Desktop cloud task, from a Replay Vision scan of real new-source onboarding sessions.

- No duplicate: searched open PRs for the scene, the banner wording, and the credential handoff. Nothing open touches this copy.
- Public artifact: nothing from the session material reached the code, the commit message, or this description. The observed friction is described generically.
- Skills invoked: `/writing-pr-descriptions`.
- CodeRabbit CLI pass: paused, so this PR opened without a local pass.
