### PR TITLE
fix(experiments): count all runner skip reasons in precompute overview

### DIFF
--- a/.agents/skills/analyzing-experiment-query-performance/SKILL.md
+++ b/.agents/skills/analyzing-experiment-query-performance/SKILL.md
@@ -188,7 +188,9 @@ Check enablement in the UI, or in code via `TeamExperimentsConfig.experiment_pre
 - `experiment_exposures_path` / `experiment_metric_events_path` — how the read sourced each side:
   `precomputed` (fast path), `direct_scan` (full events scan), `not_applicable`.
 - `experiment_precompute_skip_reason` — set on reads that **never attempted** precompute:
-  `team_disabled`, `min_runtime`, `override_direct`, `data_warehouse`, `group_aggregation`.
+  `override_direct`, `team_disabled`, `min_runtime`, `activation_config`, `cohort_not_calculated`,
+  `data_warehouse`, `group_aggregation`
+  (the `PrecomputeSkipReason` enum in `products/experiments/backend/hogql_queries/types.py`).
   **An empty skip reason on a `direct_scan` read means precompute was attempted but the data wasn't ready**
   (build failed or too slow) — that read paid for the build _and_ the full scan.
   This is the bucket to watch; it should stay near zero.

--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -36,6 +36,7 @@ from posthog.settings.base_variables import DEBUG
 from posthog.settings.data_stores import CLICKHOUSE_AUX_CLUSTER, CLICKHOUSE_CLUSTER, CLICKHOUSE_DATABASE
 
 from products.analytics_platform.backend.models import PreaggregationJob
+from products.experiments.backend.hogql_queries.types import PrecomputeSkipReason
 from products.experiments.backend.models.team_experiments_config import TeamExperimentsConfig
 
 logger = logging.getLogger(__name__)
@@ -770,13 +771,7 @@ class DebugCHQueries(viewsets.ViewSet):
     # Skip reasons the runner tags on reads that never attempted precompute. An empty reason on a
     # direct-scan read means precompute WAS attempted but the data wasn't ready (build failed/slow) —
     # that read paid for the build AND the full events scan, so it's the bucket to watch.
-    _PRECOMPUTE_SKIP_REASONS = (
-        "team_disabled",
-        "min_runtime",
-        "override_direct",
-        "data_warehouse",
-        "group_aggregation",
-    )
+    _PRECOMPUTE_SKIP_REASONS = tuple(reason.value for reason in PrecomputeSkipReason)
 
     @action(detail=False, methods=["GET"], url_path="precompute_overview", required_scopes=["query_performance:read"])
     def precompute_overview(self, request):
@@ -805,7 +800,7 @@ class DebugCHQueries(viewsets.ViewSet):
         # Reads query_log_archive (not system.query_log, which retains only hours): log_comment is a
         # typed JSON column there, so tags are dot-accessed; ifNull(toString(...), '') preserves the
         # ''-when-missing semantics JSONExtractString gave us on the raw column.
-        # nosemgrep: clickhouse-fstring-param-audit - skip_reason_counts is built from a hardcoded tuple
+        # nosemgrep: clickhouse-fstring-param-audit - skip_reason_counts is built from the PrecomputeSkipReason enum
         reads_sql = f"""
             SELECT
                 coalesce(

--- a/posthog/api/test/test_debug_ch_queries.py
+++ b/posthog/api/test/test_debug_ch_queries.py
@@ -15,6 +15,7 @@ from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.utils import generate_random_token_personal, hash_key_value
 from posthog.settings.data_stores import CLICKHOUSE_AUX_CLUSTER, CLICKHOUSE_CLUSTER
 
+from products.experiments.backend.hogql_queries.types import PrecomputeSkipReason
 from products.experiments.backend.models.team_experiments_config import TeamExperimentsConfig
 
 
@@ -177,6 +178,36 @@ class TestDebugCHQuery(APIBaseTest):
         self.assertEqual(reads["precomputed_p90_duration_ms"][i], 450)
         self.assertEqual(reads["fully_precomputed_avg_read_bytes"][i], 2048)
         self.assertEqual(sum(reads["precomputed_p50_duration_ms"]), 120)
+
+    def test_precompute_overview_counts_every_runner_skip_reason(self):
+        # A reason the runner emits but the breakdown omits leaves those reads counted in the
+        # totals while appearing in no skip_reasons bucket.
+        self.user.is_staff = True
+        self.user.save()
+        skip_counts = {reason.value: i + 1 for i, reason in enumerate(PrecomputeSkipReason)}
+        reads_row = (
+            "direct_scan",
+            sum(skip_counts.values()),  # reads
+            0,  # failed_reads
+            *skip_counts.values(),
+            0,  # attempted
+            0,  # me_precomputed
+            sum(skip_counts.values()),  # me_direct_scan
+            0,  # me_not_applicable
+            10.0,  # avg_duration_ms
+            10.0,  # p50_duration_ms
+            20.0,  # p90_duration_ms
+            1024.0,  # avg_read_bytes
+            4096,  # total_read_bytes
+        )
+
+        with patch("posthog.api.debug_ch_queries.sync_execute", side_effect=[[reads_row], []]):
+            resp = self.client.get("/api/debug_ch_queries/precompute_overview/?hours=24")
+
+        self.assertEqual(resp.status_code, HTTP_200_OK, resp.content)
+        data = resp.json()
+        self.assertEqual(data["reads"]["by_exposures_path"]["direct_scan"]["skip_reasons"], skip_counts)
+        self.assertEqual(data["reads"]["total"], sum(skip_counts.values()))
 
     @patch("posthog.api.debug_ch_queries.sync_execute", return_value=[])
     def test_slowest_queries_pat_with_scope_and_staff_allowed(self, _mock_execute):

--- a/products/experiments/backend/hogql_queries/experiment_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_query_runner.py
@@ -72,6 +72,7 @@ from products.experiments.backend.hogql_queries.exposure_query_logic import (
     get_multiple_variant_handling_from_experiment,
     has_activation_config,
 )
+from products.experiments.backend.hogql_queries.types import PrecomputeSkipReason
 from products.experiments.backend.hogql_queries.utils import (
     aggregate_variants_across_breakdowns,
     get_bayesian_experiment_result,
@@ -433,27 +434,27 @@ class ExperimentQueryRunner(QueryRunner):
 
         return not has_uncalculated_cohorts(self.team, self.experiment.exposure_criteria, self.metric)
 
-    def _precompute_skip_reason(self) -> Optional[str]:
+    def _precompute_skip_reason(self) -> Optional[PrecomputeSkipReason]:
         """Why precompute was not used, for the query-performance UI. None when it was attempted."""
         if self.query.precomputation_mode == PrecomputationMode.PRECOMPUTED:
             return None
         if self.query.precomputation_mode == PrecomputationMode.DIRECT:
-            return "override_direct"
+            return PrecomputeSkipReason.OVERRIDE_DIRECT
         if not self._team_experiments_config.experiment_precomputation_enabled:
-            return "team_disabled"
+            return PrecomputeSkipReason.TEAM_DISABLED
         if not experiment_has_min_runtime_for_precomputation(
             self.experiment.start_date,
             self.experiment.end_date,
         ):
-            return "min_runtime"
+            return PrecomputeSkipReason.MIN_RUNTIME
         if has_activation_config(self.experiment.exposure_criteria):
-            return "activation_config"
+            return PrecomputeSkipReason.ACTIVATION_CONFIG
         if has_uncalculated_cohorts(self.team, self.experiment.exposure_criteria, self.metric):
-            return "cohort_not_calculated"
+            return PrecomputeSkipReason.COHORT_NOT_CALCULATED
         if self.is_data_warehouse_query:
-            return "data_warehouse"
+            return PrecomputeSkipReason.DATA_WAREHOUSE
         if self.group_type_index is not None:
-            return "group_aggregation"
+            return PrecomputeSkipReason.GROUP_AGGREGATION
         return None  # precompute was attempted; a direct path means the build failed / wasn't ready
 
     def _retention_metric_events_precomputation_enabled(self) -> bool:
@@ -668,11 +669,12 @@ class ExperimentQueryRunner(QueryRunner):
         # Tag after _get_experiment_query() which sets the precompute flags
         exposures_path = "precomputed" if self._is_precomputed else "direct_scan"
         metric_events_path = self.metric_events_path
+        skip_reason = self._precompute_skip_reason()
         tag_queries(
             experiment_exposures_path=exposures_path,
             experiment_metric_events_path=metric_events_path,
             experiment_execution_path=exposures_path,
-            experiment_precompute_skip_reason=self._precompute_skip_reason(),
+            experiment_precompute_skip_reason=skip_reason.value if skip_reason is not None else None,
             experiment_scan_date_from=self.date_range.date_from,
             experiment_scan_date_to=self.date_range.date_to,
         )

--- a/products/experiments/backend/hogql_queries/types.py
+++ b/products/experiments/backend/hogql_queries/types.py
@@ -1,7 +1,22 @@
-from enum import Enum
+from enum import Enum, StrEnum
 
 
 class ExperimentMetricType(Enum):
     COUNT = "count"
     CONTINUOUS = "continuous"
     FUNNEL = "funnel"
+
+
+class PrecomputeSkipReason(StrEnum):
+    """Why a metric read never attempted precompute. Tagged on the query as
+    `experiment_precompute_skip_reason` and counted per reason by the
+    `precompute_overview` staff endpoint, which iterates this enum — a reason
+    missing here is invisible in the staff tooling."""
+
+    OVERRIDE_DIRECT = "override_direct"
+    TEAM_DISABLED = "team_disabled"
+    MIN_RUNTIME = "min_runtime"
+    ACTIVATION_CONFIG = "activation_config"
+    COHORT_NOT_CALCULATED = "cohort_not_calculated"
+    DATA_WAREHOUSE = "data_warehouse"
+    GROUP_AGGREGATION = "group_aggregation"


### PR DESCRIPTION
## Problem

The precompute overview on /experiments/staff shows a skip-reason breakdown that is missing two reasons the query runner emits: `activation_config` and `cohort_not_calculated`. Reads skipped for those reasons are counted in the totals but appear in no bucket, so the buckets do not sum to the total and those fallbacks are invisible to staff.

The endpoint kept its own hardcoded copy of the runner's reason list, which drifted when the runner gained the two reasons.

## Changes

- The overview breakdown now shows all seven skip reasons, and the buckets sum to the read total.
- The reasons live in one `PrecomputeSkipReason` enum. The runner returns its members and the endpoint iterates the enum, so a new reason shows up in the tooling without a second edit.
- Mechanical: the `analyzing-experiment-query-performance` skill doc lists the full reason set.

## How did you test this code?

- New `precompute_overview` test (the endpoint's first) asserts every enum reason lands in its own bucket with the right count. It fails on the previous code, where the two newer reasons were dropped.
- Ran `posthog/api/test/test_debug_ch_queries.py`, `test_precomputation_gate.py`, and `test_experiment_exposure_preaggregation.py` locally, plus repo-wide mypy.
- Not run: a live check against production data; the drift was confirmed in prod US before the fix (5 buckets returned while reads carried 7 distinct reasons).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None (staff-only internal tooling; the skill doc update is in this PR).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found during an audit of the /experiments/staff tooling: the live overview returned five skip-reason buckets while the runner tags seven. First of a planned series of small correctness fixes to this endpoint. Skills invoked: /wt, /improving-drf-endpoints, /writing-tests, /writing-code-comments conventions, /writing-pr-descriptions. No open PR covers this (searched "skip reason precompute").
