### PR TITLE
revert(mcp): drop CSP _meta from UI app entries in resources/list

### DIFF
--- a/services/mcp/src/hono/resource-catalog.ts
+++ b/services/mcp/src/hono/resource-catalog.ts
@@ -185,7 +185,6 @@ export class ResourceCatalog {
                 uri: app.uri,
                 mimeType: RESOURCE_MIME_TYPE,
                 description: app.description,
-                _meta: meta,
             })
             this.uiAppReadEntries.set(app.uri, {
                 uri: app.uri,

--- a/services/mcp/tests/hono/resource-catalog.test.ts
+++ b/services/mcp/tests/hono/resource-catalog.test.ts
@@ -143,22 +143,6 @@ describe('ResourceCatalog', () => {
             expect(mockManifestEntriesSet).toHaveBeenCalledWith(2)
         })
 
-        it('lists UI app resources with the same CSP _meta the read entry carries', async () => {
-            vi.mocked(fetchAndExtractEntries).mockResolvedValue([])
-            vi.mocked(getPromptsFromManifest).mockResolvedValue([])
-
-            const catalog = new ResourceCatalog(mockEnv, redis)
-            await catalog.warmup()
-
-            const uri = 'ui://posthog/query-results.html'
-            const listed = catalog.getResourcesList().resources.find((r) => r.uri === uri)
-            const read = await catalog.readResource({ uri })
-
-            const readMeta = read.contents[0]?._meta as { 'openai/widgetCSP': { resource_domains: string[] } }
-            expect(listed?._meta).toEqual(readMeta)
-            expect(readMeta['openai/widgetCSP'].resource_domains).toEqual(['https://apps.test'])
-        })
-
         it('pre-merges resource list so getResourcesList returns a stable array', async () => {
             vi.mocked(fetchAndExtractEntries).mockResolvedValue([makeEntry('a')])
             vi.mocked(getPromptsFromManifest).mockResolvedValue([])


### PR DESCRIPTION
## Problem

- PostHog widgets still render blank in ChatGPT. The `_meta` block added to the `resources/list` entry in #98901 did not change how ChatGPT builds the widget CSP.
- The code is now dead weight: no host reads the CSP from the list entry, and Claude reads it from `resources/read`, which this PR does not touch.

## Changes

- Reverts #98901. The `resources/list` entry for a UI app carries no `_meta` again.
- Nothing changes for users. Widgets render in Claude as before, and stay broken in ChatGPT until the CSP problem is fixed on OpenAI's side.
- Removes the test that asserted the list entry `_meta` matched the read entry, because the behavior it covered is gone.

## How did you test this code?

- Not run: the `services/mcp` vitest suite. This sandbox has no `node_modules` and a full monorepo install was out of proportion for a revert. CI runs it.
- The diff is the exact inverse of #98901, so the tree returns to a state CI already verified.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Slack app, from a thread about ChatGPT MCP UI apps rendering blank. Skills invoked: `/writing-pr-descriptions`. Applied `gh pr diff 98901` in reverse; no other edits.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1788360835430769?thread_ts=1788360835.430769&cid=C09SK2PAGKF)*
