### PR TITLE
fix(signals): return to the scout page after dismissing its report

### DIFF
--- a/products/signals/frontend/inbox/components/cards/SignalRunCard.tsx
+++ b/products/signals/frontend/inbox/components/cards/SignalRunCard.tsx
@@ -8,6 +8,7 @@ import { urls } from 'scenes/urls'
 
 import { captureInboxRunOpened } from '../../inboxAnalytics'
 import { SignalRun } from '../../types'
+import { inboxReportDetailUrl } from '../../utils/inboxReportUrls'
 import { stripScoutPrefix } from '../../utils/scoutRunsWindow'
 import { inboxCardRowClassName } from './inboxCardRowClassName'
 import { resolveRunVariant, RunStatusIndicator } from './runStatusVariant'
@@ -58,7 +59,7 @@ export function SignalRunCard({ run }: { run: SignalRun }): JSX.Element {
             {run.report_id && (
                 <div className="flex items-center shrink-0 @lg:self-stretch @lg:border-l @lg:border-primary @lg:pl-3">
                     <Link
-                        to={urls.inboxReport('reports', run.report_id)}
+                        to={inboxReportDetailUrl(run.report_id, urls.inboxRuns())}
                         className="text-xs font-medium text-accent no-underline"
                     >
                         View report

--- a/products/signals/frontend/inbox/components/config/scouts/ScoutDetailView.tsx
+++ b/products/signals/frontend/inbox/components/config/scouts/ScoutDetailView.tsx
@@ -207,7 +207,12 @@ function ScoutReportsSection({ skillName }: { skillName: string }): JSX.Element 
                 </div>
             ) : (
                 reportRows.map(({ report, action }) => (
-                    <ScoutReportCard key={report.id} report={report} action={action} />
+                    <ScoutReportCard
+                        key={report.id}
+                        report={report}
+                        action={action}
+                        backUrl={urls.inboxScout(skillName)}
+                    />
                 ))
             )}
         </div>
@@ -272,6 +277,7 @@ function ScoutSignalsSection({ skillName }: { skillName: string }): JSX.Element 
                         // mark the newest matching emission — rows are newest-first — to keep the
                         // highlight/scroll deterministic for a single shared link.
                         isDeepLinked={emission.id === deepLinkedEmissionId}
+                        backUrl={urls.inboxScout(skillName)}
                     />
                 ))
             )}

--- a/products/signals/frontend/inbox/components/config/scouts/ScoutEmissionCard.tsx
+++ b/products/signals/frontend/inbox/components/config/scouts/ScoutEmissionCard.tsx
@@ -11,6 +11,7 @@ import { urls } from 'scenes/urls'
 
 import { captureScoutAction } from '../../../inboxAnalytics'
 import { LinkedSignalReport, SignalScoutEmission, SignalScoutRunSummary } from '../../../types'
+import { inboxReportDetailUrl } from '../../../utils/inboxReportUrls'
 import { prettifyScoutSkillName } from '../../../utils/scoutRunsWindow'
 import { SignalReportPriorityBadge } from '../../badges/SignalReportPriorityBadge'
 import { ScoutTimestamp } from './ScoutTimestamp'
@@ -44,6 +45,7 @@ export const ScoutEmissionCard = memo(function ScoutEmissionCard({
     report,
     isDeepLinked = false,
     showScout = false,
+    backUrl,
 }: {
     skillName: string
     emission: SignalScoutEmission
@@ -54,6 +56,8 @@ export const ScoutEmissionCard = memo(function ScoutEmissionCard({
     isDeepLinked?: boolean
     /** Cross-fleet listings set this to surface the scout (name in the header, "View scout" footer link). */
     showScout?: boolean
+    /** The surface listing this card, so the linked report returns here when it is read or given a verdict. */
+    backUrl?: string
 }): JSX.Element {
     const [expanded, setExpanded] = useState(isDeepLinked)
     const confidencePercent = Math.round((emission.confidence ?? 0) * 100)
@@ -151,7 +155,7 @@ export const ScoutEmissionCard = memo(function ScoutEmissionCard({
 
                 {report && (
                     <Link
-                        to={urls.inboxReport('reports', report.id)}
+                        to={inboxReportDetailUrl(report.id, backUrl)}
                         className="mt-2 inline-flex max-w-full items-center gap-1 rounded bg-primary-highlight px-2 py-0.5 text-xs font-medium text-primary"
                         onClick={() =>
                             captureScoutAction({

--- a/products/signals/frontend/inbox/components/config/scouts/ScoutReportCard.tsx
+++ b/products/signals/frontend/inbox/components/config/scouts/ScoutReportCard.tsx
@@ -1,10 +1,10 @@
 import { LemonTag, Link } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
-import { urls } from 'scenes/urls'
 
 import { ScoutReportAction } from '../../../logics/scoutDetailLogic'
 import { SignalReport } from '../../../types'
+import { inboxReportDetailUrl } from '../../../utils/inboxReportUrls'
 import {
     deriveHeadline,
     displayConventionalCommitTitle,
@@ -28,11 +28,14 @@ export function ScoutReportCard({
     report,
     action,
     skillName,
+    backUrl,
 }: {
     report: SignalReport
     action: ScoutReportAction
     /** Set on cross-fleet listings to show the touching scout's name (omitted on the per-scout page). */
     skillName?: string
+    /** The surface listing this card, so the report returns here when it is read, dismissed or resolved. */
+    backUrl?: string
 }): JSX.Element {
     const conventionalTitle = parseConventionalCommitTitle(report.title)
     const cardTitle = displayConventionalCommitTitle(report.title, 'Untitled report')
@@ -40,7 +43,7 @@ export function ScoutReportCard({
 
     return (
         <Link
-            to={urls.inboxReport('reports', report.id)}
+            to={inboxReportDetailUrl(report.id, backUrl)}
             className="group flex w-full items-start gap-3 rounded border border-primary bg-surface-primary px-4 py-3.5 text-left no-underline transition-all duration-150 hover:border-secondary hover:bg-surface-secondary"
         >
             {report.priority && (

--- a/products/signals/frontend/inbox/components/config/scouts/ScoutRunHistorySection.tsx
+++ b/products/signals/frontend/inbox/components/config/scouts/ScoutRunHistorySection.tsx
@@ -11,6 +11,7 @@ import { urls } from 'scenes/urls'
 import { captureScoutAction } from '../../../inboxAnalytics'
 import { scoutFleetLogic } from '../../../logics/scoutFleetLogic'
 import { SignalScoutRunSummary } from '../../../types'
+import { inboxReportDetailUrl } from '../../../utils/inboxReportUrls'
 import {
     deriveRunFailureKind,
     formatRunDuration,
@@ -87,6 +88,8 @@ const ScoutRunRow = memo(function ScoutRunRow({
     const reportActivityLabel = scoutReportActivityLabel(run)
     const { authored: authoredReportIds, edited: editedReportIds } = runReportActivity(run)
     const hasBody = Boolean(run.summary) || status === 'failed' || expanded
+    // This list only renders on the scout's own page, so a report opened from it returns there.
+    const backUrl = urls.inboxScout(skillName)
 
     return (
         <div className="flex flex-col border-b border-primary last:border-b-0">
@@ -153,7 +156,7 @@ const ScoutRunRow = memo(function ScoutRunRow({
                             {authoredReportIds.map((reportId) => (
                                 <Link
                                     key={reportId}
-                                    to={urls.inboxReport('reports', reportId)}
+                                    to={inboxReportDetailUrl(reportId, backUrl)}
                                     className="flex items-center gap-1 font-medium shrink-0"
                                     onClick={() => captureOpenLinkedReport(skillName, reportId, 'authored')}
                                 >
@@ -163,7 +166,7 @@ const ScoutRunRow = memo(function ScoutRunRow({
                             {editedReportIds.map((reportId) => (
                                 <Link
                                     key={reportId}
-                                    to={urls.inboxReport('reports', reportId)}
+                                    to={inboxReportDetailUrl(reportId, backUrl)}
                                     className="flex items-center gap-1 font-medium shrink-0"
                                     onClick={() => captureOpenLinkedReport(skillName, reportId, 'edited')}
                                 >

--- a/products/signals/frontend/inbox/components/detail/ReportDetail.tsx
+++ b/products/signals/frontend/inbox/components/detail/ReportDetail.tsx
@@ -23,6 +23,7 @@ import { inboxDetailLayoutLogic } from '../../logics/inboxDetailLayoutLogic'
 import { inboxReportDetailLogic } from '../../logics/inboxReportDetailLogic'
 import { SignalCard } from '../../SignalCard'
 import { SignalReport, SignalReportStatus } from '../../types'
+import { inboxReportBackPath } from '../../utils/inboxReportUrls'
 import { canCreateImplementationPr } from '../../utils/reportActions'
 import {
     displayConventionalCommitTitle,
@@ -205,10 +206,9 @@ export function InboxDetailFrame({
 }: InboxDetailFrameProps): JSX.Element {
     const { searchParams } = useValues(router)
     // A `?back=` internal path (set by surfaces embedding inbox cards, e.g. the customer analytics
-    // feed) redirects the back button there instead of the inbox list tab.
-    const rawBack = searchParams.back
-    const backOverride =
-        typeof rawBack === 'string' && rawBack.startsWith('/') && !rawBack.startsWith('//') ? rawBack : null
+    // feed, and by the scout surfaces that list reports) redirects the back button there instead of
+    // the inbox list tab.
+    const backOverride = inboxReportBackPath(searchParams)
     const backLabel = backOverride
         ? backOverride.startsWith(urls.inboxTriage())
             ? 'Triage'

--- a/products/signals/frontend/inbox/components/detail/ReportDetailActions.tsx
+++ b/products/signals/frontend/inbox/components/detail/ReportDetailActions.tsx
@@ -6,13 +6,13 @@ import { IconCheckCircle, IconHide, IconReceipt, IconUndo } from '@posthog/icons
 import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
-import { urls } from 'scenes/urls'
 
 import { captureInboxReportAction } from '../../inboxAnalytics'
 import { inboxSceneLogic } from '../../inboxSceneLogic'
 import { inboxBulkActionsLogic } from '../../logics/inboxBulkActionsLogic'
 import { INBOX_REPORT_SECTION_LIST_PARAMS, reportListLogic } from '../../logics/reportListLogic'
 import { SignalReport, SignalReportStatus } from '../../types'
+import { inboxReportReturnPath } from '../../utils/inboxReportUrls'
 import { canResolveReport } from '../../utils/reportActions'
 import { useReportDismiss } from '../cards/useReportDismiss'
 import { useReportRefund } from '../cards/useReportRefund'
@@ -40,7 +40,11 @@ export function useReportDetailActions(report: SignalReport): ReportDetailAction
     const { reportStateChanged } = useActions(inboxBulkActionsLogic)
     const { activeTab } = useValues(inboxSceneLogic)
     const { loadSelectedReport } = useActions(inboxSceneLogic)
+    const { searchParams } = useValues(router)
     const [isRestoring, setIsRestoring] = useState(false)
+    // A verdict closes the report, so it leaves for wherever the report was opened from — the same
+    // path its back button takes.
+    const returnPath = inboxReportReturnPath(searchParams, activeTab)
 
     const isDismissed = report.status === SignalReportStatus.SUPPRESSED
     // Resolved reports are terminal – nothing to dismiss, restore, or resolve.
@@ -51,11 +55,11 @@ export function useReportDetailActions(report: SignalReport): ReportDetailAction
     const staysPutOnRefund = isResolved && report.implementation_pr_merged === true
 
     // Once a verdict persists, broadcast so every mounted list reconciles against the server (the
-    // report leaves Needs decision / Review and merge and joins Resolved or Dismissed), then return to
-    // the list.
-    const leaveForList = (): void => {
+    // report leaves Needs decision / Review and merge and joins Resolved or Dismissed), then leave
+    // the report.
+    const leaveForOrigin = (): void => {
         reportStateChanged()
-        router.actions.push(urls.inbox(activeTab))
+        router.actions.push(returnPath)
     }
 
     const { isDismissing, onDismissClick } = useReportDismiss({
@@ -63,24 +67,24 @@ export function useReportDetailActions(report: SignalReport): ReportDetailAction
         cardTitle: report.title ?? 'Untitled report',
         report,
         surface: 'detail_pane',
-        onDismissed: leaveForList,
+        onDismissed: leaveForOrigin,
     })
 
     const { isResolving, onResolveClick } = useReportResolve({
         report,
         surface: 'detail_pane',
-        onResolved: leaveForList,
+        onResolved: leaveForOrigin,
     })
 
     const { canRefund, refundDisabledReason, isRefunding, onRefundClick } = useReportRefund({
         report,
         surface: 'detail_pane',
         // Refunding dismisses the report server-side, so reconcile the lists the same way and
-        // return to the list — except for resolved reports, which stay where they are.
+        // leave the report — except for resolved reports, which stay where they are.
         onRefunded: () => {
             reportStateChanged()
             if (!staysPutOnRefund) {
-                router.actions.push(urls.inbox(activeTab))
+                router.actions.push(returnPath)
             } else {
                 // These reports stay on this page, so refetch: the fresh copy carries `refund`,
                 // which surfaces the Refunded badge and drops Refund from the actions.
@@ -109,7 +113,7 @@ export function useReportDetailActions(report: SignalReport): ReportDetailAction
         if (dismissedList) {
             // The list logic fires the `restore` analytics; just drive navigation here.
             dismissedList.actions.restoreReport(report.id, 'detail_pane')
-            router.actions.push(urls.inbox(activeTab))
+            router.actions.push(returnPath)
             return
         }
         // Fallback for a deep-linked detail with no mounted Dismissed list (e.g. cold load), and for
@@ -122,7 +126,7 @@ export function useReportDetailActions(report: SignalReport): ReportDetailAction
             // Broadcast so any mounted list (including that Archive instance) reconciles against the
             // server before we navigate back; nothing else in this path repairs its stale row + count.
             reportStateChanged()
-            router.actions.push(urls.inbox(activeTab))
+            router.actions.push(returnPath)
         } catch (error: any) {
             lemonToast.error(error?.detail || error?.message || 'Failed to restore report')
         } finally {

--- a/products/signals/frontend/inbox/components/detail/ReportDetailLegacy.tsx
+++ b/products/signals/frontend/inbox/components/detail/ReportDetailLegacy.tsx
@@ -18,6 +18,7 @@ import { captureInboxReportAction } from '../../inboxAnalytics'
 import { inboxReportDetailLogic } from '../../logics/inboxReportDetailLogic'
 import { SignalCard } from '../../SignalCard'
 import { InboxTabKey, INBOX_TAB_LABEL, SignalReport, SignalReportStatus, SignalSourceProduct } from '../../types'
+import { inboxReportBackPath } from '../../utils/inboxReportUrls'
 import { canCreateImplementationPr } from '../../utils/reportActions'
 import {
     displayConventionalCommitTitle,
@@ -273,10 +274,9 @@ function InboxDetailFrameLegacy({
 }: InboxDetailFrameProps): JSX.Element {
     const { searchParams } = useValues(router)
     // A `?back=` internal path (set by surfaces embedding inbox cards, e.g. the customer analytics
-    // feed) redirects the back button there instead of the inbox list tab.
-    const rawBack = searchParams.back
-    const backOverride =
-        typeof rawBack === 'string' && rawBack.startsWith('/') && !rawBack.startsWith('//') ? rawBack : null
+    // feed, and by the scout surfaces that list reports) redirects the back button there instead of
+    // the inbox list tab.
+    const backOverride = inboxReportBackPath(searchParams)
     const logicProps = { reportId: report.id, report }
     const {
         reportSignals,

--- a/products/signals/frontend/inbox/components/findings/FindingsPanel.tsx
+++ b/products/signals/frontend/inbox/components/findings/FindingsPanel.tsx
@@ -5,6 +5,7 @@ import { LemonBanner, LemonButton, LemonInput, LemonSelect, LemonSkeleton } from
 
 import { TZLabel } from 'lib/components/TZLabel'
 import { pluralize } from 'lib/utils/strings'
+import { urls } from 'scenes/urls'
 
 import {
     FINDINGS_SCOUT_FILTER_ALL,
@@ -190,6 +191,7 @@ export function FindingsPanel(): JSX.Element {
                                         report={row.report}
                                         action={row.action}
                                         skillName={row.skillName}
+                                        backUrl={urls.inboxFindings()}
                                     />
                                 ))
                             )}
@@ -222,6 +224,7 @@ export function FindingsPanel(): JSX.Element {
                                         run={row.run}
                                         report={row.report}
                                         showScout
+                                        backUrl={urls.inboxFindings()}
                                     />
                                 ))
                             )}

--- a/products/signals/frontend/inbox/utils/inboxReportUrls.test.ts
+++ b/products/signals/frontend/inbox/utils/inboxReportUrls.test.ts
@@ -1,6 +1,11 @@
 import { urls } from 'scenes/urls'
 
-import { inboxReportDetailUrl, inboxTabRedirectPath } from './inboxReportUrls'
+import {
+    inboxReportBackPath,
+    inboxReportDetailUrl,
+    inboxReportReturnPath,
+    inboxTabRedirectPath,
+} from './inboxReportUrls'
 
 describe('inbox report urls', () => {
     describe('inboxReportDetailUrl', () => {
@@ -16,6 +21,37 @@ describe('inbox report urls', () => {
 
         it('addresses the report through its legacy tab when asked', () => {
             expect(inboxReportDetailUrl('r1', undefined, 'pulls')).toBe(urls.inboxReport('pulls', 'r1'))
+        })
+    })
+
+    // The back path decides where the report's back button and its verdict actions leave to. It is
+    // read from a URL param that reaches the app from anywhere, so a non-internal value is rejected
+    // to keep it from becoming an open redirect.
+    describe('inboxReportBackPath', () => {
+        it.each<[string, any, string | null]>([
+            ['an internal path', '/inbox/scouts/signals-scout-general', '/inbox/scouts/signals-scout-general'],
+            ['no back param', undefined, null],
+            ['an absolute url', 'https://evil.test/phish', null],
+            ['a protocol-relative url', '//evil.test/phish', null],
+            ['a non-string value', 42, null],
+        ])('honors %s', (_label, back, expected) => {
+            expect(inboxReportBackPath({ back })).toBe(expected)
+        })
+    })
+
+    describe('inboxReportReturnPath', () => {
+        it('returns to the surface a report was opened from', () => {
+            expect(inboxReportReturnPath({ back: '/inbox/scouts/signals-scout-general' }, 'reports')).toBe(
+                '/inbox/scouts/signals-scout-general'
+            )
+        })
+
+        it('falls back to the active list tab for a report opened straight off a list', () => {
+            expect(inboxReportReturnPath({}, 'reports')).toBe(urls.inbox('reports'))
+        })
+
+        it('ignores a non-internal back path and falls back to the list', () => {
+            expect(inboxReportReturnPath({ back: 'https://evil.test' }, 'reports')).toBe(urls.inbox('reports'))
         })
     })
 

--- a/products/signals/frontend/inbox/utils/inboxReportUrls.ts
+++ b/products/signals/frontend/inbox/utils/inboxReportUrls.ts
@@ -17,6 +17,26 @@ export function inboxReportDetailUrl(reportId: string, backUrl?: string, tab: In
 }
 
 /**
+ * The `?back=` path a report was opened with, or null when it carries none. Only an internal path is
+ * honored: the value reaches the URL from anywhere, so an absolute or protocol-relative one would
+ * turn the back button (and the verdict actions that follow it) into an open redirect.
+ */
+export function inboxReportBackPath(searchParams: Record<string, any>): string | null {
+    const raw = searchParams.back
+    return typeof raw === 'string' && raw.startsWith('/') && !raw.startsWith('//') ? raw : null
+}
+
+/**
+ * Where a report's back button and its verdict actions (dismiss, resolve, refund, restore) leave to:
+ * the surface the report was opened from when it carries one, the current list tab otherwise. A
+ * report opened from a scout page, the findings panel or triage has to come back to it — the reader
+ * was working through that surface, not the list.
+ */
+export function inboxReportReturnPath(searchParams: Record<string, any>, activeTab: InboxTabKey): string {
+    return inboxReportBackPath(searchParams) ?? urls.inbox(activeTab)
+}
+
+/**
  * Where an `/inbox/<tab>` segment from the other inbox layout lands, or null for a segment the
  * current layout serves itself. Slack notifications, bookmarks, and links from other products
  * carry whichever segments were live when they were written, and the flag can flip between


### PR DESCRIPTION
## Problem

Someone reading a scout's page in Self-driving, who dismisses one of the reports listed there, lands back on the Reports list instead of the scout they were working through. The same happens on the cross-fleet findings panel and the runs list, and for every verdict: dismiss, resolve, refund and restore.

The verdict handlers in `ReportDetailActions` always pushed `urls.inbox(activeTab)`. The report's back button already followed a `?back=` origin param, but the scout surfaces never set it and the verdict actions never read it, so the two controls disagreed about where the report came from.

## Changes

- A verdict now returns the reader to the surface the report was opened from, matching where its back button already went. Reports opened straight off a list still return to that list.
- The scout page, the findings panel and the runs list now stamp their own path onto the report links they render, so the origin survives the trip into the report.
- `inboxReportBackPath` / `inboxReportReturnPath` in `inboxReportUrls.ts` resolve that target in one place. The back button and the verdict actions both read it, so they cannot drift apart again. Only an internal path is honored, so the param cannot become an open redirect.
- Mechanical: the two detail frames now call the shared helper instead of each parsing the param inline.

Nothing looks different. This changes only where a verdict navigates to.

## How did you test this code?

Added unit tests for the two new helpers in `inboxReportUrls.test.ts`: an origin round-trip, the fallback to the active list tab, and rejection of absolute and protocol-relative paths. They cover the origin-resolution logic the fix turns on, which no existing test reached.

Not manually tested: this ran in a sandbox without the app stack, so the navigation was not exercised in a browser. `typescript:check` is also unverified here — the sandbox workspace fails to resolve `kea` and `react` types across whole products, and reports the same 4348 errors on an untouched master. CI is the check for both.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing documentation covers this navigation.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raised in a Slack thread and fixed by the PostHog Slack app (Claude Opus 5). Skills invoked: `/writing-kea-logics`, `/writing-tests`, `/writing-pr-descriptions`, `/reviewing-with-coderabbit`. The CodeRabbit pass is paused, so this PR opened without a local pass.

The first approach was to make the verdict handlers read the `?back=` param directly. That left two copies of the same parsing rule, one in the detail frames and one in the actions, which is how the original drift happened. Extracting `inboxReportBackPath` and `inboxReportReturnPath` and pointing both callers at them keeps the back button and the verdict actions on one definition of "where this report came from".

No duplicate: `gh pr list --state open --search` over the dismiss/scout/inbox-navigation keywords found no open PR fixing this.

Public artifact: the diff, tests and this description carry no material from the originating thread.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1789099521884739?thread_ts=1789099521.884739&cid=C0ACRAMJUAG)*
