### PR TITLE
fix(clerk): reject a secret key that can't be sent in a header

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/clerk.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/clerk.py
@@ -238,10 +238,20 @@ _FORBIDDEN_KEY_MESSAGE = (
     "Your Clerk secret key does not have permission to access this endpoint. Please check the "
     "key's permissions in your Clerk dashboard."
 )
+_UNSUPPORTED_CHARACTER_MESSAGE = (
+    "Your Clerk secret key contains a character that can't be sent to Clerk, such as an invisible "
+    "one pasted from another app. Copy the key again from your Clerk dashboard and reconnect."
+)
 
 
 def validate_credentials(secret_key: str) -> tuple[bool, str | None]:
     """Validate Clerk API credentials by making a test request."""
+    # The key rides in the Authorization header, which http.client encodes as latin-1. A character
+    # outside that range raises UnicodeEncodeError mid-request, so reject it as user input rather
+    # than letting the encoding error surface.
+    if not secret_key.isascii():
+        return False, _UNSUPPORTED_CHARACTER_MESSAGE
+
     url = "https://api.clerk.com/v1/users"
     headers = {
         "Authorization": f"Bearer {secret_key}",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/test_clerk.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/test_clerk.py
@@ -619,6 +619,17 @@ class TestClerkValidateCredentials:
             validate_credentials("sk_test_key")
         assert mock_capture.called is should_capture
 
+    @pytest.mark.parametrize("secret_key", ["sk_live_\u200bkey", "sk_live_\u3042key"])
+    def test_non_ascii_key_is_rejected_before_any_request(self, secret_key: str) -> None:
+        # Such a key can't be encoded into the Authorization header, so dispatching the request
+        # raises UnicodeEncodeError; the guard must catch it first and explain what to do.
+        with patch(_VALIDATE_SESSION) as mock_session:
+            is_valid, message = validate_credentials(secret_key)
+        assert is_valid is False
+        assert "Copy the key again" in (message or "")
+        assert "latin-1" not in (message or "")
+        mock_session.assert_not_called()
+
     def test_network_error_returns_actionable_message_without_leaking_exception(self) -> None:
         with patch(_VALIDATE_SESSION) as mock_session:
             mock_session.return_value.get.side_effect = RequestException("connection reset by peer")


### PR DESCRIPTION
## Problem

- Someone connecting a Clerk source with a secret key that carries a non-ASCII character cannot get past the setup screen, and sees no explanation.
- The key rides in the `Authorization` header, which `http.client` encodes as latin-1.
- A character outside that range raises `UnicodeEncodeError` inside the request, so validation never returns a verdict.
- Reported by error tracking: [issue 01a09025](https://us.posthog.com/project/2/error_tracking/01a09025-0754-78b0-b40a-42b19767e40a).

Such a character is usually invisible, for example a zero-width space picked up when the key is copied out of another app.

## Changes

- The setup screen now says the key contains a character that can't be sent, and to copy it again from the Clerk dashboard.
- Clerk credential validation checks `secret_key.isascii()` before it builds the request.
- The check runs first, so no request goes out for a key that cannot be encoded.
- A Clerk secret key is ASCII by construction, so this rejects nothing that could have worked.
- The Attio and Sentry sources already guard their credentials this way.
- No frontend change. The message renders in the existing source setup error area.

## How did you test this code?

- Added two cases to `TestClerkValidateCredentials`, one per character class (zero-width space, and a character outside latin-1).
- They catch the regression where a non-ASCII key reaches the header and raises `UnicodeEncodeError` instead of returning a message. No existing case covered a key that fails before the response is read.
- Ran the Clerk credential validation tests locally.
- Not run: the database-backed warehouse suites, because this sandbox has no database.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged from an error tracking issue delivered by webhook. Claude Code (Opus 5) read the issue and the Clerk source, then wrote the fix.
- Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`.
- CodeRabbit CLI pass: paused, so this PR opened without a local pass.
- No duplicate: searched open PRs for the exception type, "clerk", and the maintainer's own open PRs. Nothing covers this code path.
- Decision: treated as a bug rather than a `NonRetryableErrors` entry. The failure happens at setup, before a sync exists, and the input is rejectable without a round trip.
- Public artifact: nothing in the diff comes from the session. The test keys are invented, and the message quotes no customer value.
