### PR TITLE
fix(actions): validate action step regex patterns with re2

### DIFF
--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -1678,6 +1678,7 @@ def steps_to_expr(steps: list[ActionStepJSON], team: Team, events_alias: Optiona
                 exprs.append(tag_name_to_expr(step.tag_name))
             if step.href is not None:
                 if step.href_matching == "regex":
+                    _validate_regex(step.href)
                     exprs.append(
                         ast.CompareOperation(
                             op=ast.CompareOperationOp.Regex,
@@ -1704,6 +1705,7 @@ def steps_to_expr(steps: list[ActionStepJSON], team: Team, events_alias: Optiona
             if step.text is not None:
                 value = step.text
                 if step.text_matching == "regex":
+                    _validate_regex(value)
                     exprs.append(
                         parse_expr(
                             "arrayExists(x -> x =~ {value}, elements_chain_texts)",
@@ -1739,6 +1741,7 @@ def steps_to_expr(steps: list[ActionStepJSON], team: Team, events_alias: Optiona
                     right=ast.Constant(value=step.url),
                 )
             elif step.url_matching == "regex":
+                _validate_regex(step.url)
                 expr = ast.CompareOperation(
                     op=ast.CompareOperationOp.Regex,
                     left=ast.Field(

--- a/posthog/hogql/test/test_action_to_expr.py
+++ b/posthog/hogql/test/test_action_to_expr.py
@@ -2,11 +2,16 @@ from typing import Any, Optional
 
 from posthog.test.base import BaseTest, _create_event
 
+from django.test import SimpleTestCase
+
 from posthog.hogql import ast
+from posthog.hogql.errors import QueryError
 from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.property import action_to_expr, steps_to_expr
 from posthog.hogql.query import execute_hogql_query
 from posthog.hogql.visitor import clear_locations
+
+from posthog.models.team import Team
 
 from products.actions.backend.models.action import Action, ActionStepJSON
 
@@ -176,3 +181,30 @@ class TestActionToExpr(BaseTest):
             clear_locations(steps_to_expr([], self.team)),
             clear_locations(parse_expr("true")),
         )
+
+
+class TestStepsToExprRegexValidation(SimpleTestCase):
+    def setUp(self):
+        super().setUp()
+        self.team = Team(id=1)
+
+    def test_steps_to_expr_invalid_url_regex(self):
+        steps = [
+            ActionStepJSON(event="$pageview", url="/shardlibrary/\\d+/\\", url_matching="regex"),
+        ]
+        with self.assertRaisesMessage(QueryError, "Invalid regular expression: '/shardlibrary/\\d+/\\'"):
+            steps_to_expr(steps, self.team)
+
+    def test_steps_to_expr_invalid_href_regex(self):
+        steps = [
+            ActionStepJSON(event="$autocapture", href="^abc\\", href_matching="regex"),
+        ]
+        with self.assertRaisesMessage(QueryError, "Invalid regular expression: '^abc\\'"):
+            steps_to_expr(steps, self.team)
+
+    def test_steps_to_expr_invalid_text_regex(self):
+        steps = [
+            ActionStepJSON(event="$autocapture", text="^foo(?!bar).+", text_matching="regex"),
+        ]
+        with self.assertRaisesMessage(QueryError, "Invalid regular expression: '^foo(?!bar).+'"):
+            steps_to_expr(steps, self.team)

--- a/products/actions/backend/api/action.py
+++ b/products/actions/backend/api/action.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 from django.db import connection
 from django.db.models import Count
 
+import re2
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, PolymorphicProxySerializer, extend_schema, extend_schema_field
 from rest_framework import request, serializers, viewsets
@@ -137,6 +138,34 @@ class ActionStepJSONSerializer(serializers.Serializer):
             return build_selector_regex(selector)
         except Exception:
             return None
+
+    def validate(self, attrs: dict) -> dict:
+        attrs = super().validate(attrs)
+        errors: dict[str, str] = {}
+
+        regex_fields = [
+            ("url", "url_matching"),
+            ("href", "href_matching"),
+            ("text", "text_matching"),
+        ]
+        for field_name, matching_field in regex_fields:
+            matching_mode = attrs.get(matching_field)
+            if matching_mode is None and self.instance:
+                matching_mode = getattr(self.instance, matching_field, None)
+            field_val = attrs.get(field_name)
+            if field_val is None and self.instance:
+                field_val = getattr(self.instance, field_name, None)
+
+            if matching_mode == "regex" and isinstance(field_val, str):
+                try:
+                    re2.compile(field_val)
+                except re2.error:
+                    errors[field_name] = f"Invalid regular expression: '{field_val}'"
+
+        if errors:
+            raise serializers.ValidationError(errors)
+
+        return attrs
 
 
 class ActionSerializer(

--- a/products/actions/backend/api/test/test_action.py
+++ b/products/actions/backend/api/test/test_action.py
@@ -10,11 +10,14 @@ from posthog.test.base import (
 )
 from unittest.mock import ANY, patch
 
+from django.test import SimpleTestCase
+
 from parameterized import parameterized
 from rest_framework import status
 
 from posthog.models import Tag, User
 
+from products.actions.backend.api.action import ActionStepJSONSerializer
 from products.actions.backend.models.action import Action
 from products.cdp.backend.models.hog_functions.hog_function import HogFunction
 from products.cohorts.backend.models.cohort import Cohort
@@ -98,6 +101,92 @@ class TestActionApi(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             team=ANY,
             request=ANY,
         )
+
+    def test_create_action_invalid_regex_url(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/actions/",
+            data={
+                "name": "bad regex url action",
+                "steps": [
+                    {
+                        "url": "/shardlibrary/\\d+/\\",
+                        "url_matching": "regex",
+                    }
+                ],
+            },
+            headers={"origin": "http://testserver"},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+        assert response.json()["type"] == "validation_error"
+        assert "Invalid regular expression" in str(response.json()["detail"])
+
+    def test_create_action_invalid_regex_href(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/actions/",
+            data={
+                "name": "bad regex href action",
+                "steps": [
+                    {
+                        "href": "(unclosed",
+                        "href_matching": "regex",
+                    }
+                ],
+            },
+            headers={"origin": "http://testserver"},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+        assert response.json()["type"] == "validation_error"
+        assert "Invalid regular expression" in str(response.json()["detail"])
+
+    def test_create_action_invalid_regex_text(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/actions/",
+            data={
+                "name": "bad regex text action",
+                "steps": [
+                    {
+                        "text": "^foo(?!bar).+",
+                        "text_matching": "regex",
+                    }
+                ],
+            },
+            headers={"origin": "http://testserver"},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+        assert response.json()["type"] == "validation_error"
+        assert "Invalid regular expression" in str(response.json()["detail"])
+
+    def test_create_action_valid_regex(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/actions/",
+            data={
+                "name": "valid regex action",
+                "steps": [
+                    {
+                        "url": r"https://example\.com/.*",
+                        "url_matching": "regex",
+                    }
+                ],
+            },
+            headers={"origin": "http://testserver"},
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+
+    def test_create_action_non_regex_with_backslash(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/actions/",
+            data={
+                "name": "contains with backslash",
+                "steps": [
+                    {
+                        "url": "/path/with/\\",
+                        "url_matching": "contains",
+                    }
+                ],
+            },
+            headers={"origin": "http://testserver"},
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
 
     def test_create_action_generates_bytecode(self):
         response = self.client.post(
@@ -902,3 +991,48 @@ class TestActionApi(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         results = response.json()["results"]
         action_result = next(r for r in results if r["id"] == action.id)
         assert action_result["reference_count"] == 4
+
+
+class TestActionStepJSONSerializer(SimpleTestCase):
+    def test_valid_regex(self):
+        serializer = ActionStepJSONSerializer(data={"url": r"https://example\.com/.*", "url_matching": "regex"})
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_invalid_url_regex(self):
+        serializer = ActionStepJSONSerializer(data={"url": "/shardlibrary/\\d+/\\", "url_matching": "regex"})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("url", serializer.errors)
+        self.assertIn("Invalid regular expression", str(serializer.errors["url"]))
+
+    def test_invalid_href_regex(self):
+        serializer = ActionStepJSONSerializer(data={"href": "(unclosed", "href_matching": "regex"})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("href", serializer.errors)
+        self.assertIn("Invalid regular expression", str(serializer.errors["href"]))
+
+    def test_invalid_text_regex(self):
+        serializer = ActionStepJSONSerializer(data={"text": "^foo(?!bar).+", "text_matching": "regex"})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("text", serializer.errors)
+        self.assertIn("Invalid regular expression", str(serializer.errors["text"]))
+
+    def test_contains_matching_does_not_validate_as_regex(self):
+        serializer = ActionStepJSONSerializer(data={"url": "/shardlibrary/\\d+/\\", "url_matching": "contains"})
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_exact_matching_does_not_validate_as_regex(self):
+        serializer = ActionStepJSONSerializer(data={"url": "/shardlibrary/\\d+/\\", "url_matching": "exact"})
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_multiple_invalid_fields(self):
+        serializer = ActionStepJSONSerializer(
+            data={
+                "url": "/shardlibrary/\\d+/\\",
+                "url_matching": "regex",
+                "text": "(unclosed",
+                "text_matching": "regex",
+            }
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("url", serializer.errors)
+        self.assertIn("text", serializer.errors)


### PR DESCRIPTION
## Problem

Users could save action steps with invalid regex patterns (such as trailing backslashes or unclosed brackets). When querying insights or HogQL referencing such actions, ClickHouse fails with `CANNOT_COMPILE_REGEXP`, resulting in a generic 500 error for users.

Closes #96347

## Changes

- Validates `url`, `href`, and `text` step values using `re2.compile` in `ActionStepJSONSerializer.validate()` whenever matching mode is set to `"regex"`. Returns a 400 validation error instead of saving invalid patterns.
- Validates regex steps in `posthog.hogql.property.steps_to_expr()` using `_validate_regex()`, raising a user-facing `QueryError` instead of letting ClickHouse fail with an internal 500 error for any pre-existing bad actions.
- Added comprehensive unit and API test coverage for valid/invalid regex patterns and non-regex matching with backslashes.

## How did you test this code?

- Automated unit tests:
  - `products/actions/backend/api/test/test_action.py::TestActionStepJSONSerializer` (7 tests covering invalid url/href/text regex, valid regex, contains/exact with backslash, and multiple errors).
  - `posthog/hogql/test/test_action_to_expr.py::TestStepsToExprRegexValidation` (3 tests verifying `QueryError` is raised for invalid url/href/text patterns in `steps_to_expr`).
- Ran:
  - `DEBUG=1 TEST=1 PYTHONPATH=. uv run pytest posthog/hogql/test/test_action_to_expr.py::TestStepsToExprRegexValidation products/actions/backend/api/test/test_action.py::TestActionStepJSONSerializer` -> 10 passed in 0.12s.
  - `./bin/hogli tool:ruff check` -> All checks passed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- **Tools/agent used:** Antigravity agent CLI.
- **Skills invoked:** `improving-drf-endpoints`, `hogli`.
- **Decisions made:** Evaluated regexes using `re2` (matching ClickHouse's internal regex engine) rather than standard library `re`, ensuring syntax compatibility with ClickHouse RE2 constraints. Added defense-in-depth validation both at input serializer level and query compilation level.
- **CodeRabbit CLI pass:** Paused for now, opening without local pass per repository instructions.
