### PR TITLE
fix(aio): stop the shared logic rewriting other scenes' URLs on mount

### DIFF
--- a/products/ai_observability/frontend/aiObservabilitySharedLogic.test.ts
+++ b/products/ai_observability/frontend/aiObservabilitySharedLogic.test.ts
@@ -1,7 +1,11 @@
+import { MOCK_DEFAULT_TEAM } from 'lib/api.mock'
+
+import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 import { runInThisContext } from 'node:vm'
 
 import { productSetupStatusLogic } from 'lib/components/ProductEmptyState/productSetupStatusLogic'
+import { urls } from 'scenes/urls'
 
 import { ProductKey } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
@@ -103,6 +107,40 @@ describe('aiObservabilitySharedLogic', () => {
             expect(payload.dateFrom).toBe('-30d')
             expect(payload.dateTo).toBe('-1d')
             expect(payload.shouldFilterTestAccounts).toBe(true)
+        })
+    })
+
+    // A DataTable `person` cell mounts this logic on any scene, so a URL write on mount lands there.
+    describe('test-account default and the URL', () => {
+        beforeEach(() => {
+            jest.clearAllMocks()
+            mockHasRecentAIEvents.mockResolvedValue(false)
+            initKeaTests(true, { ...MOCK_DEFAULT_TEAM, test_account_filters_default_checked: true })
+        })
+
+        it("leaves another scene's URL alone when mounted there", async () => {
+            const drillDown = { kind: 'DataTableNode', source: { kind: 'ActorsQuery', select: ['person'] } }
+            router.actions.push(urls.insightNew({ query: drillDown as any }))
+            const { pathname, search, hash } = router.values.location
+
+            const logic = aiObservabilitySharedLogic()
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.shouldFilterTestAccounts).toBe(false)
+            expect(router.values.location).toMatchObject({ pathname, search, hash })
+        })
+
+        it('applies the default on its own route without dropping the hash', async () => {
+            router.actions.push(urls.aiObservabilityTraces(), {}, { panel: 'max' })
+
+            const logic = aiObservabilitySharedLogic()
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.shouldFilterTestAccounts).toBe(true)
+            expect(router.values.searchParams.filter_test_accounts).toBe(true)
+            expect(router.values.hashParams.panel).toBe('max')
         })
     })
 

--- a/products/ai_observability/frontend/aiObservabilitySharedLogic.ts
+++ b/products/ai_observability/frontend/aiObservabilitySharedLogic.ts
@@ -597,9 +597,14 @@ export const aiObservabilitySharedLogic = kea<aiObservabilitySharedLogicType>([
                     ? date_to
                     : INITIAL_DATE_TO
                 : values.dateFilter.dateTo
-            const filterTestAccountsValue = [true, 'true', 1, '1'].includes(
-                filter_test_accounts as string | number | boolean
-            )
+            // A DataTable `person` cell mounts this logic on whatever scene renders it, so the team
+            // default is applied only once a route of this product matches. Applying it on mount would
+            // write this product's params over that scene's URL and drop its `#q=` state.
+            const filterTestAccountsValue =
+                filter_test_accounts === undefined && !cache.enteredAIObservabilityRoute
+                    ? values.filterTestAccountsDefault
+                    : [true, 'true', 1, '1'].includes(filter_test_accounts as string | number | boolean)
+            markAIObservabilityRouteEntered()
             const newSearchQuery = typeof trace_search === 'string' ? trace_search : ''
 
             const filtersChanged = !objectsEqual(parsedFilters, values.propertyFilters)
@@ -631,9 +636,17 @@ export const aiObservabilitySharedLogic = kea<aiObservabilitySharedLogicType>([
                             cleanParams[key] = value
                         }
                     }
-                    router.actions.replace(router.values.location.pathname, cleanParams)
+                    router.actions.replace(router.values.location.pathname, cleanParams, router.values.hashParams)
                 }
             }
+        }
+
+        function markAIObservabilityRouteEntered(): void {
+            if (cache.enteredAIObservabilityRoute) {
+                return
+            }
+            cache.enteredAIObservabilityRoute = true
+            globalSetupLogic.findMounted()?.actions.markTaskAsCompleted(SetupTaskId.TrackCosts)
         }
 
         function clearDashboardTimer(): void {
@@ -750,6 +763,7 @@ export const aiObservabilitySharedLogic = kea<aiObservabilitySharedLogicType>([
                     trace_search:
                         (searchQuery ?? (router.values.searchParams.trace_search as string | undefined)) || undefined,
                 },
+                router.values.hashParams,
             ],
             setPropertyFilters: ({ propertyFilters }) => [
                 router.values.location.pathname,
@@ -757,6 +771,7 @@ export const aiObservabilitySharedLogic = kea<aiObservabilitySharedLogicType>([
                     ...sharedSearchParams(),
                     filters: propertyFilters.length > 0 ? propertyFilters : undefined,
                 },
+                router.values.hashParams,
             ],
             setDates: ({ dateFrom, dateTo }) => [
                 router.values.location.pathname,
@@ -765,6 +780,7 @@ export const aiObservabilitySharedLogic = kea<aiObservabilitySharedLogicType>([
                     date_from: dateFrom === INITIAL_EVENTS_DATE_FROM ? undefined : dateFrom || undefined,
                     date_to: dateTo || undefined,
                 },
+                router.values.hashParams,
             ],
             setDashboardDates: ({ dateFrom, dateTo }) => [
                 router.values.location.pathname,
@@ -773,6 +789,7 @@ export const aiObservabilitySharedLogic = kea<aiObservabilitySharedLogicType>([
                     date_from: dateFrom ?? 'all',
                     date_to: dateTo || undefined,
                 },
+                router.values.hashParams,
             ],
             setShouldFilterTestAccounts: ({ shouldFilterTestAccounts }) => [
                 router.values.location.pathname,
@@ -780,6 +797,7 @@ export const aiObservabilitySharedLogic = kea<aiObservabilitySharedLogicType>([
                     ...sharedSearchParams(),
                     filter_test_accounts: shouldFilterTestAccounts ? 'true' : undefined,
                 },
+                router.values.hashParams,
             ],
             setSearchQuery: ({ searchQuery }) => [
                 router.values.location.pathname,
@@ -787,6 +805,7 @@ export const aiObservabilitySharedLogic = kea<aiObservabilitySharedLogicType>([
                     ...sharedSearchParams(),
                     trace_search: searchQuery || undefined,
                 },
+                router.values.hashParams,
             ],
         }
     }),
@@ -822,12 +841,6 @@ export const aiObservabilitySharedLogic = kea<aiObservabilitySharedLogicType>([
 
         detectAIEventsIfProjectKnown()
         registerSetupPoll()
-        globalSetupLogic.findMounted()?.actions.markTaskAsCompleted(SetupTaskId.TrackCosts)
-
-        const urlHasTestAccountsParam = 'filter_test_accounts' in router.values.searchParams
-        if (!urlHasTestAccountsParam && values.filterTestAccountsDefault !== values.shouldFilterTestAccounts) {
-            actions.setShouldFilterTestAccounts(values.filterTestAccountsDefault)
-        }
     }),
 
     beforeUnmount(({ cache }) => {


### PR DESCRIPTION
## Problem

- Clicking "Open as new insight" on a funnel or trends drill-down showed the people table, then about a second later replaced it with the stock pageview trends chart. Teams with "Filter out internal and test users" on by default hit it on every drill-down; other teams never did.
- The events explorer, group pages, dashboards, person pages, and saved insights lost their URL state the same way whenever a data table with a `person` column rendered.
- The `person` column of every DataTable resolves to AI observability's `PersonColumnCell`, which reads `aiObservabilitySharedLogic` and so mounts it on whichever scene renders the table.
- On mount, that logic applied the team's test-account default and dispatched `setShouldFilterTestAccounts`.
- Its URL mapping returned the current pathname plus search params and no hash, so kea-router pushed `/insights/new?filter_test_accounts=true` and the `#q=` drill-down was gone.
- The insight scene reads a `/insights/new` push without a query as a request for a blank insight and builds the default trends query.
- The same mount hook also marked the "track costs" setup task complete on those unrelated pages.
- The push started firing outside AI observability when the tab-aware URL sync was replaced with plain `urlToAction` in #61990.

Supersedes #97984, which guards the insight scene against the push but leaves the URL at `/insights/new?filter_test_accounts=true` with no hash, and does nothing for the other affected pages.

## Changes

- Drill-down tables opened as a new insight stay on screen, and their `#q=` URL survives, whatever the team's test-account default.
- The events explorer and other pages that render a `person` column keep their search and hash state.
- The team's test-account default is applied from AI observability's own route handlers, once per mount, instead of from `afterMount`.
- Every URL write in the logic now carries `router.values.hashParams`, so AI observability pages keep hash state such as `#panel=max`.
- The "track costs" setup task completes once one of AI observability's routes matches, not when the logic mounts elsewhere.
- Nothing looks different on AI observability pages. The default still lands in the URL as `?filter_test_accounts=true` on first visit.

> [!NOTE]
> The `person` renderer registered for every DataTable still mounts this scene logic. That coupling is a follow-up; with this change a mount is harmless.

## How did you test this code?

Two cases added to `aiObservabilitySharedLogic.test.ts`. No existing test mounted the logic under a foreign URL, so neither could be a row in an existing block.

- Mounting on `/insights/new#q=...` with the team default on leaves pathname, search, and hash unchanged and the filter state off. This fails on master.
- Mounting on the traces route with `#panel=max` applies the default, writes the param, and keeps the hash. This guards the behavior the removed `afterMount` block provided, and fails if a mapping drops the hash again.

A throwaway jest case that landed a drill-down on `/insights/new` and then mounted the logic reproduced the flip on master and passed with this change for both team defaults. It is not in the PR because the two cases above cover the same regression at a lower level.

Not checked: the flow in a browser, and the events explorer page.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (Fable 5.1) in Claude Code, directed by the assignee. The root cause came from our own product analytics rather than from the insight scene code: the post-flip URLs carried `?filter_test_accounts=true`, and the "track costs" task fired on pages outside AI observability, which pointed at this logic's mount hook.

- Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, `/reviewing-with-coderabbit`.
- CodeRabbit pass is paused, so the PR opened without a local pass.
- Duplicate search found #97984 as the only related open PR; it treats the symptom in the insight scene, so this one is still needed.
- Ran locally: the AI observability jest suites for the shared logic, the scene logic, the sessions empty state, and the cluster logics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
