### PR TITLE
chore(signals): make scout guidance use lazy references

### DIFF
--- a/products/signals/skills/authoring-scouts/SKILL.md
+++ b/products/signals/skills/authoring-scouts/SKILL.md
@@ -85,14 +85,17 @@ It also makes the key point that **a scout can watch any source PostHog ingests 
 And where a built-in signals source already covers the surface (GitHub and Linear issues), the issue-tracker pattern says where that source stops and a scout starts paying for itself.
 Find the closest pattern, then write the body.
 
-Follow [`references/scout-anatomy.md`](references/scout-anatomy.md) — it has the frontmatter schema (including the `allowed_tools` report-channel opt-in every scout needs), the canonical body structure (quick close-out → orient → domain discriminator → explore patterns → save-memory → decide → disqualifiers → close-out), the lean-body rule, and copy-ready skeleton templates for both a specialist and the generalist.
+Follow [`references/scout-anatomy.md`](references/scout-anatomy.md) — it has the frontmatter schema, the `allowed_tools` report-channel opt-in, and a copy-ready lean core/router skeleton.
+Keep the discriminator, safe stop gates, route conditions, pre-route invariants, and universal task rules in `SKILL.md`.
+Move lane-specific queries, thresholds, classification, disqualifiers, candidate handling, and memory formats into self-contained lazy references.
+Do not copy generic harness behavior for prior runs, notes, scratchpad use, report authoring, reviewer routing, tool discovery, or close-out into the scout.
 
-Two craft references the whole fleet reasons in terms of — a good scout's **Decide** and **memory** sections are built on them, so read them before writing those sections:
+Two craft references define the fleet-wide behavior. Read them before writing task-specific decision or memory rules:
 
 - [`references/report-contract.md`](references/report-contract.md) — the report tools (`scout-emit-report` / `scout-edit-report`), the report bar (author 1:1 only for a finding you'd own end-to-end), `suggested_reviewers` routing, the dedup-via-`report_id` discipline (the channel isn't idempotent — reconcile against existing reports via the vanilla `inbox-reports-list` / `inbox-reports-retrieve` before authoring), and the accepted caveat that the pipeline may later rewrite an authored title/summary.
-  This is how your scout decides _what clears the bar_ and _how to file it_.
+  Use it to define the task-specific evidence that clears the bar without copying the generic filing procedure into the scout.
 - [`references/dedupe-and-memory.md`](references/dedupe-and-memory.md) — the four-states classifier (net-new / material-update / already-covered / addressed-or-noise), the scratchpad key-prefix vocabulary, and the cross-project noise patterns.
-  This is how your scout avoids re-filing and learns across runs.
+  Use it to define only the task-specific keys or state a route must preserve.
 
 The single most important design decision in any scout is its **signal-vs-noise discriminator** — the cheap profile-shape read that separates "worth investigating" from "baseline".
 For error tracking it's the `count` vs `distinct_users` ratio; for CSP it's reach over raw count.
@@ -237,10 +240,10 @@ Keep the two in sync when the scout config / run / scratchpad surfaces change.
 
 - A named, cheap **signal-vs-noise discriminator** anchored near the top (on a measurement scout, the rubric and sampling recipe take this slot).
 - A **quick close-out** so a quiet run is cheap (don't pay for deep exploration when the watched surface is at baseline or absent) — except on a measurement scout, which exits early only when the window held no eligible items, since its ordinary judgments are the denominator.
-- 2–4 concrete **explore patterns** with the actual queries/tools to run — starting points, not a rigid checklist.
-- **Disqualifiers** listing this project's known noise (single-user quirks, dev-env bursts, allowlisted entities).
-- A **Decide** section calibrated against the report contract — author 1:1 only for a finding the scout would own end-to-end, set `suggested_reviewers`, and write memory instead when a candidate is below the bar.
-- **Save-memory** guidance using the scratchpad prefixes so the scout gets smarter each run.
-- A lean body (push depth into `references/`) — every line is a recurring token cost on every run.
+- Clear **route conditions** that name the exact reference file for each investigation lane.
+- Only the **pre-route invariants** and task rules that every lane needs.
+- Self-contained route references with concrete queries, thresholds, disqualifiers, task-specific Decide rules, and task-specific memory formats.
+- A lean body that does not repeat generic harness instructions — every line is a recurring token cost on every run.
+- Route fixtures and golden-behavior cases that pass before rollout; see [`references/lifecycle-and-testing.md`](references/lifecycle-and-testing.md).
 - A **tight frontmatter `description`** — a sentence or two naming the surface and the shapes it watches.
   Every scout's description loads into the caller's AI plugin together, so wordy descriptions waste token budget and get truncated; skip the fleet-wide boilerplate (report bar, durable memory, self-contained peer).

--- a/products/signals/skills/authoring-scouts/references/lifecycle-and-testing.md
+++ b/products/signals/skills/authoring-scouts/references/lifecycle-and-testing.md
@@ -86,6 +86,15 @@ Authoring a new canonical scout is just creating `signals-scout-<scope>/SKILL.md
 
 ## Testing
 
+Before using live project data or spending a scout run, validate the skill package locally:
+
+1. **Measure context.** Record tokens for the startup core, one representative route, one candidate-heavy route, and the full package. The routed counts include the core plus only the references that route loads.
+2. **Test routing deterministically.** Create fixtures for the common input shapes. For each fixture, assert the exact reference files that should load and whether the scout should stop. Include rejected-candidate and all-clear paths when they write task-specific memory.
+3. **Freeze golden behavior before editing.** Write cases for the important decisions, evidence requirements, safety rules, and required outputs. Derive these cases from the current skill before optimizing it.
+4. **Compare behavior.** Run the optimized route against the golden rubric. An LLM judge may score the result, but the deterministic route checks and explicit safety assertions remain authoritative.
+
+Do not ask an open-ended judge to compare the complete old and new skill bodies. Large prompt differences can produce false regressions, while a judge can still miss one exact rule. Judge the behavior produced for a defined case instead.
+
 **Dogfood the scout yourself first — before spending any real run.** The authoring agent has the same PostHog MCP tools a scout uses at runtime (`execute-sql`, `read-data-schema`, the per-product list tools, `scout-project-profile-get`), so the cheapest iteration is to walk the scout's own logic against the live project by hand: confirm the watched entity exists and has the assumed shape, run the **discriminator** to check it separates signal from noise on this project's data, and run each **explore pattern**'s queries.
 Free and instant — refine the body, re-run the queries, repeat, until the logic holds on real data.
 

--- a/products/signals/skills/authoring-scouts/references/scout-anatomy.md
+++ b/products/signals/skills/authoring-scouts/references/scout-anatomy.md
@@ -7,7 +7,7 @@ Keep the body lean and push depth into references — every line of the body is 
 
 - Naming
 - Frontmatter
-- Body structure (the ten canonical sections)
+- Body structure (lean core and task routes)
 - References
 - Skeleton — specialist scout
 - Skeleton — broad / cross-product scout
@@ -58,67 +58,47 @@ A sentence or two that names the surface and the shapes is the whole job.
 
 ## Body structure
 
-The canonical body is a workflow, not a script — it reads like how an experienced analyst would approach the surface, and trusts the agent to adapt.
-(One variant departs from it: a **recurring measurement / LLM-judge scout** on the structured-output channel replaces the discriminator + Decide sections with a rubric and a sample → judge → record loop — see that pattern in [`scout-patterns.md`](scout-patterns.md); orient and memory stay the same, and so does close-out — except its quick early-exit fires only on an empty eligible population, never at a steady baseline, since the scout samples and records every verdict (the unremarkable ones are the denominator) on any run with items to judge.)
-The fleet's specialists all share this shape:
+Treat `SKILL.md` as a lean core and route selector. It loads on every run. A reference loads only when its route needs it.
 
-1. **Identity + discriminator (the most important lines).** One sentence on what the scout is, then **name the signal-vs-noise discriminator explicitly** and tell the agent to internalize it.
-   This is the cheap profile-shape read that separates "worth a look" from "baseline".
-   Examples: `count` vs `distinct_users` ratio (error tracking); reach over raw count (CSP); negative+mixed share vs baseline (MCP feedback).
-   Without this, the scout wastes every run re-deciding what "normal" means.
+Keep these items in the core:
 
-2. **Quick close-out.** A cheap early-exit so a quiet run costs almost nothing: if the watched event is absent from the profile's `top_events` or sitting at baseline (no fresh 24h activity), write one scratchpad entry and stop.
-   This keeps idle scouts cheap.
-   `top_events` counts are windowed (each row carries `window_days`), not lifetime — a project whose ingestion recently went dark reads identically to one that never had traffic. Before closing out a busy-looking project as empty on `top_events` thinness alone, rule out a capture gap with a direct `execute-sql` over a longer window (e.g. 30d); only close out when the low volume holds there.
+1. **Identity and discriminator.** State the scout's task and name the cheap signal-vs-noise discriminator. Examples include `count` against `distinct_users`, reach over raw count, or negative share against baseline.
+2. **Stop gates.** Define the cheapest safe conditions for ending a quiet run. Include any pre-route check needed to avoid a false empty result, such as checking a longer window when `top_events` is thin.
+3. **Route conditions.** Define the small set of investigation lanes and name the exact reference file to read for each lane. Make the routes mutually clear. State when several routes may run.
+4. **Pre-route invariants.** Keep only the task-specific facts that every route needs before selection, such as source availability, ownership, or one shared discriminator query.
+5. **Universal task rules.** Keep a rule in the core only when it is specific to this scout and applies to every route.
 
-   ```text
-   key:     not-in-use:<scope>:team{team_id}     # if the surface is absent entirely
-        or  pattern:<scope>:baseline-team{team_id} # if it fires at a steady baseline
-   content: "<surface> baseline ~{count}/day, no fresh 24h burst at {timestamp}"
-   ```
+Put task depth in lazy references:
 
-3. **Orient.** Three cheap reads cold-start every run — bake them into the body:
-   - `scout-scratchpad-search` (`text=<scope keyword>`) — durable steering from past runs; the `pattern:` / `noise:` / `addressed:` / `dedupe:` entries tell the scout what's normal and what's already covered.
-   - `scout-runs-list` (last 7d) — what prior runs of this scout found and ruled out.
-     Pull `-runs-retrieve` only for a summary worth drilling into.
-     The fleet-wide read (siblings' runs, and following an interesting summary into the report it produced) is already in the harness prompt for every scout, so don't restate it in your body.
-   - `scout-project-profile-get` — the deterministic snapshot; read the discriminator metrics off the relevant `top_events` row.
+- Lane-specific SQL, tool sequences, thresholds, and classification logic.
+- Candidate-only reporting criteria and disqualifiers.
+- Task-specific memory keys and content formats.
+- Detailed examples, taxonomies, and edge cases.
 
-4. **Profile shape / discriminator table.** A small table mapping the discriminator's shapes to what they usually mean, so the agent triages fast.
-   (See the error-tracking scout's `count`-vs-`distinct_users` table for the canonical example.)
+A recurring measurement / LLM-judge scout uses the same structure. Its core contains the population gate and route selection. Its task reference contains the rubric, sampling rules, and record shape. It stops early only when there are no eligible items because ordinary judgments form the denominator.
 
-5. **Explore patterns.** 2–4 named investigation patterns — **starting points, not a checklist**.
-   Each names the concrete tools/queries to run and the shape that confirms it.
-   E.g.
-   "Burst with broad reach" → list active issues, SQL hourly breakdown, look for the one-occurrence-per-distinct-user shape.
-   Give the agent real queries, not generic advice.
+Do not copy behavior that the scout harness already supplies. In particular, do not restate:
 
-6. **Save memory as you go.** Tell the scout to write scratchpad entries continuously, encoding the category in the key prefix (see [`dedupe-and-memory.md`](dedupe-and-memory.md)).
-   Give 2–3 worked example entries scoped to this surface so the agent matches the format.
+- Generic prior-run, sibling-run, notes, or scratchpad lookup.
+- Generic scratchpad prefixes or save-as-you-go instructions.
+- The generic report author/edit contract or reviewer routing.
+- The generic tool catalog.
+- The generic run-summary or close-out contract.
 
-7. **Decide.** Author / edit / remember / skip, calibrated against the report contract (see [`report-contract.md`](report-contract.md)) and the four-states classifier (see [`dedupe-and-memory.md`](dedupe-and-memory.md)).
-   State the surface-specific "report-worthy" thresholds (e.g. "a broad-reach burst with concrete entity ids and counts in the evidence").
-   Tell it to cross-check `inbox-reports-list` before authoring — an existing report on the topic gets an `edit_report`, not a duplicate.
-
-8. **Disqualifiers.** The known noise for this surface that should be skipped (single-user quirks, dev-env bursts, allowlisted domains, known upstream provider errors).
-   "When in doubt, write memory instead of filing a report."
-
-9. **MCP tools.** List the direct (read-only) calls and the harness-level tools the scout uses, so the agent doesn't rediscover them each run.
-
-10. **Close out.** One paragraph: looked at what, filed/edited what, remembered what, ruled out what.
-    The harness saves this as the run summary; future runs read it via `scout-runs-list`.
-    Tell it **not** to write a separate "run metadata" scratchpad entry — the summary already serves that role.
-    "Looked but found nothing meaningful" is a real outcome.
-
-Not every scout needs all ten sections, but every scout needs 1 (discriminator), 2 (quick close-out), 3 (orient), 7 (decide), 8 (disqualifiers), and 10 (close out).
-Sections 4–6 and 9 are where a specialist earns its keep.
+Add only the task-specific part of those behaviors. For example, a route may define the exact memory key for a rejected warehouse candidate, or the evidence required before a GitHub item is report-worthy. Do not repeat how to call the generic memory or report tools.
 
 ## References
 
-The generalist carries `references/conventions.md` (the four-states author/edit classifier + scratchpad vocab); the report-channel contract itself rides in the harness prompt (injected into every report-channel scout), so a scout bundles no copy of it.
-For a **per-team** scout you usually don't need to bundle your own copies — the canonical scout already encodes the conventions inline, and your scout body can too.
-Bundle a reference only when you have genuinely surface-specific depth (a long SQL cookbook, a taxonomy of fingerprints) that would bloat the body.
-Attach bundled files to a per-team scout with `posthog:skill-file-create`; in the repo, drop them in `references/` and they're collected automatically.
+Use references for task-specific depth by default. This keeps startup context small and loads only the instructions needed for the selected lane. A small scout may need one task reference. A scout with distinct lanes should normally have one reference per lane.
+
+Every reference must be self-contained for the route that loads it:
+
+- Do not depend on text described as "above", "below", or "at the top of this file".
+- Do not link to a section that the route does not also load.
+- Repeat a small task-specific invariant when that is necessary to make the route safe in isolation.
+- Route every outcome that needs task-specific memory to the reference that defines that memory, including rejected candidates and all-clear digests.
+
+Do not bundle copies of fleet-wide conventions or the report-channel contract. Attach references to a per-team scout with `posthog:skill-file-create`; in the repo, place them in `references/` so the build collects them.
 
 ## Skeleton — specialist scout
 
@@ -142,75 +122,46 @@ metadata:
 
 # Signals scout: <surface>
 
-You are a focused <surface> scout. Spot meaningful changes in <event/metric> — <the
-shapes> — and file a report only when a finding clears the report bar.
+You are a focused <surface> scout. Watch <event/metric> for <meaningful shapes>.
 
-<Name the discriminator here.> The relationship between <X> and <Y> is the most important
-signal-vs-noise discriminator. Internalize that shape.
+The relationship between <X> and <Y> is the primary signal-vs-noise discriminator.
 
-## Quick close-out: is <surface> even loud?
+## Stop gates
 
-If <event> is absent from `top_events` or at baseline (no fresh 24h activity), <surface>
-isn't where the signal is today. Cheap scratchpad entry + close out empty.
+- If <safe empty condition>, stop.
+- If <ambiguous empty condition>, first check <longer-window or source-health invariant>.
 
-## How a run works
+## Route
 
-Cycle between these moves; skip what's not useful.
+After the stop gates and shared check, choose the matching lane:
 
-### Get oriented
+- **<Lane A>:** when <condition>, read `references/lane-a.md` and follow it.
+- **<Lane B>:** when <condition>, read `references/lane-b.md` and follow it.
+- **No matching lane:** stop.
 
-- `scout-scratchpad-search` (`text=<scope keyword>`) — durable steering.
-- `scout-runs-list` (last 7d) — what prior runs found and ruled out.
-- `scout-project-profile-get` — read the discriminator metrics off `top_events`.
+Run more than one lane only when <task-specific condition>.
 
-### Profile shape
+## Shared task invariant
 
-| Pattern   | What it usually means           |
-| --------- | ------------------------------- |
-| <shape A> | <meaning A — investigate first> |
-| <shape B> | <meaning B — usually noise>     |
+Before selecting a lane, <one check that every lane requires>.
+```
 
-### Explore
+Example `references/lane-a.md`:
 
-Patterns to watch — starting points, not a checklist.
+```markdown
+# <Lane A>
 
-#### <Pattern 1>
+Use <specific query or tool sequence>.
 
-<the concrete queries/tools and the confirming shape>
+## Classification
 
-#### <Pattern 2>
+- <shape and threshold> means <task-specific outcome>.
+- Reject <task-specific disqualifier>.
 
-<...>
+## Candidate handling
 
-### Save memory as you go
-
-Write a scratchpad entry whenever you observe something a future run should know. Encode the
-category in the key prefix — `pattern:`, `noise:`, `addressed:`, `dedupe:`.
-
-- key `pattern:<scope>:baseline` — "<normal shape for this project>"
-- key `dedupe:<scope>:<entity>` — "<surfaced when, with what condition for next run>"
-
-### Decide
-
-- **Author** a report via `scout-emit-report` above the bar (a well-formed
-  finding you'd own end-to-end, concrete entity ids + counts in evidence).
-  Cross-check `inbox-reports-list` first — an existing report on the topic gets a
-  `scout-edit-report` instead of a duplicate.
-- **Remember** if below the bar but worth carrying forward.
-- **Skip** if a `noise:` / `addressed:` / `dedupe:` entry already covers it.
-
-### Close out
-
-One paragraph: looked at what, filed/edited what, remembered what, ruled out what.
-
-## Disqualifiers (skip these)
-
-- <surface-specific noise: single-user, dev-env, allowlisted, known-upstream>
-
-## MCP tools
-
-Direct (read-only): <list>. Harness-level: project-profile-get, scratchpad-search,
-runs-list, runs-retrieve, emit-report, edit-report, scratchpad-remember.
+For a qualifying candidate, require <specific evidence>.
+For a rejected candidate, remember `<scope>:rejected:<entity>` with <task-specific fields>.
 ```
 
 ## Skeleton — broad / cross-product scout


### PR DESCRIPTION
## Problem

Scout authors can follow the current guide and repeat harness rules in every skill. This increases startup context and limits lazy loading.

## Changes

- Scout cores now keep only discriminators, stop gates, route conditions, shared invariants, and universal task rules.
- Self-contained references now hold task-specific queries, thresholds, disqualifiers, candidate handling, and memory formats.
- Local validation now covers token counts, deterministic routes, and golden behavior before rollout.
- This guidance change does not alter the scout runtime or existing scout skills.

## How did you test this code?

- `hogli lint:skills`
- `hogli ci:preflight --fix`
- Not completed: `hogli build:skills` requires a local database migration for `posthog_organization.is_hipaa`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The scout authoring guide is the documentation changed by this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used the authoring-scouts, writing-skills, and writing-pr-descriptions skills. Local repository tools validated and prepared the change.

No private source material appears in the committed files or PR description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*