### PR TITLE
fix(instagram): say what to do when the credential probe fails

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instagram/instagram.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instagram/instagram.py
@@ -10,6 +10,8 @@ from structlog.types import FilteringBoundLogger
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 from urllib3.util.retry import Retry
 
+from posthog.exceptions_capture import capture_exception
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.typings import SourceResponse
@@ -688,8 +690,21 @@ def validate_credentials(
             "The Instagram connection is missing permissions this source needs. Reconnect it and grant "
             "access to your page, Instagram insights and comments."
         )
-    except Exception:
-        return False, "Could not reach the Instagram API with this connection."
+    except (InstagramRetryableError, InstagramRequestBudgetError):
+        return False, "Instagram is busy or temporarily unavailable. Wait a few minutes and try again."
+    except InstagramBadRequestError:
+        return False, (
+            "Instagram rejected the request for that account. Check the account is an Instagram "
+            "professional account linked to your Facebook page, then try again."
+        )
+    except Exception as e:
+        # Anything left is a transport failure or a bug on our side. The probe returns a message
+        # rather than raising, so nothing above the source would record it otherwise.
+        capture_exception(e)
+        return (
+            False,
+            "PostHog couldn't check this Instagram connection. Reconnect your Instagram account and try again.",
+        )
 
     if not body.get("id"):
         return False, "That account is not an Instagram professional account. Pick a different account."

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instagram/tests/test_instagram.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instagram/tests/test_instagram.py
@@ -835,6 +835,32 @@ class TestValidateCredentials:
         assert is_valid is False
         assert message is not None and expected_fragment in message
 
+    @pytest.mark.parametrize(
+        "error,expected_fragment",
+        [
+            (InstagramRetryableError("Instagram API error (retryable): status=503"), "temporarily unavailable"),
+            (
+                InstagramRequestBudgetError("Instagram API request budget of 1 requests spent"),
+                "temporarily unavailable",
+            ),
+            (InstagramBadRequestError("Instagram API error: status=400, code=100"), "professional account"),
+            (RuntimeError("boom"), "Reconnect your Instagram account"),
+        ],
+    )
+    def test_remaining_failures_get_actionable_messages(self, error: Exception, expected_fragment: str) -> None:
+        # These all used to collapse into one message that named no next step, and the unexpected
+        # case was swallowed without being recorded anywhere.
+        with (
+            mock.patch.object(InstagramClient, "get", side_effect=error),
+            mock.patch(f"{MODULE}.capture_exception") as capture,
+        ):
+            is_valid, message = validate_credentials("tok", "v23.0", LOGGER, instagram_account_id=ACCOUNT_ID)
+
+        assert is_valid is False
+        assert message is not None and expected_fragment in message
+        assert str(error) not in message
+        assert capture.called is isinstance(error, RuntimeError)
+
     def test_a_node_without_an_id_is_not_a_professional_account(self) -> None:
         session = FakeSession([(ACCOUNT_ID, FakeResponse(200, {}))])
         with mock.patch(f"{MODULE}.make_tracked_session", return_value=session):


### PR DESCRIPTION
## Problem

Every unexpected failure in the Instagram credential probe came back as one sentence that named no next step, so someone who could not connect an account had nothing to act on. It covered four unrelated situations — a Meta outage or throttle, the request budget running out, a rejected account node, and a genuine transport failure or bug on our side — and the last of those was swallowed without being recorded anywhere, so we could not see it either.

## Changes

- A busy or unavailable Instagram now says so and tells the user to wait and retry, instead of implying their connection is wrong.
- A rejected account node now points at the actual requirement: the account has to be an Instagram professional account linked to a Facebook page.
- Anything left keeps a short reconnect message and is now sent to error tracking. The probe returns a message rather than raising, so nothing above the source recorded it before.
- No change to what counts as a valid connection, or to sync behaviour.

## How did you test this code?

Added `test_remaining_failures_get_actionable_messages`, covering the retryable, budget, bad-request, and unexpected branches. It catches two regressions no existing test did: a branch collapsing back into a single unactionable message, and the unexpected branch going unrecorded. It also asserts none of the messages leaks the raw Graph API detail. Ran `TestValidateCredentials` locally (15 passed). Not manually exercised in the wizard.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a day of failed source-creation attempts in the new-source wizard and classified each error message. This one fell into "message gives the user nothing to act on". Split the catch-all by the exception types the client already raises rather than inventing new ones, and kept the copy to what the reader can actually do.

- No duplicate: searched open PRs for the message text, the source path, and `instagram`, and listed the maintainer's own open PRs. Nothing covers this.
- Public artifact: the failure counts came from an analytics event. Nothing from it is committed — the test values are invented and the assertions use stable message fragments, not customer data.
- Agent: Claude Opus 5 via PostHog Desktop. Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-pr-descriptions`. CodeRabbit CLI pass is paused, so this opened without a local pass.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
