### PR TITLE
fix(cloudflare): skip zones that reject the legacy firewall rules API

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/settings.py
@@ -67,17 +67,22 @@ CLOUDFLARE_ENDPOINTS: dict[str, CloudflareEndpointConfig] = {
         parent_key="_zone_id",
     ),
     # --- Zone-scoped security configuration ---
+    # Cloudflare deprecated the legacy Firewall Rules API (and the Filters API its rules
+    # reference) in favor of the Ruleset Engine; a zone that has moved to WAF custom rules
+    # gets a 400 on both rather than an empty list. Same shape as `rate_limits` below.
     "firewall_rules": CloudflareEndpointConfig(
         name="firewall_rules",
         path="/zones/{zone_id}/firewall/rules",
         parent=ZONES_PARENT,
         parent_key="_zone_id",
+        extra_skip_status_codes=(400,),
     ),
     "filters": CloudflareEndpointConfig(
         name="filters",
         path="/zones/{zone_id}/filters",
         parent=ZONES_PARENT,
         parent_key="_zone_id",
+        extra_skip_status_codes=(400,),
     ),
     "rulesets": CloudflareEndpointConfig(
         name="rulesets",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/tests/test_cloudflare_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/tests/test_cloudflare_client.py
@@ -231,12 +231,18 @@ class TestZoneFanout:
 
     @pytest.mark.parametrize(
         ("endpoint", "status_code"),
-        [("rate_limits", 410), ("custom_certificates", 400)],
+        [
+            ("rate_limits", 410),
+            ("custom_certificates", 400),
+            ("firewall_rules", 400),
+            ("filters", 400),
+        ],
     )
     @mock.patch(CLIENT_SESSION_PATCH)
     def test_skips_zone_missing_plan_feature_and_continues(self, MockSession, endpoint, status_code) -> None:
         # Cloudflare returns a non-403/404 error when a zone's plan doesn't include a
-        # feature (e.g. legacy rate limiting is 410 Gone, custom certs are 400) rather
+        # feature, or when it has moved off a deprecated API (legacy rate limiting is
+        # 410 Gone, custom certs and the legacy firewall rules/filters are 400), rather
         # than an empty list — one such zone must not abort the whole stream.
         session = MockSession.return_value
         _wire(


### PR DESCRIPTION
## Problem

- A Cloudflare source's `firewall_rules` table fails on every run for teams that hold a mix of zones, and the sync error they read is a bare HTTP status with an API URL in it.
- Cloudflare deprecated the legacy Firewall Rules API, and the Filters API its rules reference, in favor of the Ruleset Engine. A zone that moved to WAF custom rules answers 400 instead of an empty list.
- The per-zone fan-out only ignores 403 and 404, so one such zone aborts the whole stream. Every other zone the token can read syncs nothing.
- Nothing rewrites the stored message either, so the failure is retried to the activity limit and then shown raw.

## Changes

- The table now syncs the zones that still serve the legacy API, and silently skips the ones that do not. No error, no disabled table.
- `firewall_rules` and `filters` get `extra_skip_status_codes=(400,)`. That field exists for this case, and `rate_limits` already uses it for the 410 the legacy Rate Limiting API returns.
- Both endpoints move together because a legacy firewall rule references a filter, so a zone that rejects one rejects the other.
- Nothing user-visible changes for a zone that does serve the API.

> [!NOTE]
> A zone skipped this way contributes no rows, the same as a zone the token cannot read. Legacy firewall rules that a zone has migrated are available through the `rulesets` table.

## How did you test this code?

- Extended `test_skips_zone_missing_plan_feature_and_continues` with both endpoints, which asserts one zone's 400 leaves the following zone's rows in the stream. No existing case covered these two endpoints, so a 400 on either failed the whole fan-out.
- Ran the Cloudflare client suite locally.
- Not run: the Temporal end-to-end suite, since this sandbox has no dev stack.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The endpoint catalog and table list do not change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged from a daily ranking of `ExternalDataJob.latest_error` failure classes. This class covered a small number of teams, and its stored error was one of the few left as a raw HTTP status.
- No duplicate: searched open PRs for `cloudflare`, `firewall`, and the source module path, and listed every open PR by the maintainer. None touch this source's endpoint catalog or its fan-out skip behavior.
- Public artifact: the diff, the tests and this description carry no material from the triage session. The failure was reproduced against the existing test fixtures, which use invented zone ids.
- Skills invoked: `/writing-tests` before extending the test, `/writing-code-comments` for the endpoint comment, `/writing-pr-descriptions` for this body.
- CodeRabbit CLI pass: paused, so this PR opened without a local pass.
