### PR TITLE
fix(clickhouse): classify a pyarrow mid-stream truncation as retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
@@ -355,6 +355,14 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
             # `_get_client`'s in-process retry never sees it; Temporal's activity retry
             # reopens a fresh tunnel + client and resumes from the last committed cursor.
             "Connection broken: IncompleteRead",
+            # pyarrow raises this `OSError` from its own IPC framing (not urllib3) when the
+            # connection carrying `query_arrow_stream` closes mid-message: the Arrow message
+            # header already promised a body length, and the stream delivered fewer bytes
+            # than that before ending. Same mid-transfer connection drop as
+            # "Connection broken: IncompleteRead" above, just detected one layer up, in
+            # pyarrow's message reader instead of urllib3. The byte counts vary; the
+            # "bytes for message body, got" wording is stable.
+            "bytes for message body, got",
             # requests/urllib3 raises this when the server accepts the connection but never
             # answers within our timeout — typically ClickHouse Cloud still cold-resuming an
             # idle service past our `METADATA_QUERY_TIMEOUT_SECONDS` allowance. Not in

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -730,6 +730,9 @@ class TestClickHouseSourceRetryableErrors:
             "('Connection broken: IncompleteRead(0 bytes read)', IncompleteRead(0 bytes read))",
             "('Connection broken: IncompleteRead(12345 bytes read, 67 more expected)', "
             "IncompleteRead(12345 bytes read, 67 more expected))",
+            # pyarrow's own IPC reader detects the same kind of mid-stream connection drop,
+            # one layer above urllib3, and raises OSError instead. Byte counts vary.
+            "Expected to be able to read 5226856 bytes for message body, got 5056408",
             # The server accepted the connection but never answered within our timeout —
             # typically ClickHouse Cloud still cold-resuming past our allowance.
             "Error HTTPSConnectionPool(host='play.clickhouse.com', port=8443): Read timed out. "


### PR DESCRIPTION
## Problem

- A ClickHouse table sync fails and reports an `OSError` to error tracking: "Expected to be able to read N bytes for message body, got M".
- The stack trace shows pyarrow's own IPC reader raising it while `get_rows` iterates `query_arrow_stream` in `products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py`.
- The connection carrying the Arrow stream closed mid-message, the same failure `ClickHouseSource.get_retryable_errors()` already recognizes as `"Connection broken: IncompleteRead"` when urllib3 detects it first. Here pyarrow's own message framing notices the short read instead, so the existing entry doesn't match and the transient blip gets reported as noise.

## Changes

- Add `"bytes for message body, got"` to `ClickHouseSource.get_retryable_errors()`, so this failure is logged as a warning and kept out of error tracking, the same treatment the sibling `IncompleteRead` entry already gets.
- Retry behavior is unchanged: `_handle_import_error` still re-raises as `NonReportableError`, and Temporal retries the activity, reopening a fresh connection and resuming from the last committed cursor.

## How did you test this code?

- Extended the existing parameterized case in `TestClickHouseSourceRetryableErrors.test_transient_errors_are_retryable` with the exact message shape from error tracking, alongside the sibling `IncompleteRead` case it mirrors.
- Ran `pytest products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py -k Retryable` — all 38 cases pass.
- `ruff check` and `ruff format --check` clean on both changed files.
- Not run: a live ClickHouse sync (no test infra for reproducing a real mid-stream connection drop).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing, API, or config change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code, triaging a webhook-delivered error tracking issue (OSError, `products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py`).
- Skills invoked: `/writing-pr-descriptions`, `/writing-tests`.
- Checked for duplicates: searched open PRs for this exception type, module path, and message text, and listed all open PRs from this automation's author. No open PR addresses this failure; the one PR touching the same file (#97144) covers a different, unrelated egress-proxy classification.
- No customer- or session-specific material in this PR. The byte counts in the test case are copied from the error-tracking event; they carry no host, credential, or account information.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*