### PR TITLE
fix(aio): keep created-by filter in prompts list url

### DIFF
--- a/products/ai_observability/frontend/prompts/llmPromptsLogic.ts
+++ b/products/ai_observability/frontend/prompts/llmPromptsLogic.ts
@@ -245,7 +245,10 @@ export const llmPromptsLogic = kea<llmPromptsLogicType>([
 
     trackedActionToUrl(({ values }) => {
         const changeUrl = (): [string, Record<string, any>, Record<string, any>, { replace: boolean }] | void => {
-            const nextValues = cleanPagedSearchOrderParams(values.filters)
+            const nextValues = {
+                ...cleanPagedSearchOrderParams(values.filters),
+                created_by_id: values.filters.created_by_id,
+            }
             const urlValues = cleanFilters(router.values.searchParams)
 
             if (!objectsEqual(values.filters, urlValues)) {


### PR DESCRIPTION
## Problem

Filtering the prompts list by creator does not stick. Changing pages resets the picker to "Any user" and shows all prompts. Filtering while on page 2, or with an active search, reverts the selection instantly. The filter is also lost on refresh.

The URL writer serializes only page, search, and order_by, so `created_by_id` never reaches the URL. The URL handler treats the URL as the source of truth and wipes the filter on the next sync.

## Changes

- The creator filter now survives pagination, search, refresh, and shared links.
- The URL writer in `llmPromptsLogic.ts` now includes `created_by_id` next to the shared page/search/order params. Deep links with the param already worked; this makes the writer symmetric with the reader.

No visual change; only filter persistence across URL updates.

## How did you test this code?

Not run: frontend jest and typecheck (light worktree without node_modules). CI covers both. The read path (`cleanFilters`) already parses `created_by_id` from the URL, as deep links show; this change only adds the param on the write path.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found during an audit of the Prompts feature. Skills invoked: /wt, /writing-pr-descriptions. No open PR fixes this (`gh pr list --search` on the branch topic found nothing).
