### PR TITLE
fix(experiments): Flag empty precompute canary reads instead of skipping them

### DIFF
--- a/products/experiments/backend/temporal/canary_logic.py
+++ b/products/experiments/backend/temporal/canary_logic.py
@@ -285,7 +285,9 @@ def evaluate_canary_runs(
     under the per-query byte cap: stability is still checked, and a clean pair verdicts as
     uncheckable rather than pass because correctness stays unverified."""
     runs = tuple(run for run in (run_a, run_b, run_c) if run is not None)
-    if any(not run.variants for run in runs):
+    # Skip only when every run is empty. A run that is empty while a sibling has data is a broken
+    # read, not a young experiment — fall through so the path-flip and variant-set checks classify it.
+    if all(not run.variants for run in runs):
         return CanaryVerdict(outcome=OUTCOME_SKIPPED, detail="empty results (no exposures yet)")
 
     # Checked before the variant-set comparison: a flipped run compares live vs frozen data, so it can

--- a/products/experiments/backend/temporal/test_canary_logic.py
+++ b/products/experiments/backend/temporal/test_canary_logic.py
@@ -174,6 +174,16 @@ class TestEvaluateCanaryRuns:
                 {"control": (500.0, 3090), "test": (500.0, 3000)},
                 OUTCOME_DIVERGENCE,
             ),
+            ("all_runs_empty_is_skipped", "funnel", {}, {}, {}, OUTCOME_SKIPPED),
+            (
+                # A cache that lost its content must not pass as "no exposures yet".
+                "empty_precomputed_reads_with_populated_direct_scan_is_error",
+                "funnel",
+                {},
+                {},
+                _BASE,
+                OUTCOME_ERROR,
+            ),
         ]
     )
     def test_outcomes(self, _name, metric_type, a, b, c, expected):
@@ -237,10 +247,6 @@ class TestEvaluateCanaryRuns:
             "funnel", _snapshot("a", _BASE), _snapshot("b", _BASE), _snapshot("c", {"control": (1000.0, 10000)})
         )
         assert verdict.outcome == OUTCOME_ERROR
-
-    def test_empty_results_are_skipped(self):
-        verdict = evaluate_canary_runs("funnel", _snapshot("a", _BASE), _snapshot("b", {}), _snapshot("c", _BASE))
-        assert verdict.outcome == OUTCOME_SKIPPED
 
     def test_low_volume_is_skipped(self):
         low = {"control": (10.0, 50), "test": (12.0, 60)}


### PR DESCRIPTION
## Problem

When the precomputed canary reads return no variants but the direct scan returns data, the canary files the metric as "skipped (no exposures yet)". A cache that lost its content is the failure the canary exists to catch, and it never surfaces.

## Changes

- The canary skips a metric only when every run is empty.
- A run that is empty while a sibling has data falls through to the path-flip and variant-set checks, so it lands as `path_flip` or `error` instead of `skipped`.

## How did you test this code?

Two parameterized cases in `test_canary_logic.py`: all runs empty stays `skipped`; empty precomputed reads with a populated direct scan now verdict as `error`. The old standalone empty-results test pinned the buggy behavior and is folded into these cases.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found during an audit of the canary's verdict logic. Skills invoked: /wt, /writing-tests, /writing-pr-descriptions. Opened without a CodeRabbit local pass (paused).
