### PR TITLE
feat(personhog): time the leader's release-fence phases and fallback pool waits

### DIFF
--- a/rust/personhog-leader/src/fence.rs
+++ b/rust/personhog-leader/src/fence.rs
@@ -323,6 +323,7 @@ pub async fn mark_status(
     team_id: i64,
     person_id: i64,
 ) -> Result<Option<String>, sqlx::Error> {
+    let mut conn = crate::pg::acquire_timed(pool, "mark_status").await?;
     sqlx::query_scalar(
         "SELECT status FROM lifecycle_op_person \
          WHERE op_id = $1 AND team_id = $2 AND person_id = $3 AND role <> 'target'",
@@ -330,7 +331,7 @@ pub async fn mark_status(
     .bind(op_id)
     .bind(team_id as i32)
     .bind(person_id)
-    .fetch_optional(pool)
+    .fetch_optional(&mut *conn)
     .await
 }
 
@@ -349,6 +350,7 @@ pub async fn target_mark_status(
     team_id: i64,
     person_id: i64,
 ) -> Result<Option<String>, sqlx::Error> {
+    let mut conn = crate::pg::acquire_timed(pool, "target_mark_status").await?;
     sqlx::query_scalar(
         "SELECT status FROM lifecycle_op_person \
          WHERE op_id = $1 AND team_id = $2 AND person_id = $3 AND role = 'target'",
@@ -356,6 +358,6 @@ pub async fn target_mark_status(
     .bind(op_id)
     .bind(team_id as i32)
     .bind(person_id)
-    .fetch_optional(pool)
+    .fetch_optional(&mut *conn)
     .await
 }

--- a/rust/personhog-leader/src/main.rs
+++ b/rust/personhog-leader/src/main.rs
@@ -201,6 +201,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 WRITE_PATH_LATENCY_BUCKETS_MS,
             ),
             (
+                Matcher::Full("personhog_leader_release_phase_ms".into()),
+                WRITE_PATH_LATENCY_BUCKETS_MS,
+            ),
+            (
+                Matcher::Full("personhog_leader_fallback_pool_acquire_ms".into()),
+                WRITE_PATH_LATENCY_BUCKETS_MS,
+            ),
+            (
                 Matcher::Full("grpc_server_request_duration_ms".into()),
                 WRITE_PATH_LATENCY_BUCKETS_MS,
             ),
@@ -296,13 +304,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             statement_timeout_ms: Some(5_000),
             ..Default::default()
         };
-        Some(PgFallback {
+        let fallback = PgFallback {
             pool: common_database::get_pool_with_config(
                 &config.fallback_database_url,
                 pool_config,
             )?,
             table: config.fallback_table.clone(),
-        })
+        };
+        personhog_common::spawn_pool_monitor(
+            vec![personhog_common::MonitoredPool {
+                pool: fallback.pool.clone(),
+                label: "fallback".to_string(),
+                max_connections: config.fallback_pg_max_connections,
+            }],
+            Duration::from_secs(10),
+        );
+        Some(fallback)
     };
 
     // Connect to etcd for coordination and the partition count

--- a/rust/personhog-leader/src/pg.rs
+++ b/rust/personhog-leader/src/pg.rs
@@ -18,9 +18,8 @@ pub struct PgFallback {
     pub table: String,
 }
 
-/// Take a fallback-pool connection, recording the wait. The pool is small
-/// and shared by cache-miss loads and the sagas' mark checks, so a burst
-/// of releases can queue here while every query stays fast.
+/// Take a fallback-pool connection, recording the wait: the pool is small
+/// and shared by cache-miss loads and the sagas' mark checks.
 pub async fn acquire_timed(
     pool: &PgPool,
     caller: &'static str,
@@ -72,6 +71,8 @@ pub async fn load_person_from_pg(
     .bind(key.person_id)
     .fetch_optional(&mut *conn)
     .await?;
+    // The row is owned; parsing its properties must not hold the pool slot.
+    drop(conn);
 
     histogram!("personhog_leader_pg_fallback_duration_ms")
         .record(start.elapsed().as_secs_f64() * 1000.0);

--- a/rust/personhog-leader/src/pg.rs
+++ b/rust/personhog-leader/src/pg.rs
@@ -1,7 +1,10 @@
+use std::time::Instant;
+
 use metrics::{counter, histogram};
 use personhog_common::properties::rewrite_out_of_range_numbers;
+use sqlx::pool::PoolConnection;
 use sqlx::postgres::PgPool;
-use sqlx::Row;
+use sqlx::{Postgres, Row};
 
 use crate::cache::{approx_person_bytes, CachedPerson, PersonCacheKey};
 
@@ -13,6 +16,20 @@ use crate::cache::{approx_person_bytes, CachedPerson, PersonCacheKey};
 pub struct PgFallback {
     pub pool: PgPool,
     pub table: String,
+}
+
+/// Take a fallback-pool connection, recording the wait. The pool is small
+/// and shared by cache-miss loads and the sagas' mark checks, so a burst
+/// of releases can queue here while every query stays fast.
+pub async fn acquire_timed(
+    pool: &PgPool,
+    caller: &'static str,
+) -> Result<PoolConnection<Postgres>, sqlx::Error> {
+    let start = Instant::now();
+    let conn = pool.acquire().await;
+    histogram!("personhog_leader_fallback_pool_acquire_ms", "caller" => caller)
+        .record(start.elapsed().as_secs_f64() * 1000.0);
+    conn
 }
 
 /// Validate a configured table identifier before it is interpolated into
@@ -32,7 +49,8 @@ pub async fn load_person_from_pg(
     table: &str,
     key: &PersonCacheKey,
 ) -> Result<Option<CachedPerson>, sqlx::Error> {
-    let start = std::time::Instant::now();
+    let start = Instant::now();
+    let mut conn = acquire_timed(pool, "load_person").await?;
 
     let team_id_i32 = i32::try_from(key.team_id)
         .map_err(|_| sqlx::Error::Protocol(format!("team_id {} exceeds i32 range", key.team_id)))?;
@@ -52,7 +70,7 @@ pub async fn load_person_from_pg(
     ))
     .bind(team_id_i32)
     .bind(key.person_id)
-    .fetch_optional(pool)
+    .fetch_optional(&mut *conn)
     .await?;
 
     histogram!("personhog_leader_pg_fallback_duration_ms")

--- a/rust/personhog-leader/src/service.rs
+++ b/rust/personhog-leader/src/service.rs
@@ -887,10 +887,8 @@ fn partition_from_metadata<T>(request: &Request<T>) -> Result<u32, Status> {
         .map_err(|_| Status::invalid_argument("x-partition metadata is not a valid u32"))
 }
 
-/// Wall time of one committed-release phase. The release is the slowest
-/// leader RPC, and its end-to-end histogram cannot say whether the time
-/// is the per-person lock, the person load, the mark-row check on the
-/// fallback pool, or the changelog produce.
+/// Per-phase wall time of a committed release; the RPC histogram alone
+/// cannot separate the lock, the load, the mark check, and the produce.
 fn record_release_phase(phase: &'static str, started: Instant) {
     histogram!("personhog_leader_release_phase_ms", "phase" => phase)
         .record(started.elapsed().as_secs_f64() * 1000.0);
@@ -1760,7 +1758,6 @@ impl PersonHogLeader for PersonHogLeaderService {
             .clone();
         let lock_started = Instant::now();
         let _guard = mutex.lock().await;
-        record_release_phase("lock_wait", lock_started);
 
         // Releasing another op's fence would break that op's seal.
         if let Some(entry) = self.fences.get(&cache_key) {
@@ -1771,6 +1768,7 @@ impl PersonHogLeader for PersonHogLeaderService {
 
         match outcome {
             ReleaseOutcome::Committed => {
+                record_release_phase("lock_wait", lock_started);
                 // 0 is a legitimate sealed version (a fresh stub's),
                 // which is why the field is explicitly optional in the proto.
                 let Some(sealed_version) = req.sealed_version else {

--- a/rust/personhog-leader/src/service.rs
+++ b/rust/personhog-leader/src/service.rs
@@ -887,6 +887,15 @@ fn partition_from_metadata<T>(request: &Request<T>) -> Result<u32, Status> {
         .map_err(|_| Status::invalid_argument("x-partition metadata is not a valid u32"))
 }
 
+/// Wall time of one committed-release phase. The release is the slowest
+/// leader RPC, and its end-to-end histogram cannot say whether the time
+/// is the per-person lock, the person load, the mark-row check on the
+/// fallback pool, or the changelog produce.
+fn record_release_phase(phase: &'static str, started: Instant) {
+    histogram!("personhog_leader_release_phase_ms", "phase" => phase)
+        .record(started.elapsed().as_secs_f64() * 1000.0);
+}
+
 #[tonic::async_trait]
 impl PersonHogLeader for PersonHogLeaderService {
     async fn get_person(
@@ -1749,7 +1758,9 @@ impl PersonHogLeader for PersonHogLeaderService {
             .or_default()
             .value()
             .clone();
+        let lock_started = Instant::now();
         let _guard = mutex.lock().await;
+        record_release_phase("lock_wait", lock_started);
 
         // Releasing another op's fence would break that op's seal.
         if let Some(entry) = self.fences.get(&cache_key) {
@@ -1793,7 +1804,10 @@ impl PersonHogLeader for PersonHogLeaderService {
                 // Release must stay idempotent for the saga's retry and the
                 // sweeper, so a person the leader cannot load anymore is
                 // tolerated.
-                let current = match self.lookup_or_load_locked(partition, &cache_key).await {
+                let load_started = Instant::now();
+                let loaded = self.lookup_or_load_locked(partition, &cache_key).await;
+                record_release_phase("load", load_started);
+                let current = match loaded {
                     Ok(person) => Some(person),
                     Err(status) if status.code() == tonic::Code::NotFound => None,
                     Err(status) => return Err(status),
@@ -1835,7 +1849,10 @@ impl PersonHogLeader for PersonHogLeaderService {
                         "no-lifecycle-db",
                     ));
                 };
-                match mark_status(&fallback.pool, op_id, req.team_id, req.person_id).await {
+                let verify_started = Instant::now();
+                let mark = mark_status(&fallback.pool, op_id, req.team_id, req.person_id).await;
+                record_release_phase("verify_mark", verify_started);
+                match mark {
                     // A live mark: the op holds the person; proceed.
                     Ok(Some(status)) if status == "marked" || status == "sealed" => {}
                     // The mark already settled as deleted: this release
@@ -1907,7 +1924,10 @@ impl PersonHogLeader for PersonHogLeaderService {
                     last_seen_at: None,
                     approx_bytes: approx_person_bytes(2),
                 };
-                self.commit_document(partition, &cache_key, death).await?;
+                let produce_started = Instant::now();
+                let committed = self.commit_document(partition, &cache_key, death).await;
+                record_release_phase("produce", produce_started);
+                committed?;
                 // The death document stays cached while its mark stands,
                 // answering an authoritative not-found from memory; the
                 // prune-time settle drops it once the writer confirms,


### PR DESCRIPTION
## Problem

- A person delete takes several seconds per batch in dev, and most of that is the release-fence calls the identity saga makes to the leader: p50 133ms at the leader for a call whose changelog produce costs about 22ms.
- The leader's end-to-end RPC histogram cannot say where the rest goes. A committed release takes the per-person lock, loads the person on a cache miss, checks the op's mark row in the lifecycle database, and produces the death document, and none of those steps has a timer.
- The mark check and the cache-miss loads share the leader's fallback pool, which is 5 connections with 1 kept warm. Whether a burst of releases queues there is unmeasurable today: the pool has no acquire-wait histogram and no size or idle gauges.

## Changes

- Operators can now split a slow release into its parts. `personhog_leader_release_phase_ms{phase}` records `lock_wait`, `load`, `verify_mark`, and `produce` once per committed release, on both the success and the error path.
- Fallback pool pressure is now visible. Every acquire on the pool records `personhog_leader_fallback_pool_acquire_ms{caller}` with `load_person`, `mark_status`, or `target_mark_status`, and the pool reports `personhog_db_pool_size`, `personhog_db_pool_idle`, and `personhog_db_pool_max` under `pool="fallback"`, the same gauges identity and the replica publish.
- Mechanical: the three fallback-pool queries acquire a connection explicitly through one timed helper instead of executing on the pool; the queries themselves are unchanged. Both new histograms use the leader's fine write-path bucket ladder.
- Nothing user-visible changes.

## How did you test this code?

- Ran locally: clippy on the leader crate and its full test suite, including the fence and release tests, which exercise the instrumented paths.
- No new tests. The change adds timers around existing calls; asserting that a histogram received a value would only test the metrics library.
- Not run: anything against a live router, Kafka, or etcd.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5.1) with the dev Grafana MCP. Skills invoked: /writing-code-comments, /writing-tests, /writing-pr-descriptions.
- The phase set comes from reading the committed-release path against dev numbers: produce and person load are already timed and account for under 30ms of a 133ms p50, so the untimed lock wait and mark check are the candidates. This PR measures rather than guesses.
- Duplicate search before opening: `gh pr list --state open --search "leader release fence metrics"` found nothing related.

https://claude.ai/code/session_012TP24aeMLiBwde9SkpHpmL
