### PR TITLE
fix(mcp): remove stale keepalive reference

### DIFF
--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -44,9 +44,8 @@ const RATE_LIMIT_TOTAL_WAIT_BUDGET_MS = 30_000
 const SSE_DEFAULT_TIMEOUT_MS = 10 * 60 * 1000
 
 // Per-read inactivity timeout: if no chunk (not even a keepalive comment) arrives
-// within this window, the server is assumed dead. Must comfortably exceed the
-// server-side keepalive interval — kept in sync with `SSE_KEEPALIVE_INTERVAL = 15s`
-// in `ee/api/session_summaries.py`. If you change one, check the other.
+// within this window, the server is assumed dead. It must comfortably exceed
+// expected server keepalive intervals.
 const SSE_READ_TIMEOUT_MS = 30_000
 
 // Page size for the `query-*-actors` tools. The ceiling bounds how much of a caller's context


### PR DESCRIPTION
## Problem

- MCP maintainers could update a timeout based on a deleted endpoint reference.
- Why: stale guidance makes future timeout changes harder to review.

## Changes

- The client now states the durable requirement for its inactivity timeout.
- This comment-only change has no user-visible behavior change.

## How did you test this code?

- `pnpm --dir services/mcp lint`
- `pnpm --dir services/mcp format:check`
- No runtime test applies because the change only updates a comment.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No docs update is needed because this does not change a user-facing workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Checked the linked Inbox report and the current code. No matching open issue or PR exists.
- Invoked `/inbox-exploration`, `/writing-code-comments`, and `/writing-pr-descriptions`.
- The changed comment is not runtime code, so patch coverage does not apply.
- The public diff contains no private session material.
- CodeRabbit local pass is paused.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0C0LU050GN/p1789092806674729?thread_ts=1789092806.674729&cid=C0C0LU050GN)*