### PR TITLE
feat(desktop): notify when a cloud task finishes or needs input

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/task-activity/taskActivity.contribution.test.ts
+++ b/products/desktop/packages/ui/src/features/canvas/task-activity/taskActivity.contribution.test.ts
@@ -10,6 +10,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TaskActivityContribution } from "./taskActivity.contribution";
 
 let activityListener: ((signal: TaskActivitySignal) => void) | undefined;
+const promptCompleteSpy = vi.fn();
+const permissionRequestSpy = vi.fn();
 const notificationBus = {
   subscribeToTaskActivity: vi.fn(
     (listener: (signal: TaskActivitySignal) => void) => {
@@ -17,7 +19,38 @@ const notificationBus = {
       return vi.fn();
     },
   ),
+  notifyPromptComplete: promptCompleteSpy,
+  notifyPermissionRequest: permissionRequestSpy,
 } as unknown as NotificationBus;
+
+function activityRow(
+  overrides: Partial<TaskActivityPage["results"][number]> = {},
+): TaskActivityPage["results"][number] {
+  return {
+    id: "activity-1",
+    task_id: "task-1",
+    task_title: "Nightly issue triage",
+    channel_id: null,
+    channel_name: null,
+    activity_at: "2026-07-27T09:00:00Z",
+    activity_kind: "completed",
+    snippet: "",
+    latest_author: null,
+    latest_message_id: null,
+    is_unread: true,
+    ...overrides,
+  };
+}
+
+function setFeed(
+  queryClient: QueryClient,
+  results: TaskActivityPage["results"],
+): void {
+  queryClient.setQueryData<InfiniteData<TaskActivityPage>>(["task-activity"], {
+    pages: [{ results, unread_count: 0 }],
+    pageParams: [undefined],
+  });
+}
 
 function task(overrides: Partial<Task> = {}): Task {
   return {
@@ -42,6 +75,67 @@ describe("TaskActivityContribution", () => {
     queryClient = new QueryClient();
     contribution = new TaskActivityContribution(notificationBus, queryClient);
     contribution.start();
+  });
+
+  it("raises a notification for agent activity that arrives from the cloud, once", () => {
+    queryClient.setQueryDefaults(["task-activity"], {
+      meta: AUTH_SCOPED_QUERY_META,
+    });
+    // The first page seeds what is already known; nothing in it is new.
+    setFeed(queryClient, [activityRow({ id: "activity-1" })]);
+    expect(promptCompleteSpy).not.toHaveBeenCalled();
+
+    setFeed(queryClient, [
+      activityRow({
+        id: "activity-2",
+        task_id: "task-2",
+        task_title: "Weekly PR digest",
+        activity_kind: "awaiting_input",
+        activity_at: "2026-07-27T10:00:00Z",
+      }),
+      activityRow({ id: "activity-1" }),
+    ]);
+    expect(permissionRequestSpy).toHaveBeenCalledTimes(1);
+    expect(permissionRequestSpy).toHaveBeenCalledWith(
+      "Weekly PR digest",
+      "task-2",
+      { source: "task_activity_feed", activityId: "activity-2" },
+    );
+
+    // A refetch with the same rows, and a row the user already read, stay quiet.
+    setFeed(queryClient, [
+      activityRow({
+        id: "activity-2",
+        task_id: "task-2",
+        activity_kind: "awaiting_input",
+        activity_at: "2026-07-27T10:00:00Z",
+      }),
+      activityRow({
+        id: "activity-3",
+        task_id: "task-3",
+        activity_at: "2026-07-27T11:00:00Z",
+        is_unread: false,
+      }),
+    ]);
+    expect(permissionRequestSpy).toHaveBeenCalledTimes(1);
+    expect(promptCompleteSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not re-raise a local session's activity when its cloud row lands", () => {
+    queryClient.setQueryDefaults(["task-activity"], {
+      meta: AUTH_SCOPED_QUERY_META,
+    });
+    setFeed(queryClient, []);
+    activityListener?.({
+      taskId: "task-1",
+      taskTitle: "Channel task",
+      activityKind: "completed",
+      activityAt: "2026-07-27T10:00:00Z",
+    });
+    setFeed(queryClient, [
+      activityRow({ id: "server-1", activity_at: "2026-07-27T09:59:58Z" }),
+    ]);
+    expect(promptCompleteSpy).not.toHaveBeenCalled();
   });
 
   it("shows task activity immediately when its backend projection is not available yet", () => {

--- a/products/desktop/packages/ui/src/features/canvas/task-activity/taskActivity.contribution.ts
+++ b/products/desktop/packages/ui/src/features/canvas/task-activity/taskActivity.contribution.ts
@@ -1,5 +1,9 @@
 import type { Contribution } from "@posthog/di/contribution";
-import type { Task, TaskActivityPage } from "@posthog/shared/domain-types";
+import type {
+  Task,
+  TaskActivity,
+  TaskActivityPage,
+} from "@posthog/shared/domain-types";
 import {
   NotificationBus,
   type TaskActivitySignal,
@@ -15,6 +19,11 @@ import { TASK_ACTIVITY_QUERY_KEY } from "./taskActivityQuery";
 
 @injectable()
 export class TaskActivityContribution implements Contribution {
+  // Newest activity_at seen per task, so a refetch never re-raises a row and
+  // the cloud projection of a locally notified run stays quiet.
+  private readonly seenAt = new Map<string, string>();
+  private seeded = false;
+
   constructor(
     @inject(NotificationBus)
     private readonly notificationBus: NotificationBus,
@@ -26,9 +35,49 @@ export class TaskActivityContribution implements Contribution {
     this.notificationBus.subscribeToTaskActivity((signal) => {
       this.apply(signal);
     });
+    this.queryClient.getQueryCache().subscribe((event) => {
+      if (event.type !== "updated") return;
+      if (event.query.queryHash !== JSON.stringify(TASK_ACTIVITY_QUERY_KEY))
+        return;
+      const data = event.query.state.data as
+        | InfiniteData<TaskActivityPage>
+        | undefined;
+      const rows = data?.pages[0]?.results;
+      if (rows) this.raiseNewRows(rows);
+    });
+  }
+
+  private raiseNewRows(rows: TaskActivity[]): void {
+    const seeding = !this.seeded;
+    this.seeded = true;
+    for (const row of rows) {
+      const last = this.seenAt.get(row.task_id);
+      if (last !== undefined && row.activity_at <= last) continue;
+      this.seenAt.set(row.task_id, row.activity_at);
+      if (seeding || !row.is_unread) continue;
+      // Cloud runs have no local session to notify from, so the feed poll is
+      // the only signal Desktop gets that an agent finished or stopped for input.
+      const debug = { source: "task_activity_feed", activityId: row.id };
+      if (row.activity_kind === "completed") {
+        this.notificationBus.notifyPromptComplete(
+          row.task_title,
+          "end_turn",
+          row.task_id,
+          undefined,
+          debug,
+        );
+      } else if (row.activity_kind === "awaiting_input") {
+        this.notificationBus.notifyPermissionRequest(
+          row.task_title,
+          row.task_id,
+          debug,
+        );
+      }
+    }
   }
 
   private apply(signal: TaskActivitySignal): void {
+    this.seenAt.set(signal.taskId, signal.activityAt);
     const activityQuery = this.queryClient.getQueryCache().find({
       queryKey: TASK_ACTIVITY_QUERY_KEY,
       exact: true,


### PR DESCRIPTION
## Problem

When an agent task finishes or stops for input in the cloud, the Desktop owner gets no notification. The row lands in the Activity feed and the badge updates, but nothing is raised. Local sessions notify; cloud runs, including every loop run, stay silent.

## Changes

- Desktop now raises the same notification for a cloud run as for a local one: a toast when the app is focused elsewhere, a native banner when it is not, and the completion sound. Clicking it opens the task.
- The task activity contribution watches the feed poll for new unread "completed" and "awaiting input" rows and hands them to the existing `notifyPromptComplete` / `notifyPermissionRequest` producers.
- The first page after boot is seeded silently, a refetch never re-raises a row, and a run already notified from a local session is not raised again when its cloud row arrives.

No visible change until a cloud task finishes; the notification itself is the existing one.

## How did you test this code?

- `taskActivity.contribution.test.ts` covers a new unread row raising once, a refetch and a read row staying quiet, and a locally notified run not being re-raised by its cloud row.
- Not checked: a live run in the Desktop dev app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code, with `/writing-pr-descriptions`. The session first built a workflow notify step and a Desktop poller on the notifications API, then found that API is session-only and that cloud task completions already project into the task activity feed. The change shrank to this contribution. CodeRabbit local pass is paused, so the PR opened without one.

https://claude.ai/code/session_01RQ928F9ufxwQwP3XBiDwVw
