### PR TITLE
feat(visual-review): send a daily debt digest to owning teams

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -1098,26 +1098,6 @@ ERROR_TRACKING_WEEKLY_DIGEST_ALLOWED_EMAILS = get_list(get_from_env("ERROR_TRACK
 # webhook secret used initially for ET weekly digest workflow webhook but feel free to adopt it
 WORKFLOWS_WEBHOOK_SECRET = get_from_env("WORKFLOWS_WEBHOOK_SECRET", "")
 
-# How far the daily visual review debt digest goes. "off" runs nothing. "preview" evaluates,
-# attributes and renders every team's message and logs it. "shadow" posts every team's message
-# into one channel instead of theirs. "live" posts to the channel each team declared.
-VISUAL_REVIEW_DEBT_DIGEST_MODE = get_from_env("VISUAL_REVIEW_DEBT_DIGEST_MODE", "off")
-
-# Comma-separated `owner/name` repos the digest runs for. Empty means no repo, so a mode left on
-# by accident still sends nothing.
-VISUAL_REVIEW_DEBT_DIGEST_REPOS = get_list(get_from_env("VISUAL_REVIEW_DEBT_DIGEST_REPOS", ""))
-
-# Where "shadow" mode posts.
-VISUAL_REVIEW_DEBT_DIGEST_SHADOW_CHANNEL = get_from_env("VISUAL_REVIEW_DEBT_DIGEST_SHADOW_CHANNEL", "#alerts-devex")
-
-# The GitHub Actions artifact the Storybook build uploads. The digest reads its story index to name
-# the file behind a snapshot.
-VISUAL_REVIEW_STORYBOOK_ARTIFACT_NAME = get_from_env("VISUAL_REVIEW_STORYBOOK_ARTIFACT_NAME", "storybook-build")
-
-# Where the Storybook package sits in the repository. Story import paths in the index are relative
-# to it, so this is what turns one into a repository path.
-VISUAL_REVIEW_STORYBOOK_PACKAGE_DIR = get_from_env("VISUAL_REVIEW_STORYBOOK_PACKAGE_DIR", "common/storybook")
-
 ####
 # OAuth
 

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -1098,6 +1098,26 @@ ERROR_TRACKING_WEEKLY_DIGEST_ALLOWED_EMAILS = get_list(get_from_env("ERROR_TRACK
 # webhook secret used initially for ET weekly digest workflow webhook but feel free to adopt it
 WORKFLOWS_WEBHOOK_SECRET = get_from_env("WORKFLOWS_WEBHOOK_SECRET", "")
 
+# How far the daily visual review debt digest goes. "off" runs nothing. "preview" evaluates,
+# attributes and renders every team's message and logs it. "shadow" posts every team's message
+# into one channel instead of theirs. "live" posts to the channel each team declared.
+VISUAL_REVIEW_DEBT_DIGEST_MODE = get_from_env("VISUAL_REVIEW_DEBT_DIGEST_MODE", "off")
+
+# Comma-separated `owner/name` repos the digest runs for. Empty means no repo, so a mode left on
+# by accident still sends nothing.
+VISUAL_REVIEW_DEBT_DIGEST_REPOS = get_list(get_from_env("VISUAL_REVIEW_DEBT_DIGEST_REPOS", ""))
+
+# Where "shadow" mode posts.
+VISUAL_REVIEW_DEBT_DIGEST_SHADOW_CHANNEL = get_from_env("VISUAL_REVIEW_DEBT_DIGEST_SHADOW_CHANNEL", "#alerts-devex")
+
+# The GitHub Actions artifact the Storybook build uploads. The digest reads its story index to name
+# the file behind a snapshot.
+VISUAL_REVIEW_STORYBOOK_ARTIFACT_NAME = get_from_env("VISUAL_REVIEW_STORYBOOK_ARTIFACT_NAME", "storybook-build")
+
+# Where the Storybook package sits in the repository. Story import paths in the index are relative
+# to it, so this is what turns one into a repository path.
+VISUAL_REVIEW_STORYBOOK_PACKAGE_DIR = get_from_env("VISUAL_REVIEW_STORYBOOK_PACKAGE_DIR", "common/storybook")
+
 ####
 # OAuth
 

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -1075,6 +1075,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         crontab(hour="7", minute="30"),
         send_visual_review_debt_digests.s(),
         name="send visual review debt digests",
+        expires_seconds=60 * 60,
     )
 
     sender.add_periodic_task(

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -126,7 +126,7 @@ from products.tasks.backend.facade.tasks import (
     sweep_inactive_tasks_task,
     sweep_loop_task_retention_task,
 )
-from products.visual_review.backend.facade.tasks import sweep_visual_review_retention
+from products.visual_review.backend.facade.tasks import send_visual_review_debt_digests, sweep_visual_review_retention
 from products.warehouse_sources.backend.facade.tasks import sweep_stopped_schema_syncs
 from products.web_analytics.backend.achievements.tasks import sweep_web_analytics_achievement_team_tracks
 from products.web_analytics.backend.tasks.heatmap_screenshot import (
@@ -1068,6 +1068,13 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         crontab(hour="2", minute="23"),
         sweep_visual_review_retention.s(),
         name="sweep visual review retention",
+    )
+
+    add_periodic_task_with_expiry(
+        sender,
+        crontab(hour="7", minute="30"),
+        send_visual_review_debt_digests.s(),
+        name="send visual review debt digests",
     )
 
     sender.add_periodic_task(

--- a/posthog/team_notifications/slack.py
+++ b/posthog/team_notifications/slack.py
@@ -1,8 +1,8 @@
 """Find a team's Slack channel by name, and post an automated message into it.
 
-The two pieces every product that posts a routed digest needs, and nothing else. Which channel a
-team's message belongs in, what the message says, and what a failed post does to the product's own
-records all stay with the product.
+What every product that posts a routed digest needs: which channel a team's message belongs in, the
+limits Slack puts on a message, and what a refused post says. What the message says, and what a
+failure does to the product's own records, stay with the product.
 """
 
 from __future__ import annotations
@@ -18,6 +18,23 @@ from posthog.dataclasses import frozen
 from posthog.models.integration import Integration, SlackIntegration
 
 logger = structlog.get_logger(__name__)
+
+# Slack rejects a section block over 3000 characters. The margin covers the mrkdwn escaping, which
+# can turn one character into five.
+MAX_SECTION_CHARS = 2900
+
+
+def clip_text(text: str, limit: int) -> str:
+    """Cut display text down to `limit` characters, marking that something was cut."""
+    if len(text) <= limit:
+        return text
+    return text[: max(limit - 1, 0)] + "…"
+
+
+def section_block(text: str) -> list[dict]:
+    """One mrkdwn section, in the block list a post takes."""
+    return [{"type": "section", "text": {"type": "mrkdwn", "text": text}}]
+
 
 # Slack channel flags that mark a channel as shared beyond this workspace. A caller that maps a team
 # name onto a Slack channel by name can land on a shared channel carrying that name, which sends an

--- a/posthog/team_notifications/test/test_slack.py
+++ b/posthog/team_notifications/test/test_slack.py
@@ -2,7 +2,7 @@ from django.test import SimpleTestCase
 
 from parameterized import parameterized
 
-from posthog.team_notifications.slack import SlackChannel, find_channel
+from posthog.team_notifications.slack import SlackChannel, clip_text, find_channel
 
 _TEAM_CHANNEL = SlackChannel(channel_id="C1", shared=False)
 _SHARED_CHANNEL = SlackChannel(channel_id="C2", shared=True)
@@ -25,3 +25,16 @@ class TestFindChannel(SimpleTestCase):
         match = find_channel(_CHANNELS, channel_name, allow_shared=allow_shared)
 
         self.assertEqual((match.channel, match.reason), (channel, reason))
+
+
+class TestClipText(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("shorter_than_the_limit_is_untouched", "one line", 20, "one line"),
+            ("exactly_the_limit_is_untouched", "one line", 8, "one line"),
+            ("over_the_limit_is_cut_to_the_limit", "one line", 4, "one…"),
+            ("a_limit_of_zero_keeps_no_text", "one line", 0, "…"),
+        ]
+    )
+    def test_clip(self, _name: str, text: str, limit: int, expected: str) -> None:
+        self.assertEqual(clip_text(text, limit), expected)

--- a/products/engineering_analytics/backend/facade/api.py
+++ b/products/engineering_analytics/backend/facade/api.py
@@ -18,6 +18,7 @@ then delegates to the read layer — source selection and access control live in
 not in the query builders below it.
 """
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from posthog.models.team import Team
@@ -36,6 +37,7 @@ from products.engineering_analytics.backend.facade.contracts import (
     GitHubSource,
     MasterFailureGroup,
     MergedPullRequest,
+    PathOwnership,
     PRCostSummary,
     PRLifecycle,
     PullRequestList,
@@ -624,3 +626,13 @@ def list_job_aggregates(
         branch=branch,
         run_scope=run_scope,
     )
+
+
+def resolve_path_owners(repository: str, paths: Sequence[str]) -> PathOwnership:
+    """Name the team that owns each repository path, from the repository's own ownership files.
+
+    No team parameter: the answer comes from the repository as it stands on its default branch, not
+    from anything this PostHog team stores. Callers outside this product reach it here so the fetch,
+    the cache, and the failure contract stay in one place.
+    """
+    return logic.resolve_path_owners(repository, paths)

--- a/products/engineering_analytics/backend/facade/contracts.py
+++ b/products/engineering_analytics/backend/facade/contracts.py
@@ -21,10 +21,12 @@ read layer maps them into these types. Reviewers and file paths are
 intentionally absent until the warehouse data that backs them lands.
 """
 
+from collections.abc import Mapping
 from dataclasses import field
 from datetime import date, datetime
 from enum import StrEnum
 
+from posthog_owners.schema import TeamEntry
 from pydantic.dataclasses import dataclass
 
 from posthog.hogql.database.models import FieldOrTable
@@ -1547,3 +1549,20 @@ class WorkflowJobAggregate:
     retry_job_count: int
     billable_minutes: float | None
     estimated_cost_usd: float | None
+
+
+@dataclass(frozen=True)
+class PathOwnership:
+    """Which team owns each of a set of repository paths, plus the repo's Slack registry.
+
+    The registry rides along because the caller that asks who owns a path usually has to reach
+    that team next, and the root ``owners.yaml`` answers both questions in one read.
+
+    ``resolved`` is false when the ownership files could not be read, which leaves every path
+    ``UNOWNED_TEAM`` and the registry empty. A caller that says so beats one that reads the blind
+    answer as "nobody owns this".
+    """
+
+    team_by_path: Mapping[str, str]
+    registry: Mapping[str, TeamEntry]
+    resolved: bool

--- a/products/engineering_analytics/backend/logic/__init__.py
+++ b/products/engineering_analytics/backend/logic/__init__.py
@@ -22,6 +22,7 @@ from products.engineering_analytics.backend.logic.dora import (
     build_dora_overview as build_dora_overview,
     get_dora_environment_choices as get_dora_environment_choices,
 )
+from products.engineering_analytics.backend.logic.ownership import resolve_path_owners as resolve_path_owners
 from products.engineering_analytics.backend.logic.pull_requests import (
     build_author_workflow_costs as build_author_workflow_costs,
     build_ci_cards as build_ci_cards,

--- a/products/engineering_analytics/backend/logic/ownership.py
+++ b/products/engineering_analytics/backend/logic/ownership.py
@@ -6,7 +6,7 @@ files are fetched and cached.
 """
 
 import random
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from http import HTTPStatus
 from time import monotonic
@@ -18,13 +18,14 @@ import requests
 import structlog
 from posthog_owners import OwnershipSource, OwnersResolver
 from posthog_owners.matcher import normalize_path
+from posthog_owners.resolver import teams_registry
 from requests.adapters import HTTPAdapter
 
 from posthog.dataclasses import frozen
 from posthog.egress.github.transport import github_request
 from posthog.models.integration.github import _is_safe_github_repo_path
 
-from products.engineering_analytics.backend.facade.contracts import UNOWNED_TEAM
+from products.engineering_analytics.backend.facade.contracts import UNOWNED_TEAM, PathOwnership
 
 logger = structlog.get_logger(__name__)
 
@@ -208,6 +209,35 @@ def resolve_test_ownership(
         # rather than attributing part of it.
         logger.exception("repo_ownership_unavailable", repository=repository)
         return RepoOwnershipResult(tests=[UNPLACED] * len(tests), resolved=False)
+
+
+def resolve_path_owners(repository: str, paths: Sequence[str], files: RepoFiles | None = None) -> PathOwnership:
+    """Name the team that owns each repository path, and hand back the repo's Slack registry.
+
+    The paths are resolved exactly as given. There is no candidate-path search: that exists because
+    a test suite reports a path relative to its own root, and a caller who already holds a
+    repo-relative path has nothing to guess at.
+    """
+    reader = files if files is not None else GitHubRepoFiles(repository)
+    try:
+        return _own_paths(repository, reader, list(dict.fromkeys(paths)))
+    except OwnershipUnavailable:
+        logger.exception("repo_path_ownership_unavailable", repository=repository)
+        return PathOwnership(team_by_path=dict.fromkeys(paths, UNOWNED_TEAM), registry={}, resolved=False)
+
+
+def _own_paths(repository: str, files: RepoFiles, paths: list[str]) -> PathOwnership:
+    root = files.read(_ROOT_OWNERS_FILE)
+    if root is None:
+        raise OwnershipUnavailable(f"{repository} has no root {_ROOT_OWNERS_FILE}")
+    resolver = OwnersResolver(source=files)
+    files.read_all(resolver.ownership_file_paths(paths))
+    owners = resolver.map(paths)
+    return PathOwnership(
+        team_by_path={path: _team(owners[path].owners) for path in paths},
+        registry=teams_registry(root),
+        resolved=True,
+    )
 
 
 def _place(repository: str, files: RepoFiles, tests: list[QuarantinedTestFile]) -> list[PlacedTest]:

--- a/products/engineering_analytics/backend/tests/test_ownership.py
+++ b/products/engineering_analytics/backend/tests/test_ownership.py
@@ -19,11 +19,19 @@ from products.engineering_analytics.backend.logic.ownership import (
     OwnershipUnavailable,
     PlacedTest,
     QuarantinedTestFile,
+    resolve_path_owners,
     resolve_test_ownership,
 )
 
+_ROOT_OWNERS = """version: 1
+owners: [team-root]
+teams:
+  team-ingestion:
+    notifications: '#alerts-ingestion'
+"""
+
 _OWNERS = {
-    "owners.yaml": "version: 1\nowners: [team-root]\n",
+    "owners.yaml": _ROOT_OWNERS,
     "nodejs/src/owners.yaml": "version: 1\nowners: [team-ingestion]\n",
     "frontend/src/scenes/owners.yaml": "version: 1\nowners: [team-product-analytics]\n",
     "rust/owners.yaml": "version: 1\nowners: [team-rust]\n",
@@ -113,6 +121,27 @@ class TestRepoOwnership(SimpleTestCase):
 
     def test_a_resolved_batch_says_so(self) -> None:
         assert resolve_test_ownership("PostHog/posthog", [], files=_FakeRepoFiles()).resolved
+
+
+class TestPathOwnership(SimpleTestCase):
+    def test_places_each_path_exactly_and_returns_the_registry(self) -> None:
+        # Exact resolution, not the suite-root search: 'src/...' is a real repo-relative path here
+        # and must not be repositioned under nodejs/ the way a reported test path is.
+        owned = resolve_path_owners(
+            "PostHog/posthog",
+            ["nodejs/src/cdp/worker.ts", "src/cdp/worker.ts"],
+            files=_FakeRepoFiles(),
+        )
+        assert owned.resolved
+        assert owned.team_by_path == {"nodejs/src/cdp/worker.ts": "team-ingestion", "src/cdp/worker.ts": "team-root"}
+        assert owned.registry["team-ingestion"].notifications == "#alerts-ingestion"
+
+    def test_an_unreadable_repository_owns_nothing_and_says_so(self) -> None:
+        no_root = _FakeRepoFiles(owners={k: v for k, v in _OWNERS.items() if k != "owners.yaml"})
+        owned = resolve_path_owners("PostHog/posthog", ["nodejs/src/cdp/worker.ts"], files=no_root)
+        assert not owned.resolved
+        assert owned.team_by_path == {"nodejs/src/cdp/worker.ts": UNOWNED_TEAM}
+        assert owned.registry == {}
 
 
 class TestGitHubRepoFiles(SimpleTestCase):

--- a/products/visual_review/README.md
+++ b/products/visual_review/README.md
@@ -41,6 +41,65 @@ The windows and the reasons behind them are constants in `backend/logic/retentio
   An artifact row is what makes the CLI skip an upload, so a row without its object is the one state to avoid; a leaked object only costs storage.
 - Each invocation is capped by rows and by a time budget, so a backlog drains over days.
 
+### Daily debt digest
+
+A daily Celery task, `send visual review debt digests`, posts each team a Slack reminder about the visual review debt it still carries.
+The digest is stateless: every morning both conditions below are evaluated from current data, and nothing is stored about what was sent.
+An item repeats every day while it stands, and stops the day the condition no longer holds.
+
+Two conditions, and nothing else:
+
+- **Quarantine expiring.**
+  An active quarantine that runs out inside `FLAKINESS_EXPIRY_SOON_DAYS`.
+  It clears when somebody extends it past the window, lifts it, or lets it lapse.
+- **N accepted variants of the current baseline.**
+  `VARIANT_PILEUP_MIN` or more active intentional tolerations recorded against the hash the baseline currently holds, with no quarantine already covering the identity.
+  This is not the ninety-day tolerated count on the baselines page, which measures how often somebody accepted drift in a window.
+  This count has no window, because an accepted variant keeps matching without a new record.
+  It clears when the tolerations are removed, or when the baseline changes.
+
+A baseline change invalidates the tolerations recorded against the old baseline: they can never match again, so the count drops to zero.
+That is not evidence the story recovered.
+Reminders about retained exceptions repeat until they are removed or no longer apply.
+
+Attribution runs through the Storybook build behind the current baseline, and then through `owners.yaml`.
+The build uploads its story index as a GitHub Actions artifact, so the digest reads the artifact of the workflow run recorded on that baseline run (`metadata["github_run_id"]`), and the index names the file each story lives in.
+A snapshot identifier is a story id plus the theme, the browser when it is not chromium, and the viewport width for a story that snapshots several.
+The full story id is looked up first and the width suffix is only stripped when that misses, because a story can be named after a width.
+The parsed index is cached per repository and workflow run for two days, and the key rotates on its own whenever the baseline moves.
+Nothing is guessed from the identifier: a story name is not a path.
+Only Storybook runs are attributed today.
+
+Three outcomes have no owning team, and the digest keeps them apart:
+
+- **Nobody owns the file.** The story maps to a file, and no owners entry covers it. Add one for the path, which stays on the line.
+- **The story is not in the index.** It moved, was renamed, was deleted, or it only exists on a branch.
+- **Ownership could not be worked out.** The artifact was missing or expired, the download failed, the team has no GitHub integration, or the run type is not supported yet.
+
+All three go to whoever owns `products/visual_review/`, in a triage part of that team's digest kept separate from the items those maintainers own.
+Holding an item until a team takes it is not owning it, and the wording says so.
+A missing artifact never turns the digest into "nobody owns this": the items still go out, and the lead says ownership is worked out again tomorrow.
+When nobody owns `products/visual_review/` either, the items are logged and dropped rather than posted somewhere arbitrary.
+The artifact is kept for one day, which is enough for a daily read of a moving baseline.
+A baseline that has not moved for longer reads as ownership could not be worked out, and the digest says so instead of guessing.
+
+Routing goes to the team's `notifications` channel in the repository's root `owners.yaml` registry, under the `visual_review` producer.
+A team opts out with `notifications: {visual_review: false}` under its entry.
+A shared Slack channel is refused, so a name match never carries an internal reminder out of the workspace.
+
+Settings, all in `posthog/settings/web.py`:
+
+- `VISUAL_REVIEW_DEBT_DIGEST_MODE` is `off` (the default), `preview`, `shadow`, or `live`.
+  `preview` evaluates, attributes and renders every team's message into the log and posts nothing.
+  `shadow` posts every team's message into one channel, with a lead naming the channel it would have gone to.
+  `live` posts to each team's own channel.
+- `VISUAL_REVIEW_DEBT_DIGEST_REPOS` is the comma-separated `owner/name` list the digest runs for. Empty means no repo.
+- `VISUAL_REVIEW_DEBT_DIGEST_SHADOW_CHANNEL` is where `shadow` posts.
+- `VISUAL_REVIEW_STORYBOOK_ARTIFACT_NAME` is the GitHub Actions artifact the Storybook build uploads, `storybook-build` by default.
+- `VISUAL_REVIEW_STORYBOOK_PACKAGE_DIR` is where the Storybook package sits in the repository, `common/storybook` by default. Story import paths in the index are relative to it.
+
+`./manage.py visual_review_debt_digest --repo owner/name [--mode preview]` runs one repo synchronously and prints what it rendered.
+
 ## The flow
 
 ### Single-command flow (`vr submit`)

--- a/products/visual_review/README.md
+++ b/products/visual_review/README.md
@@ -87,18 +87,12 @@ Routing goes to the team's `notifications` channel in the repository's root `own
 A team opts out with `notifications: {visual_review: false}` under its entry.
 A shared Slack channel is refused, so a name match never carries an internal reminder out of the workspace.
 
-Settings, all in `posthog/settings/web.py`:
+There is nothing to configure.
+The daily beat task runs the digest for every repository, and a repository that owes nothing posts nothing.
 
-- `VISUAL_REVIEW_DEBT_DIGEST_MODE` is `off` (the default), `preview`, `shadow`, or `live`.
-  `preview` evaluates, attributes and renders every team's message into the log and posts nothing.
-  `shadow` posts every team's message into one channel, with a lead naming the channel it would have gone to.
-  `live` posts to each team's own channel.
-- `VISUAL_REVIEW_DEBT_DIGEST_REPOS` is the comma-separated `owner/name` list the digest runs for. Empty means no repo.
-- `VISUAL_REVIEW_DEBT_DIGEST_SHADOW_CHANNEL` is where `shadow` posts.
-- `VISUAL_REVIEW_STORYBOOK_ARTIFACT_NAME` is the GitHub Actions artifact the Storybook build uploads, `storybook-build` by default.
-- `VISUAL_REVIEW_STORYBOOK_PACKAGE_DIR` is where the Storybook package sits in the repository, `common/storybook` by default. Story import paths in the index are relative to it.
-
-`./manage.py visual_review_debt_digest --repo owner/name [--mode preview]` runs one repo synchronously and prints what it rendered.
+`./manage.py visual_review_debt_digest --repo owner/name [--mode preview]` runs one repository by hand.
+`--mode preview`, the default, renders every team's message and logs it without posting.
+`--mode live` posts.
 
 ## The flow
 

--- a/products/visual_review/backend/facade/api.py
+++ b/products/visual_review/backend/facade/api.py
@@ -319,9 +319,9 @@ def get_baselines_overview(repo_id: UUID) -> contracts.BaselineOverview:
         run = snapshot.run
         artifact = snapshot.current_artifact
         thumbnail = artifact.thumbnail if artifact is not None else None
-        # `(run_type, identifier)` keys because the same identifier in
-        # different run types is a different baseline.
-        key = (run.run_type, identifier)
+        # Keyed per identity because the same identifier in different run types
+        # is a different baseline.
+        key = run_queries.SnapshotKey(run_type=run.run_type, identifier=identifier)
         metadata = snapshot.metadata or {}
         active_quarantine = raw.active_quarantines_by_key.get(key)
         entries.append(

--- a/products/visual_review/backend/facade/api.py
+++ b/products/visual_review/backend/facade/api.py
@@ -334,6 +334,7 @@ def get_baselines_overview(repo_id: UUID) -> contracts.BaselineOverview:
                 height=artifact.height if artifact is not None else None,
                 tolerate_count_30d=raw.tolerate_30d_by_id.get(identifier, 0),
                 tolerate_count_90d=raw.tolerate_90d_by_id.get(identifier, 0),
+                active_variants_current_baseline=raw.active_variants_by_key.get(key, 0),
                 is_quarantined=active_quarantine is not None,
                 last_run_at=run.completed_at or run.created_at,
                 baseline_change_count=raw.change_count_by_key.get(key, 0),
@@ -351,6 +352,7 @@ def get_baselines_overview(repo_id: UUID) -> contracts.BaselineOverview:
         recently_tolerated=raw.totals_recent,
         frequently_tolerated=raw.totals_frequent,
         currently_quarantined=raw.totals_quarantined,
+        variant_pileups=raw.totals_variant_pileups,
         by_run_type=raw.by_run_type,
     )
 

--- a/products/visual_review/backend/facade/contracts.py
+++ b/products/visual_review/backend/facade/contracts.py
@@ -511,6 +511,11 @@ BASELINE_OVERVIEW_MAX_ENTRIES = 5000
 # to wash out a single jittery render while staying responsive on real changes.
 BASELINE_DRIFT_RECENT_RUN_COUNT = 10
 
+# Accepted variants against one current baseline at which the baseline stops describing one
+# rendering and starts describing a set. Three is the point where a reader can no longer hold what
+# "the baseline" means for that snapshot, and the same floor the frequently-tolerated stat uses.
+VARIANT_PILEUP_MIN = 3
+
 
 @dataclass(frozen=True)
 class BaselineQuarantineSummary:
@@ -546,6 +551,11 @@ class BaselineEntry:
     height: int | None
     tolerate_count_30d: int
     tolerate_count_90d: int
+    # Accepted variants still recorded against the hash this baseline currently holds. Distinct
+    # from the two counts above, which measure how often somebody accepted drift in a rolling
+    # window. A baseline change drops this to zero, because a toleration is recorded against the
+    # baseline hash it was decided for and stops matching when that hash moves.
+    active_variants_current_baseline: int
     is_quarantined: bool
     last_run_at: datetime
     # Lifetime count of YAML baseline flips on master/main for this identifier.
@@ -576,6 +586,8 @@ class BaselineTotals:
     recently_tolerated: int
     frequently_tolerated: int
     currently_quarantined: int
+    # Baselines carrying at least `VARIANT_PILEUP_MIN` accepted variants of their current hash.
+    variant_pileups: int
     by_run_type: dict[str, int]
 
 

--- a/products/visual_review/backend/facade/tasks.py
+++ b/products/visual_review/backend/facade/tasks.py
@@ -1,5 +1,5 @@
 """Celery tasks core schedules for visual_review (see products/architecture.md, wiring couplings)."""
 
-from products.visual_review.backend.tasks.tasks import sweep_visual_review_retention
+from products.visual_review.backend.tasks.tasks import send_visual_review_debt_digests, sweep_visual_review_retention
 
-__all__ = ["sweep_visual_review_retention"]
+__all__ = ["send_visual_review_debt_digests", "sweep_visual_review_retention"]

--- a/products/visual_review/backend/logic/baseline_overview.py
+++ b/products/visual_review/backend/logic/baseline_overview.py
@@ -14,6 +14,7 @@ from posthog.dataclasses import frozen
 from ..facade.enums import INTENTIONAL_TOLERATE_REASONS, RunStatus, SnapshotResult
 from ..models import QuarantinedIdentifier, Run, RunSnapshot, ToleratedHash
 from . import run_queries, toleration
+from .run_queries import SnapshotKey
 
 
 def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
@@ -138,7 +139,7 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
     # `BASELINE_OVERVIEW_MAX_ENTRIES`. `Run.metadata` (JSONField) and
     # `Run.error_message` (TextField) can be large and aren't needed by the
     # summary — defer them to keep the response light.
-    active_quarantines_by_key: dict[tuple[str, str], QuarantinedIdentifier] = {}
+    active_quarantines_by_key: dict[SnapshotKey, QuarantinedIdentifier] = {}
     if universe_identifiers:
         for q in (
             QuarantinedIdentifier.objects.filter(
@@ -150,7 +151,7 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
             .defer("source_run__metadata", "source_run__error_message")
             .order_by("-created_at")
         ):
-            key = (q.run_type, q.identifier)
+            key = SnapshotKey(run_type=q.run_type, identifier=q.identifier)
             # Multiple active rows for the same key shouldn't happen — create
             # auto-supersedes prior — but if it does, keep the latest (sorted
             # above) and ignore the rest.
@@ -180,8 +181,8 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
     #     resolve the run IDs first (sub-ms) and aggregate via PK-indexed
     #     run_id__in, otherwise the planner inlines a CTE that produces a
     #     ROW_NUMBER plan over the full RunSnapshot table.
-    change_count_by_key: dict[tuple[str, str], int] = {}
-    recent_drift_by_key: dict[tuple[str, str], float] = {}
+    change_count_by_key: dict[SnapshotKey, int] = {}
+    recent_drift_by_key: dict[SnapshotKey, float] = {}
     if universe_identifiers:
         for identifier, run_type, c in (
             RunSnapshot.objects.filter(
@@ -194,7 +195,7 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
             .annotate(c=Count("id"))
             .values_list("identifier", "run__run_type", "c")
         ):
-            change_count_by_key[(run_type, identifier)] = c
+            change_count_by_key[SnapshotKey(run_type=run_type, identifier=identifier)] = c
 
         # Top-N per run_type via window function. There's no pure-ORM
         # equivalent: Postgres doesn't allow filtering on a window result,
@@ -232,7 +233,7 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
                 .values_list("identifier", "run__run_type", "drift_avg")
             ):
                 if drift_avg is not None:
-                    recent_drift_by_key[(run_type, identifier)] = drift_avg
+                    recent_drift_by_key[SnapshotKey(run_type=run_type, identifier=identifier)] = drift_avg
 
     # 4. Totals computed across the *full* universe (not the truncated slice)
     # so the stat row stays correct when the entries are clipped.
@@ -290,7 +291,7 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
             .count()
         )
     else:
-        quarantined_id_count = len({identifier for _, identifier in active_quarantines_by_key})
+        quarantined_id_count = len({key.identifier for key in active_quarantines_by_key})
 
     # by_run_type counts every entry in the universe. Aggregate query under
     # truncation so it doesn't undercount; in-memory Counter when not truncated
@@ -334,19 +335,19 @@ class _BaselineOverviewRaw:
     entries: list[RunSnapshot]
     tolerate_30d_by_id: dict[str, int]
     tolerate_90d_by_id: dict[str, int]
-    # Accepted variants standing against each baseline's current hash, keyed by
-    # `(run_type, identifier)`. Only non-zero counts are present.
-    active_variants_by_key: dict[tuple[str, str], int]
+    # Accepted variants standing against each baseline's current hash. Only non-zero counts
+    # are present.
+    active_variants_by_key: dict[SnapshotKey, int]
     # Latest active QuarantinedIdentifier (with `source_run` preloaded) for each
     # `(run_type, identifier)` in the universe — lets the facade build the rich
     # quarantine summary embedded on each BaselineEntry. Membership doubles as
     # the "is_quarantined" signal — no separate set needed.
-    active_quarantines_by_key: dict[tuple[str, str], QuarantinedIdentifier]
-    # Stability signals keyed by `(run_type, identifier)` because the same
-    # identifier in different run types is a different baseline; merging would
-    # bleed storybook stability into playwright stability.
-    change_count_by_key: dict[tuple[str, str], int]
-    recent_drift_by_key: dict[tuple[str, str], float]
+    active_quarantines_by_key: dict[SnapshotKey, QuarantinedIdentifier]
+    # Stability signals keyed per identity because the same identifier in
+    # different run types is a different baseline; merging would bleed storybook
+    # stability into playwright stability.
+    change_count_by_key: dict[SnapshotKey, int]
+    recent_drift_by_key: dict[SnapshotKey, float]
     totals_all: int
     totals_recent: int
     totals_frequent: int

--- a/products/visual_review/backend/logic/baseline_overview.py
+++ b/products/visual_review/backend/logic/baseline_overview.py
@@ -13,7 +13,7 @@ from posthog.dataclasses import frozen
 
 from ..facade.enums import INTENTIONAL_TOLERATE_REASONS, RunStatus, SnapshotResult
 from ..models import QuarantinedIdentifier, Run, RunSnapshot, ToleratedHash
-from . import run_queries
+from . import run_queries, toleration
 
 
 def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
@@ -28,6 +28,7 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
       - 1 query for the universe runs (one row per run_type, indexed)
       - 1 query for the universe rows (with thumbnail + artifact prefetch)
       - 2 grouped queries for tolerate counts (30d + 90d)
+      - 3 queries for the accepted variants standing against the current baseline
       - 1 grouped query for active quarantines
       - 1 grouped query for lifetime baseline-flip count
       - 2 queries for the recent-drift average (resolve last-N runs, aggregate)
@@ -35,32 +36,19 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
     """
     from datetime import timedelta
 
-    from ..facade.contracts import BASELINE_DRIFT_RECENT_RUN_COUNT, BASELINE_OVERVIEW_MAX_ENTRIES
+    from ..facade.contracts import BASELINE_DRIFT_RECENT_RUN_COUNT, BASELINE_OVERVIEW_MAX_ENTRIES, VARIANT_PILEUP_MIN
 
     now = timezone.now()
 
-    # 1. Find the latest *completed* run on the default branch per (repo,
-    # branch, run_type). Filtering on `superseded_by IS NULL` looks tempting
-    # but is wrong here: a freshly started PENDING/PROCESSING master run is
-    # un-superseded yet has zero (or sparse) RunSnapshots ingested, and would
-    # collapse the universe to whatever it has loaded so far. `status=completed`
-    # makes the universe fall through to the most recent fully-ingested run.
-    universe_runs = list(
-        Run.objects.filter(
-            repo_id=repo_id,
-            branch__in=run_queries._DEFAULT_BRANCHES,
-            status=RunStatus.COMPLETED,
-        )
-        .order_by("repo_id", "branch", "run_type", "-created_at")
-        .distinct("repo_id", "branch", "run_type")
-        .only("id", "run_type", "completed_at", "created_at")
-    )
+    # 1. Find the latest *completed* run on the default branch per (repo, branch, run_type).
+    universe_runs = run_queries.latest_default_branch_runs(repo_id)
     universe_run_ids = [r.id for r in universe_runs]
     if not universe_run_ids:
         return _BaselineOverviewRaw(
             entries=[],
             tolerate_30d_by_id={},
             tolerate_90d_by_id={},
+            active_variants_by_key={},
             active_quarantines_by_key={},
             change_count_by_key={},
             recent_drift_by_key={},
@@ -68,6 +56,7 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
             totals_recent=0,
             totals_frequent=0,
             totals_quarantined=0,
+            totals_variant_pileups=0,
             by_run_type={},
             truncated=False,
             generated_at=now,
@@ -134,6 +123,10 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
             .values_list("identifier", "c")
         ):
             tolerate_90d_by_id[identifier] = count
+
+    # 3a-bis. Accepted variants still standing against each baseline's current hash. Scoped to the
+    # whole universe rather than the truncated slice, because the totals below read it too.
+    active_variants_by_key = toleration.count_active_variants_against_current_baseline(repo_id, now=now)
 
     # 3b. Active quarantines for this repo, scoped to the universe identifiers
     # AND the run_types they live on (quarantine is per (repo, run_type, id)).
@@ -314,6 +307,7 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
         entries=universe,
         tolerate_30d_by_id=tolerate_30d_by_id,
         tolerate_90d_by_id=tolerate_90d_by_id,
+        active_variants_by_key=active_variants_by_key,
         active_quarantines_by_key=active_quarantines_by_key,
         change_count_by_key=change_count_by_key,
         recent_drift_by_key=recent_drift_by_key,
@@ -321,6 +315,7 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
         totals_recent=len(recent_ids),
         totals_frequent=len(frequent_ids),
         totals_quarantined=quarantined_id_count,
+        totals_variant_pileups=sum(1 for count in active_variants_by_key.values() if count >= VARIANT_PILEUP_MIN),
         by_run_type=by_run_type,
         truncated=truncated,
         generated_at=now,
@@ -337,6 +332,9 @@ class _BaselineOverviewRaw:
     entries: list[RunSnapshot]
     tolerate_30d_by_id: dict[str, int]
     tolerate_90d_by_id: dict[str, int]
+    # Accepted variants standing against each baseline's current hash, keyed by
+    # `(run_type, identifier)`. Only non-zero counts are present.
+    active_variants_by_key: dict[tuple[str, str], int]
     # Latest active QuarantinedIdentifier (with `source_run` preloaded) for each
     # `(run_type, identifier)` in the universe — lets the facade build the rich
     # quarantine summary embedded on each BaselineEntry. Membership doubles as
@@ -351,6 +349,7 @@ class _BaselineOverviewRaw:
     totals_recent: int
     totals_frequent: int
     totals_quarantined: int
+    totals_variant_pileups: int
     by_run_type: dict[str, int]
     truncated: bool
     generated_at: datetime

--- a/products/visual_review/backend/logic/baseline_overview.py
+++ b/products/visual_review/backend/logic/baseline_overview.py
@@ -28,7 +28,7 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
       - 1 query for the universe runs (one row per run_type, indexed)
       - 1 query for the universe rows (with thumbnail + artifact prefetch)
       - 2 grouped queries for tolerate counts (30d + 90d)
-      - 3 queries for the accepted variants standing against the current baseline
+      - 2 queries for the accepted variants standing against the current baseline
       - 1 grouped query for active quarantines
       - 1 grouped query for lifetime baseline-flip count
       - 2 queries for the recent-drift average (resolve last-N runs, aggregate)
@@ -126,7 +126,9 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
 
     # 3a-bis. Accepted variants still standing against each baseline's current hash. Scoped to the
     # whole universe rather than the truncated slice, because the totals below read it too.
-    active_variants_by_key = toleration.count_active_variants_against_current_baseline(repo_id, now=now)
+    active_variants_by_key = toleration.count_active_variants_against_current_baseline(
+        repo_id, now=now, newest_run_by_type=run_queries.newest_run_by_run_type(universe_runs)
+    )
 
     # 3b. Active quarantines for this repo, scoped to the universe identifiers
     # AND the run_types they live on (quarantine is per (repo, run_type, id)).

--- a/products/visual_review/backend/logic/debt_digest.py
+++ b/products/visual_review/backend/logic/debt_digest.py
@@ -422,7 +422,8 @@ def lead_text(digest: TeamDigest, repo: Repo) -> str:
             "Ownership could not be worked out for some of them today, because "
             f"{escape_slack_mrkdwn('; '.join(details))}. The digest tries again tomorrow."
         )
-    return " ".join(sentences)
+    # The lead is one Slack section like every thread line, so it takes the same cap.
+    return clip_text(" ".join(sentences), MAX_SECTION_CHARS)
 
 
 def _triage_line(item: DebtItem) -> str:

--- a/products/visual_review/backend/logic/debt_digest.py
+++ b/products/visual_review/backend/logic/debt_digest.py
@@ -80,6 +80,11 @@ _NO_BASELINE_RUN_DETAIL = "there is no default branch run to read"
 # Slack rejects a section block over 3000 characters. The margin covers the mrkdwn escaping, which
 # can turn one character into five.
 _MAX_SECTION_CHARS = 2900
+# One line's own cap, under half the section cap so two bounded lines always share a block.
+_MAX_LINE_CHARS = 1400
+# The full identifier still goes into the URL, so a cut display costs the reader nothing.
+_MAX_IDENTIFIER_CHARS = 160
+_MAX_REASON_CHARS = 200
 
 MODE_OFF = "off"
 MODE_PREVIEW = "preview"
@@ -202,6 +207,13 @@ def _escape_mrkdwn(text: str) -> str:
     return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 
+def _ellipsize(text: str, limit: int) -> str:
+    """Cut display text down to `limit` characters, marking that something was cut."""
+    if len(text) <= limit:
+        return text
+    return text[: max(limit - 1, 0)] + "…"
+
+
 def _snapshot_url(repo: Repo, run_type: str, identifier: str) -> str:
     return (
         f"{settings.SITE_URL}/project/{repo.team_id}/visual_review/repos/{repo.id}"
@@ -209,21 +221,43 @@ def _snapshot_url(repo: Repo, run_type: str, identifier: str) -> str:
     )
 
 
+def _repo_snapshots_url(repo: Repo) -> str:
+    """The repo's snapshot list. It names no snapshot, so its length does not follow the identifier."""
+    return f"{settings.SITE_URL}/project/{repo.team_id}/visual_review/repos/{repo.id}/snapshots"
+
+
+def _linked_line(repo: Repo, body: str, run_type: str, identifier: str) -> str:
+    """One item's line with its link, kept under the per-line cap.
+
+    A non-ASCII identifier percent-encodes to nine characters each, so the snapshot URL alone can
+    outgrow a Slack block however short the displayed text is cut. Point at the repo's snapshot
+    list instead: the reader still gets a link, and one long item no longer costs the team the
+    rest of its thread.
+    """
+    line = f"{body} · {_snapshot_url(repo, run_type, identifier)}"
+    if len(line) <= _MAX_LINE_CHARS:
+        return line
+    listed = f" · listed under the repo's snapshots: {_repo_snapshots_url(repo)}"
+    return f"{_ellipsize(body, _MAX_LINE_CHARS - len(listed))}{listed}"
+
+
 def _quarantine_line(repo: Repo, entry: QuarantinedIdentifier, authors: dict[int, str], now: datetime) -> str:
     days = max((entry.expires_at - now).days, 0) if entry.expires_at is not None else 0
     who = authors.get(entry.created_by_id or 0, "someone")
-    return (
-        f"Quarantine expires in {days} days · {_escape_mrkdwn(entry.identifier)} ({entry.run_type})"
-        f' · opened by {_escape_mrkdwn(who)} for "{_escape_mrkdwn(entry.reason)}"'
-        f" · {_snapshot_url(repo, entry.run_type, entry.identifier)}"
+    body = (
+        f"Quarantine expires in {days} days"
+        f" · {_escape_mrkdwn(_ellipsize(entry.identifier, _MAX_IDENTIFIER_CHARS))} ({entry.run_type})"
+        f' · opened by {_escape_mrkdwn(who)} for "{_escape_mrkdwn(_ellipsize(entry.reason, _MAX_REASON_CHARS))}"'
     )
+    return _linked_line(repo, body, entry.run_type, entry.identifier)
 
 
 def _pileup_line(repo: Repo, run_type: str, identifier: str, count: int) -> str:
-    return (
-        f"{count} accepted variants of the current baseline · {_escape_mrkdwn(identifier)} ({run_type})"
-        f" · {_snapshot_url(repo, run_type, identifier)}"
+    body = (
+        f"{count} accepted variants of the current baseline"
+        f" · {_escape_mrkdwn(_ellipsize(identifier, _MAX_IDENTIFIER_CHARS))} ({run_type})"
     )
+    return _linked_line(repo, body, run_type, identifier)
 
 
 def _display_names(user_ids: set[int]) -> dict[int, str]:
@@ -455,6 +489,8 @@ def thread_texts(digest: TeamDigest) -> list[str]:
         lines.append(_TRIAGE_HEADERS[group.reason])
         lines.extend(_triage_line(item) for item in group.items)
     lines.append(_FOOTER)
+    # A cut line costs one reader one path; a line Slack refuses costs the team the rest of the thread.
+    lines = [_ellipsize(line, _MAX_SECTION_CHARS) for line in lines]
     messages: list[str] = []
     current: list[str] = []
     for line in lines:
@@ -529,6 +565,10 @@ def send_debt_digest(repo: Repo, mode: str | None = None) -> list[str]:
     run would send without reaching into the logs.
     """
     mode = mode or settings.VISUAL_REVIEW_DEBT_DIGEST_MODE
+    # `deliver` reads anything that is not shadow as the team's own channel, so an undefined mode posts live.
+    if mode not in MODES:
+        logger.warning("visual_review.debt_digest_mode_unknown", mode=mode)
+        return []
     if mode == MODE_OFF:
         return []
 

--- a/products/visual_review/backend/logic/debt_digest.py
+++ b/products/visual_review/backend/logic/debt_digest.py
@@ -305,7 +305,7 @@ def collect_debt(repo: Repo, now: datetime) -> RepoDebt:
         if count >= VARIANT_PILEUP_MIN and key not in quarantined_keys
     }
 
-    run_types = {entry.run_type for entry in expiring} | {run_type for run_type, _ in piled_up}
+    run_types = {entry.run_type for entry in expiring} | {key.run_type for key in piled_up}
     sources = _attribution_sources(repo, run_types, newest_run_by_type)
     authors = _display_names({entry.created_by_id for entry in expiring if entry.created_by_id})
 
@@ -321,12 +321,15 @@ def collect_debt(repo: Repo, now: datetime) -> RepoDebt:
         ],
         variant_pileups=[
             DebtItem(
-                identifier=identifier,
-                run_type=run_type,
-                attribution=_attribution(sources, run_type, identifier),
-                line=_pileup_line(repo, run_type, identifier, count),
+                identifier=key.identifier,
+                run_type=key.run_type,
+                attribution=_attribution(sources, key.run_type, key.identifier),
+                line=_pileup_line(repo, key.run_type, key.identifier, count),
             )
-            for (run_type, identifier), count in sorted(piled_up.items(), key=lambda item: (-item[1], item[0]))
+            # Biggest pile first, then by identity so a tie reads the same way every morning.
+            for key, count in sorted(
+                piled_up.items(), key=lambda item: (-item[1], item[0].run_type, item[0].identifier)
+            )
         ],
     )
 

--- a/products/visual_review/backend/logic/debt_digest.py
+++ b/products/visual_review/backend/logic/debt_digest.py
@@ -33,6 +33,7 @@ from dataclasses import field
 from datetime import datetime
 from enum import StrEnum
 from urllib.parse import quote
+from uuid import UUID
 
 from django.conf import settings
 from django.utils import timezone
@@ -41,16 +42,20 @@ import structlog
 from posthog_owners.resolver import Purpose, team_channel
 from posthog_owners.schema import Producer, TeamEntry
 
+from posthog.comment.formatting import escape_slack_mrkdwn
 from posthog.dataclasses import frozen
 from posthog.models.integration import Integration, SlackIntegration
 from posthog.models.user import User
 from posthog.team_notifications.slack import (
+    MAX_SECTION_CHARS,
     SlackChannel,
     SlackPostRefused,
+    clip_text,
     fetch_channel_map,
     find_channel,
     post_message,
     post_with_join,
+    section_block,
 )
 
 from products.engineering_analytics.backend.facade.api import resolve_path_owners
@@ -58,7 +63,7 @@ from products.engineering_analytics.backend.facade.contracts import UNOWNED_TEAM
 
 from ..facade.contracts import VARIANT_PILEUP_MIN
 from ..facade.enums import RunType
-from ..models import QuarantinedIdentifier, Repo
+from ..models import QuarantinedIdentifier, Repo, Run
 from . import quarantine, run_queries, story_index, toleration
 
 logger = structlog.get_logger(__name__)
@@ -77,11 +82,7 @@ _PRODUCT_PATH = "products/visual_review/"
 # Said of a run type whose items have no default-branch run to attribute against.
 _NO_BASELINE_RUN_DETAIL = "there is no default branch run to read"
 
-# Slack rejects a section block over 3000 characters. The margin covers the mrkdwn escaping, which
-# can turn one character into five.
-_MAX_SECTION_CHARS = 2900
-# One line's own cap, under half the section cap so two bounded lines always share a block.
-_MAX_LINE_CHARS = 1400
+_MAX_LINE_CHARS = MAX_SECTION_CHARS // 2
 # The full identifier still goes into the URL, so a cut display costs the reader nothing.
 _MAX_IDENTIFIER_CHARS = 160
 _MAX_REASON_CHARS = 200
@@ -106,26 +107,13 @@ class AttributionKind(StrEnum):
     UNAVAILABLE = "unavailable"  # there is no index to ask for this run type today
 
 
-class TriageReason(StrEnum):
-    """Why an item has no owning team, and therefore sits with the visual review maintainers.
-
-    The three are kept apart everywhere, because each asks for a different fix: an owners entry, a
-    look at what happened to the story, or nothing at all.
-    """
-
-    UNOWNED_FILE = "unowned_file"
-    STORY_ABSENT = "story_absent"
-    UNAVAILABLE = "unavailable"
-
-
-_TRIAGE_HEADERS: dict[TriageReason, str] = {
-    TriageReason.UNOWNED_FILE: (
-        "*Nobody owns the file yet.* Add an owners entry for the path at the end of each line."
-    ),
-    TriageReason.STORY_ABSENT: (
+# Each outcome asks the reader for a different fix. A placed path in triage is one no owners entry covers.
+_TRIAGE_HEADERS: dict[AttributionKind, str] = {
+    AttributionKind.PLACED: "*Nobody owns the file yet.* Add an owners entry for the path at the end of each line.",
+    AttributionKind.STORY_ABSENT: (
         "*The story is not in the Storybook index.* Check whether it moved, was renamed, or was deleted."
     ),
-    TriageReason.UNAVAILABLE: (
+    AttributionKind.UNAVAILABLE: (
         "*Ownership could not be worked out today.* Nothing to do, the digest tries again tomorrow."
     ),
 }
@@ -170,9 +158,9 @@ class RepoDebt:
 
 @frozen
 class TriageGroup:
-    """The items that share one reason for having no owning team."""
+    """The items that share one attribution outcome, and so one reason for having no owning team."""
 
-    reason: TriageReason
+    kind: AttributionKind
     items: list[DebtItem]
 
 
@@ -195,23 +183,6 @@ class Delivery:
     channel_id: str
     channel_name: str
     lead_prefix: str
-
-
-def _escape_mrkdwn(text: str) -> str:
-    """Neutralize Slack mrkdwn control characters in text a contributor wrote.
-
-    A quarantine reason and a snapshot identifier are both user input. Escaping `&`, `<` and `>`
-    stops one from smuggling a `<!channel>` mention or breaking out of a link; Slack renders the
-    escaped entities back as the literal characters.
-    """
-    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-
-
-def _ellipsize(text: str, limit: int) -> str:
-    """Cut display text down to `limit` characters, marking that something was cut."""
-    if len(text) <= limit:
-        return text
-    return text[: max(limit - 1, 0)] + "…"
 
 
 def _snapshot_url(repo: Repo, run_type: str, identifier: str) -> str:
@@ -238,7 +209,7 @@ def _linked_line(repo: Repo, body: str, run_type: str, identifier: str) -> str:
     if len(line) <= _MAX_LINE_CHARS:
         return line
     listed = f" · listed under the repo's snapshots: {_repo_snapshots_url(repo)}"
-    return f"{_ellipsize(body, _MAX_LINE_CHARS - len(listed))}{listed}"
+    return f"{clip_text(body, _MAX_LINE_CHARS - len(listed))}{listed}"
 
 
 def _quarantine_line(repo: Repo, entry: QuarantinedIdentifier, authors: dict[int, str], now: datetime) -> str:
@@ -246,8 +217,8 @@ def _quarantine_line(repo: Repo, entry: QuarantinedIdentifier, authors: dict[int
     who = authors.get(entry.created_by_id or 0, "someone")
     body = (
         f"Quarantine expires in {days} days"
-        f" · {_escape_mrkdwn(_ellipsize(entry.identifier, _MAX_IDENTIFIER_CHARS))} ({entry.run_type})"
-        f' · opened by {_escape_mrkdwn(who)} for "{_escape_mrkdwn(_ellipsize(entry.reason, _MAX_REASON_CHARS))}"'
+        f" · {escape_slack_mrkdwn(clip_text(entry.identifier, _MAX_IDENTIFIER_CHARS))} ({entry.run_type})"
+        f' · opened by {escape_slack_mrkdwn(who)} for "{escape_slack_mrkdwn(clip_text(entry.reason, _MAX_REASON_CHARS))}"'
     )
     return _linked_line(repo, body, entry.run_type, entry.identifier)
 
@@ -255,7 +226,7 @@ def _quarantine_line(repo: Repo, entry: QuarantinedIdentifier, authors: dict[int
 def _pileup_line(repo: Repo, run_type: str, identifier: str, count: int) -> str:
     body = (
         f"{count} accepted variants of the current baseline"
-        f" · {_escape_mrkdwn(_ellipsize(identifier, _MAX_IDENTIFIER_CHARS))} ({run_type})"
+        f" · {escape_slack_mrkdwn(clip_text(identifier, _MAX_IDENTIFIER_CHARS))} ({run_type})"
     )
     return _linked_line(repo, body, run_type, identifier)
 
@@ -269,54 +240,54 @@ def _display_names(user_ids: set[int]) -> dict[int, str]:
     }
 
 
-@frozen
-class RunTypeAttribution:
-    """What one run type can be attributed against today: a story index, or why there is none."""
+def _workflow_run_id(run: Run) -> str | None:
+    """The GitHub workflow run that produced one run, or None when the run records none.
 
-    index: story_index.StoryIndex | None
-    detail: str
+    Read on a query of its own because the shared default-branch universe defers `metadata`. Every
+    other reader of that universe needs the run ids alone, so it stays lean for the pages that use
+    it.
+    """
+    metadata = Run.objects.filter(id=run.id).values_list("metadata", flat=True).first()
+    github_run_id = (metadata or {}).get("github_run_id")
+    return github_run_id if isinstance(github_run_id, str) and github_run_id else None
 
 
-def _attribution_sources(repo: Repo, run_types: set[str]) -> dict[str, RunTypeAttribution]:
-    """Read the story index of the run behind the current baseline, for each run type in play.
+def _attribution_sources(
+    repo: Repo, run_types: set[str], newest_run_by_type: Mapping[str, Run]
+) -> dict[str, story_index.StoryIndex | str]:
+    """What each run type in play can be attributed against: a story index, or why there is none.
 
     One artifact read per run type, not per item. A run type nothing owes today is never read, so a
     repo with no Storybook debt costs no download at all.
     """
-    if not run_types:
-        return {}
-    newest_by_run_type = run_queries.newest_run_by_run_type(run_queries.latest_default_branch_runs(repo.id))
-    sources: dict[str, RunTypeAttribution] = {}
+    sources: dict[str, story_index.StoryIndex | str] = {}
     for run_type in run_types:
         if run_type != RunType.STORYBOOK:
-            sources[run_type] = RunTypeAttribution(index=None, detail=f"{run_type} runs are not supported yet")
+            sources[run_type] = f"{run_type} runs are not supported yet"
             continue
-        run = newest_by_run_type.get(run_type)
+        run = newest_run_by_type.get(run_type)
         if run is None:
-            sources[run_type] = RunTypeAttribution(index=None, detail=_NO_BASELINE_RUN_DETAIL)
+            sources[run_type] = _NO_BASELINE_RUN_DETAIL
             continue
-        github_run_id = (run.metadata or {}).get("github_run_id")
-        if not isinstance(github_run_id, str) or not github_run_id:
-            sources[run_type] = RunTypeAttribution(
-                index=None, detail="the run behind the baseline records no workflow run"
-            )
+        github_run_id = _workflow_run_id(run)
+        if github_run_id is None:
+            sources[run_type] = "the run behind the baseline records no workflow run"
             continue
         index = story_index.fetch_story_index(repo, github_run_id)
-        sources[run_type] = RunTypeAttribution(
-            index=index,
-            detail="" if index is not None else f"the Storybook build artifact for run {github_run_id} was not read",
+        sources[run_type] = (
+            index if index is not None else f"the Storybook build artifact for run {github_run_id} was not read"
         )
     return sources
 
 
-def _attribution(sources: Mapping[str, RunTypeAttribution], run_type: str, identifier: str) -> Attribution:
+def _attribution(sources: Mapping[str, story_index.StoryIndex | str], run_type: str, identifier: str) -> Attribution:
     """Where one snapshot's story lives, or why the index cannot say."""
     source = sources.get(run_type)
     if source is None:
         return Attribution(kind=AttributionKind.UNAVAILABLE, detail=_NO_BASELINE_RUN_DETAIL)
-    if source.index is None:
-        return Attribution(kind=AttributionKind.UNAVAILABLE, detail=source.detail)
-    path = story_index.story_path(source.index, identifier)
+    if isinstance(source, str):
+        return Attribution(kind=AttributionKind.UNAVAILABLE, detail=source)
+    path = story_index.story_path(source, identifier)
     if path is None:
         return Attribution(kind=AttributionKind.STORY_ABSENT)
     return Attribution(kind=AttributionKind.PLACED, source_path=path)
@@ -324,11 +295,14 @@ def _attribution(sources: Mapping[str, RunTypeAttribution], run_type: str, ident
 
 def collect_debt(repo: Repo, now: datetime) -> RepoDebt:
     """Evaluate both conditions against current data, attribute each item, and render its line."""
+    newest_run_by_type = run_queries.newest_run_by_run_type(run_queries.latest_default_branch_runs(repo.id))
     expiring = quarantine.list_expiring_quarantines(repo.id, now=now)
     quarantined_keys = quarantine.active_quarantine_keys(repo.id, now=now)
     piled_up = {
         key: count
-        for key, count in toleration.count_active_variants_against_current_baseline(repo.id, now=now).items()
+        for key, count in toleration.count_active_variants_against_current_baseline(
+            repo.id, now=now, newest_run_by_type=newest_run_by_type
+        ).items()
         # Any live quarantine, expiring or not, already says somebody knows the snapshot is
         # unreliable, so asking them about the variants underneath it is a second reminder about
         # one problem.
@@ -336,7 +310,7 @@ def collect_debt(repo: Repo, now: datetime) -> RepoDebt:
     }
 
     run_types = {entry.run_type for entry in expiring} | {run_type for run_type, _ in piled_up}
-    sources = _attribution_sources(repo, run_types)
+    sources = _attribution_sources(repo, run_types, newest_run_by_type)
     authors = _display_names({entry.created_by_id for entry in expiring if entry.created_by_id})
 
     return RepoDebt(
@@ -374,15 +348,6 @@ def _owning_team(item: DebtItem, ownership: PathOwnership) -> str:
     return ownership.team_by_path.get(item.attribution.source_path, UNOWNED_TEAM)
 
 
-def _triage_reason(item: DebtItem) -> TriageReason:
-    """Why an item nobody owns is in triage. A placed path with no owner needs an owners entry."""
-    if item.attribution.kind == AttributionKind.PLACED:
-        return TriageReason.UNOWNED_FILE
-    if item.attribution.kind == AttributionKind.STORY_ABSENT:
-        return TriageReason.STORY_ABSENT
-    return TriageReason.UNAVAILABLE
-
-
 def split_by_team(debt: RepoDebt, ownership: PathOwnership) -> list[TeamDigest]:
     """Group a repo's debt by the team that owns each item's story file.
 
@@ -393,7 +358,7 @@ def split_by_team(debt: RepoDebt, ownership: PathOwnership) -> list[TeamDigest]:
     fallback = ownership.team_by_path.get(_PRODUCT_PATH, UNOWNED_TEAM)
     expiring_by_team: dict[str, list[DebtItem]] = {}
     pileups_by_team: dict[str, list[DebtItem]] = {}
-    triage_by_reason: dict[TriageReason, list[DebtItem]] = {}
+    triage_by_kind: dict[AttributionKind, list[DebtItem]] = {}
     for items, bucket in ((debt.expiring_quarantines, expiring_by_team), (debt.variant_pileups, pileups_by_team)):
         for item in items:
             team = _owning_team(item, ownership)
@@ -408,14 +373,10 @@ def split_by_team(debt: RepoDebt, ownership: PathOwnership) -> list[TeamDigest]:
                     source_path=item.attribution.source_path,
                 )
                 continue
-            triage_by_reason.setdefault(_triage_reason(item), []).append(item)
+            triage_by_kind.setdefault(item.attribution.kind, []).append(item)
 
     # Declaration order, so the three groups always read in the same order.
-    triage = [
-        TriageGroup(reason=reason, items=triage_by_reason[reason])
-        for reason in TriageReason
-        if reason in triage_by_reason
-    ]
+    triage = [TriageGroup(kind=kind, items=triage_by_kind[kind]) for kind in AttributionKind if kind in triage_by_kind]
     teams = expiring_by_team.keys() | pileups_by_team.keys()
     if triage:
         teams = teams | {fallback}
@@ -433,13 +394,7 @@ def split_by_team(debt: RepoDebt, ownership: PathOwnership) -> list[TeamDigest]:
 def _unavailable_details(digest: TeamDigest) -> list[str]:
     """Every distinct reason ownership could not be worked out for this digest's triage items."""
     return sorted(
-        {
-            item.attribution.detail
-            for group in digest.triage
-            if group.reason == TriageReason.UNAVAILABLE
-            for item in group.items
-            if item.attribution.detail
-        }
+        {item.attribution.detail for group in digest.triage for item in group.items if item.attribution.detail}
     )
 
 
@@ -465,7 +420,7 @@ def lead_text(digest: TeamDigest, repo: Repo) -> str:
     if details:
         sentences.append(
             "Ownership could not be worked out for some of them today, because "
-            f"{_escape_mrkdwn('; '.join(details))}. The digest tries again tomorrow."
+            f"{escape_slack_mrkdwn('; '.join(details))}. The digest tries again tomorrow."
         )
     return " ".join(sentences)
 
@@ -473,9 +428,9 @@ def lead_text(digest: TeamDigest, repo: Repo) -> str:
 def _triage_line(item: DebtItem) -> str:
     """One triage item's line, carrying what its group's header asks the reader to act on."""
     if item.attribution.kind == AttributionKind.PLACED:
-        return f"{item.line} · {_escape_mrkdwn(item.attribution.source_path)}"
+        return f"{item.line} · {escape_slack_mrkdwn(item.attribution.source_path)}"
     if item.attribution.kind == AttributionKind.UNAVAILABLE:
-        return f"{item.line} · {_escape_mrkdwn(item.attribution.detail)}"
+        return f"{item.line} · {escape_slack_mrkdwn(item.attribution.detail)}"
     return item.line
 
 
@@ -486,25 +441,21 @@ def thread_texts(digest: TeamDigest) -> list[str]:
         *(item.line for item in digest.variant_pileups),
     ]
     for group in digest.triage:
-        lines.append(_TRIAGE_HEADERS[group.reason])
+        lines.append(_TRIAGE_HEADERS[group.kind])
         lines.extend(_triage_line(item) for item in group.items)
     lines.append(_FOOTER)
     # A cut line costs one reader one path; a line Slack refuses costs the team the rest of the thread.
-    lines = [_ellipsize(line, _MAX_SECTION_CHARS) for line in lines]
+    lines = [clip_text(line, MAX_SECTION_CHARS) for line in lines]
     messages: list[str] = []
     current: list[str] = []
     for line in lines:
-        if current and len("\n".join([*current, line])) > _MAX_SECTION_CHARS:
+        if current and len("\n".join([*current, line])) > MAX_SECTION_CHARS:
             messages.append("\n".join(current))
             current = []
         current.append(line)
     if current:
         messages.append("\n".join(current))
     return messages
-
-
-def _blocks(text: str) -> list[dict]:
-    return [{"type": "section", "text": {"type": "mrkdwn", "text": text}}]
 
 
 def resolve_channel(
@@ -580,14 +531,14 @@ def send_debt_digest(repo: Repo, mode: str | None = None) -> list[str]:
     ownership = resolve_path_owners(repo.repo_full_name, paths_to_resolve(debt))
     digests = split_by_team(debt, ownership)
 
-    integration: Integration | None = None
-    channels_by_name: dict[str, SlackChannel] = {}
-    if mode != MODE_PREVIEW:
-        integration = Integration.objects.filter(team_id=repo.team_id, kind="slack").first()
-        if integration is None:
-            logger.info("visual_review.debt_digest_no_slack_integration", team_id=repo.team_id)
-            return []
-        channels_by_name = fetch_channel_map(integration)
+    if mode == MODE_PREVIEW:
+        return [_preview_one(repo, digest, ownership.registry) for digest in digests]
+
+    integration = Integration.objects.filter(team_id=repo.team_id, kind="slack").first()
+    if integration is None:
+        logger.info("visual_review.debt_digest_no_slack_integration", team_id=repo.team_id)
+        return []
+    channels_by_name = fetch_channel_map(integration)
 
     rendered: list[str] = []
     for digest in digests:
@@ -605,38 +556,44 @@ def send_debt_digest(repo: Repo, mode: str | None = None) -> list[str]:
     return rendered
 
 
+def _preview_one(repo: Repo, digest: TeamDigest, registry: Mapping[str, TeamEntry]) -> str:
+    """Render one team's digest and log it, without reading Slack at all."""
+    rendered = "\n".join([lead_text(digest, repo), *thread_texts(digest)])
+    # Preview holds no channel map, because fetching one needs the integration it deliberately does
+    # not touch. So the routing here only ever reports the team's own opt-out.
+    resolved = resolve_channel(digest, registry, {})
+    logger.info(
+        "visual_review.debt_digest_preview",
+        repo_id=str(repo.id),
+        team_slug=digest.team_slug,
+        channel_name=resolved.channel_name if resolved is not None else None,
+        item_count=len(digest.expiring_quarantines) + len(digest.variant_pileups),
+        triage_count=sum(len(group.items) for group in digest.triage),
+        rendered=rendered,
+    )
+    return rendered
+
+
 def _send_one(
     repo: Repo,
     digest: TeamDigest,
     registry: Mapping[str, TeamEntry],
     channels_by_name: Mapping[str, SlackChannel],
-    integration: Integration | None,
+    integration: Integration,
     mode: str,
 ) -> str:
     lead = lead_text(digest, repo)
     thread = thread_texts(digest)
-    if mode == MODE_PREVIEW:
-        resolved = resolve_channel(digest, registry, channels_by_name)
-        rendered = "\n".join([lead, *thread])
-        logger.info(
-            "visual_review.debt_digest_preview",
-            repo_id=str(repo.id),
-            team_slug=digest.team_slug,
-            channel_name=resolved.channel_name if resolved is not None else None,
-            item_count=len(digest.expiring_quarantines) + len(digest.variant_pileups),
-            triage_count=sum(len(group.items) for group in digest.triage),
-            rendered=rendered,
-        )
-        return rendered
-
     delivery = deliver(digest, registry, channels_by_name, mode)
-    if delivery is None or integration is None:
+    if delivery is None:
         return ""
 
     slack = SlackIntegration(integration)
     lead = f"{delivery.lead_prefix}{lead}"
     try:
-        thread_ts = post_with_join(slack, delivery.channel_id, _blocks(lead), lead, channel_name=delivery.channel_name)
+        thread_ts = post_with_join(
+            slack, delivery.channel_id, section_block(lead), lead, channel_name=delivery.channel_name
+        )
     except SlackPostRefused as e:
         logger.warning("visual_review.debt_digest_post_refused", team_slug=digest.team_slug, error=str(e))
         return ""
@@ -644,14 +601,18 @@ def _send_one(
     # posts, which is the noise the thread exists to remove.
     if thread_ts is not None:
         for text in thread:
-            post_message(slack, delivery.channel_id, _blocks(text), text, thread_ts=thread_ts)
+            post_message(slack, delivery.channel_id, section_block(text), text, thread_ts=thread_ts)
     return "\n".join([lead, *thread])
 
 
-def repos_in_scope() -> list[Repo]:
-    """The repos the digest is configured for, by `owner/name`."""
+def repos_in_scope() -> list[tuple[int, UUID]]:
+    """The `(team_id, repo_id)` of each repo the digest is configured for, by `owner/name`.
+
+    The fan-out task only routes, so it never needs a hydrated row.
+    """
     configured: Sequence[str] = settings.VISUAL_REVIEW_DEBT_DIGEST_REPOS
     if not configured:
         return []
     # nosemgrep: idor-lookup-without-team — cross-team beat sweep over a settings allowlist
-    return list(Repo.objects.unscoped().filter(repo_full_name__in=list(configured)).order_by("created_at"))
+    configured_repos = Repo.objects.unscoped().filter(repo_full_name__in=list(configured)).order_by("created_at")
+    return list(configured_repos.values_list("team_id", "id"))

--- a/products/visual_review/backend/logic/debt_digest.py
+++ b/products/visual_review/backend/logic/debt_digest.py
@@ -1,0 +1,617 @@
+"""The daily reminder about visual review debt a team is still carrying.
+
+Stateless by design. Every morning the two conditions below are evaluated from current data,
+attributed to the team that owns the file the snapshot's story lives in today, and posted. Nothing
+is stored about what was sent, so an item repeats every day until the condition stops holding and
+disappears the moment it does. A team whose post fails is logged and the run moves on; tomorrow
+recomputes everything from scratch.
+
+The two conditions:
+
+  Quarantine expiring. An active quarantine that runs out inside `FLAKINESS_EXPIRY_SOON_DAYS`.
+  Somebody has to extend it, lift it, or decide to let it lapse.
+
+  Variant pile-up. `VARIANT_PILEUP_MIN` or more accepted variants standing against the baseline's
+  current hash, with no quarantine already covering the identity. The baseline has stopped
+  describing one rendering.
+
+A baseline change clears the second condition, and that is not the same as the story recovering: it
+invalidates the tolerations recorded against the old baseline, because they can never match again.
+Nothing here claims a snapshot got better.
+
+Attribution runs through the Storybook build behind the current baseline. Its story index names the
+file each story lives in, and the repository's own ownership files name the team that owns that file.
+Three things stop that: no owners entry covers the file, the index has no such story, or there is no
+index to read. All three go to the visual review maintainers as triage, kept apart from the items
+those maintainers own, because holding an item until a team takes it is not owning it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import field
+from datetime import datetime
+from enum import StrEnum
+from urllib.parse import quote
+
+from django.conf import settings
+from django.utils import timezone
+
+import structlog
+from posthog_owners.resolver import Purpose, team_channel
+from posthog_owners.schema import Producer, TeamEntry
+
+from posthog.dataclasses import frozen
+from posthog.models.integration import Integration, SlackIntegration
+from posthog.models.user import User
+from posthog.team_notifications.slack import (
+    SlackChannel,
+    SlackPostRefused,
+    fetch_channel_map,
+    find_channel,
+    post_message,
+    post_with_join,
+)
+
+from products.engineering_analytics.backend.facade.api import resolve_path_owners
+from products.engineering_analytics.backend.facade.contracts import UNOWNED_TEAM, PathOwnership
+
+from ..facade.contracts import VARIANT_PILEUP_MIN
+from ..facade.enums import RunType
+from ..models import QuarantinedIdentifier, Repo
+from . import quarantine, run_queries, story_index, toleration
+
+logger = structlog.get_logger(__name__)
+
+# The digest is automation, so it asks the registry where automation posts rather than where the
+# team's people are. That falls back to the people channel when a team never separates the two.
+_CHANNEL_PURPOSE: Purpose = "notifications"
+# Named so a team can keep this digest out of its channel while other bots keep posting there.
+_PRODUCER: Producer = "visual_review"
+
+# Whose digest carries the items no team owns. The people who built the product can read a story
+# name and find who to ask; nobody else can. Routed like any other team, so there is no second
+# delivery path to keep working.
+_PRODUCT_PATH = "products/visual_review/"
+
+# Said of a run type whose items have no default-branch run to attribute against.
+_NO_BASELINE_RUN_DETAIL = "there is no default branch run to read"
+
+# Slack rejects a section block over 3000 characters. The margin covers the mrkdwn escaping, which
+# can turn one character into five.
+_MAX_SECTION_CHARS = 2900
+
+MODE_OFF = "off"
+MODE_PREVIEW = "preview"
+MODE_SHADOW = "shadow"
+MODE_LIVE = "live"
+MODES = (MODE_OFF, MODE_PREVIEW, MODE_SHADOW, MODE_LIVE)
+
+_FOOTER = (
+    "This repeats daily while the items stay unresolved. "
+    "To opt out, set notifications: {visual_review: false} under your team in owners.yaml."
+)
+
+
+class AttributionKind(StrEnum):
+    """What the story index can say about the file behind one snapshot."""
+
+    PLACED = "placed"  # the story maps to a file in the repository
+    STORY_ABSENT = "story_absent"  # the index was read, and it holds no such story
+    UNAVAILABLE = "unavailable"  # there is no index to ask for this run type today
+
+
+class TriageReason(StrEnum):
+    """Why an item has no owning team, and therefore sits with the visual review maintainers.
+
+    The three are kept apart everywhere, because each asks for a different fix: an owners entry, a
+    look at what happened to the story, or nothing at all.
+    """
+
+    UNOWNED_FILE = "unowned_file"
+    STORY_ABSENT = "story_absent"
+    UNAVAILABLE = "unavailable"
+
+
+_TRIAGE_HEADERS: dict[TriageReason, str] = {
+    TriageReason.UNOWNED_FILE: (
+        "*Nobody owns the file yet.* Add an owners entry for the path at the end of each line."
+    ),
+    TriageReason.STORY_ABSENT: (
+        "*The story is not in the Storybook index.* Check whether it moved, was renamed, or was deleted."
+    ),
+    TriageReason.UNAVAILABLE: (
+        "*Ownership could not be worked out today.* Nothing to do, the digest tries again tomorrow."
+    ),
+}
+
+
+@frozen
+class Attribution:
+    """The file behind one debt item, or the reason there is none.
+
+    Never guessed from the identifier: a story name is not a path, and a wrong guess sends a team a
+    reminder about somebody else's snapshot.
+    """
+
+    kind: AttributionKind
+    # Repo-relative path of the story's file. Set only when the kind is PLACED.
+    source_path: str = ""
+    # Short phrase naming what stopped the lookup. Set only when the kind is UNAVAILABLE.
+    detail: str = ""
+
+
+@frozen
+class DebtItem:
+    """One thing somebody still has to decide about, and what is known about where it lives."""
+
+    identifier: str
+    run_type: str
+    attribution: Attribution
+    line: str
+
+
+@frozen
+class RepoDebt:
+    """Everything one repo owes today, before it is split by owning team."""
+
+    expiring_quarantines: list[DebtItem]
+    variant_pileups: list[DebtItem]
+
+    @property
+    def items(self) -> list[DebtItem]:
+        return [*self.expiring_quarantines, *self.variant_pileups]
+
+
+@frozen
+class TriageGroup:
+    """The items that share one reason for having no owning team."""
+
+    reason: TriageReason
+    items: list[DebtItem]
+
+
+@frozen
+class TeamDigest:
+    """One team's share of a repo's debt, ready to post."""
+
+    team_slug: str
+    expiring_quarantines: list[DebtItem]
+    variant_pileups: list[DebtItem]
+    # Items nobody owns yet. Only the maintainers' digest carries them, and they hold them until a
+    # team takes them.
+    triage: list[TriageGroup] = field(default_factory=list)
+
+
+@frozen
+class Delivery:
+    """Where one team's digest goes, and what the lead says about how it got there."""
+
+    channel_id: str
+    channel_name: str
+    lead_prefix: str
+
+
+def _escape_mrkdwn(text: str) -> str:
+    """Neutralize Slack mrkdwn control characters in text a contributor wrote.
+
+    A quarantine reason and a snapshot identifier are both user input. Escaping `&`, `<` and `>`
+    stops one from smuggling a `<!channel>` mention or breaking out of a link; Slack renders the
+    escaped entities back as the literal characters.
+    """
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def _snapshot_url(repo: Repo, run_type: str, identifier: str) -> str:
+    return (
+        f"{settings.SITE_URL}/project/{repo.team_id}/visual_review/repos/{repo.id}"
+        f"/{quote(run_type, safe='')}/snapshots/{quote(identifier, safe='')}"
+    )
+
+
+def _quarantine_line(repo: Repo, entry: QuarantinedIdentifier, authors: dict[int, str], now: datetime) -> str:
+    days = max((entry.expires_at - now).days, 0) if entry.expires_at is not None else 0
+    who = authors.get(entry.created_by_id or 0, "someone")
+    return (
+        f"Quarantine expires in {days} days · {_escape_mrkdwn(entry.identifier)} ({entry.run_type})"
+        f' · opened by {_escape_mrkdwn(who)} for "{_escape_mrkdwn(entry.reason)}"'
+        f" · {_snapshot_url(repo, entry.run_type, entry.identifier)}"
+    )
+
+
+def _pileup_line(repo: Repo, run_type: str, identifier: str, count: int) -> str:
+    return (
+        f"{count} accepted variants of the current baseline · {_escape_mrkdwn(identifier)} ({run_type})"
+        f" · {_snapshot_url(repo, run_type, identifier)}"
+    )
+
+
+def _display_names(user_ids: set[int]) -> dict[int, str]:
+    if not user_ids:
+        return {}
+    return {
+        user.id: user.first_name or user.email
+        for user in User.objects.filter(id__in=user_ids).only("id", "first_name", "email")
+    }
+
+
+@frozen
+class RunTypeAttribution:
+    """What one run type can be attributed against today: a story index, or why there is none."""
+
+    index: story_index.StoryIndex | None
+    detail: str
+
+
+def _attribution_sources(repo: Repo, run_types: set[str]) -> dict[str, RunTypeAttribution]:
+    """Read the story index of the run behind the current baseline, for each run type in play.
+
+    One artifact read per run type, not per item. A run type nothing owes today is never read, so a
+    repo with no Storybook debt costs no download at all.
+    """
+    if not run_types:
+        return {}
+    newest_by_run_type = run_queries.newest_run_by_run_type(run_queries.latest_default_branch_runs(repo.id))
+    sources: dict[str, RunTypeAttribution] = {}
+    for run_type in run_types:
+        if run_type != RunType.STORYBOOK:
+            sources[run_type] = RunTypeAttribution(index=None, detail=f"{run_type} runs are not supported yet")
+            continue
+        run = newest_by_run_type.get(run_type)
+        if run is None:
+            sources[run_type] = RunTypeAttribution(index=None, detail=_NO_BASELINE_RUN_DETAIL)
+            continue
+        github_run_id = (run.metadata or {}).get("github_run_id")
+        if not isinstance(github_run_id, str) or not github_run_id:
+            sources[run_type] = RunTypeAttribution(
+                index=None, detail="the run behind the baseline records no workflow run"
+            )
+            continue
+        index = story_index.fetch_story_index(repo, github_run_id)
+        sources[run_type] = RunTypeAttribution(
+            index=index,
+            detail="" if index is not None else f"the Storybook build artifact for run {github_run_id} was not read",
+        )
+    return sources
+
+
+def _attribution(sources: Mapping[str, RunTypeAttribution], run_type: str, identifier: str) -> Attribution:
+    """Where one snapshot's story lives, or why the index cannot say."""
+    source = sources.get(run_type)
+    if source is None:
+        return Attribution(kind=AttributionKind.UNAVAILABLE, detail=_NO_BASELINE_RUN_DETAIL)
+    if source.index is None:
+        return Attribution(kind=AttributionKind.UNAVAILABLE, detail=source.detail)
+    path = story_index.story_path(source.index, identifier)
+    if path is None:
+        return Attribution(kind=AttributionKind.STORY_ABSENT)
+    return Attribution(kind=AttributionKind.PLACED, source_path=path)
+
+
+def collect_debt(repo: Repo, now: datetime) -> RepoDebt:
+    """Evaluate both conditions against current data, attribute each item, and render its line."""
+    expiring = quarantine.list_expiring_quarantines(repo.id, now=now)
+    quarantined_keys = quarantine.active_quarantine_keys(repo.id, now=now)
+    piled_up = {
+        key: count
+        for key, count in toleration.count_active_variants_against_current_baseline(repo.id, now=now).items()
+        # Any live quarantine, expiring or not, already says somebody knows the snapshot is
+        # unreliable, so asking them about the variants underneath it is a second reminder about
+        # one problem.
+        if count >= VARIANT_PILEUP_MIN and key not in quarantined_keys
+    }
+
+    run_types = {entry.run_type for entry in expiring} | {run_type for run_type, _ in piled_up}
+    sources = _attribution_sources(repo, run_types)
+    authors = _display_names({entry.created_by_id for entry in expiring if entry.created_by_id})
+
+    return RepoDebt(
+        expiring_quarantines=[
+            DebtItem(
+                identifier=entry.identifier,
+                run_type=entry.run_type,
+                attribution=_attribution(sources, entry.run_type, entry.identifier),
+                line=_quarantine_line(repo, entry, authors, now),
+            )
+            for entry in expiring
+        ],
+        variant_pileups=[
+            DebtItem(
+                identifier=identifier,
+                run_type=run_type,
+                attribution=_attribution(sources, run_type, identifier),
+                line=_pileup_line(repo, run_type, identifier, count),
+            )
+            for (run_type, identifier), count in sorted(piled_up.items(), key=lambda item: (-item[1], item[0]))
+        ],
+    )
+
+
+def paths_to_resolve(debt: RepoDebt) -> list[str]:
+    """Every path the run needs an owner for, including the product's own directory."""
+    placed = {item.attribution.source_path for item in debt.items if item.attribution.kind == AttributionKind.PLACED}
+    return [_PRODUCT_PATH, *sorted(placed)]
+
+
+def _owning_team(item: DebtItem, ownership: PathOwnership) -> str:
+    """The team that owns the item's story file, or `UNOWNED_TEAM` when there is nobody to name."""
+    if item.attribution.kind != AttributionKind.PLACED:
+        return UNOWNED_TEAM
+    return ownership.team_by_path.get(item.attribution.source_path, UNOWNED_TEAM)
+
+
+def _triage_reason(item: DebtItem) -> TriageReason:
+    """Why an item nobody owns is in triage. A placed path with no owner needs an owners entry."""
+    if item.attribution.kind == AttributionKind.PLACED:
+        return TriageReason.UNOWNED_FILE
+    if item.attribution.kind == AttributionKind.STORY_ABSENT:
+        return TriageReason.STORY_ABSENT
+    return TriageReason.UNAVAILABLE
+
+
+def split_by_team(debt: RepoDebt, ownership: PathOwnership) -> list[TeamDigest]:
+    """Group a repo's debt by the team that owns each item's story file.
+
+    Everything else is triage rather than debt of the maintainers' own: it goes into the digest of
+    the team that owns the product directory, grouped by why it has no owner. When that team is
+    unowned too, the item is dropped with a log line rather than posted somewhere arbitrary.
+    """
+    fallback = ownership.team_by_path.get(_PRODUCT_PATH, UNOWNED_TEAM)
+    expiring_by_team: dict[str, list[DebtItem]] = {}
+    pileups_by_team: dict[str, list[DebtItem]] = {}
+    triage_by_reason: dict[TriageReason, list[DebtItem]] = {}
+    for items, bucket in ((debt.expiring_quarantines, expiring_by_team), (debt.variant_pileups, pileups_by_team)):
+        for item in items:
+            team = _owning_team(item, ownership)
+            if team != UNOWNED_TEAM:
+                bucket.setdefault(team, []).append(item)
+                continue
+            if fallback == UNOWNED_TEAM:
+                logger.info(
+                    "visual_review.debt_digest_item_unowned",
+                    identifier=item.identifier,
+                    attribution=str(item.attribution.kind),
+                    source_path=item.attribution.source_path,
+                )
+                continue
+            triage_by_reason.setdefault(_triage_reason(item), []).append(item)
+
+    # Declaration order, so the three groups always read in the same order.
+    triage = [
+        TriageGroup(reason=reason, items=triage_by_reason[reason])
+        for reason in TriageReason
+        if reason in triage_by_reason
+    ]
+    teams = expiring_by_team.keys() | pileups_by_team.keys()
+    if triage:
+        teams = teams | {fallback}
+    return [
+        TeamDigest(
+            team_slug=team,
+            expiring_quarantines=expiring_by_team.get(team, []),
+            variant_pileups=pileups_by_team.get(team, []),
+            triage=triage if team == fallback else [],
+        )
+        for team in sorted(teams)
+    ]
+
+
+def _unavailable_details(digest: TeamDigest) -> list[str]:
+    """Every distinct reason ownership could not be worked out for this digest's triage items."""
+    return sorted(
+        {
+            item.attribution.detail
+            for group in digest.triage
+            if group.reason == TriageReason.UNAVAILABLE
+            for item in group.items
+            if item.attribution.detail
+        }
+    )
+
+
+def lead_text(digest: TeamDigest, repo: Repo) -> str:
+    expiring = len(digest.expiring_quarantines)
+    pileups = len(digest.variant_pileups)
+    # A digest that carries triage only still names the team and the repo, so the maintainers can
+    # see whose channel it landed in without opening the thread.
+    owed = (
+        f"{expiring} quarantine{'' if expiring == 1 else 's'} expire{'s' if expiring == 1 else ''} soon, "
+        f"{pileups} snapshot{'' if pileups == 1 else 's'} with piled-up variants."
+        if expiring or pileups
+        else "nothing this team owns today."
+    )
+    sentences = [f"Visual review debt for {digest.team_slug} in {repo.repo_full_name}: {owed}"]
+    triage_count = sum(len(group.items) for group in digest.triage)
+    if triage_count:
+        sentences.append(
+            f"Plus {triage_count} in triage that nobody owns yet: visual review maintainers hold them "
+            "until a team takes them."
+        )
+    details = _unavailable_details(digest)
+    if details:
+        sentences.append(
+            "Ownership could not be worked out for some of them today, because "
+            f"{_escape_mrkdwn('; '.join(details))}. The digest tries again tomorrow."
+        )
+    return " ".join(sentences)
+
+
+def _triage_line(item: DebtItem) -> str:
+    """One triage item's line, carrying what its group's header asks the reader to act on."""
+    if item.attribution.kind == AttributionKind.PLACED:
+        return f"{item.line} · {_escape_mrkdwn(item.attribution.source_path)}"
+    if item.attribution.kind == AttributionKind.UNAVAILABLE:
+        return f"{item.line} · {_escape_mrkdwn(item.attribution.detail)}"
+    return item.line
+
+
+def thread_texts(digest: TeamDigest) -> list[str]:
+    """The item lines, grouped by condition and then by triage reason, split to fit Slack's section cap."""
+    lines = [
+        *(item.line for item in digest.expiring_quarantines),
+        *(item.line for item in digest.variant_pileups),
+    ]
+    for group in digest.triage:
+        lines.append(_TRIAGE_HEADERS[group.reason])
+        lines.extend(_triage_line(item) for item in group.items)
+    lines.append(_FOOTER)
+    messages: list[str] = []
+    current: list[str] = []
+    for line in lines:
+        if current and len("\n".join([*current, line])) > _MAX_SECTION_CHARS:
+            messages.append("\n".join(current))
+            current = []
+        current.append(line)
+    if current:
+        messages.append("\n".join(current))
+    return messages
+
+
+def _blocks(text: str) -> list[dict]:
+    return [{"type": "section", "text": {"type": "mrkdwn", "text": text}}]
+
+
+def resolve_channel(
+    digest: TeamDigest, registry: Mapping[str, TeamEntry], channels_by_name: Mapping[str, SlackChannel]
+) -> Delivery | None:
+    """The team's own notifications channel, or None when it opted out or the name does not resolve."""
+    answer = team_channel(digest.team_slug, registry, _CHANNEL_PURPOSE, _PRODUCER)
+    if answer.channel is None:
+        logger.info("visual_review.debt_digest_team_opted_out", team_slug=digest.team_slug)
+        return None
+    name = answer.channel.removeprefix("#")
+    match = find_channel(channels_by_name, name, allow_shared=False)
+    if match.channel is None:
+        logger.info(
+            "visual_review.debt_digest_channel_unusable",
+            team_slug=digest.team_slug,
+            channel_name=name,
+            reason=match.reason,
+        )
+        return None
+    return Delivery(channel_id=match.channel.channel_id, channel_name=name, lead_prefix="")
+
+
+def deliver(
+    digest: TeamDigest,
+    registry: Mapping[str, TeamEntry],
+    channels_by_name: Mapping[str, SlackChannel],
+    mode: str,
+) -> Delivery | None:
+    """Where this team's digest goes under the run's mode. None means nothing is posted."""
+    resolved = resolve_channel(digest, registry, channels_by_name)
+    if mode != MODE_SHADOW:
+        return resolved
+    shadow_channel = settings.VISUAL_REVIEW_DEBT_DIGEST_SHADOW_CHANNEL
+    match = find_channel(channels_by_name, shadow_channel, allow_shared=False)
+    if match.channel is None:
+        logger.warning(
+            "visual_review.debt_digest_shadow_channel_unusable",
+            channel_name=shadow_channel,
+            reason=match.reason,
+        )
+        return None
+    return Delivery(
+        channel_id=match.channel.channel_id,
+        channel_name=shadow_channel.removeprefix("#"),
+        # Names the channel the message would have gone to, so a reader of the shadow channel can
+        # check the routing without re-deriving it.
+        lead_prefix=(
+            f"Shadow for #{resolved.channel_name}: " if resolved is not None else "Shadow, no channel resolved: "
+        ),
+    )
+
+
+def send_debt_digest(repo: Repo, mode: str | None = None) -> list[str]:
+    """Evaluate, attribute, and post one repo's digest. One team's failure does not stop the rest.
+
+    Returns each team's rendered message, so an operator running this by hand can read what the
+    run would send without reaching into the logs.
+    """
+    mode = mode or settings.VISUAL_REVIEW_DEBT_DIGEST_MODE
+    if mode == MODE_OFF:
+        return []
+
+    debt = collect_debt(repo, timezone.now())
+    if not debt.items:
+        logger.info("visual_review.debt_digest_nothing_owed", repo_id=str(repo.id), team_id=repo.team_id)
+        return []
+
+    ownership = resolve_path_owners(repo.repo_full_name, paths_to_resolve(debt))
+    digests = split_by_team(debt, ownership)
+
+    integration: Integration | None = None
+    channels_by_name: dict[str, SlackChannel] = {}
+    if mode != MODE_PREVIEW:
+        integration = Integration.objects.filter(team_id=repo.team_id, kind="slack").first()
+        if integration is None:
+            logger.info("visual_review.debt_digest_no_slack_integration", team_id=repo.team_id)
+            return []
+        channels_by_name = fetch_channel_map(integration)
+
+    rendered: list[str] = []
+    for digest in digests:
+        try:
+            rendered.append(_send_one(repo, digest, ownership.registry, channels_by_name, integration, mode))
+        except Exception as e:
+            # One team's Slack failure must not cost the rest of the repo its reminder, and there is
+            # nothing to retry against: tomorrow's run sends the same items again.
+            logger.warning(
+                "visual_review.debt_digest_team_failed",
+                repo_id=str(repo.id),
+                team_slug=digest.team_slug,
+                error=str(e),
+            )
+    return rendered
+
+
+def _send_one(
+    repo: Repo,
+    digest: TeamDigest,
+    registry: Mapping[str, TeamEntry],
+    channels_by_name: Mapping[str, SlackChannel],
+    integration: Integration | None,
+    mode: str,
+) -> str:
+    lead = lead_text(digest, repo)
+    thread = thread_texts(digest)
+    if mode == MODE_PREVIEW:
+        resolved = resolve_channel(digest, registry, channels_by_name)
+        rendered = "\n".join([lead, *thread])
+        logger.info(
+            "visual_review.debt_digest_preview",
+            repo_id=str(repo.id),
+            team_slug=digest.team_slug,
+            channel_name=resolved.channel_name if resolved is not None else None,
+            item_count=len(digest.expiring_quarantines) + len(digest.variant_pileups),
+            triage_count=sum(len(group.items) for group in digest.triage),
+            rendered=rendered,
+        )
+        return rendered
+
+    delivery = deliver(digest, registry, channels_by_name, mode)
+    if delivery is None or integration is None:
+        return ""
+
+    slack = SlackIntegration(integration)
+    lead = f"{delivery.lead_prefix}{lead}"
+    try:
+        thread_ts = post_with_join(slack, delivery.channel_id, _blocks(lead), lead, channel_name=delivery.channel_name)
+    except SlackPostRefused as e:
+        logger.warning("visual_review.debt_digest_post_refused", team_slug=digest.team_slug, error=str(e))
+        return ""
+    # Without a parent to hang them on, the item lines land in the channel as separate top-level
+    # posts, which is the noise the thread exists to remove.
+    if thread_ts is not None:
+        for text in thread:
+            post_message(slack, delivery.channel_id, _blocks(text), text, thread_ts=thread_ts)
+    return "\n".join([lead, *thread])
+
+
+def repos_in_scope() -> list[Repo]:
+    """The repos the digest is configured for, by `owner/name`."""
+    configured: Sequence[str] = settings.VISUAL_REVIEW_DEBT_DIGEST_REPOS
+    if not configured:
+        return []
+    # nosemgrep: idor-lookup-without-team — cross-team beat sweep over a settings allowlist
+    return list(Repo.objects.unscoped().filter(repo_full_name__in=list(configured)).order_by("created_at"))

--- a/products/visual_review/backend/logic/debt_digest.py
+++ b/products/visual_review/backend/logic/debt_digest.py
@@ -497,6 +497,11 @@ def send_debt_digest(repo: Repo, mode: str) -> list[str]:
         return []
 
     ownership = resolve_path_owners(repo.repo_full_name, paths_to_resolve(debt))
+    if not ownership.resolved:
+        # A blind answer names no team and carries no registry, so every item would read as
+        # unowned and be dropped. Say so instead, and send the same items tomorrow.
+        logger.warning("visual_review.debt_digest_ownership_unavailable", repo_id=str(repo.id), team_id=repo.team_id)
+        return []
     digests = split_by_team(debt, ownership)
 
     if mode == MODE_PREVIEW:

--- a/products/visual_review/backend/logic/debt_digest.py
+++ b/products/visual_review/backend/logic/debt_digest.py
@@ -28,12 +28,11 @@ those maintainers own, because holding an item until a team takes it is not owni
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from dataclasses import field
 from datetime import datetime
 from enum import StrEnum
 from urllib.parse import quote
-from uuid import UUID
 
 from django.conf import settings
 from django.utils import timezone
@@ -87,11 +86,9 @@ _MAX_LINE_CHARS = MAX_SECTION_CHARS // 2
 _MAX_IDENTIFIER_CHARS = 160
 _MAX_REASON_CHARS = 200
 
-MODE_OFF = "off"
 MODE_PREVIEW = "preview"
-MODE_SHADOW = "shadow"
 MODE_LIVE = "live"
-MODES = (MODE_OFF, MODE_PREVIEW, MODE_SHADOW, MODE_LIVE)
+MODES = (MODE_PREVIEW, MODE_LIVE)
 
 _FOOTER = (
     "This repeats daily while the items stay unresolved. "
@@ -178,11 +175,10 @@ class TeamDigest:
 
 @frozen
 class Delivery:
-    """Where one team's digest goes, and what the lead says about how it got there."""
+    """Where one team's digest goes."""
 
     channel_id: str
     channel_name: str
-    lead_prefix: str
 
 
 def _snapshot_url(repo: Repo, run_type: str, identifier: str) -> str:
@@ -476,51 +472,18 @@ def resolve_channel(
             reason=match.reason,
         )
         return None
-    return Delivery(channel_id=match.channel.channel_id, channel_name=name, lead_prefix="")
+    return Delivery(channel_id=match.channel.channel_id, channel_name=name)
 
 
-def deliver(
-    digest: TeamDigest,
-    registry: Mapping[str, TeamEntry],
-    channels_by_name: Mapping[str, SlackChannel],
-    mode: str,
-) -> Delivery | None:
-    """Where this team's digest goes under the run's mode. None means nothing is posted."""
-    resolved = resolve_channel(digest, registry, channels_by_name)
-    if mode != MODE_SHADOW:
-        return resolved
-    shadow_channel = settings.VISUAL_REVIEW_DEBT_DIGEST_SHADOW_CHANNEL
-    match = find_channel(channels_by_name, shadow_channel, allow_shared=False)
-    if match.channel is None:
-        logger.warning(
-            "visual_review.debt_digest_shadow_channel_unusable",
-            channel_name=shadow_channel,
-            reason=match.reason,
-        )
-        return None
-    return Delivery(
-        channel_id=match.channel.channel_id,
-        channel_name=shadow_channel.removeprefix("#"),
-        # Names the channel the message would have gone to, so a reader of the shadow channel can
-        # check the routing without re-deriving it.
-        lead_prefix=(
-            f"Shadow for #{resolved.channel_name}: " if resolved is not None else "Shadow, no channel resolved: "
-        ),
-    )
-
-
-def send_debt_digest(repo: Repo, mode: str | None = None) -> list[str]:
+def send_debt_digest(repo: Repo, mode: str) -> list[str]:
     """Evaluate, attribute, and post one repo's digest. One team's failure does not stop the rest.
 
     Returns each team's rendered message, so an operator running this by hand can read what the
     run would send without reaching into the logs.
     """
-    mode = mode or settings.VISUAL_REVIEW_DEBT_DIGEST_MODE
-    # `deliver` reads anything that is not shadow as the team's own channel, so an undefined mode posts live.
+    # Anything that is not preview posts, so an undefined mode must stop here rather than go live.
     if mode not in MODES:
         logger.warning("visual_review.debt_digest_mode_unknown", mode=mode)
-        return []
-    if mode == MODE_OFF:
         return []
 
     debt = collect_debt(repo, timezone.now())
@@ -543,7 +506,7 @@ def send_debt_digest(repo: Repo, mode: str | None = None) -> list[str]:
     rendered: list[str] = []
     for digest in digests:
         try:
-            rendered.append(_send_one(repo, digest, ownership.registry, channels_by_name, integration, mode))
+            rendered.append(_send_one(repo, digest, ownership.registry, channels_by_name, integration))
         except Exception as e:
             # One team's Slack failure must not cost the rest of the repo its reminder, and there is
             # nothing to retry against: tomorrow's run sends the same items again.
@@ -580,16 +543,14 @@ def _send_one(
     registry: Mapping[str, TeamEntry],
     channels_by_name: Mapping[str, SlackChannel],
     integration: Integration,
-    mode: str,
 ) -> str:
     lead = lead_text(digest, repo)
     thread = thread_texts(digest)
-    delivery = deliver(digest, registry, channels_by_name, mode)
+    delivery = resolve_channel(digest, registry, channels_by_name)
     if delivery is None:
         return ""
 
     slack = SlackIntegration(integration)
-    lead = f"{delivery.lead_prefix}{lead}"
     try:
         thread_ts = post_with_join(
             slack, delivery.channel_id, section_block(lead), lead, channel_name=delivery.channel_name
@@ -605,14 +566,11 @@ def _send_one(
     return "\n".join([lead, *thread])
 
 
-def repos_in_scope() -> list[tuple[int, UUID]]:
-    """The `(team_id, repo_id)` of each repo the digest is configured for, by `owner/name`.
+def repos_in_scope() -> list[Repo]:
+    """Every repo, oldest first.
 
-    The fan-out task only routes, so it never needs a hydrated row.
+    No allowlist: the per-repo task stops as soon as a repo owes nothing, so a repo that never
+    carries debt costs one cheap read a day. The fan-out only routes, so the rows stay unhydrated.
     """
-    configured: Sequence[str] = settings.VISUAL_REVIEW_DEBT_DIGEST_REPOS
-    if not configured:
-        return []
-    # nosemgrep: idor-lookup-without-team — cross-team beat sweep over a settings allowlist
-    configured_repos = Repo.objects.unscoped().filter(repo_full_name__in=list(configured)).order_by("created_at")
-    return list(configured_repos.values_list("team_id", "id"))
+    # nosemgrep: idor-lookup-without-team — cross-team beat sweep, no user input
+    return list(Repo.objects.unscoped().only("id", "team_id").order_by("created_at"))

--- a/products/visual_review/backend/logic/debt_digest.py
+++ b/products/visual_review/backend/logic/debt_digest.py
@@ -213,7 +213,8 @@ def _quarantine_line(repo: Repo, entry: QuarantinedIdentifier, authors: dict[int
     who = authors.get(entry.created_by_id or 0, "someone")
     body = (
         f"Quarantine expires in {days} days"
-        f" · {escape_slack_mrkdwn(clip_text(entry.identifier, _MAX_IDENTIFIER_CHARS))} ({entry.run_type})"
+        f" · {escape_slack_mrkdwn(clip_text(entry.identifier, _MAX_IDENTIFIER_CHARS))}"
+        f" ({escape_slack_mrkdwn(entry.run_type)})"
         f' · opened by {escape_slack_mrkdwn(who)} for "{escape_slack_mrkdwn(clip_text(entry.reason, _MAX_REASON_CHARS))}"'
     )
     return _linked_line(repo, body, entry.run_type, entry.identifier)
@@ -222,7 +223,7 @@ def _quarantine_line(repo: Repo, entry: QuarantinedIdentifier, authors: dict[int
 def _pileup_line(repo: Repo, run_type: str, identifier: str, count: int) -> str:
     body = (
         f"{count} accepted variants of the current baseline"
-        f" · {escape_slack_mrkdwn(clip_text(identifier, _MAX_IDENTIFIER_CHARS))} ({run_type})"
+        f" · {escape_slack_mrkdwn(clip_text(identifier, _MAX_IDENTIFIER_CHARS))} ({escape_slack_mrkdwn(run_type)})"
     )
     return _linked_line(repo, body, run_type, identifier)
 

--- a/products/visual_review/backend/logic/flakiness.py
+++ b/products/visual_review/backend/logic/flakiness.py
@@ -20,7 +20,6 @@ from posthog.dataclasses import frozen
 
 from ..facade.contracts import (
     FLAKINESS_BROKEN_RATE,
-    FLAKINESS_EXPIRY_SOON_DAYS,
     FLAKINESS_MAX_ENTRIES,
     FLAKINESS_MIN_HEADROOM,
     FLAKINESS_MIN_WINDOW_RUNS,
@@ -31,6 +30,7 @@ from ..facade.contracts import (
 from ..facade.enums import ClassificationReason, FlakinessState, ReviewState, RunStatus, SnapshotResult, ToleratedReason
 from ..models import QuarantinedIdentifier, Run, RunSnapshot, ToleratedHash
 from . import run_queries
+from .quarantine import expiry_soon_cutoff, is_expiring_soon
 
 # Rows a run recorded as a difference from the baseline, split by what that
 # difference cost. `_HARD` failed the gate and blocked whoever was merging.
@@ -188,20 +188,7 @@ def get_flakiness_overview(repo_id: UUID) -> _FlakinessRaw:
         if quarantine_key not in active_quarantines_by_key:
             active_quarantines_by_key[quarantine_key] = active_quarantine
 
-    # `status=completed` rather than `superseded_by IS NULL`: a freshly started
-    # run on the default branch is un-superseded but has few or no RunSnapshots
-    # ingested yet, which would collapse the universe to whatever it has loaded
-    # so far. Same reasoning as `baseline_overview.get_baselines_overview`.
-    universe_runs = list(
-        Run.objects.filter(
-            repo_id=repo_id,
-            branch__in=run_queries._DEFAULT_BRANCHES,
-            status=RunStatus.COMPLETED,
-        )
-        .order_by("repo_id", "branch", "run_type", "-created_at")
-        .distinct("repo_id", "branch", "run_type")
-        .only("id", "run_type", "created_at")
-    )
+    universe_runs = run_queries.latest_default_branch_runs(repo_id)
     if not universe_runs:
         return _quarantine_only_raw(
             active_quarantines_by_key,
@@ -210,15 +197,7 @@ def get_flakiness_overview(repo_id: UUID) -> _FlakinessRaw:
             max_entries=FLAKINESS_MAX_ENTRIES,
         )
 
-    # `universe_runs` holds one run per branch and run type, so a repo with runs
-    # on both master and main has two per run type. The row identity carries no
-    # branch, so keep only the newest run per run type. Otherwise whichever
-    # branch happened to be read last decided the baseline, and two identical
-    # requests could disagree.
-    newest_run_by_type: dict[str, Run] = {}
-    for run in sorted(universe_runs, key=lambda r: r.created_at, reverse=True):
-        newest_run_by_type.setdefault(run.run_type, run)
-
+    newest_run_by_type = run_queries.newest_run_by_run_type(universe_runs)
     run_type_by_run_id = {run.id: run_type for run_type, run in newest_run_by_type.items()}
     universe_run_ids = list(run_type_by_run_id)
 
@@ -363,7 +342,7 @@ def get_flakiness_overview(repo_id: UUID) -> _FlakinessRaw:
         if moved_at is not None:
             baseline_moved_at_by_key[_SnapshotKey(run_type=run_type, identifier=identifier)] = moved_at
 
-    expiry_soon_cutoff = now + timedelta(days=FLAKINESS_EXPIRY_SOON_DAYS)
+    expiry_cutoff = expiry_soon_cutoff(now)
 
     # An identity can carry something to report and still have no current
     # baseline: a quarantine opened before the first run, or a snapshot that
@@ -438,7 +417,7 @@ def get_flakiness_overview(repo_id: UUID) -> _FlakinessRaw:
                 needs_decision=_needs_decision(
                     quarantine=quarantine,
                     hard_count=hard_count,
-                    expiry_soon_cutoff=expiry_soon_cutoff,
+                    expiry_cutoff=expiry_cutoff,
                 ),
             )
         )
@@ -670,7 +649,7 @@ def _needs_decision(
     *,
     quarantine: QuarantinedIdentifier | None,
     hard_count: int,
-    expiry_soon_cutoff: datetime,
+    expiry_cutoff: datetime,
 ) -> bool:
     """Whether an active quarantine has stopped matching what it was opened for.
 
@@ -696,7 +675,7 @@ def _needs_decision(
         return False
     if hard_count == 0:
         return True
-    return quarantine.expires_at is not None and quarantine.expires_at <= expiry_soon_cutoff
+    return is_expiring_soon(quarantine, expiry_cutoff)
 
 
 def _daily_series(counts_by_day: dict[date, int], *, strip_start: date, length: int) -> list[int]:

--- a/products/visual_review/backend/logic/flakiness.py
+++ b/products/visual_review/backend/logic/flakiness.py
@@ -31,6 +31,7 @@ from ..facade.enums import ClassificationReason, FlakinessState, ReviewState, Ru
 from ..models import QuarantinedIdentifier, Run, RunSnapshot, ToleratedHash
 from . import run_queries
 from .quarantine import expiry_soon_cutoff, is_expiring_soon
+from .run_queries import SnapshotKey
 
 # Rows a run recorded as a difference from the baseline, split by what that
 # difference cost. `_HARD` failed the gate and blocked whoever was merging.
@@ -71,14 +72,6 @@ _SOFT = Q(result=SnapshotResult.UNCHANGED) & (
         tolerated_hash_match__reason=ToleratedReason.AUTO_THRESHOLD,
     )
 )
-
-
-@frozen
-class _SnapshotKey:
-    """One snapshot identity. The same identifier under two run types is two."""
-
-    run_type: str
-    identifier: str
 
 
 @frozen
@@ -174,7 +167,7 @@ def get_flakiness_overview(repo_id: UUID) -> _FlakinessRaw:
     # Hydrated so each row can render reason, expiry, who and the source run
     # without a per-row fetch. `Run.metadata` and `Run.error_message` can be
     # large and are not needed for the summary.
-    active_quarantines_by_key: dict[_SnapshotKey, QuarantinedIdentifier] = {}
+    active_quarantines_by_key: dict[SnapshotKey, QuarantinedIdentifier] = {}
     for active_quarantine in (
         QuarantinedIdentifier.objects.filter(repo_id=repo_id)
         .filter(live)
@@ -182,7 +175,7 @@ def get_flakiness_overview(repo_id: UUID) -> _FlakinessRaw:
         .defer("source_run__metadata", "source_run__error_message")
         .order_by("-created_at")
     ):
-        quarantine_key = _SnapshotKey(run_type=active_quarantine.run_type, identifier=active_quarantine.identifier)
+        quarantine_key = SnapshotKey(run_type=active_quarantine.run_type, identifier=active_quarantine.identifier)
         # Creating a quarantine supersedes the prior active row, so duplicates
         # should not exist. Keep the newest if one ever does.
         if quarantine_key not in active_quarantines_by_key:
@@ -204,12 +197,12 @@ def get_flakiness_overview(repo_id: UUID) -> _FlakinessRaw:
     # The baseline hash each identifier would be compared against right now.
     # values_list rather than model hydration: the universe can run to
     # thousands of rows and only the listed ones need thumbnails later.
-    baseline_hash_by_key: dict[_SnapshotKey, str] = {}
+    baseline_hash_by_key: dict[SnapshotKey, str] = {}
     for run_id, identifier, baseline_hash in RunSnapshot.objects.filter(run_id__in=universe_run_ids).values_list(
         "run_id", "identifier", "baseline_hash"
     ):
         if baseline_hash:
-            baseline_hash_by_key[_SnapshotKey(run_type=run_type_by_run_id[run_id], identifier=identifier)] = (
+            baseline_hash_by_key[SnapshotKey(run_type=run_type_by_run_id[run_id], identifier=identifier)] = (
                 baseline_hash
             )
 
@@ -326,7 +319,7 @@ def get_flakiness_overview(repo_id: UUID) -> _FlakinessRaw:
     # neighbour does. The history it reads reaches back only as far as retention
     # keeps default-branch runs, which is
     # `retention.DEFAULT_BRANCH_RUN_RETENTION_DAYS`.
-    baseline_moved_at_by_key: dict[_SnapshotKey, datetime] = {}
+    baseline_moved_at_by_key: dict[SnapshotKey, datetime] = {}
     for identifier, run_type, moved_at in (
         RunSnapshot.objects.filter(
             run__repo_id=repo_id,
@@ -340,7 +333,7 @@ def get_flakiness_overview(repo_id: UUID) -> _FlakinessRaw:
         .values_list("identifier", "run__run_type", "moved_at")
     ):
         if moved_at is not None:
-            baseline_moved_at_by_key[_SnapshotKey(run_type=run_type, identifier=identifier)] = moved_at
+            baseline_moved_at_by_key[SnapshotKey(run_type=run_type, identifier=identifier)] = moved_at
 
     expiry_cutoff = expiry_soon_cutoff(now)
 
@@ -350,7 +343,7 @@ def get_flakiness_overview(repo_id: UUID) -> _FlakinessRaw:
     # default-branch run. Those keys are absent from `baseline_hash_by_key`, so
     # walk them too rather than silently drop what they recorded.
     baseline_less_keys = (active_quarantines_by_key.keys() | hard_activity.keys()) - baseline_hash_by_key.keys()
-    scored_keys: list[tuple[_SnapshotKey, str]] = [
+    scored_keys: list[tuple[SnapshotKey, str]] = [
         *baseline_hash_by_key.items(),
         *((key, "") for key in baseline_less_keys),
     ]
@@ -447,7 +440,7 @@ def get_flakiness_overview(repo_id: UUID) -> _FlakinessRaw:
     snapshots_by_key = _hydrate_snapshots(
         universe_run_ids=universe_run_ids,
         run_type_by_run_id=run_type_by_run_id,
-        keys={_SnapshotKey(run_type=row.run_type, identifier=row.identifier) for row in listed},
+        keys={SnapshotKey(run_type=row.run_type, identifier=row.identifier) for row in listed},
     )
 
     return _FlakinessRaw(
@@ -468,7 +461,7 @@ def get_flakiness_overview(repo_id: UUID) -> _FlakinessRaw:
 
 
 def _quarantine_only_raw(
-    active_quarantines_by_key: dict[_SnapshotKey, QuarantinedIdentifier],
+    active_quarantines_by_key: dict[SnapshotKey, QuarantinedIdentifier],
     *,
     generated_at: datetime,
     strip_days: int,
@@ -529,7 +522,7 @@ def _read_activity(
     in_window: Q,
     match: Q,
     identifiers: list[str] | None = None,
-) -> dict[_SnapshotKey, _Activity]:
+) -> dict[SnapshotKey, _Activity]:
     """Window activity per snapshot identity, for the rows `match` selects.
 
     Grouped by day so one query serves both the rate and the activity strip:
@@ -539,10 +532,10 @@ def _read_activity(
     if identifiers is not None:
         queryset = queryset.filter(identifier__in=identifiers)
 
-    daily: dict[_SnapshotKey, dict[date, int]] = defaultdict(dict)
-    totals: Counter[_SnapshotKey] = Counter()
-    last_at: dict[_SnapshotKey, datetime] = {}
-    worst: dict[_SnapshotKey, float] = {}
+    daily: dict[SnapshotKey, dict[date, int]] = defaultdict(dict)
+    totals: Counter[SnapshotKey] = Counter()
+    last_at: dict[SnapshotKey, datetime] = {}
+    worst: dict[SnapshotKey, float] = {}
     for run_type, identifier, day, day_count, latest, worst_diff in (
         queryset.annotate(day=TruncDate("run__created_at"))
         .values("run__run_type", "identifier", "day")
@@ -553,7 +546,7 @@ def _read_activity(
         )
         .values_list("run__run_type", "identifier", "day", "day_count", "latest", "worst_diff")
     ):
-        key = _SnapshotKey(run_type=run_type, identifier=identifier)
+        key = SnapshotKey(run_type=run_type, identifier=identifier)
         daily[key][day] = day_count
         totals[key] += day_count
         seen_last = last_at.get(key)
@@ -640,9 +633,9 @@ def _latest(*moments: datetime | None) -> datetime | None:
     return max(known) if known else None
 
 
-def snapshot_key(row: _FlakinessRow) -> _SnapshotKey:
+def snapshot_key(row: _FlakinessRow) -> SnapshotKey:
     """Key for `_FlakinessRaw.snapshots_by_key`, for the facade to look a row up."""
-    return _SnapshotKey(run_type=row.run_type, identifier=row.identifier)
+    return SnapshotKey(run_type=row.run_type, identifier=row.identifier)
 
 
 def _needs_decision(
@@ -687,13 +680,13 @@ def _hydrate_snapshots(
     *,
     universe_run_ids: list[UUID],
     run_type_by_run_id: dict[UUID, str],
-    keys: set[_SnapshotKey],
-) -> dict[_SnapshotKey, RunSnapshot]:
+    keys: set[SnapshotKey],
+) -> dict[SnapshotKey, RunSnapshot]:
     """Thumbnail and dimension data for the listed rows only."""
     if not keys:
         return {}
     identifiers = list({key.identifier for key in keys})
-    hydrated: dict[_SnapshotKey, RunSnapshot] = {}
+    hydrated: dict[SnapshotKey, RunSnapshot] = {}
     for snapshot in (
         RunSnapshot.objects.filter(run_id__in=universe_run_ids, identifier__in=identifiers)
         .select_related("current_artifact__thumbnail")
@@ -706,7 +699,7 @@ def _hydrate_snapshots(
             "current_artifact__thumbnail__content_hash",
         )
     ):
-        key = _SnapshotKey(run_type=run_type_by_run_id[snapshot.run_id], identifier=snapshot.identifier)
+        key = SnapshotKey(run_type=run_type_by_run_id[snapshot.run_id], identifier=snapshot.identifier)
         if key in keys:
             hydrated[key] = snapshot
     return hydrated
@@ -766,7 +759,7 @@ class _FlakinessRaw:
     """
 
     rows: list[_FlakinessRow]
-    snapshots_by_key: dict[_SnapshotKey, RunSnapshot]
+    snapshots_by_key: dict[SnapshotKey, RunSnapshot]
     tracked_total: int
     totals_broken: int
     totals_unstable: int

--- a/products/visual_review/backend/logic/github_api.py
+++ b/products/visual_review/backend/logic/github_api.py
@@ -159,6 +159,7 @@ def _github_api_request(
     repo: Repo,
     path: str,
     *,
+    params: dict[str, str | int] | None = None,
     json: Mapping[str, object] | None = None,
     timeout: int = 10,
 ) -> requests.Response:
@@ -174,7 +175,9 @@ def _github_api_request(
 
     github = get_github_integration_for_repo(repo)
 
-    response = github.api_request(method, f"/repos/{repo.repo_full_name}/{safe_path}", json_body=json, timeout=timeout)
+    response = github.api_request(
+        method, f"/repos/{repo.repo_full_name}/{safe_path}", params=params, json_body=json, timeout=timeout
+    )
 
     if response.status_code == 404 and repo.repo_external_id:
         new_full_name = _resolve_repo_by_id(github, repo.repo_external_id)
@@ -189,7 +192,7 @@ def _github_api_request(
             repo.save(update_fields=["repo_full_name"])
 
             response = github.api_request(
-                method, f"/repos/{new_full_name}/{safe_path}", json_body=json, timeout=timeout
+                method, f"/repos/{new_full_name}/{safe_path}", params=params, json_body=json, timeout=timeout
             )
 
     return response

--- a/products/visual_review/backend/logic/quarantine.py
+++ b/products/visual_review/backend/logic/quarantine.py
@@ -14,6 +14,7 @@ from ..facade.contracts import FLAKINESS_EXPIRY_SOON_DAYS
 from ..facade.enums import ActorType
 from ..models import QuarantinedIdentifier, Run
 from . import errors, repos
+from .run_queries import SnapshotKey
 
 
 def list_quarantined_identifiers(
@@ -70,14 +71,15 @@ def list_expiring_quarantines(repo_id: UUID, *, now: datetime) -> list[Quarantin
     )
 
 
-def active_quarantine_keys(repo_id: UUID, *, now: datetime) -> set[tuple[str, str]]:
-    """Every `(run_type, identifier)` under a quarantine that has not run out, whatever its expiry."""
-    return set(
-        QuarantinedIdentifier.objects.using(READER_DB)
+def active_quarantine_keys(repo_id: UUID, *, now: datetime) -> set[SnapshotKey]:
+    """Every identity under a quarantine that has not run out, whatever its expiry."""
+    return {
+        SnapshotKey(run_type=run_type, identifier=identifier)
+        for run_type, identifier in QuarantinedIdentifier.objects.using(READER_DB)
         .filter(repo_id=repo_id)
         .filter(Q(expires_at__isnull=True) | Q(expires_at__gt=now))
         .values_list("run_type", "identifier")
-    )
+    }
 
 
 @transaction.atomic(using=WRITER_DB)

--- a/products/visual_review/backend/logic/quarantine.py
+++ b/products/visual_review/backend/logic/quarantine.py
@@ -2,14 +2,15 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from uuid import UUID
 
 from django.db import transaction
 from django.db.models import Q
 from django.utils import timezone
 
-from ..db import WRITER_DB
+from ..db import READER_DB, WRITER_DB
+from ..facade.contracts import FLAKINESS_EXPIRY_SOON_DAYS
 from ..facade.enums import ActorType
 from ..models import QuarantinedIdentifier, Run
 from . import errors, repos
@@ -36,6 +37,37 @@ def list_quarantined_identifiers(
         now = timezone.now()
         qs = qs.filter(Q(expires_at__isnull=True) | Q(expires_at__gt=now))
     return list(qs.order_by("-created_at"))
+
+
+def expiry_soon_cutoff(now: datetime) -> datetime:
+    """The moment past which an expiry is close enough that somebody has to decide about it."""
+    return now + timedelta(days=FLAKINESS_EXPIRY_SOON_DAYS)
+
+
+def is_expiring_soon(entry: QuarantinedIdentifier, cutoff: datetime) -> bool:
+    """Whether an active quarantine runs out inside the window.
+
+    An entry with no expiry never does. It is a standing exception, and nothing about it changes
+    on its own, so there is no date for a reminder to hang off.
+    """
+    return entry.expires_at is not None and entry.expires_at <= cutoff
+
+
+def list_expiring_quarantines(repo_id: UUID, *, now: datetime) -> list[QuarantinedIdentifier]:
+    """Active quarantines that run out inside the window, soonest first.
+
+    An entry leaves this list when somebody extends it past the window, lifts it, or lets it lapse.
+    """
+    return list(
+        QuarantinedIdentifier.objects.using(READER_DB)
+        .filter(repo_id=repo_id, expires_at__gt=now, expires_at__lte=expiry_soon_cutoff(now))
+        # Preload `source_run` so the caller can render the "what was wrong" link without an extra
+        # fetch per row. `Run.metadata` (JSONField) and `Run.error_message` (TextField) can be
+        # large and aren't needed for the summary.
+        .select_related("source_run")
+        .defer("source_run__metadata", "source_run__error_message")
+        .order_by("expires_at")
+    )
 
 
 @transaction.atomic(using=WRITER_DB)

--- a/products/visual_review/backend/logic/quarantine.py
+++ b/products/visual_review/backend/logic/quarantine.py
@@ -70,6 +70,16 @@ def list_expiring_quarantines(repo_id: UUID, *, now: datetime) -> list[Quarantin
     )
 
 
+def active_quarantine_keys(repo_id: UUID, *, now: datetime) -> set[tuple[str, str]]:
+    """Every `(run_type, identifier)` under a quarantine that has not run out, whatever its expiry."""
+    return set(
+        QuarantinedIdentifier.objects.using(READER_DB)
+        .filter(repo_id=repo_id)
+        .filter(Q(expires_at__isnull=True) | Q(expires_at__gt=now))
+        .values_list("run_type", "identifier")
+    )
+
+
 @transaction.atomic(using=WRITER_DB)
 def quarantine_identifier(
     repo_id: UUID,

--- a/products/visual_review/backend/logic/run_queries.py
+++ b/products/visual_review/backend/logic/run_queries.py
@@ -174,9 +174,7 @@ def latest_default_branch_runs(repo_id: UUID) -> list[Run]:
         )
         .order_by("repo_id", "branch", "run_type", "-created_at")
         .distinct("repo_id", "branch", "run_type")
-        # `metadata` rides along because a caller that anchors on these runs reads the workflow run
-        # id off them; deferring it costs one extra query per run.
-        .only("id", "run_type", "completed_at", "created_at", "metadata")
+        .only("id", "run_type", "completed_at", "created_at")
     )
 
 

--- a/products/visual_review/backend/logic/run_queries.py
+++ b/products/visual_review/backend/logic/run_queries.py
@@ -174,7 +174,9 @@ def latest_default_branch_runs(repo_id: UUID) -> list[Run]:
         )
         .order_by("repo_id", "branch", "run_type", "-created_at")
         .distinct("repo_id", "branch", "run_type")
-        .only("id", "run_type", "completed_at", "created_at")
+        # `metadata` rides along because a caller that anchors on these runs reads the workflow run
+        # id off them; deferring it costs one extra query per run.
+        .only("id", "run_type", "completed_at", "created_at", "metadata")
     )
 
 

--- a/products/visual_review/backend/logic/run_queries.py
+++ b/products/visual_review/backend/logic/run_queries.py
@@ -152,3 +152,41 @@ def get_run_snapshots(run_id: UUID, team_id: int | None = None) -> list[RunSnaps
 # include both candidates and assume nobody has both — whichever has rows wins.
 # When `trunk`/`develop`-style defaults show up, this becomes a `Repo` field.
 _DEFAULT_BRANCHES = ("master", "main")
+
+
+def latest_default_branch_runs(repo_id: UUID) -> list[Run]:
+    """The newest completed run per `(branch, run_type)` on the default branches.
+
+    The universe every "current baseline" read is anchored on: one row per
+    `(run_type, identifier)` in these runs is the closest thing to what a new
+    capture would be compared against right now.
+
+    `status=completed` rather than `superseded_by IS NULL`: a freshly started
+    run on the default branch is un-superseded but has few or no RunSnapshots
+    ingested yet, which would collapse the universe to whatever it has loaded
+    so far.
+    """
+    return list(
+        Run.objects.filter(
+            repo_id=repo_id,
+            branch__in=_DEFAULT_BRANCHES,
+            status=RunStatus.COMPLETED,
+        )
+        .order_by("repo_id", "branch", "run_type", "-created_at")
+        .distinct("repo_id", "branch", "run_type")
+        .only("id", "run_type", "completed_at", "created_at")
+    )
+
+
+def newest_run_by_run_type(runs: list[Run]) -> dict[str, Run]:
+    """One run per run type, newest first.
+
+    `latest_default_branch_runs` holds one run per branch and run type, so a repo with runs on
+    both master and main has two per run type. A `(run_type, identifier)` identity carries no
+    branch, so without this reduction whichever branch was read last decides the baseline and two
+    identical requests can disagree.
+    """
+    newest: dict[str, Run] = {}
+    for run in sorted(runs, key=lambda r: r.created_at, reverse=True):
+        newest.setdefault(run.run_type, run)
+    return newest

--- a/products/visual_review/backend/logic/run_queries.py
+++ b/products/visual_review/backend/logic/run_queries.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from django.db import models as db_models
 from django.db.models import Count, Q
 
+from posthog.dataclasses import frozen
 from posthog.helpers.trigram_search import (
     TrigramSearchField,
     apply_trigram_search,
@@ -18,6 +19,14 @@ from ..db import WRITER_DB
 from ..facade.enums import RunPurpose, RunStatus, SnapshotResult
 from ..models import Run, RunSnapshot
 from . import errors
+
+
+@frozen
+class SnapshotKey:
+    """One snapshot identity. The same identifier under two run types is two."""
+
+    run_type: str
+    identifier: str
 
 
 def is_run_stale(run: Run) -> bool:

--- a/products/visual_review/backend/logic/story_index.py
+++ b/products/visual_review/backend/logic/story_index.py
@@ -46,9 +46,8 @@ _CACHE_TTL_SECONDS = 2 * 24 * 60 * 60
 
 @frozen
 class StoryIndex:
-    """The story-to-file map of one Storybook build, and the workflow run it was read from."""
+    """The story-to-file map of one Storybook build."""
 
-    github_run_id: str
     path_by_story_id: Mapping[str, str]
 
 
@@ -170,7 +169,7 @@ def fetch_story_index(repo: Repo, github_run_id: str) -> StoryIndex | None:
     cache_key = f"visual_review_story_index:{repo.id}:{github_run_id}"
     cached = cache.get(cache_key)
     if isinstance(cached, dict):
-        return StoryIndex(github_run_id=github_run_id, path_by_story_id=cached)
+        return StoryIndex(path_by_story_id=cached)
 
     try:
         raw = _fetch_index_member(repo, github_run_id)
@@ -188,4 +187,4 @@ def fetch_story_index(repo: Repo, github_run_id: str) -> StoryIndex | None:
         return None
 
     cache.set(cache_key, paths, timeout=_CACHE_TTL_SECONDS)
-    return StoryIndex(github_run_id=github_run_id, path_by_story_id=paths)
+    return StoryIndex(path_by_story_id=paths)

--- a/products/visual_review/backend/logic/story_index.py
+++ b/products/visual_review/backend/logic/story_index.py
@@ -44,6 +44,10 @@ STORYBOOK_PACKAGE_DIR = "common/storybook"
 _INDEX_MEMBER = "index.json"
 # The zip is tens of megabytes, so it needs far longer than an API read.
 _ZIP_TIMEOUT_SECONDS = 60
+# Both are read into memory whole, so an artifact far past the size of a real build is refused
+# rather than made the worker's problem.
+_MAX_ARTIFACT_BYTES = 512 * 1024 * 1024
+_MAX_INDEX_BYTES = 32 * 1024 * 1024
 _CACHE_TTL_SECONDS = 2 * 24 * 60 * 60
 
 
@@ -144,6 +148,9 @@ def _fetch_index_member(repo: Repo, github_run_id: str) -> bytes | None:
     if artifact.get("expired"):
         _log_unavailable(repo, github_run_id, "artifact_expired")
         return None
+    if (artifact.get("size_in_bytes") or 0) > _MAX_ARTIFACT_BYTES:
+        _log_unavailable(repo, github_run_id, "artifact_too_large")
+        return None
 
     # GitHub answers this with a 302 to a signed blob URL. Requests follows it and drops the
     # Authorization header on the host change, so the GitHub token never reaches the blob host.
@@ -157,6 +164,9 @@ def _fetch_index_member(repo: Repo, github_run_id: str) -> bytes | None:
     with zipfile.ZipFile(io.BytesIO(download.content)) as archive:
         if _INDEX_MEMBER not in archive.namelist():
             _log_unavailable(repo, github_run_id, "index_missing")
+            return None
+        if archive.getinfo(_INDEX_MEMBER).file_size > _MAX_INDEX_BYTES:
+            _log_unavailable(repo, github_run_id, "artifact_too_large")
             return None
         return archive.read(_INDEX_MEMBER)
 

--- a/products/visual_review/backend/logic/story_index.py
+++ b/products/visual_review/backend/logic/story_index.py
@@ -114,7 +114,8 @@ def _parse_story_index(raw: bytes, package_dir: str) -> dict[str, str]:
             continue
         path = posixpath.normpath(posixpath.join(package_dir, import_path))
         # A story imported from outside the checkout has no repository path, so no team can own it.
-        if path.startswith(".."):
+        # An absolute import path drops the package directory on the join, so it lands here too.
+        if path.startswith("..") or posixpath.isabs(path):
             continue
         paths[story_id] = path
     return paths

--- a/products/visual_review/backend/logic/story_index.py
+++ b/products/visual_review/backend/logic/story_index.py
@@ -16,7 +16,6 @@ import zipfile
 import posixpath
 from collections.abc import Mapping
 
-from django.conf import settings
 from django.core.cache import cache
 
 import requests
@@ -37,6 +36,10 @@ logger = structlog.get_logger(__name__)
 _THEMES = ("light", "dark")
 _SUFFIXED_BROWSERS = ("webkit",)
 _VIEWPORT_WIDTHS = ("narrow", "medium", "wide", "superwide")
+
+# Where the PostHog repository builds Storybook, and the artifact its workflow uploads the build as.
+STORYBOOK_ARTIFACT_NAME = "storybook-build"
+STORYBOOK_PACKAGE_DIR = "common/storybook"
 
 _INDEX_MEMBER = "index.json"
 # The zip is tens of megabytes, so it needs far longer than an API read.
@@ -131,9 +134,8 @@ def _fetch_index_member(repo: Repo, github_run_id: str) -> bytes | None:
         _log_unavailable(repo, github_run_id, "artifact_missing")
         return None
 
-    wanted = settings.VISUAL_REVIEW_STORYBOOK_ARTIFACT_NAME
     artifact = next(
-        (item for item in listing.json().get("artifacts") or [] if item.get("name") == wanted),
+        (item for item in listing.json().get("artifacts") or [] if item.get("name") == STORYBOOK_ARTIFACT_NAME),
         None,
     )
     if artifact is None:
@@ -175,7 +177,7 @@ def fetch_story_index(repo: Repo, github_run_id: str) -> StoryIndex | None:
         raw = _fetch_index_member(repo, github_run_id)
         if raw is None:
             return None
-        paths = _parse_story_index(raw, settings.VISUAL_REVIEW_STORYBOOK_PACKAGE_DIR)
+        paths = _parse_story_index(raw, STORYBOOK_PACKAGE_DIR)
     except errors.GitHubIntegrationNotFoundError:
         _log_unavailable(repo, github_run_id, "no_github_integration")
         return None

--- a/products/visual_review/backend/logic/story_index.py
+++ b/products/visual_review/backend/logic/story_index.py
@@ -1,0 +1,191 @@
+"""Which repository file each Storybook snapshot renders, read from the run's build artifact.
+
+A snapshot identifier is built from a story id, and only the Storybook build knows which file a
+story came from. The build uploads its story index as a GitHub Actions artifact, so the index of the
+run behind the current baseline is the map from a snapshot back to a file somebody owns.
+
+Nothing is stored. The artifact of one workflow run never changes, so a parsed index is cached under
+that run id and the key rotates on its own when the baseline moves.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+import posixpath
+from collections.abc import Mapping
+
+from django.conf import settings
+from django.core.cache import cache
+
+import requests
+import structlog
+
+from posthog.dataclasses import frozen
+from posthog.egress.github.transport import GitHubRateLimitError
+from posthog.models.github_integration_base import GitHubIntegrationError
+
+from ..models import Repo
+from . import errors, github_api
+
+logger = structlog.get_logger(__name__)
+
+# These mirror the snapshot naming in common/storybook/.storybook/test-runner.ts. An identifier is
+# "<story id>--<theme>", with "--<browser>" appended for a browser other than chromium, and the
+# story id carries "--<width>" for a story that snapshots several viewport widths.
+_THEMES = ("light", "dark")
+_SUFFIXED_BROWSERS = ("webkit",)
+_VIEWPORT_WIDTHS = ("narrow", "medium", "wide", "superwide")
+
+_INDEX_MEMBER = "index.json"
+# The zip is tens of megabytes, so it needs far longer than an API read.
+_ZIP_TIMEOUT_SECONDS = 60
+_CACHE_TTL_SECONDS = 2 * 24 * 60 * 60
+
+
+@frozen
+class StoryIndex:
+    """The story-to-file map of one Storybook build, and the workflow run it was read from."""
+
+    github_run_id: str
+    path_by_story_id: Mapping[str, str]
+
+
+def _strip_theme_and_browser(identifier: str) -> str | None:
+    """The story id an identifier was built from, before any width suffix is considered.
+
+    None when the identifier carries no theme, which means the test runner did not write it.
+    """
+    rest = identifier
+    for browser in _SUFFIXED_BROWSERS:
+        if rest.endswith(f"--{browser}"):
+            rest = rest.removesuffix(f"--{browser}")
+            break
+    for theme in _THEMES:
+        if rest.endswith(f"--{theme}"):
+            return rest.removesuffix(f"--{theme}")
+    return None
+
+
+def story_path(index: StoryIndex, identifier: str) -> str | None:
+    """The repository path behind one snapshot identifier, or None when the index has no such story.
+
+    The full story id is looked up first, because a story can be named after a viewport width
+    ("lemon-ui-lemon-banner--narrow" is a story of its own). Stripping the width first would place
+    that snapshot in the file of a different story.
+    """
+    story_id = _strip_theme_and_browser(identifier)
+    if story_id is None:
+        return None
+    path = index.path_by_story_id.get(story_id)
+    if path is not None:
+        return path
+    for width in _VIEWPORT_WIDTHS:
+        if story_id.endswith(f"--{width}"):
+            return index.path_by_story_id.get(story_id.removesuffix(f"--{width}"))
+    return None
+
+
+def _parse_story_index(raw: bytes, package_dir: str) -> dict[str, str]:
+    """Story id to repository path, for the story entries of a Storybook index.
+
+    Raises ValueError when the payload is not a story index. `json.JSONDecodeError` is a ValueError,
+    so a truncated download lands in the same branch.
+    """
+    document = json.loads(raw)
+    entries = document.get("entries") if isinstance(document, dict) else None
+    if not isinstance(entries, dict):
+        raise ValueError("storybook index has no entries")
+
+    paths: dict[str, str] = {}
+    for story_id, entry in entries.items():
+        # Docs pages carry an importPath too, and no snapshot is taken of one.
+        if not isinstance(entry, dict) or entry.get("type") != "story":
+            continue
+        import_path = entry.get("importPath")
+        if not isinstance(import_path, str) or not import_path:
+            continue
+        path = posixpath.normpath(posixpath.join(package_dir, import_path))
+        # A story imported from outside the checkout has no repository path, so no team can own it.
+        if path.startswith(".."):
+            continue
+        paths[story_id] = path
+    return paths
+
+
+def _log_unavailable(repo: Repo, github_run_id: str, reason: str) -> None:
+    logger.info(
+        "visual_review.story_index_unavailable",
+        repo_id=str(repo.id),
+        github_run_id=github_run_id,
+        reason=reason,
+    )
+
+
+def _fetch_index_member(repo: Repo, github_run_id: str) -> bytes | None:
+    """The raw index.json of a run's Storybook artifact. None when it cannot be read."""
+    listing = github_api._github_api_request(
+        "GET", repo, f"actions/runs/{github_run_id}/artifacts", params={"per_page": 100}
+    )
+    if listing.status_code != 200:
+        _log_unavailable(repo, github_run_id, "artifact_missing")
+        return None
+
+    wanted = settings.VISUAL_REVIEW_STORYBOOK_ARTIFACT_NAME
+    artifact = next(
+        (item for item in listing.json().get("artifacts") or [] if item.get("name") == wanted),
+        None,
+    )
+    if artifact is None:
+        _log_unavailable(repo, github_run_id, "artifact_missing")
+        return None
+    if artifact.get("expired"):
+        _log_unavailable(repo, github_run_id, "artifact_expired")
+        return None
+
+    # GitHub answers this with a 302 to a signed blob URL. Requests follows it and drops the
+    # Authorization header on the host change, so the GitHub token never reaches the blob host.
+    download = github_api._github_api_request(
+        "GET", repo, f"actions/artifacts/{artifact['id']}/zip", timeout=_ZIP_TIMEOUT_SECONDS
+    )
+    if download.status_code != 200:
+        _log_unavailable(repo, github_run_id, "download_failed")
+        return None
+
+    with zipfile.ZipFile(io.BytesIO(download.content)) as archive:
+        if _INDEX_MEMBER not in archive.namelist():
+            _log_unavailable(repo, github_run_id, "index_missing")
+            return None
+        return archive.read(_INDEX_MEMBER)
+
+
+def fetch_story_index(repo: Repo, github_run_id: str) -> StoryIndex | None:
+    """The story index of one workflow run's Storybook build. None means attribution is unavailable.
+
+    Only a success is cached, so a run whose artifact was gone this morning is read again tomorrow.
+    Every failure is answered with None: the digest reports what it could not attribute, and never
+    fails over a missing artifact.
+    """
+    cache_key = f"visual_review_story_index:{repo.id}:{github_run_id}"
+    cached = cache.get(cache_key)
+    if isinstance(cached, dict):
+        return StoryIndex(github_run_id=github_run_id, path_by_story_id=cached)
+
+    try:
+        raw = _fetch_index_member(repo, github_run_id)
+        if raw is None:
+            return None
+        paths = _parse_story_index(raw, settings.VISUAL_REVIEW_STORYBOOK_PACKAGE_DIR)
+    except errors.GitHubIntegrationNotFoundError:
+        _log_unavailable(repo, github_run_id, "no_github_integration")
+        return None
+    except (GitHubIntegrationError, GitHubRateLimitError, requests.RequestException, zipfile.BadZipFile):
+        _log_unavailable(repo, github_run_id, "download_failed")
+        return None
+    except ValueError:
+        _log_unavailable(repo, github_run_id, "index_invalid")
+        return None
+
+    cache.set(cache_key, paths, timeout=_CACHE_TTL_SECONDS)
+    return StoryIndex(github_run_id=github_run_id, path_by_story_id=paths)

--- a/products/visual_review/backend/logic/toleration.py
+++ b/products/visual_review/backend/logic/toleration.py
@@ -108,11 +108,13 @@ def count_active_variants_against_current_baseline(repo_id: UUID, *, now: dateti
         return {}
 
     live = Q(expires_at__isnull=True) | Q(expires_at__gt=now)
+    # The exact pair is still matched below, because two identifiers can share a baseline hash.
     counts_by_pair = {
         (identifier, baseline_hash): count
         for identifier, baseline_hash, count in ToleratedHash.objects.filter(
             repo_id=repo_id,
             identifier__in=list({identifier for _, identifier in baseline_hash_by_key}),
+            baseline_hash__in=list(set(baseline_hash_by_key.values())),
             reason__in=INTENTIONAL_TOLERATE_REASONS,
         )
         .filter(live)

--- a/products/visual_review/backend/logic/toleration.py
+++ b/products/visual_review/backend/logic/toleration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import datetime
 from uuid import UUID
 
@@ -88,7 +89,9 @@ def mark_snapshot_as_tolerated(
     return snapshot
 
 
-def count_active_variants_against_current_baseline(repo_id: UUID, *, now: datetime) -> dict[tuple[str, str], int]:
+def count_active_variants_against_current_baseline(
+    repo_id: UUID, *, now: datetime, newest_run_by_type: Mapping[str, Run] | None = None
+) -> dict[tuple[str, str], int]:
     """How many accepted variants each `(run_type, identifier)` still carries against the baseline
     it would be compared against right now.
 
@@ -102,8 +105,11 @@ def count_active_variants_against_current_baseline(repo_id: UUID, *, now: dateti
 
     Keys carry the run type because the same identifier under two run types is two baselines.
     Only non-zero counts are returned.
+
+    A caller that already holds the default-branch run universe passes it as `newest_run_by_type`,
+    so the same page or digest run does not read it twice.
     """
-    baseline_hash_by_key = _current_baseline_hashes(repo_id)
+    baseline_hash_by_key = _current_baseline_hashes(repo_id, newest_run_by_type)
     if not baseline_hash_by_key:
         return {}
 
@@ -130,13 +136,16 @@ def count_active_variants_against_current_baseline(repo_id: UUID, *, now: dateti
     return counts
 
 
-def _current_baseline_hashes(repo_id: UUID) -> dict[tuple[str, str], str]:
+def _current_baseline_hashes(
+    repo_id: UUID, newest_run_by_type: Mapping[str, Run] | None = None
+) -> dict[tuple[str, str], str]:
     """The baseline hash each `(run_type, identifier)` would be compared against right now.
 
     values_list rather than model hydration: the universe runs to thousands of rows and nothing
     here needs anything else off them.
     """
-    newest_run_by_type = run_queries.newest_run_by_run_type(run_queries.latest_default_branch_runs(repo_id))
+    if newest_run_by_type is None:
+        newest_run_by_type = run_queries.newest_run_by_run_type(run_queries.latest_default_branch_runs(repo_id))
     run_type_by_run_id = {run.id: run_type for run_type, run in newest_run_by_type.items()}
     if not run_type_by_run_id:
         return {}

--- a/products/visual_review/backend/logic/toleration.py
+++ b/products/visual_review/backend/logic/toleration.py
@@ -14,6 +14,7 @@ from ..db import WRITER_DB
 from ..facade.enums import INTENTIONAL_TOLERATE_REASONS, ActorType, ReviewState, SnapshotResult, ToleratedReason
 from ..models import Run, RunSnapshot, ToleratedHash
 from . import errors, run_queries
+from .run_queries import SnapshotKey
 
 
 @transaction.atomic(using=WRITER_DB)
@@ -91,9 +92,9 @@ def mark_snapshot_as_tolerated(
 
 def count_active_variants_against_current_baseline(
     repo_id: UUID, *, now: datetime, newest_run_by_type: Mapping[str, Run] | None = None
-) -> dict[tuple[str, str], int]:
-    """How many accepted variants each `(run_type, identifier)` still carries against the baseline
-    it would be compared against right now.
+) -> dict[SnapshotKey, int]:
+    """How many accepted variants each snapshot identity still carries against the baseline it
+    would be compared against right now.
 
     A toleration is recorded under the baseline hash it was decided for, so a baseline change
     invalidates the whole pile at once and this count drops back to zero. That is what makes the
@@ -119,7 +120,7 @@ def count_active_variants_against_current_baseline(
         (identifier, baseline_hash): count
         for identifier, baseline_hash, count in ToleratedHash.objects.filter(
             repo_id=repo_id,
-            identifier__in=list({identifier for _, identifier in baseline_hash_by_key}),
+            identifier__in=list({key.identifier for key in baseline_hash_by_key}),
             baseline_hash__in=list(set(baseline_hash_by_key.values())),
             reason__in=INTENTIONAL_TOLERATE_REASONS,
         )
@@ -128,9 +129,9 @@ def count_active_variants_against_current_baseline(
         .annotate(c=Count("id"))
         .values_list("identifier", "baseline_hash", "c")
     }
-    counts: dict[tuple[str, str], int] = {}
+    counts: dict[SnapshotKey, int] = {}
     for key, baseline_hash in baseline_hash_by_key.items():
-        count = counts_by_pair.get((key[1], baseline_hash), 0)
+        count = counts_by_pair.get((key.identifier, baseline_hash), 0)
         if count:
             counts[key] = count
     return counts
@@ -138,8 +139,8 @@ def count_active_variants_against_current_baseline(
 
 def _current_baseline_hashes(
     repo_id: UUID, newest_run_by_type: Mapping[str, Run] | None = None
-) -> dict[tuple[str, str], str]:
-    """The baseline hash each `(run_type, identifier)` would be compared against right now.
+) -> dict[SnapshotKey, str]:
+    """The baseline hash each snapshot identity would be compared against right now.
 
     values_list rather than model hydration: the universe runs to thousands of rows and nothing
     here needs anything else off them.
@@ -150,7 +151,7 @@ def _current_baseline_hashes(
     if not run_type_by_run_id:
         return {}
     return {
-        (run_type_by_run_id[run_id], identifier): baseline_hash
+        SnapshotKey(run_type=run_type_by_run_id[run_id], identifier=identifier): baseline_hash
         for run_id, identifier, baseline_hash in RunSnapshot.objects.filter(
             run_id__in=list(run_type_by_run_id)
         ).values_list("run_id", "identifier", "baseline_hash")

--- a/products/visual_review/backend/logic/toleration.py
+++ b/products/visual_review/backend/logic/toleration.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from uuid import UUID
 
 from django.db import transaction
+from django.db.models import Count, Q
 from django.utils import timezone
 
 from ..db import WRITER_DB
@@ -84,6 +86,67 @@ def mark_snapshot_as_tolerated(
     Run.objects.using(WRITER_DB).filter(id=run.id).update(tolerated_match_count=tolerated_count)
 
     return snapshot
+
+
+def count_active_variants_against_current_baseline(repo_id: UUID, *, now: datetime) -> dict[tuple[str, str], int]:
+    """How many accepted variants each `(run_type, identifier)` still carries against the baseline
+    it would be compared against right now.
+
+    A toleration is recorded under the baseline hash it was decided for, so a baseline change
+    invalidates the whole pile at once and this count drops back to zero. That is what makes the
+    number worth acting on: every row it counts is still in use.
+
+    Counted with no recency cutoff, unlike the 30-day and 90-day counts on the baselines overview.
+    Those measure how often somebody accepted drift; this measures how many accepted renderings the
+    baseline is standing in for, and an accepted variant keeps matching without a new record.
+
+    Keys carry the run type because the same identifier under two run types is two baselines.
+    Only non-zero counts are returned.
+    """
+    baseline_hash_by_key = _current_baseline_hashes(repo_id)
+    if not baseline_hash_by_key:
+        return {}
+
+    live = Q(expires_at__isnull=True) | Q(expires_at__gt=now)
+    counts_by_pair = {
+        (identifier, baseline_hash): count
+        for identifier, baseline_hash, count in ToleratedHash.objects.filter(
+            repo_id=repo_id,
+            identifier__in=list({identifier for _, identifier in baseline_hash_by_key}),
+            reason__in=INTENTIONAL_TOLERATE_REASONS,
+        )
+        .filter(live)
+        .values_list("identifier", "baseline_hash")
+        .annotate(c=Count("id"))
+        .values_list("identifier", "baseline_hash", "c")
+    }
+    counts: dict[tuple[str, str], int] = {}
+    for key, baseline_hash in baseline_hash_by_key.items():
+        count = counts_by_pair.get((key[1], baseline_hash), 0)
+        if count:
+            counts[key] = count
+    return counts
+
+
+def _current_baseline_hashes(repo_id: UUID) -> dict[tuple[str, str], str]:
+    """The baseline hash each `(run_type, identifier)` would be compared against right now.
+
+    values_list rather than model hydration: the universe runs to thousands of rows and nothing
+    here needs anything else off them.
+    """
+    newest_run_by_type = run_queries.newest_run_by_run_type(run_queries.latest_default_branch_runs(repo_id))
+    run_type_by_run_id = {run.id: run_type for run_type, run in newest_run_by_type.items()}
+    if not run_type_by_run_id:
+        return {}
+    return {
+        (run_type_by_run_id[run_id], identifier): baseline_hash
+        for run_id, identifier, baseline_hash in RunSnapshot.objects.filter(
+            run_id__in=list(run_type_by_run_id)
+        ).values_list("run_id", "identifier", "baseline_hash")
+        # A snapshot with no baseline yet has nothing for a toleration to be recorded against, and
+        # an empty hash would otherwise match every other baseline-less identity's rows.
+        if baseline_hash
+    }
 
 
 def get_tolerated_hashes_for_identifier(repo_id: UUID, identifier: str) -> list[ToleratedHash]:

--- a/products/visual_review/backend/management/commands/visual_review_debt_digest.py
+++ b/products/visual_review/backend/management/commands/visual_review_debt_digest.py
@@ -1,0 +1,33 @@
+"""Run one repo's visual review debt digest synchronously, in the mode you name."""
+
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandError
+
+from posthog.models.scoping import team_scope
+
+from products.visual_review.backend.logic import debt_digest
+from products.visual_review.backend.models import Repo
+
+
+class Command(BaseCommand):
+    help = "Evaluate and render (or post) the visual review debt digest for one repo"
+
+    def add_arguments(self, parser: Any) -> None:
+        parser.add_argument("--repo", type=str, required=True, help="Repository as owner/name.")
+        parser.add_argument(
+            "--mode",
+            type=str,
+            default=debt_digest.MODE_PREVIEW,
+            choices=list(debt_digest.MODES),
+            help="preview renders and prints, shadow posts to the shadow channel, live posts to each team's.",
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        # nosemgrep: idor-lookup-without-team — operator-run command, repo named on the command line
+        repo = Repo.objects.unscoped().filter(repo_full_name=options["repo"]).order_by("created_at").first()
+        if repo is None:
+            raise CommandError(f"No visual review repo named {options['repo']}")
+        with team_scope(repo.team_id):
+            rendered = debt_digest.send_debt_digest(repo, mode=options["mode"])
+        self.stdout.write("\n\n".join(rendered) or "Nothing owed.")

--- a/products/visual_review/backend/management/commands/visual_review_debt_digest.py
+++ b/products/visual_review/backend/management/commands/visual_review_debt_digest.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
             type=str,
             default=debt_digest.MODE_PREVIEW,
             choices=list(debt_digest.MODES),
-            help="preview renders and prints, shadow posts to the shadow channel, live posts to each team's.",
+            help="preview renders and prints, live posts to each team's channel.",
         )
 
     def handle(self, *args: Any, **options: Any) -> None:

--- a/products/visual_review/backend/management/commands/visual_review_debt_digest.py
+++ b/products/visual_review/backend/management/commands/visual_review_debt_digest.py
@@ -10,11 +10,31 @@ from products.visual_review.backend.logic import debt_digest
 from products.visual_review.backend.models import Repo
 
 
+def find_repo(repo_full_name: str, team_id: int | None) -> Repo:
+    """The one repo that goes by this name, or a CommandError saying why there is no single answer.
+
+    A name is unique inside a team, not across them, so two teams can register the same repository
+    and each carries its own debt.
+    """
+    # nosemgrep: idor-lookup-without-team — operator-run command, repo named on the command line
+    matches = Repo.objects.unscoped().filter(repo_full_name=repo_full_name)
+    if team_id is not None:
+        matches = matches.filter(team_id=team_id)
+    found = list(matches.order_by("created_at"))
+    if not found:
+        raise CommandError(f"No visual review repo named {repo_full_name}")
+    if len(found) > 1:
+        teams = ", ".join(str(repo.team_id) for repo in found)
+        raise CommandError(f"{repo_full_name} is registered by more than one team ({teams}). Pick one with --team-id.")
+    return found[0]
+
+
 class Command(BaseCommand):
     help = "Evaluate and render (or post) the visual review debt digest for one repo"
 
     def add_arguments(self, parser: Any) -> None:
         parser.add_argument("--repo", type=str, required=True, help="Repository as owner/name.")
+        parser.add_argument("--team-id", type=int, help="Team that registered the repository.")
         parser.add_argument(
             "--mode",
             type=str,
@@ -24,10 +44,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args: Any, **options: Any) -> None:
-        # nosemgrep: idor-lookup-without-team — operator-run command, repo named on the command line
-        repo = Repo.objects.unscoped().filter(repo_full_name=options["repo"]).order_by("created_at").first()
-        if repo is None:
-            raise CommandError(f"No visual review repo named {options['repo']}")
+        repo = find_repo(options["repo"], options.get("team_id"))
         with team_scope(repo.team_id):
             rendered = debt_digest.send_debt_digest(repo, mode=options["mode"])
         self.stdout.write("\n\n".join(rendered) or "Nothing owed.")

--- a/products/visual_review/backend/presentation/serializers.py
+++ b/products/visual_review/backend/presentation/serializers.py
@@ -350,6 +350,13 @@ class BaselineEntrySerializer(DataclassSerializer):
         required=False,
         help_text="Active quarantine details when `is_quarantined` is true. Null otherwise.",
     )
+    active_variants_current_baseline = serializers.IntegerField(
+        help_text=(
+            "Accepted variants still recorded against this baseline's current hash. Unlike the "
+            "30-day and 90-day counts, this has no time window: an accepted variant keeps matching "
+            "without a new record. A baseline change resets it to zero."
+        )
+    )
 
     class Meta:
         dataclass = BaselineEntry
@@ -357,6 +364,9 @@ class BaselineEntrySerializer(DataclassSerializer):
 
 class BaselineTotalsSerializer(DataclassSerializer):
     by_run_type = serializers.DictField(child=serializers.IntegerField())
+    variant_pileups = serializers.IntegerField(
+        help_text="Baselines carrying three or more accepted variants of their current hash."
+    )
 
     class Meta:
         dataclass = BaselineTotals

--- a/products/visual_review/backend/tasks/tasks.py
+++ b/products/visual_review/backend/tasks/tasks.py
@@ -35,6 +35,10 @@ TRACER = trace.get_tracer(__name__)
 # which the next run resends.
 _DEBT_DIGEST_LOCK_SECONDS = 900
 
+# A child task worth running is a child task worth running today. A worker draining a backlog past
+# this drops it, and the next morning's run recomputes what is still owed.
+_DEBT_DIGEST_EXPIRY_SECONDS = 60 * 60
+
 
 @shared_task(
     name="products.visual_review.backend.tasks.emit_run_processing_metrics",
@@ -233,7 +237,9 @@ def send_visual_review_debt_digests() -> None:
     from ..logic import debt_digest  # noqa: PLC0415 — avoids the logic/tasks circular import
 
     for repo in debt_digest.repos_in_scope():
-        send_visual_review_debt_digest.delay(repo.team_id, str(repo.id))
+        send_visual_review_debt_digest.apply_async(
+            args=(repo.team_id, str(repo.id)), expires=_DEBT_DIGEST_EXPIRY_SECONDS
+        )
 
 
 @shared_task(

--- a/products/visual_review/backend/tasks/tasks.py
+++ b/products/visual_review/backend/tasks/tasks.py
@@ -225,15 +225,15 @@ def sweep_visual_review_retention() -> None:
 )
 @skip_team_scope_audit  # cross-team beat sweep; the per-repo task below scopes every query
 def send_visual_review_debt_digests() -> None:
-    """Fan out to the configured repos, one task each.
+    """Fan out to every repo, one task each.
 
     One repo's failure must not stop the rest, and nothing is stored about what was sent, so the
     next morning's run recomputes and resends whatever is still owed.
     """
     from ..logic import debt_digest  # noqa: PLC0415 — avoids the logic/tasks circular import
 
-    for team_id, repo_id in debt_digest.repos_in_scope():
-        send_visual_review_debt_digest.delay(team_id, str(repo_id))
+    for repo in debt_digest.repos_in_scope():
+        send_visual_review_debt_digest.delay(repo.team_id, str(repo.id))
 
 
 @shared_task(
@@ -258,4 +258,4 @@ def send_visual_review_debt_digest(team_id: int, repo_id: str) -> None:
     if repo is None:
         logger.warning("visual_review.debt_digest_repo_missing", repo_id=repo_id, team_id=team_id)
         return
-    debt_digest.send_debt_digest(repo)
+    debt_digest.send_debt_digest(repo, mode=debt_digest.MODE_LIVE)

--- a/products/visual_review/backend/tasks/tasks.py
+++ b/products/visual_review/backend/tasks/tasks.py
@@ -12,6 +12,8 @@ import time
 from datetime import date
 from uuid import UUID
 
+from django.core.cache import cache
+
 import structlog
 from celery import shared_task
 from opentelemetry import trace
@@ -27,6 +29,11 @@ from ..models import Repo
 
 logger = structlog.get_logger(__name__)
 TRACER = trace.get_tracer(__name__)
+
+# Long enough that a slow repo's Slack round trips finish inside it, short enough that a worker
+# killed mid-run does not hold the next scheduled run out. A held lock costs one day of reminders,
+# which the next run resends.
+_DEBT_DIGEST_LOCK_SECONDS = 900
 
 
 @shared_task(
@@ -210,3 +217,45 @@ def sweep_visual_review_retention() -> None:
             objects_leaked=result.objects_leaked,
             duration_seconds=round(time.monotonic() - started, 1),
         )
+
+
+@shared_task(
+    name="products.visual_review.backend.tasks.send_visual_review_debt_digests",
+    ignore_result=True,
+)
+@skip_team_scope_audit  # cross-team beat sweep; the per-repo task below scopes every query
+def send_visual_review_debt_digests() -> None:
+    """Fan out to the configured repos, one task each.
+
+    One repo's failure must not stop the rest, and nothing is stored about what was sent, so the
+    next morning's run recomputes and resends whatever is still owed.
+    """
+    from ..logic import debt_digest  # noqa: PLC0415 — avoids the logic/tasks circular import
+
+    for repo in debt_digest.repos_in_scope():
+        send_visual_review_debt_digest.delay(repo.team_id, str(repo.id))
+
+
+@shared_task(
+    name="products.visual_review.backend.tasks.send_visual_review_debt_digest",
+    ignore_result=True,
+)
+@with_team_scope()
+def send_visual_review_debt_digest(team_id: int, repo_id: str) -> None:
+    """Post one repo's digest.
+
+    The lock is what stops a retried or double-scheduled run from posting the same reminders twice.
+    Nothing records what was sent, so an overlapping run has no other way to tell.
+    """
+    from ..logic import debt_digest  # noqa: PLC0415 — avoids the logic/tasks circular import
+
+    lock_key = f"visual_review_debt_digest:{repo_id}"
+    if not cache.add(lock_key, "locked", timeout=_DEBT_DIGEST_LOCK_SECONDS):
+        logger.info("visual_review.debt_digest_already_running", repo_id=repo_id, team_id=team_id)
+        return
+
+    repo = Repo.objects.filter(id=UUID(repo_id), team_id=team_id).first()
+    if repo is None:
+        logger.warning("visual_review.debt_digest_repo_missing", repo_id=repo_id, team_id=team_id)
+        return
+    debt_digest.send_debt_digest(repo)

--- a/products/visual_review/backend/tasks/tasks.py
+++ b/products/visual_review/backend/tasks/tasks.py
@@ -232,8 +232,8 @@ def send_visual_review_debt_digests() -> None:
     """
     from ..logic import debt_digest  # noqa: PLC0415 — avoids the logic/tasks circular import
 
-    for repo in debt_digest.repos_in_scope():
-        send_visual_review_debt_digest.delay(repo.team_id, str(repo.id))
+    for team_id, repo_id in debt_digest.repos_in_scope():
+        send_visual_review_debt_digest.delay(team_id, str(repo_id))
 
 
 @shared_task(

--- a/products/visual_review/backend/tests/logic/test_debt_digest.py
+++ b/products/visual_review/backend/tests/logic/test_debt_digest.py
@@ -1,0 +1,362 @@
+"""Unit tests for logic/debt_digest.py — the daily visual review debt reminder."""
+
+from datetime import timedelta
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from django.utils import timezone
+
+from posthog_owners.schema import TeamEntry
+
+from posthog.team_notifications.slack import SlackChannel, SlackPostRefused
+
+from products.engineering_analytics.backend.facade.contracts import PathOwnership
+from products.visual_review.backend.facade.contracts import (
+    FLAKINESS_EXPIRY_SOON_DAYS,
+    CreateRunInput,
+    SnapshotManifestItem,
+)
+from products.visual_review.backend.facade.enums import RunType
+from products.visual_review.backend.logic import artifact_store, debt_digest, quarantine, repos, runs, story_index
+from products.visual_review.backend.models import ToleratedHash
+from products.visual_review.backend.tests.conftest import PRODUCT_DATABASES
+
+_PRODUCT_PATH = "products/visual_review/"
+_SOURCE_PATH = "frontend/src/scenes/Button.stories.tsx"
+_STORY_ID = "scenes-app-button--primary"
+_IDENTIFIER = f"{_STORY_ID}--light"
+_ABSENT_IDENTIFIER = "scenes-app-gone--primary--light"
+_GITHUB_RUN_ID = "98765"
+_INDEX = story_index.StoryIndex(github_run_id=_GITHUB_RUN_ID, path_by_story_id={_STORY_ID: _SOURCE_PATH})
+
+_PLACED = debt_digest.Attribution(kind=debt_digest.AttributionKind.PLACED, source_path=_SOURCE_PATH)
+_STORY_ABSENT = debt_digest.Attribution(kind=debt_digest.AttributionKind.STORY_ABSENT)
+_UNAVAILABLE = debt_digest.Attribution(
+    kind=debt_digest.AttributionKind.UNAVAILABLE,
+    detail=f"the Storybook build artifact for run {_GITHUB_RUN_ID} was not read",
+)
+
+
+def _ownership(team_by_path: dict[str, str], registry: dict[str, TeamEntry] | None = None) -> PathOwnership:
+    return PathOwnership(team_by_path=team_by_path, registry=registry or {}, resolved=True)
+
+
+def _item(
+    attribution: debt_digest.Attribution, identifier: str = _IDENTIFIER, line: str = "a line"
+) -> debt_digest.DebtItem:
+    return debt_digest.DebtItem(identifier=identifier, run_type="storybook", attribution=attribution, line=line)
+
+
+def _with_index(index: story_index.StoryIndex | None):
+    return patch("products.visual_review.backend.logic.story_index.fetch_story_index", return_value=index)
+
+
+def _digest(team_slug: str = "team-devex") -> debt_digest.TeamDigest:
+    return debt_digest.TeamDigest(team_slug=team_slug, expiring_quarantines=[_item(_PLACED)], variant_pileups=[])
+
+
+def _triage_digest() -> debt_digest.TeamDigest:
+    return debt_digest.TeamDigest(
+        team_slug="team-devex",
+        expiring_quarantines=[],
+        variant_pileups=[],
+        triage=[
+            debt_digest.TriageGroup(reason=debt_digest.TriageReason.UNOWNED_FILE, items=[_item(_PLACED)]),
+            debt_digest.TriageGroup(reason=debt_digest.TriageReason.UNAVAILABLE, items=[_item(_UNAVAILABLE)]),
+        ],
+    )
+
+
+class TestRendering:
+    def test_escapes_slack_control_characters_in_user_text(self) -> None:
+        # A reason and an identifier are both contributor input; either could otherwise smuggle a
+        # <!channel> mention into every owning team's channel.
+        entry = MagicMock(
+            identifier="Button<!channel>",
+            run_type="storybook",
+            reason="flaky & <!here>",
+            expires_at=timezone.now() + timedelta(days=3),
+            created_by_id=None,
+        )
+        repo = MagicMock(id="00000000-0000-0000-0000-000000000001", team_id=7, repo_full_name="PostHog/posthog")
+
+        line = debt_digest._quarantine_line(repo, entry, {}, timezone.now())
+
+        assert "<!channel>" not in line
+        assert "<!here>" not in line
+        assert "&lt;!channel&gt;" in line
+        assert "flaky &amp; &lt;!here&gt;" in line
+
+    def test_links_to_the_snapshot_page_with_encoded_segments(self) -> None:
+        repo = MagicMock(id="abc", team_id=7, repo_full_name="PostHog/posthog")
+
+        line = debt_digest._pileup_line(repo, "storybook", "scenes/Button--dark", 4)
+
+        assert line.startswith("4 accepted variants of the current baseline · scenes/Button--dark (storybook)")
+        assert line.endswith("/project/7/visual_review/repos/abc/storybook/snapshots/scenes%2FButton--dark")
+
+    def test_splits_the_thread_when_one_group_runs_long(self) -> None:
+        long_item = _item(_PLACED, line="x" * 2000)
+        digest = debt_digest.TeamDigest(
+            team_slug="team-devex", expiring_quarantines=[long_item, long_item], variant_pileups=[]
+        )
+
+        texts = debt_digest.thread_texts(digest)
+
+        assert len(texts) > 1
+        assert all(len(text) <= debt_digest._MAX_SECTION_CHARS for text in texts)
+        assert texts[-1].endswith(debt_digest._FOOTER)
+
+    def test_the_lead_holds_triage_apart_from_what_the_team_owns(self) -> None:
+        repo = MagicMock(id="abc", team_id=7, repo_full_name="PostHog/posthog")
+
+        lead = debt_digest.lead_text(_triage_digest(), repo)
+
+        assert "nothing this team owns today" in lead
+        assert "2 in triage that nobody owns yet" in lead
+        # An artifact that could not be read must never read as "nobody owns this".
+        assert f"the Storybook build artifact for run {_GITHUB_RUN_ID} was not read" in lead
+        assert "tries again tomorrow" in lead
+
+    def test_the_thread_groups_triage_under_one_header_per_reason(self) -> None:
+        thread = "\n".join(debt_digest.thread_texts(_triage_digest()))
+
+        assert debt_digest._TRIAGE_HEADERS[debt_digest.TriageReason.UNOWNED_FILE] in thread
+        assert debt_digest._TRIAGE_HEADERS[debt_digest.TriageReason.UNAVAILABLE] in thread
+        # The path stays on the line, because it is what an owners entry is written for.
+        assert f"a line · {_SOURCE_PATH}" in thread
+        assert f"a line · the Storybook build artifact for run {_GITHUB_RUN_ID} was not read" in thread
+
+
+class TestSplitByTeam:
+    def test_routes_a_placed_item_to_the_team_that_owns_its_file(self) -> None:
+        placed = _item(_PLACED, line="placed")
+        absent = _item(_STORY_ABSENT, identifier=_ABSENT_IDENTIFIER, line="absent")
+        debt = debt_digest.RepoDebt(expiring_quarantines=[placed], variant_pileups=[absent])
+
+        digests = debt_digest.split_by_team(
+            debt, _ownership({_SOURCE_PATH: "team-product-analytics", _PRODUCT_PATH: "team-devex"})
+        )
+
+        by_slug = {d.team_slug: d for d in digests}
+        assert set(by_slug) == {"team-product-analytics", "team-devex"}
+        assert by_slug["team-product-analytics"].expiring_quarantines == [placed]
+        # The maintainers hold the other item without it counting as debt of their own.
+        assert by_slug["team-devex"].variant_pileups == []
+        assert by_slug["team-devex"].triage == [
+            debt_digest.TriageGroup(reason=debt_digest.TriageReason.STORY_ABSENT, items=[absent])
+        ]
+
+    @pytest.mark.parametrize(
+        "attribution,reason",
+        [
+            (_PLACED, debt_digest.TriageReason.UNOWNED_FILE),
+            (_STORY_ABSENT, debt_digest.TriageReason.STORY_ABSENT),
+            (_UNAVAILABLE, debt_digest.TriageReason.UNAVAILABLE),
+        ],
+    )
+    def test_keeps_the_three_unowned_outcomes_apart(
+        self, attribution: debt_digest.Attribution, reason: debt_digest.TriageReason
+    ) -> None:
+        item = _item(attribution)
+        debt = debt_digest.RepoDebt(expiring_quarantines=[item], variant_pileups=[])
+
+        digests = debt_digest.split_by_team(debt, _ownership({_PRODUCT_PATH: "team-devex"}))
+
+        assert [d.team_slug for d in digests] == ["team-devex"]
+        assert digests[0].expiring_quarantines == []
+        assert digests[0].triage == [debt_digest.TriageGroup(reason=reason, items=[item])]
+
+    def test_drops_an_item_nobody_owns(self) -> None:
+        debt = debt_digest.RepoDebt(expiring_quarantines=[_item(_STORY_ABSENT)], variant_pileups=[])
+
+        assert debt_digest.split_by_team(debt, _ownership({})) == []
+
+
+class TestRouting:
+    _CHANNELS = {
+        "team-devex": SlackChannel(channel_id="C1", shared=False),
+        "alerts-devex": SlackChannel(channel_id="CSHADOW", shared=False),
+        "team-shared": SlackChannel(channel_id="C2", shared=True),
+    }
+
+    def test_a_team_that_opted_out_is_skipped(self) -> None:
+        registry = {"team-devex": TeamEntry(notifications={"visual_review": False})}
+
+        assert debt_digest.resolve_channel(_digest(), registry, self._CHANNELS) is None
+
+    def test_a_shared_channel_is_refused(self) -> None:
+        # A name match onto a shared channel would send an internal reminder out of the workspace.
+        assert debt_digest.resolve_channel(_digest("team-shared"), {}, self._CHANNELS) is None
+
+    def test_shadow_mode_posts_to_the_shadow_channel_and_names_the_real_one(self) -> None:
+        delivery = debt_digest.deliver(_digest(), {}, self._CHANNELS, debt_digest.MODE_SHADOW)
+
+        assert delivery is not None
+        assert delivery.channel_id == "CSHADOW"
+        assert delivery.lead_prefix == "Shadow for #team-devex: "
+
+    def test_shadow_mode_says_so_when_no_channel_resolved(self) -> None:
+        delivery = debt_digest.deliver(_digest("team-shared"), {}, self._CHANNELS, debt_digest.MODE_SHADOW)
+
+        assert delivery is not None
+        assert delivery.lead_prefix == "Shadow, no channel resolved: "
+
+
+@pytest.mark.django_db(databases=PRODUCT_DATABASES)
+class TestCollectAndSend:
+    @pytest.fixture
+    def repo(self, team):
+        return repos.create_repo(team_id=team.id, repo_external_id=77771, repo_full_name="org/test-debt")
+
+    def _completed_run(self, repo, mocker, identifiers=(_IDENTIFIER,)):
+        artifact_store.get_or_create_artifact(repo_id=repo.id, content_hash="new_hash", storage_path="p/new_hash")
+        baselines = dict.fromkeys(identifiers, "old_hash")
+        run, _ = runs.create_run(
+            CreateRunInput(
+                repo_id=repo.id,
+                run_type=RunType.STORYBOOK,
+                commit_sha="abc",
+                branch="main",
+                pr_number=None,
+                metadata={"github_run_id": _GITHUB_RUN_ID},
+                snapshots=[
+                    SnapshotManifestItem(identifier=identifier, content_hash="new_hash") for identifier in identifiers
+                ],
+                baseline_hashes=baselines,
+            ),
+            team_id=repo.team_id,
+        )
+        mocker.patch(
+            "products.visual_review.backend.logic.baselines._resolve_baselines_with_merge_base",
+            return_value=(baselines, 0),
+        )
+        mocker.patch("products.visual_review.backend.tasks.tasks.process_run_diffs.delay")
+        runs.complete_run(run.id)
+        runs.finish_processing(run.id)
+        return run
+
+    def _pile_up(self, repo, identifier=_IDENTIFIER, count=3):
+        for index in range(count):
+            ToleratedHash.objects.create(
+                repo=repo,
+                team_id=repo.team_id,
+                identifier=identifier,
+                baseline_hash="old_hash",
+                alternate_hash=f"variant_{index}",
+                reason="human",
+            )
+
+    def test_collects_both_conditions_and_names_the_story_file(self, repo, team, user, mocker):
+        self._completed_run(repo, mocker)
+        self._pile_up(repo)
+        now = timezone.now()
+        quarantine.quarantine_identifier(
+            repo_id=repo.id,
+            identifier=_ABSENT_IDENTIFIER,
+            run_type=RunType.STORYBOOK,
+            reason="non-deterministic",
+            user_id=user.id,
+            team_id=team.id,
+            expires_at=now + timedelta(days=FLAKINESS_EXPIRY_SOON_DAYS - 1),
+        )
+
+        with _with_index(_INDEX):
+            debt = debt_digest.collect_debt(repo, now)
+
+        assert [(item.identifier, item.attribution) for item in debt.variant_pileups] == [(_IDENTIFIER, _PLACED)]
+        # A story the index does not hold is absent, which is not the same as nobody owning it.
+        assert [(item.identifier, item.attribution) for item in debt.expiring_quarantines] == [
+            (_ABSENT_IDENTIFIER, _STORY_ABSENT)
+        ]
+        assert "3 accepted variants of the current baseline" in debt.variant_pileups[0].line
+
+    def test_an_unreadable_artifact_leaves_the_items_unattributed(self, repo, mocker):
+        self._completed_run(repo, mocker)
+        self._pile_up(repo)
+
+        with _with_index(None):
+            debt = debt_digest.collect_debt(repo, timezone.now())
+
+        assert [item.attribution for item in debt.variant_pileups] == [_UNAVAILABLE]
+
+    @pytest.mark.parametrize(
+        "expires_in,expected_expiring",
+        [
+            (timedelta(days=1), [_IDENTIFIER]),
+            (timedelta(days=60), []),
+            (None, []),
+        ],
+    )
+    def test_a_quarantined_identity_is_not_also_reported_for_its_variants(
+        self, repo, team, user, mocker, expires_in, expected_expiring
+    ):
+        self._completed_run(repo, mocker)
+        self._pile_up(repo)
+        now = timezone.now()
+        quarantine.quarantine_identifier(
+            repo_id=repo.id,
+            identifier=_IDENTIFIER,
+            run_type=RunType.STORYBOOK,
+            reason="non-deterministic",
+            user_id=user.id,
+            team_id=team.id,
+            expires_at=now + expires_in if expires_in is not None else None,
+        )
+
+        with _with_index(_INDEX):
+            debt = debt_digest.collect_debt(repo, now)
+
+        assert [item.identifier for item in debt.expiring_quarantines] == expected_expiring
+        assert debt.variant_pileups == []
+
+    def test_preview_renders_every_team_and_posts_nothing(self, repo, mocker):
+        self._completed_run(repo, mocker)
+        self._pile_up(repo)
+        with (
+            _with_index(_INDEX),
+            patch(
+                "products.visual_review.backend.logic.debt_digest.resolve_path_owners",
+                return_value=_ownership({_SOURCE_PATH: "team-devex", _PRODUCT_PATH: "team-devex"}),
+            ),
+            patch("products.visual_review.backend.logic.debt_digest.fetch_channel_map") as channel_map,
+            patch("products.visual_review.backend.logic.debt_digest.post_with_join") as post,
+        ):
+            rendered = debt_digest.send_debt_digest(repo, mode=debt_digest.MODE_PREVIEW)
+
+        assert post.call_count == 0
+        assert channel_map.call_count == 0
+        assert len(rendered) == 1
+        assert rendered[0].startswith("Visual review debt for team-devex in org/test-debt: ")
+
+    def test_one_team_failing_does_not_stop_the_next(self, repo, mocker):
+        self._completed_run(repo, mocker, (_IDENTIFIER, _ABSENT_IDENTIFIER))
+        self._pile_up(repo)
+        self._pile_up(repo, identifier=_ABSENT_IDENTIFIER)
+        with (
+            _with_index(_INDEX),
+            patch(
+                "products.visual_review.backend.logic.debt_digest.resolve_path_owners",
+                return_value=_ownership({_SOURCE_PATH: "team-one", _PRODUCT_PATH: "team-two"}),
+            ),
+            patch("products.visual_review.backend.logic.debt_digest.Integration") as integration,
+            patch("products.visual_review.backend.logic.debt_digest.SlackIntegration"),
+            patch(
+                "products.visual_review.backend.logic.debt_digest.fetch_channel_map",
+                return_value={
+                    "team-one": SlackChannel(channel_id="C1", shared=False),
+                    "team-two": SlackChannel(channel_id="C2", shared=False),
+                },
+            ),
+            patch(
+                "products.visual_review.backend.logic.debt_digest.post_with_join",
+                side_effect=[SlackPostRefused("no"), "1700000000.1"],
+            ) as post,
+            patch("products.visual_review.backend.logic.debt_digest.post_message") as thread_post,
+        ):
+            integration.objects.filter.return_value.first.return_value = MagicMock()
+            debt_digest.send_debt_digest(repo, mode=debt_digest.MODE_LIVE)
+
+        assert post.call_count == 2
+        assert thread_post.call_count == 1

--- a/products/visual_review/backend/tests/logic/test_debt_digest.py
+++ b/products/visual_review/backend/tests/logic/test_debt_digest.py
@@ -13,7 +13,7 @@ from posthog_owners.schema import TeamEntry
 from posthog.models.team.team import Team
 from posthog.team_notifications.slack import MAX_SECTION_CHARS, SlackChannel, SlackPostRefused
 
-from products.engineering_analytics.backend.facade.contracts import PathOwnership
+from products.engineering_analytics.backend.facade.contracts import UNOWNED_TEAM, PathOwnership
 from products.visual_review.backend.facade.contracts import (
     FLAKINESS_EXPIRY_SOON_DAYS,
     CreateRunInput,
@@ -370,6 +370,23 @@ class TestCollectAndSend:
         assert channel_map.call_count == 0
         assert len(rendered) == 1
         assert rendered[0].startswith("Visual review debt for team-devex in org/test-debt: ")
+
+    def test_an_unreadable_owners_file_sends_nothing(self, repo, mocker):
+        self._completed_run(repo, mocker)
+        self._pile_up(repo)
+        # Every path reads as unowned when the owners files could not be read, which would
+        # otherwise drop the whole repo's debt as nobody's.
+        blind = PathOwnership(
+            team_by_path={_SOURCE_PATH: UNOWNED_TEAM, _PRODUCT_PATH: UNOWNED_TEAM}, registry={}, resolved=False
+        )
+        with (
+            _with_index(_INDEX),
+            patch("products.visual_review.backend.logic.debt_digest.resolve_path_owners", return_value=blind),
+            patch("products.visual_review.backend.logic.debt_digest.post_with_join") as post,
+        ):
+            assert debt_digest.send_debt_digest(repo, mode=debt_digest.MODE_LIVE) == []
+
+        assert post.call_count == 0
 
     def test_one_team_failing_does_not_stop_the_next(self, repo, mocker):
         self._completed_run(repo, mocker, (_IDENTIFIER, _ABSENT_IDENTIFIER))

--- a/products/visual_review/backend/tests/logic/test_debt_digest.py
+++ b/products/visual_review/backend/tests/logic/test_debt_digest.py
@@ -71,12 +71,13 @@ def _triage_digest() -> debt_digest.TeamDigest:
 
 
 class TestRendering:
-    def test_escapes_slack_control_characters_in_user_text(self) -> None:
-        # A reason and an identifier are both contributor input; either could otherwise smuggle a
-        # <!channel> mention into every owning team's channel.
+    @pytest.mark.parametrize("run_type", ["storybook", "<!channel>"])
+    def test_escapes_slack_control_characters_in_user_text(self, run_type: str) -> None:
+        # A reason, an identifier and a run type are all contributor input; any of them could
+        # otherwise smuggle a <!channel> mention into every owning team's channel.
         entry = MagicMock(
             identifier="Button<!channel>",
-            run_type="storybook",
+            run_type=run_type,
             reason="flaky & <!here>",
             expires_at=timezone.now() + timedelta(days=3),
             created_by_id=None,
@@ -84,8 +85,10 @@ class TestRendering:
         repo = MagicMock(id="00000000-0000-0000-0000-000000000001", team_id=7, repo_full_name="PostHog/posthog")
 
         line = debt_digest._quarantine_line(repo, entry, {}, timezone.now())
+        pileup = debt_digest._pileup_line(repo, run_type, "Button", 4)
 
         assert "<!channel>" not in line
+        assert "<!channel>" not in pileup
         assert "<!here>" not in line
         assert "&lt;!channel&gt;" in line
         assert "flaky &amp; &lt;!here&gt;" in line

--- a/products/visual_review/backend/tests/logic/test_debt_digest.py
+++ b/products/visual_review/backend/tests/logic/test_debt_digest.py
@@ -5,6 +5,8 @@ from datetime import timedelta
 import pytest
 from unittest.mock import MagicMock, patch
 
+from django.conf import settings
+from django.test import override_settings
 from django.utils import timezone
 
 from posthog_owners.schema import TeamEntry
@@ -95,6 +97,41 @@ class TestRendering:
 
         assert line.startswith("4 accepted variants of the current baseline · scenes/Button--dark (storybook)")
         assert line.endswith("/project/7/visual_review/repos/abc/storybook/snapshots/scenes%2FButton--dark")
+
+    @pytest.mark.parametrize(
+        "identifier,reason,links_to_the_snapshot",
+        [
+            ("b" * 512, "non-deterministic", True),
+            # Each of these percent-encodes to nine characters, so the URL alone outgrows a block.
+            ("界" * 400, "non-deterministic", False),
+            ("Button--light", "because " * 100, True),
+        ],
+    )
+    def test_one_oversized_item_still_fits_a_slack_block(
+        self, identifier: str, reason: str, links_to_the_snapshot: bool
+    ) -> None:
+        repo = MagicMock(id="abc", team_id=7, repo_full_name="PostHog/posthog")
+        entry = MagicMock(
+            identifier=identifier,
+            run_type="storybook",
+            reason=reason,
+            expires_at=timezone.now() + timedelta(days=3),
+            created_by_id=None,
+        )
+
+        line = debt_digest._quarantine_line(repo, entry, {}, timezone.now())
+        texts = debt_digest.thread_texts(
+            debt_digest.TeamDigest(
+                team_slug="team-devex",
+                expiring_quarantines=[_item(_PLACED, identifier=identifier, line=line)] * 2,
+                variant_pileups=[],
+            )
+        )
+
+        assert len(line) <= debt_digest._MAX_LINE_CHARS
+        assert settings.SITE_URL in line
+        assert ("/snapshots/" in line) == links_to_the_snapshot
+        assert all(len(text) <= debt_digest._MAX_SECTION_CHARS for text in texts)
 
     def test_splits_the_thread_when_one_group_runs_long(self) -> None:
         long_item = _item(_PLACED, line="x" * 2000)
@@ -202,6 +239,18 @@ class TestRouting:
 
         assert delivery is not None
         assert delivery.lead_prefix == "Shadow, no channel resolved: "
+
+    @pytest.mark.parametrize("mode", ["preveiw", ""])
+    def test_an_unknown_mode_evaluates_nothing_and_posts_nothing(self, mode: str) -> None:
+        with (
+            override_settings(VISUAL_REVIEW_DEBT_DIGEST_MODE=mode),
+            patch("products.visual_review.backend.logic.debt_digest.collect_debt") as collect,
+            patch("products.visual_review.backend.logic.debt_digest.post_with_join") as post,
+        ):
+            assert debt_digest.send_debt_digest(MagicMock(), mode=mode) == []
+
+        assert collect.call_count == 0
+        assert post.call_count == 0
 
 
 @pytest.mark.django_db(databases=PRODUCT_DATABASES)

--- a/products/visual_review/backend/tests/logic/test_debt_digest.py
+++ b/products/visual_review/backend/tests/logic/test_debt_digest.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 
 from posthog_owners.schema import TeamEntry
 
-from posthog.team_notifications.slack import SlackChannel, SlackPostRefused
+from posthog.team_notifications.slack import MAX_SECTION_CHARS, SlackChannel, SlackPostRefused
 
 from products.engineering_analytics.backend.facade.contracts import PathOwnership
 from products.visual_review.backend.facade.contracts import (
@@ -30,7 +30,7 @@ _STORY_ID = "scenes-app-button--primary"
 _IDENTIFIER = f"{_STORY_ID}--light"
 _ABSENT_IDENTIFIER = "scenes-app-gone--primary--light"
 _GITHUB_RUN_ID = "98765"
-_INDEX = story_index.StoryIndex(github_run_id=_GITHUB_RUN_ID, path_by_story_id={_STORY_ID: _SOURCE_PATH})
+_INDEX = story_index.StoryIndex(path_by_story_id={_STORY_ID: _SOURCE_PATH})
 
 _PLACED = debt_digest.Attribution(kind=debt_digest.AttributionKind.PLACED, source_path=_SOURCE_PATH)
 _STORY_ABSENT = debt_digest.Attribution(kind=debt_digest.AttributionKind.STORY_ABSENT)
@@ -64,8 +64,8 @@ def _triage_digest() -> debt_digest.TeamDigest:
         expiring_quarantines=[],
         variant_pileups=[],
         triage=[
-            debt_digest.TriageGroup(reason=debt_digest.TriageReason.UNOWNED_FILE, items=[_item(_PLACED)]),
-            debt_digest.TriageGroup(reason=debt_digest.TriageReason.UNAVAILABLE, items=[_item(_UNAVAILABLE)]),
+            debt_digest.TriageGroup(kind=debt_digest.AttributionKind.PLACED, items=[_item(_PLACED)]),
+            debt_digest.TriageGroup(kind=debt_digest.AttributionKind.UNAVAILABLE, items=[_item(_UNAVAILABLE)]),
         ],
     )
 
@@ -131,7 +131,7 @@ class TestRendering:
         assert len(line) <= debt_digest._MAX_LINE_CHARS
         assert settings.SITE_URL in line
         assert ("/snapshots/" in line) == links_to_the_snapshot
-        assert all(len(text) <= debt_digest._MAX_SECTION_CHARS for text in texts)
+        assert all(len(text) <= MAX_SECTION_CHARS for text in texts)
 
     def test_splits_the_thread_when_one_group_runs_long(self) -> None:
         long_item = _item(_PLACED, line="x" * 2000)
@@ -142,7 +142,7 @@ class TestRendering:
         texts = debt_digest.thread_texts(digest)
 
         assert len(texts) > 1
-        assert all(len(text) <= debt_digest._MAX_SECTION_CHARS for text in texts)
+        assert all(len(text) <= MAX_SECTION_CHARS for text in texts)
         assert texts[-1].endswith(debt_digest._FOOTER)
 
     def test_the_lead_holds_triage_apart_from_what_the_team_owns(self) -> None:
@@ -159,8 +159,8 @@ class TestRendering:
     def test_the_thread_groups_triage_under_one_header_per_reason(self) -> None:
         thread = "\n".join(debt_digest.thread_texts(_triage_digest()))
 
-        assert debt_digest._TRIAGE_HEADERS[debt_digest.TriageReason.UNOWNED_FILE] in thread
-        assert debt_digest._TRIAGE_HEADERS[debt_digest.TriageReason.UNAVAILABLE] in thread
+        assert debt_digest._TRIAGE_HEADERS[debt_digest.AttributionKind.PLACED] in thread
+        assert debt_digest._TRIAGE_HEADERS[debt_digest.AttributionKind.UNAVAILABLE] in thread
         # The path stays on the line, because it is what an owners entry is written for.
         assert f"a line · {_SOURCE_PATH}" in thread
         assert f"a line · the Storybook build artifact for run {_GITHUB_RUN_ID} was not read" in thread
@@ -182,20 +182,11 @@ class TestSplitByTeam:
         # The maintainers hold the other item without it counting as debt of their own.
         assert by_slug["team-devex"].variant_pileups == []
         assert by_slug["team-devex"].triage == [
-            debt_digest.TriageGroup(reason=debt_digest.TriageReason.STORY_ABSENT, items=[absent])
+            debt_digest.TriageGroup(kind=debt_digest.AttributionKind.STORY_ABSENT, items=[absent])
         ]
 
-    @pytest.mark.parametrize(
-        "attribution,reason",
-        [
-            (_PLACED, debt_digest.TriageReason.UNOWNED_FILE),
-            (_STORY_ABSENT, debt_digest.TriageReason.STORY_ABSENT),
-            (_UNAVAILABLE, debt_digest.TriageReason.UNAVAILABLE),
-        ],
-    )
-    def test_keeps_the_three_unowned_outcomes_apart(
-        self, attribution: debt_digest.Attribution, reason: debt_digest.TriageReason
-    ) -> None:
+    @pytest.mark.parametrize("attribution", [_PLACED, _STORY_ABSENT, _UNAVAILABLE])
+    def test_keeps_the_three_unowned_outcomes_apart(self, attribution: debt_digest.Attribution) -> None:
         item = _item(attribution)
         debt = debt_digest.RepoDebt(expiring_quarantines=[item], variant_pileups=[])
 
@@ -203,7 +194,7 @@ class TestSplitByTeam:
 
         assert [d.team_slug for d in digests] == ["team-devex"]
         assert digests[0].expiring_quarantines == []
-        assert digests[0].triage == [debt_digest.TriageGroup(reason=reason, items=[item])]
+        assert digests[0].triage == [debt_digest.TriageGroup(kind=attribution.kind, items=[item])]
 
     def test_drops_an_item_nobody_owns(self) -> None:
         debt = debt_digest.RepoDebt(expiring_quarantines=[_item(_STORY_ABSENT)], variant_pileups=[])

--- a/products/visual_review/backend/tests/logic/test_debt_digest.py
+++ b/products/visual_review/backend/tests/logic/test_debt_digest.py
@@ -6,11 +6,11 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 from django.conf import settings
-from django.test import override_settings
 from django.utils import timezone
 
 from posthog_owners.schema import TeamEntry
 
+from posthog.models.team.team import Team
 from posthog.team_notifications.slack import MAX_SECTION_CHARS, SlackChannel, SlackPostRefused
 
 from products.engineering_analytics.backend.facade.contracts import PathOwnership
@@ -205,7 +205,6 @@ class TestSplitByTeam:
 class TestRouting:
     _CHANNELS = {
         "team-devex": SlackChannel(channel_id="C1", shared=False),
-        "alerts-devex": SlackChannel(channel_id="CSHADOW", shared=False),
         "team-shared": SlackChannel(channel_id="C2", shared=True),
     }
 
@@ -218,23 +217,9 @@ class TestRouting:
         # A name match onto a shared channel would send an internal reminder out of the workspace.
         assert debt_digest.resolve_channel(_digest("team-shared"), {}, self._CHANNELS) is None
 
-    def test_shadow_mode_posts_to_the_shadow_channel_and_names_the_real_one(self) -> None:
-        delivery = debt_digest.deliver(_digest(), {}, self._CHANNELS, debt_digest.MODE_SHADOW)
-
-        assert delivery is not None
-        assert delivery.channel_id == "CSHADOW"
-        assert delivery.lead_prefix == "Shadow for #team-devex: "
-
-    def test_shadow_mode_says_so_when_no_channel_resolved(self) -> None:
-        delivery = debt_digest.deliver(_digest("team-shared"), {}, self._CHANNELS, debt_digest.MODE_SHADOW)
-
-        assert delivery is not None
-        assert delivery.lead_prefix == "Shadow, no channel resolved: "
-
-    @pytest.mark.parametrize("mode", ["preveiw", ""])
+    @pytest.mark.parametrize("mode", ["preveiw", "shadow", ""])
     def test_an_unknown_mode_evaluates_nothing_and_posts_nothing(self, mode: str) -> None:
         with (
-            override_settings(VISUAL_REVIEW_DEBT_DIGEST_MODE=mode),
             patch("products.visual_review.backend.logic.debt_digest.collect_debt") as collect,
             patch("products.visual_review.backend.logic.debt_digest.post_with_join") as post,
         ):
@@ -242,6 +227,19 @@ class TestRouting:
 
         assert collect.call_count == 0
         assert post.call_count == 0
+
+
+@pytest.mark.django_db(databases=PRODUCT_DATABASES)
+class TestReposInScope:
+    def test_every_repo_is_in_scope_whatever_team_owns_it(self, team) -> None:
+        mine = repos.create_repo(team_id=team.id, repo_external_id=77781, repo_full_name="org/mine")
+        other_team = Team.objects.create(organization=team.organization, name="other")
+        theirs = repos.create_repo(team_id=other_team.id, repo_external_id=77782, repo_full_name="org/theirs")
+
+        assert {(repo.team_id, repo.id) for repo in debt_digest.repos_in_scope()} == {
+            (mine.team_id, mine.id),
+            (theirs.team_id, theirs.id),
+        }
 
 
 @pytest.mark.django_db(databases=PRODUCT_DATABASES)

--- a/products/visual_review/backend/tests/logic/test_quarantine.py
+++ b/products/visual_review/backend/tests/logic/test_quarantine.py
@@ -1,9 +1,12 @@
 """Unit tests for logic/quarantine.py — Quarantined identifiers."""
 
+from datetime import timedelta
+
 import pytest
 
 from django.utils import timezone
 
+from products.visual_review.backend.facade.contracts import FLAKINESS_EXPIRY_SOON_DAYS
 from products.visual_review.backend.facade.enums import RunStatus, RunType
 from products.visual_review.backend.logic import quarantine, repos
 from products.visual_review.backend.models import Repo, Run
@@ -89,3 +92,35 @@ class TestQuarantineIdentifier:
             team_id=team.id,
         )
         assert entry.source_run_id is None
+
+
+@pytest.mark.django_db(databases=PRODUCT_DATABASES)
+class TestExpiringQuarantines:
+    @pytest.fixture
+    def repo(self, team):
+        return repos.create_repo(team_id=team.id, repo_external_id=88889, repo_full_name="org/test-expiring")
+
+    @pytest.mark.parametrize(
+        "expiry_days,listed",
+        [
+            (FLAKINESS_EXPIRY_SOON_DAYS - 1, True),
+            (FLAKINESS_EXPIRY_SOON_DAYS + 1, False),
+            (-1, False),
+            (None, False),
+        ],
+    )
+    def test_lists_only_quarantines_running_out_inside_the_window(self, repo, team, user, expiry_days, listed):
+        now = timezone.now()
+        quarantine.quarantine_identifier(
+            repo_id=repo.id,
+            identifier="flake",
+            run_type=RunType.STORYBOOK,
+            reason="non-deterministic",
+            user_id=user.id,
+            team_id=team.id,
+            expires_at=None if expiry_days is None else now + timedelta(days=expiry_days),
+        )
+
+        entries = quarantine.list_expiring_quarantines(repo.id, now=now)
+
+        assert [entry.identifier for entry in entries] == (["flake"] if listed else [])

--- a/products/visual_review/backend/tests/logic/test_story_index.py
+++ b/products/visual_review/backend/tests/logic/test_story_index.py
@@ -15,7 +15,6 @@ from products.visual_review.backend.logic import errors, story_index
 _ARTIFACT_NAME = "storybook-build"
 
 _INDEX = story_index.StoryIndex(
-    github_run_id="98765",
     path_by_story_id={
         "scenes-app-button--primary": "frontend/src/scenes/Button.stories.tsx",
         # A story of its own whose name happens to be a viewport width name.
@@ -88,7 +87,6 @@ class TestFetchStoryIndex:
             index = story_index.fetch_story_index(_repo(), "98765")
 
         assert index is not None
-        assert index.github_run_id == "98765"
         assert dict(index.path_by_story_id) == {"scenes-app-button--primary": "frontend/src/scenes/Button.stories.tsx"}
 
     # Nothing here needs the database, but the product's autouse package fixture builds it, and it

--- a/products/visual_review/backend/tests/logic/test_story_index.py
+++ b/products/visual_review/backend/tests/logic/test_story_index.py
@@ -12,7 +12,7 @@ import requests
 
 from products.visual_review.backend.logic import errors, story_index
 
-_ARTIFACT_NAME = "storybook-build"
+_ARTIFACT_NAME = story_index.STORYBOOK_ARTIFACT_NAME
 
 _INDEX = story_index.StoryIndex(
     path_by_story_id={

--- a/products/visual_review/backend/tests/logic/test_story_index.py
+++ b/products/visual_review/backend/tests/logic/test_story_index.py
@@ -145,6 +145,27 @@ class TestFetchStoryIndex:
         assert request.call_count == len(responses) * 2
 
     @pytest.mark.parametrize(
+        "artifact_size,max_index_bytes",
+        [
+            (story_index._MAX_ARTIFACT_BYTES + 1, story_index._MAX_INDEX_BYTES),
+            (1000, 5),
+        ],
+    )
+    def test_an_oversized_artifact_is_not_read(self, artifact_size: int, max_index_bytes: int) -> None:
+        responses = [
+            _listing({"name": _ARTIFACT_NAME, "id": 42, "size_in_bytes": artifact_size}),
+            _response(content=_zip_bytes({"index.json": _index_document({})})),
+        ]
+        with (
+            patch.object(story_index, "_MAX_INDEX_BYTES", max_index_bytes),
+            patch(
+                "products.visual_review.backend.logic.github_api._github_api_request",
+                side_effect=responses,
+            ),
+        ):
+            assert story_index.fetch_story_index(_repo(), "98765") is None
+
+    @pytest.mark.parametrize(
         "error",
         [
             errors.GitHubIntegrationNotFoundError("no integration"),

--- a/products/visual_review/backend/tests/logic/test_story_index.py
+++ b/products/visual_review/backend/tests/logic/test_story_index.py
@@ -1,0 +1,161 @@
+"""Unit tests for logic/story_index.py — the snapshot-to-file map from the Storybook artifact."""
+
+import io
+import json
+import zipfile
+from uuid import uuid4
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from products.visual_review.backend.logic import errors, story_index
+
+_ARTIFACT_NAME = "storybook-build"
+
+_INDEX = story_index.StoryIndex(
+    github_run_id="98765",
+    path_by_story_id={
+        "scenes-app-button--primary": "frontend/src/scenes/Button.stories.tsx",
+        # A story of its own whose name happens to be a viewport width name.
+        "lemon-ui-lemon-banner--narrow": "frontend/src/lib/lemon-ui/LemonBannerNarrow.stories.tsx",
+        "lemon-ui-lemon-banner--info": "frontend/src/lib/lemon-ui/LemonBanner.stories.tsx",
+    },
+)
+
+
+def _repo() -> MagicMock:
+    return MagicMock(id=uuid4())
+
+
+def _zip_bytes(members: dict[str, bytes]) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        for name, body in members.items():
+            archive.writestr(name, body)
+    return buffer.getvalue()
+
+
+def _response(status_code: int = 200, payload: object = None, content: bytes = b"") -> MagicMock:
+    return MagicMock(status_code=status_code, content=content, json=MagicMock(return_value=payload))
+
+
+def _listing(*artifacts: dict) -> MagicMock:
+    return _response(payload={"artifacts": list(artifacts)})
+
+
+def _index_document(entries: dict[str, dict]) -> bytes:
+    return json.dumps({"v": 5, "entries": entries}).encode()
+
+
+class TestStoryPath:
+    @pytest.mark.parametrize(
+        "identifier,expected",
+        [
+            ("scenes-app-button--primary--light", "frontend/src/scenes/Button.stories.tsx"),
+            ("scenes-app-button--primary--dark", "frontend/src/scenes/Button.stories.tsx"),
+            ("scenes-app-button--primary--dark--webkit", "frontend/src/scenes/Button.stories.tsx"),
+            # The width is only stripped once the full story id misses.
+            ("lemon-ui-lemon-banner--info--superwide--light", "frontend/src/lib/lemon-ui/LemonBanner.stories.tsx"),
+            # A story named after a width matches exactly, so it keeps its own file.
+            ("lemon-ui-lemon-banner--narrow--light", "frontend/src/lib/lemon-ui/LemonBannerNarrow.stories.tsx"),
+            ("scenes-app-gone--primary--light", None),
+            # Nothing the test runner wrote looks like this, so there is no story to guess at.
+            ("scenes-app-button--primary", None),
+        ],
+    )
+    def test_resolves_an_identifier_to_its_story_file(self, identifier: str, expected: str | None) -> None:
+        assert story_index.story_path(_INDEX, identifier) == expected
+
+
+class TestFetchStoryIndex:
+    def test_keeps_story_entries_and_turns_import_paths_into_repo_paths(self) -> None:
+        entries = {
+            "scenes-app-button--primary": {
+                "type": "story",
+                "importPath": "../../frontend/src/scenes/Button.stories.tsx",
+            },
+            "scenes-app-button--docs": {"type": "docs", "importPath": "../../frontend/src/scenes/Button.mdx"},
+            # A story imported from outside the checkout has no repository path to own.
+            "vendor-thing--default": {"type": "story", "importPath": "../../../vendor/Thing.stories.tsx"},
+        }
+        zip_bytes = _zip_bytes({"index.json": _index_document(entries)})
+        with patch(
+            "products.visual_review.backend.logic.github_api._github_api_request",
+            side_effect=[_listing({"name": _ARTIFACT_NAME, "id": 42}), _response(content=zip_bytes)],
+        ):
+            index = story_index.fetch_story_index(_repo(), "98765")
+
+        assert index is not None
+        assert index.github_run_id == "98765"
+        assert dict(index.path_by_story_id) == {"scenes-app-button--primary": "frontend/src/scenes/Button.stories.tsx"}
+
+    # Nothing here needs the database, but the product's autouse package fixture builds it, and it
+    # can only do that once a test in the module asks for it.
+    @pytest.mark.django_db
+    def test_reads_the_artifact_once_per_workflow_run(self) -> None:
+        repo = _repo()
+        zip_bytes = _zip_bytes(
+            {"index.json": _index_document({"a--b": {"type": "story", "importPath": "../../frontend/src/A.tsx"}})}
+        )
+        with patch(
+            "products.visual_review.backend.logic.github_api._github_api_request",
+            side_effect=[_listing({"name": _ARTIFACT_NAME, "id": 42}), _response(content=zip_bytes)],
+        ) as request:
+            first = story_index.fetch_story_index(repo, "98765")
+            second = story_index.fetch_story_index(repo, "98765")
+
+        assert request.call_count == 2
+        assert first is not None and second is not None
+        assert dict(second.path_by_story_id) == {"a--b": "frontend/src/A.tsx"}
+
+    @pytest.mark.parametrize(
+        "responses",
+        [
+            pytest.param([_listing()], id="artifact_missing"),
+            pytest.param([_listing({"name": "other-build", "id": 7})], id="artifact_named_differently"),
+            pytest.param([_listing({"name": _ARTIFACT_NAME, "id": 42, "expired": True})], id="artifact_expired"),
+            pytest.param([_response(status_code=404, payload={})], id="run_gone"),
+            pytest.param(
+                [_listing({"name": _ARTIFACT_NAME, "id": 42}), _response(status_code=410)],
+                id="download_failed",
+            ),
+            pytest.param(
+                [
+                    _listing({"name": _ARTIFACT_NAME, "id": 42}),
+                    _response(content=_zip_bytes({"iframe.html": b"<html></html>"})),
+                ],
+                id="index_missing",
+            ),
+            pytest.param(
+                [_listing({"name": _ARTIFACT_NAME, "id": 42}), _response(content=_zip_bytes({"index.json": b"{"}))],
+                id="index_invalid",
+            ),
+        ],
+    )
+    def test_an_unreadable_artifact_is_answered_with_none_and_not_cached(self, responses: list[MagicMock]) -> None:
+        repo = _repo()
+        with patch(
+            "products.visual_review.backend.logic.github_api._github_api_request",
+            side_effect=responses * 2,
+        ) as request:
+            assert story_index.fetch_story_index(repo, "98765") is None
+            assert story_index.fetch_story_index(repo, "98765") is None
+
+        # Nothing was cached, so tomorrow's run asks GitHub again instead of repeating today's miss.
+        assert request.call_count == len(responses) * 2
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            errors.GitHubIntegrationNotFoundError("no integration"),
+            requests.ConnectionError("boom"),
+        ],
+    )
+    def test_a_failing_github_call_does_not_raise(self, error: Exception) -> None:
+        with patch(
+            "products.visual_review.backend.logic.github_api._github_api_request",
+            side_effect=error,
+        ):
+            assert story_index.fetch_story_index(_repo(), "98765") is None

--- a/products/visual_review/backend/tests/logic/test_story_index.py
+++ b/products/visual_review/backend/tests/logic/test_story_index.py
@@ -78,6 +78,8 @@ class TestFetchStoryIndex:
             "scenes-app-button--docs": {"type": "docs", "importPath": "../../frontend/src/scenes/Button.mdx"},
             # A story imported from outside the checkout has no repository path to own.
             "vendor-thing--default": {"type": "story", "importPath": "../../../vendor/Thing.stories.tsx"},
+            # An absolute path leaves the checkout too, and it drops the package directory on join.
+            "root-thing--default": {"type": "story", "importPath": "/etc/Thing.stories.tsx"},
         }
         zip_bytes = _zip_bytes({"index.json": _index_document(entries)})
         with patch(

--- a/products/visual_review/backend/tests/logic/test_toleration.py
+++ b/products/visual_review/backend/tests/logic/test_toleration.py
@@ -158,6 +158,38 @@ class TestToleratedHashes:
         assert snapshot.classification_reason == ""
         assert snapshot.tolerated_hash_match is None
 
+    @pytest.mark.parametrize(
+        "rows,expected",
+        [
+            ([("old_hash", "human", None), ("old_hash", "agent", None)], 2),
+            ([("old_hash", "human", None), ("old_hash", "agent", None), ("old_hash", "human", None)], 3),
+            # Recorded against a baseline that has since moved. The classifier can never match
+            # these again, so counting them would report a pile-up nobody can act on.
+            ([("old_hash", "human", None), ("superseded", "human", None)], 1),
+            ([("old_hash", "human", None), ("old_hash", "human", -1)], 1),
+            # Sub-threshold jitter the diff pipeline minted, not a decision anybody made.
+            ([("old_hash", "human", None), ("old_hash", "auto_threshold", None)], 1),
+            ([("old_hash", "auto_threshold", None)], 0),
+        ],
+    )
+    def test_counts_accepted_variants_of_the_current_baseline(self, repo, mocker, rows, expected):
+        self._create_completed_run(repo, mocker)
+        now = timezone.now()
+        for index, (baseline_hash, reason, expiry_days) in enumerate(rows):
+            ToleratedHash.objects.create(
+                repo=repo,
+                team_id=repo.team_id,
+                identifier="Button",
+                baseline_hash=baseline_hash,
+                alternate_hash=f"variant_{index}",
+                reason=reason,
+                expires_at=None if expiry_days is None else now + timedelta(days=expiry_days),
+            )
+
+        counts = toleration.count_active_variants_against_current_baseline(repo.id, now=now)
+
+        assert counts.get((RunType.STORYBOOK, "Button"), 0) == expected
+
     def test_get_tolerated_hashes_for_identifier(self, repo):
         from products.visual_review.backend.models import ToleratedHash
 

--- a/products/visual_review/backend/tests/logic/test_toleration.py
+++ b/products/visual_review/backend/tests/logic/test_toleration.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 from products.visual_review.backend.facade.contracts import CreateRunInput, SnapshotManifestItem
 from products.visual_review.backend.facade.enums import ActorType, RunType, SnapshotResult
 from products.visual_review.backend.logic import artifact_store, repos, runs, toleration
+from products.visual_review.backend.logic.run_queries import SnapshotKey
 from products.visual_review.backend.models import ToleratedHash
 from products.visual_review.backend.tests.conftest import PRODUCT_DATABASES
 
@@ -188,7 +189,7 @@ class TestToleratedHashes:
 
         counts = toleration.count_active_variants_against_current_baseline(repo.id, now=now)
 
-        assert counts.get((RunType.STORYBOOK, "Button"), 0) == expected
+        assert counts.get(SnapshotKey(run_type=RunType.STORYBOOK, identifier="Button"), 0) == expected
 
     def test_get_tolerated_hashes_for_identifier(self, repo):
         from products.visual_review.backend.models import ToleratedHash

--- a/products/visual_review/backend/tests/test_baselines.py
+++ b/products/visual_review/backend/tests/test_baselines.py
@@ -75,6 +75,7 @@ def _mk_snapshot(
     identifier: str,
     result: str = SnapshotResult.UNCHANGED,
     artifact: Artifact | None = None,
+    baseline_hash: str = "",
     is_quarantined: bool = False,
     tolerated_match: ToleratedHash | None = None,
     metadata: dict | None = None,
@@ -87,6 +88,7 @@ def _mk_snapshot(
         identifier=identifier,
         current_hash=artifact.content_hash if artifact else "",
         current_artifact=artifact,
+        baseline_hash=baseline_hash,
         result=result,
         is_quarantined=is_quarantined,
         tolerated_hash_match=tolerated_match,
@@ -226,7 +228,7 @@ class TestBaselinesOverview(VisualReviewTeamScopedTestMixin, APIBaseTest):
 
     def test_tolerate_counts_respect_30d_and_90d_windows(self):
         run = _mk_run(self.repo)
-        _mk_snapshot(run, identifier="flake")
+        _mk_snapshot(run, identifier="flake", baseline_hash="b")
 
         # 1 tolerate within 30d, 4 within 90d (so 3 are 30-90d old).
         for offset_days in (5, 40, 60, 80):
@@ -256,6 +258,10 @@ class TestBaselinesOverview(VisualReviewTeamScopedTestMixin, APIBaseTest):
         assert entry.tolerate_count_90d == 4
         assert result.totals.recently_tolerated == 1  # ≥1 in last 30d
         assert result.totals.frequently_tolerated == 1  # ≥3 in last 90d
+        # No window on the variants: every live row recorded against the hash the baseline holds
+        # now still matches, however old it is.
+        assert entry.active_variants_current_baseline == 4
+        assert result.totals.variant_pileups == 1
 
     def test_tolerate_counts_exclude_auto_threshold(self):
         """AUTO_THRESHOLD rows are auto-minted by the diff pipeline for

--- a/products/visual_review/backend/tests/test_debt_digest_command.py
+++ b/products/visual_review/backend/tests/test_debt_digest_command.py
@@ -1,0 +1,41 @@
+"""Tests for the visual_review_debt_digest management command."""
+
+import pytest
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from posthog.models.team.team import Team
+
+from products.visual_review.backend.logic import repos
+from products.visual_review.backend.tests.conftest import PRODUCT_DATABASES
+
+_REPO = "org/shared-by-two"
+
+
+@pytest.mark.django_db(databases=PRODUCT_DATABASES)
+class TestDebtDigestCommand:
+    @pytest.fixture
+    def two_teams(self, team):
+        other_team = Team.objects.create(organization=team.organization, name="other")
+        mine = repos.create_repo(team_id=team.id, repo_external_id=66661, repo_full_name=_REPO)
+        theirs = repos.create_repo(team_id=other_team.id, repo_external_id=66662, repo_full_name=_REPO)
+        return mine, theirs
+
+    def test_a_name_two_teams_registered_asks_which_one(self, two_teams) -> None:
+        with pytest.raises(CommandError, match="more than one team"):
+            call_command("visual_review_debt_digest", "--repo", _REPO)
+
+    @pytest.mark.parametrize("which", [0, 1])
+    def test_team_id_picks_the_row_that_team_owns(self, two_teams, which: int) -> None:
+        wanted = two_teams[which]
+
+        with patch("products.visual_review.backend.logic.debt_digest.send_debt_digest", return_value=[]) as send:
+            call_command("visual_review_debt_digest", "--repo", _REPO, "--team-id", str(wanted.team_id))
+
+        assert send.call_args.args[0].id == wanted.id
+
+    def test_an_unknown_repo_is_named_in_the_error(self) -> None:
+        with pytest.raises(CommandError, match="No visual review repo named org/nope"):
+            call_command("visual_review_debt_digest", "--repo", "org/nope")

--- a/products/visual_review/backend/tests/test_tasks.py
+++ b/products/visual_review/backend/tests/test_tasks.py
@@ -7,6 +7,8 @@ import pytest
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
+from django.core.cache import cache
+
 from parameterized import parameterized
 from PIL import Image
 
@@ -22,8 +24,12 @@ from products.visual_review.backend.facade.enums import (
     SnapshotResult,
 )
 from products.visual_review.backend.logic import artifact_store, runs
-from products.visual_review.backend.models import RunSnapshot, ToleratedHash
-from products.visual_review.backend.tasks.tasks import post_approval_comment, process_run_diffs
+from products.visual_review.backend.models import Repo, RunSnapshot, ToleratedHash
+from products.visual_review.backend.tasks.tasks import (
+    post_approval_comment,
+    process_run_diffs,
+    send_visual_review_debt_digest,
+)
 from products.visual_review.backend.tests.conftest import (
     PRODUCT_DATABASES,
     VisualReviewTeamScopedTestMixin,
@@ -543,3 +549,19 @@ class TestPostApprovalCommentTask:
 
         retry_mock.assert_called_once()
         assert retry_mock.call_args.kwargs["countdown"] == 42
+
+
+class TestDebtDigestTask(VisualReviewTeamScopedTestMixin, BaseTest):
+    databases = PRODUCT_DATABASES
+
+    def test_a_held_lock_skips_the_run(self) -> None:
+        repo = Repo.objects.create(team_id=self.team.id, repo_external_id=55511, repo_full_name="org/locked")
+        cache.set(f"visual_review_debt_digest:{repo.id}", "locked", timeout=60)
+        try:
+            with patch("products.visual_review.backend.logic.debt_digest.send_debt_digest") as send:
+                send_visual_review_debt_digest(self.team.id, str(repo.id))
+        finally:
+            cache.delete(f"visual_review_debt_digest:{repo.id}")
+
+        # Nothing records what was sent, so an overlapping run would post every reminder twice.
+        assert send.call_count == 0

--- a/products/visual_review/backend/tests/test_tasks.py
+++ b/products/visual_review/backend/tests/test_tasks.py
@@ -23,7 +23,7 @@ from products.visual_review.backend.facade.enums import (
     RunType,
     SnapshotResult,
 )
-from products.visual_review.backend.logic import artifact_store, runs
+from products.visual_review.backend.logic import artifact_store, debt_digest, runs
 from products.visual_review.backend.models import Repo, RunSnapshot, ToleratedHash
 from products.visual_review.backend.tasks.tasks import (
     post_approval_comment,
@@ -565,3 +565,13 @@ class TestDebtDigestTask(VisualReviewTeamScopedTestMixin, BaseTest):
 
         # Nothing records what was sent, so an overlapping run would post every reminder twice.
         assert send.call_count == 0
+
+    def test_the_scheduled_run_posts_rather_than_previews(self) -> None:
+        repo = Repo.objects.create(team_id=self.team.id, repo_external_id=55512, repo_full_name="org/scheduled")
+        try:
+            with patch("products.visual_review.backend.logic.debt_digest.send_debt_digest") as send:
+                send_visual_review_debt_digest(self.team.id, str(repo.id))
+        finally:
+            cache.delete(f"visual_review_debt_digest:{repo.id}")
+
+        assert send.call_args.kwargs["mode"] == debt_digest.MODE_LIVE

--- a/products/visual_review/backend/tests/test_tasks.py
+++ b/products/visual_review/backend/tests/test_tasks.py
@@ -25,10 +25,12 @@ from products.visual_review.backend.facade.enums import (
 )
 from products.visual_review.backend.logic import artifact_store, debt_digest, runs
 from products.visual_review.backend.models import Repo, RunSnapshot, ToleratedHash
+from products.visual_review.backend.tasks import tasks
 from products.visual_review.backend.tasks.tasks import (
     post_approval_comment,
     process_run_diffs,
     send_visual_review_debt_digest,
+    send_visual_review_debt_digests,
 )
 from products.visual_review.backend.tests.conftest import (
     PRODUCT_DATABASES,
@@ -565,6 +567,16 @@ class TestDebtDigestTask(VisualReviewTeamScopedTestMixin, BaseTest):
 
         # Nothing records what was sent, so an overlapping run would post every reminder twice.
         assert send.call_count == 0
+
+    def test_the_fan_out_gives_each_child_a_deadline(self) -> None:
+        repo = Repo.objects.create(team_id=self.team.id, repo_external_id=55513, repo_full_name="org/fanned-out")
+
+        with patch("products.visual_review.backend.tasks.tasks.send_visual_review_debt_digest.apply_async") as enqueue:
+            send_visual_review_debt_digests()
+
+        # A child without a deadline lets a drained backlog post yesterday's digest next to today's.
+        enqueued = {(call.kwargs["args"], call.kwargs["expires"]) for call in enqueue.call_args_list}
+        assert ((repo.team_id, str(repo.id)), tasks._DEBT_DIGEST_EXPIRY_SECONDS) in enqueued
 
     def test_the_scheduled_run_posts_rather_than_previews(self) -> None:
         repo = Repo.objects.create(team_id=self.team.id, repo_external_id=55512, repo_full_name="org/scheduled")

--- a/products/visual_review/frontend/components/SnapshotCard.tsx
+++ b/products/visual_review/frontend/components/SnapshotCard.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 
-import { IconFlag, IconPulse, IconWarning } from '@posthog/icons'
+import { IconCopy, IconFlag, IconPulse, IconWarning } from '@posthog/icons'
 import { LemonTag, Link } from '@posthog/lemon-ui'
 
 import { dayjs } from 'lib/dayjs'
@@ -96,6 +96,7 @@ export function SnapshotCard({
     const { theme } = parseTheme(entry.identifier)
     const area = parseArea(entry.identifier)
     const tolerateCount = entry.tolerate_count_30d
+    const variantCount = entry.active_variants_current_baseline
     const driftPct = entry.recent_drift_avg ?? 0
     const driftVisible = driftPct >= DRIFT_DISPLAY_FLOOR_PCT
     const driftLoud = driftPct >= DRIFT_WARNING_THRESHOLD_PCT
@@ -106,7 +107,7 @@ export function SnapshotCard({
             ? `${thumbnailBasePath}/${encodeURIComponent(entry.identifier)}/`
             : null
     const href = urls.visualReviewSnapshotHistory(repoId, entry.run_type, entry.identifier)
-    const hasMeta = driftVisible || tolerateCount > 0 || entry.baseline_change_count > 0
+    const hasMeta = driftVisible || tolerateCount > 0 || variantCount > 0 || entry.baseline_change_count > 0
 
     const quarantine = entry.quarantine ?? null
     // Yellow ring (not a 1px border) so the card pulls the eye in a grid
@@ -213,6 +214,18 @@ export function SnapshotCard({
                                     <span className="inline-flex items-center gap-0.5">
                                         <IconFlag className="w-3 h-3" />
                                         {tolerateCount}
+                                    </span>
+                                </Tooltip>
+                            )}
+                            {variantCount > 0 && (
+                                <Tooltip
+                                    title={`${variantCount} accepted variant${
+                                        variantCount === 1 ? '' : 's'
+                                    } of the current baseline`}
+                                >
+                                    <span className="inline-flex items-center gap-0.5">
+                                        <IconCopy className="w-3 h-3" />
+                                        {variantCount}
                                     </span>
                                 </Tooltip>
                             )}

--- a/products/visual_review/frontend/components/SnapshotCard.tsx
+++ b/products/visual_review/frontend/components/SnapshotCard.tsx
@@ -188,7 +188,7 @@ export function SnapshotCard({
                         {area}
                     </LemonTag>
                     {hasMeta && (
-                        <div className="flex items-center gap-2 shrink-0 tabular-nums leading-none">
+                        <div className="flex flex-wrap items-center justify-end gap-2 tabular-nums leading-none">
                             {driftVisible && (
                                 <Tooltip
                                     title={`Average pixel drift over the last ${RECENT_DRIFT_WINDOW} default-branch runs: ${driftPct.toFixed(

--- a/products/visual_review/frontend/generated/api.schemas.ts
+++ b/products/visual_review/frontend/generated/api.schemas.ts
@@ -75,6 +75,8 @@ export interface BaselineQuarantineSummaryApi {
 export interface BaselineEntryApi {
     /** Active quarantine details when `is_quarantined` is true. Null otherwise. */
     quarantine?: BaselineQuarantineSummaryApi | null
+    /** Accepted variants still recorded against this baseline's current hash. Unlike the 30-day and 90-day counts, this has no time window: an accepted variant keeps matching without a new record. A baseline change resets it to zero. */
+    active_variants_current_baseline: number
     identifier: string
     run_type: string
     /** @nullable */
@@ -98,6 +100,8 @@ export type BaselineTotalsApiByRunType = { [key: string]: number }
 
 export interface BaselineTotalsApi {
     by_run_type: BaselineTotalsApiByRunType
+    /** Baselines carrying three or more accepted variants of their current hash. */
+    variant_pileups: number
     all_snapshots: number
     recently_tolerated: number
     frequently_tolerated: number

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -12030,6 +12030,8 @@ export namespace Schemas {
     export interface BaselineEntry {
       /** Active quarantine details when `is_quarantined` is true. Null otherwise. */
       quarantine?: BaselineQuarantineSummary | null;
+      /** Accepted variants still recorded against this baseline's current hash. Unlike the 30-day and 90-day counts, this has no time window: an accepted variant keeps matching without a new record. A baseline change resets it to zero. */
+      active_variants_current_baseline: number;
       identifier: string;
       run_type: string;
       /** @nullable */
@@ -12053,6 +12055,8 @@ export namespace Schemas {
 
     export interface BaselineTotals {
       by_run_type: BaselineTotalsByRunType;
+      /** Baselines carrying three or more accepted variants of their current hash. */
+      variant_pileups: number;
       all_snapshots: number;
       recently_tolerated: number;
       frequently_tolerated: number;

--- a/tach.toml
+++ b/tach.toml
@@ -1001,6 +1001,7 @@ layer = "modules"
 path = "products.visual_review"
 depends_on = [
     "posthog",
+    "products.engineering_analytics",
 ]
 layer = "modules"
 


### PR DESCRIPTION
## Problem

- A team that quarantined a flaky snapshot or accepted a variant hears nothing afterwards. The quarantine lapses quietly, and tolerations pile up against a baseline until nobody knows which rendering is the right one.
- Visual review has no notification path and no idea which team a snapshot belongs to. The debt is only visible to whoever opens the baselines page.
- This layer builds on the shared Slack pieces from the layer below.

## Changes

- Each morning, a team's notifications channel gets one message per repository, with the items in a thread and a link to each snapshot: quarantines that expire within the flakiness window, and snapshots with at least three accepted variants of the current baseline. An item repeats every day until the condition stops holding. Nothing is stored about what was sent.
- The baselines page shows "accepted variants of the current baseline" for each snapshot, next to the existing ninety-day count. A baseline change drops it to zero, because the old tolerations can never match again. That says nothing about the story recovering.
- Attribution needs no capture change. A snapshot identifier is a story id plus theme, width and browser suffixes, and the Storybook build artifact of the run behind the current baseline holds the story index that maps a story id to its file. The lookup strips theme and browser first and a width only when that misses, because story names can equal width names. The path goes through the ownership resolver eng-analytics already runs, and the channel through the owners registry with its producer opt-out.
- Items nobody owns go to the visual review maintainers as a labelled triage part of their digest, not as ownership. Three cases stay apart in the text: a file with no owners entry (the path is shown so one can be added), a story absent from the index, and an artifact that could not be read. An unreadable artifact never labels anything unowned; the lead says ownership is retried tomorrow. The person who opened a quarantine is shown as context.
- Nothing to configure. The beat task runs the digest daily for every repository, and a repository that owes nothing posts nothing. A team keeps it out of its channel with the owners registry's producer opt-out. A management command runs one repository by hand, in preview by default and live on request.
- Mechanical: an eng-analytics facade function exposes path ownership, a tach edge lets visual review call it, a beat entry runs the fan-out with a short per-repository lock, the GitHub request helper accepts query parameters, the current-variant query filters by current baseline hashes in SQL, snapshot lookups key by a small frozen dataclass instead of a pair, and the beat entry expires after an hour so a backlogged fan-out cannot send yesterday's digest next to today's.

```mermaid
flowchart LR
    A[Storybook build artifact] --> B[Debt digest task]
    D[(Quarantines and tolerations)] --> B
    B --> C{{Ownership resolver}}
    C --> E[Owners registry]
    E --> F[Team Slack channel]
    E --> G[Maintainers triage]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class B,C phBlue;
    class F,G phYellow;
    class A,D,E phGray;
```

There was no notification path before, so there is no "before" diagram. No screenshot: the page change is one extra number on the existing snapshot card, and it was not rendered locally.

> [!NOTE]
> Recovery recommendations and post-expiry notices are deliberately out of scope. The current timestamps do not support those rules reliably.

## How did you test this code?

- Story index tests catch a width suffix stripped before the exact story id is tried, an import path that escapes the checkout, an expired or missing artifact, and a failed download being cached.
- Digest tests catch the three triage outcomes collapsing into one, an unknown mode posting live, one oversized line breaking a team's thread, a quarantined identity also reported for its variants, and one team's Slack failure stopping the next.
- Toleration tests catch a toleration recorded against a superseded baseline hash being counted.
- Task tests catch a second run on the same repository skipping the lock, and the beat task posting in anything but live mode.
- Command tests catch a repository name registered by two teams being picked silently.
- Story index tests also catch an oversized artifact or index being read into memory.
- Not checked: a preview run against real data, because the local database has no repository rows; the artifact download against live GitHub; the rendered baselines page.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The visual review README describes the digest, the attribution rule, the triage outcomes and the by-hand command.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5.1 orchestrating, Opus subagents implementing). Skills invoked: /writing-pr-descriptions, /stacking-prs, /simplify. The design was revised four times with the DRI before implementation: a notification ledger, lifecycle stages and stored evaluation tables were rejected for a stateless daily repeat; recovery and lapsed-quarantine notices were deferred; per-snapshot source-path capture in CI was built and then dropped once the story index of the existing artifact was shown to map every baseline identifier. A QA review found three defects (unknown mode posting live, one oversized line breaking a thread, the variant query loading obsolete baseline history), fixed before the PR opened. Review feedback from the DRI removed the settings block: env-var scope and a fixed shadow channel were premature and not tenant-fit, so the digest now runs the way stamphog's does. Bot reviews led to escaping the run type, bounding the artifact read, an expiry on the beat entry, and an ambiguity error in the command. Duplicate search on open PRs found nothing. Nothing in the diff draws on material outside this repository; test data is invented.

https://claude.ai/code/session_015kjvU2zz6C2XLpQzEHxMNr
