### PR TITLE
fix(migrations): tolerate a missing persistedfolder table in 1349

### DIFF
--- a/posthog/migrations/1349_delete_persistedfolder_from_state.py
+++ b/posthog/migrations/1349_delete_persistedfolder_from_state.py
@@ -16,10 +16,12 @@ class Migration(migrations.Migration):
                 # Django no longer knows the table, so it cannot include it when tests truncate
                 # posthog_team and posthog_user, and Postgres refuses to truncate a table a foreign
                 # key points to. Both statements are IF EXISTS, so a bin/migrate retry is a no-op.
+                # The table is IF EXISTS too: 1351 drops it with a no-op reverse, so a migration test
+                # that rewinds past 1351 and replays forward reaches this step with no table.
                 migrations.RunSQL(
                     sql="""
-                        ALTER TABLE posthog_persistedfolder DROP CONSTRAINT IF EXISTS posthog_persistedfolder_team_id_a8bb8f3e_fk_posthog_team_id;
-                        ALTER TABLE posthog_persistedfolder DROP CONSTRAINT IF EXISTS posthog_persistedfolder_user_id_dee73fbd_fk_posthog_user_id;
+                        ALTER TABLE IF EXISTS posthog_persistedfolder DROP CONSTRAINT IF EXISTS posthog_persistedfolder_team_id_a8bb8f3e_fk_posthog_team_id;
+                        ALTER TABLE IF EXISTS posthog_persistedfolder DROP CONSTRAINT IF EXISTS posthog_persistedfolder_user_id_dee73fbd_fk_posthog_user_id;
                     """,
                     reverse_sql=migrations.RunSQL.noop,
                 ),


### PR DESCRIPTION
## Problem

- Any migration test that rewinds past `posthog.1351` fails in teardown with `relation "posthog_persistedfolder" does not exist` ([example run](https://github.com/PostHog/posthog/actions/runs/34584866401/job/103217227807)).
- `posthog.1351` drops the table with a no-op reverse, so a rewind leaves the table gone.
- Replaying forward then runs `posthog.1349`, whose `ALTER TABLE posthog_persistedfolder DROP CONSTRAINT IF EXISTS ...` guards the constraint but not the table.
- [#99099](https://github.com/PostHog/posthog/pull/99099) removes the one test that hits this today. This PR removes the trap for the next one.

## Changes

- `posthog.1349` now runs `ALTER TABLE IF EXISTS`, so the step is a no-op when the table is already gone.
- Nothing user-visible changes. The migration is already applied on every environment, and Django does not checksum migration files, so the edit is safe.
- Same pattern as `posthog.1068`.

## How did you test this code?

- Not run locally: this machine has no database. The migration risk analysis and fresh-schema jobs run on this PR.
- Not checked: a rewind-and-replay across `1351`, because the only test that does one is deleted in [#99099](https://github.com/PostHog/posthog/pull/99099).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: Claude Code via PostHog Desktop.
- Skills invoked: `/django-migrations`, `/writing-pr-descriptions`, `/reviewing-with-coderabbit`.
- Duplicate check: no open PR touches `1349_delete_persistedfolder_from_state.py`.
- CodeRabbit pass is paused, so the PR opened without a local pass.
- No customer or session material is in this PR.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
