### PR TITLE
fix(github): say which value is missing when no access token is set

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/source.py
@@ -351,7 +351,7 @@ If automatic creation failed with a permissions error, the fix depends on how yo
             # Deterministic credential/config errors from _get_access_token and OAuthMixin.
             # These never resolve on retry — the source needs reconfiguring or reconnecting.
             "Missing GitHub integration ID": "No GitHub account is connected. Connect a GitHub account and try again.",
-            "Missing personal access token": "GitHub personal access token is not configured. Please update the source configuration.",
+            "Missing personal access token": "No GitHub personal access token is set. Enter one, or switch the authentication type to OAuth and connect a GitHub account.",
             "No repositories configured": "No repositories are selected for this source. Please update the source configuration.",
             "resolve to the same warehouse table": "Two selected repositories resolve to the same warehouse table. Please remove or rename one.",
             "Too many repositories configured": "Too many repositories are selected for this source. Please reduce the list and try again.",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_source_class.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_source_class.py
@@ -494,7 +494,10 @@ class TestGithubSource:
         "selection,expected_message",
         [
             ("oauth", "No GitHub account is connected. Connect a GitHub account and try again."),
-            ("pat", "GitHub personal access token is not configured. Please update the source configuration."),
+            (
+                "pat",
+                "No GitHub personal access token is set. Enter one, or switch the authentication type to OAuth and connect a GitHub account.",
+            ),
         ],
     )
     def test_validate_credentials_maps_config_errors_to_friendly_message(self, selection, expected_message):


### PR DESCRIPTION
## Problem

Someone who picks "Personal access token" in the GitHub source wizard and submits without filling the field in gets told the token "is not configured" and to "update the source configuration". In the new-source wizard there is no source to update yet, and the sentence never says what to do with the field in front of them. It is also the message shown in the sync error panel, where "update the source configuration" is equally vague about which value is missing.

The field is `required=False` on the backend config because the two authentication branches are flattened into one generated dataclass, so a required token would stop OAuth sources parsing. That means the wizard does not block an empty submit, and this message is the whole of what the reader gets.

## Changes

- The message is now `No GitHub personal access token is set. Enter one, or switch the authentication type to OAuth and connect a GitHub account.` — it names the missing value and gives both ways out, and reads correctly in the wizard (where no source exists) and in the sync error panel alike.
- Matches the shape of the sibling message on the other branch (`No GitHub account is connected. Connect a GitHub account and try again.`), so the same class of problem reads the same way.
- Copy only. No change to validation, sync behaviour, or the config schema.

## How did you test this code?

Updated the existing parametrized expectation in `test_validate_credentials_maps_config_errors_to_friendly_message`, which already covers both auth branches — no new test, since the regression it guards (the internal `Missing personal access token` string leaking instead of the mapped copy) is unchanged. Ran `test_github_source_class.py` locally (96 passed). Not manually exercised in the wizard.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a day of failed source-creation attempts in the new-source wizard. This one fell into "message written for the wrong context" — it directs the reader at a source that does not exist yet.

I looked at fixing the root cause instead, by marking the token field required so the wizard blocks an empty submit. That does not work as it stands: the generator turns `required=True` into a field with no default on the shared `GithubAuthMethodConfig`, which OAuth sources would then fail to parse. Making the generator force per-option fields optional would fix that, but several sources already rely on a required field nested under a select option, so it is a change to shared codegen that deserves its own PR rather than riding along here. Worth someone picking up — the same empty-branch submit is possible on every source that has an auth-method select.

- No duplicate: searched open PRs for the message text, the source path, and `github`/`personal access token` terms, and listed the maintainer's own open PRs. Nothing covers this.
- Public artifact: the failure counts came from an analytics event. Nothing from it is committed; this diff is two message strings.
- Agent: Claude Opus 5 via PostHog Desktop. Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`. CodeRabbit CLI pass is paused, so this opened without a local pass.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
