### PR TITLE
fix(desktop): require a per-target secret on the mcp proxy

### DIFF
--- a/products/desktop/packages/workspace-server/src/services/agent/auth-adapter.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/auth-adapter.test.ts
@@ -114,6 +114,7 @@ describe("AgentAuthAdapter", () => {
     expect(deps.mcpProxy.register).toHaveBeenCalledWith(
       "posthog",
       "https://mcp.posthog.com/mcp",
+      { identity: "https://app.posthog.com#1" },
     );
     expect(servers).toEqual(
       expect.arrayContaining([
@@ -222,7 +223,10 @@ describe("AgentAuthAdapter", () => {
       "installation-inst-2",
       "https://proxy.posthog.com/inst-2/",
       // An auth failure here is about the vendor's credential, not the user's PostHog token.
-      { credentialOwner: "installation" },
+      {
+        credentialOwner: "installation",
+        identity: "https://app.posthog.com#1",
+      },
     );
     expect(servers).toEqual(
       expect.arrayContaining([

--- a/products/desktop/packages/workspace-server/src/services/agent/auth-adapter.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/auth-adapter.test.ts
@@ -51,11 +51,10 @@ function createDependencies() {
     },
     mcpProxy: {
       start: vi.fn().mockResolvedValue(undefined),
-      register: vi
-        .fn()
-        .mockImplementation(
-          (id: string) => `http://127.0.0.1:9998/${encodeURIComponent(id)}`,
-        ),
+      register: vi.fn().mockImplementation((id: string) => ({
+        url: `http://127.0.0.1:9998/${encodeURIComponent(id)}`,
+        token: `proxy-token-${id}`,
+      })),
     },
     loggerFactory: {
       scope: () => ({
@@ -122,10 +121,18 @@ describe("AgentAuthAdapter", () => {
           name: "posthog",
           type: "http",
           url: "http://127.0.0.1:9998/posthog",
-          headers: expect.not.arrayContaining([
-            expect.objectContaining({ name: "Authorization" }),
+          headers: expect.arrayContaining([
+            expect.objectContaining({
+              name: "x-posthog-mcp-proxy-token",
+              value: "proxy-token-posthog",
+            }),
           ]),
         }),
+      ]),
+    );
+    expect(servers.find((s) => s.name === "posthog")?.headers).toEqual(
+      expect.not.arrayContaining([
+        expect.objectContaining({ name: "Authorization" }),
       ]),
     );
   });
@@ -222,7 +229,12 @@ describe("AgentAuthAdapter", () => {
         expect.objectContaining({
           name: "secure-server",
           url: "http://127.0.0.1:9998/installation-inst-2",
-          headers: [],
+          headers: expect.arrayContaining([
+            expect.objectContaining({
+              name: "x-posthog-mcp-proxy-token",
+              value: "proxy-token-installation-inst-2",
+            }),
+          ]),
         }),
       ]),
     );

--- a/products/desktop/packages/workspace-server/src/services/agent/auth-adapter.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/auth-adapter.ts
@@ -155,8 +155,12 @@ export class AgentAuthAdapter {
 
     await this.mcpProxy.start();
 
+    const identity = `${credentials.apiHost}#${credentials.projectId}`;
+
     if (mcpUrl) {
-      const proxiedPosthog = this.mcpProxy.register("posthog", mcpUrl);
+      const proxiedPosthog = this.mcpProxy.register("posthog", mcpUrl, {
+        identity,
+      });
 
       const posthogServer: McpServerConnection = {
         name: "posthog",
@@ -187,7 +191,7 @@ export class AgentAuthAdapter {
       const proxiedInstallation = this.mcpProxy.register(
         `installation-${installation.id}`,
         installation.proxy_url,
-        { credentialOwner: "installation" },
+        { credentialOwner: "installation", identity },
       );
       const server: McpServerConnection = {
         name,

--- a/products/desktop/packages/workspace-server/src/services/agent/auth-adapter.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/auth-adapter.ts
@@ -14,7 +14,10 @@ import { inject, injectable } from "inversify";
 import type { AuthProxyService } from "../auth-proxy/auth-proxy";
 import { AUTH_PROXY_SERVICE } from "../auth-proxy/identifiers";
 import { MCP_PROXY_SERVICE } from "../mcp-proxy/identifiers";
-import type { McpProxyService } from "../mcp-proxy/mcp-proxy";
+import {
+  MCP_PROXY_TOKEN_HEADER,
+  type McpProxyService,
+} from "../mcp-proxy/mcp-proxy";
 import { AGENT_AUTH, AGENT_LOGGER } from "./identifiers";
 import type { AgentAuth, AgentLogger, AgentScopedLogger } from "./ports";
 import type { Credentials } from "./schemas";
@@ -153,12 +156,12 @@ export class AgentAuthAdapter {
     await this.mcpProxy.start();
 
     if (mcpUrl) {
-      const proxiedPosthogUrl = this.mcpProxy.register("posthog", mcpUrl);
+      const proxiedPosthog = this.mcpProxy.register("posthog", mcpUrl);
 
       const posthogServer: McpServerConnection = {
         name: "posthog",
         type: "http",
-        url: proxiedPosthogUrl,
+        url: proxiedPosthog.url,
         headers: [
           {
             name: POSTHOG_PROJECT_ID_HEADER,
@@ -166,6 +169,7 @@ export class AgentAuthAdapter {
           },
           { name: "x-posthog-mcp-version", value: "2" },
           { name: "x-posthog-mcp-consumer", value: "posthog-code" },
+          { name: MCP_PROXY_TOKEN_HEADER, value: proxiedPosthog.token },
         ],
       };
       servers.push(posthogServer);
@@ -180,7 +184,7 @@ export class AgentAuthAdapter {
       const name =
         installation.name || installation.display_name || installation.url;
 
-      const proxiedUrl = this.mcpProxy.register(
+      const proxiedInstallation = this.mcpProxy.register(
         `installation-${installation.id}`,
         installation.proxy_url,
         { credentialOwner: "installation" },
@@ -188,8 +192,10 @@ export class AgentAuthAdapter {
       const server: McpServerConnection = {
         name,
         type: "http",
-        url: proxiedUrl,
-        headers: [],
+        url: proxiedInstallation.url,
+        headers: [
+          { name: MCP_PROXY_TOKEN_HEADER, value: proxiedInstallation.token },
+        ],
       };
       servers.push(server);
       serverInstallationIds.set(server, installation.id);

--- a/products/desktop/packages/workspace-server/src/services/mcp-proxy/mcp-proxy.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/mcp-proxy/mcp-proxy.test.ts
@@ -1,6 +1,6 @@
 import type { RootLogger } from "@posthog/di/logger";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { McpProxyService } from "./mcp-proxy";
+import { MCP_PROXY_TOKEN_HEADER, McpProxyService } from "./mcp-proxy";
 import type { McpProxyAuth } from "./ports";
 
 type AuthServiceMock = {
@@ -22,6 +22,12 @@ function createAuthServiceMock(): AuthServiceMock {
     }),
   };
 }
+
+const okJson = () =>
+  new Response('{"ok":true}', {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
 
 describe("McpProxyService", () => {
   let authServiceMock: AuthServiceMock;
@@ -52,11 +58,24 @@ describe("McpProxyService", () => {
     vi.restoreAllMocks();
   });
 
+  /** Fetch with the secret register() handed out, like a real transport. */
+  const authedFetch = (url: string, token: string, init?: RequestInit) =>
+    fetch(url, {
+      ...init,
+      headers: { ...init?.headers, [MCP_PROXY_TOKEN_HEADER]: token },
+    });
+
   describe("lifecycle", () => {
-    it("starts on a loopback port and returns a URL for register()", async () => {
+    it("starts on a loopback port and returns a URL and a secret for register()", async () => {
       await service.start();
-      const url = service.register("alpha", "https://upstream.example/path");
+      const { url, token } = service.register(
+        "alpha",
+        "https://upstream.example/path",
+      );
       expect(url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/alpha$/);
+      expect(token).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
     });
 
     it("throws from register() before start()", () => {
@@ -67,7 +86,7 @@ describe("McpProxyService", () => {
 
     it("handles concurrent start() calls without races", async () => {
       await Promise.all([service.start(), service.start(), service.start()]);
-      const url = service.register("alpha", "https://upstream.example");
+      const { url } = service.register("alpha", "https://upstream.example");
       expect(url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/alpha$/);
     });
 
@@ -81,13 +100,72 @@ describe("McpProxyService", () => {
     });
   });
 
+  describe("secret enforcement", () => {
+    it("rejects a request without the secret and never reaches the upstream", async () => {
+      authServiceMock.authenticatedFetch.mockResolvedValue(okJson());
+
+      await service.start();
+      const { url } = service.register("alpha", "https://upstream.example");
+
+      const res = await fetch(url);
+
+      expect(res.status).toBe(401);
+      expect(authServiceMock.authenticatedFetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects a request with the wrong secret, even one from another target", async () => {
+      authServiceMock.authenticatedFetch.mockResolvedValue(okJson());
+
+      await service.start();
+      const alpha = service.register("alpha", "https://upstream.example");
+      const bravo = service.register("bravo", "https://upstream.example");
+
+      const res = await authedFetch(alpha.url, bravo.token);
+
+      expect(res.status).toBe(401);
+      expect(authServiceMock.authenticatedFetch).not.toHaveBeenCalled();
+    });
+
+    it("invalidates the old secret when a target is re-registered", async () => {
+      authServiceMock.authenticatedFetch.mockResolvedValue(okJson());
+
+      await service.start();
+      const first = service.register("alpha", "https://upstream.example");
+      const second = service.register("alpha", "https://upstream.example");
+
+      const rejected = await authedFetch(first.url, first.token);
+      const accepted = await authedFetch(second.url, second.token);
+
+      expect(rejected.status).toBe(401);
+      expect(accepted.status).toBe(200);
+    });
+
+    it("answers the RFC 8414 discovery probe with 404 without a secret", async () => {
+      await service.start();
+      const { url } = service.register("alpha", "https://upstream.example");
+      const port = new URL(url).port;
+
+      const res = await fetch(
+        `http://127.0.0.1:${port}/.well-known/oauth-authorization-server`,
+      );
+
+      expect(res.status).toBe(404);
+      expect(authServiceMock.authenticatedFetch).not.toHaveBeenCalled();
+    });
+  });
+
   describe("request forwarding", () => {
     it("returns 404 for unknown targets", async () => {
       await service.start();
-      const proxyUrl = service.register("alpha", "https://upstream.example");
-      const unknownUrl = proxyUrl.replace("/alpha", "/bravo");
+      const { url, token } = service.register(
+        "alpha",
+        "https://upstream.example",
+      );
+      const unknownUrl = url.replace("/alpha", "/bravo");
 
-      const res = await fetch(unknownUrl);
+      const res = await fetch(unknownUrl, {
+        headers: { [MCP_PROXY_TOKEN_HEADER]: token },
+      });
 
       expect(res.status).toBe(404);
       expect(await res.text()).toBe("Unknown target");
@@ -95,37 +173,33 @@ describe("McpProxyService", () => {
     });
 
     it("forwards GET requests and returns the upstream body and status", async () => {
-      authServiceMock.authenticatedFetch.mockResolvedValue(
-        new Response('{"ok":true}', {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-      );
+      authServiceMock.authenticatedFetch.mockResolvedValue(okJson());
 
       await service.start();
-      const proxyUrl = service.register("alpha", "https://upstream.example");
+      const { url, token } = service.register(
+        "alpha",
+        "https://upstream.example",
+      );
 
-      const res = await fetch(proxyUrl);
+      const res = await authedFetch(url, token);
 
       expect(res.status).toBe(200);
       expect(await res.text()).toBe('{"ok":true}');
       expect(authServiceMock.authenticatedFetch).toHaveBeenCalledTimes(1);
-      const [url] = authServiceMock.authenticatedFetch.mock.calls[0];
-      expect(url).toBe("https://upstream.example");
+      const [fetchedUrl] = authServiceMock.authenticatedFetch.mock.calls[0];
+      expect(fetchedUrl).toBe("https://upstream.example");
     });
 
     it("passes a connection-lifetime signal so authenticatedFetch's default timeout does not apply", async () => {
-      authServiceMock.authenticatedFetch.mockResolvedValue(
-        new Response('{"ok":true}', {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-      );
+      authServiceMock.authenticatedFetch.mockResolvedValue(okJson());
 
       await service.start();
-      const proxyUrl = service.register("alpha", "https://upstream.example");
+      const { url, token } = service.register(
+        "alpha",
+        "https://upstream.example",
+      );
 
-      await fetch(proxyUrl);
+      await authedFetch(url, token);
 
       const [, options] = authServiceMock.authenticatedFetch.mock.calls[0];
       expect(options.signal).toBeInstanceOf(AbortSignal);
@@ -133,17 +207,15 @@ describe("McpProxyService", () => {
     });
 
     it("forwards POST body bytes to the upstream URL", async () => {
-      authServiceMock.authenticatedFetch.mockResolvedValue(
-        new Response('{"ok":true}', {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-      );
+      authServiceMock.authenticatedFetch.mockResolvedValue(okJson());
 
       await service.start();
-      const proxyUrl = service.register("alpha", "https://upstream.example");
+      const { url, token } = service.register(
+        "alpha",
+        "https://upstream.example",
+      );
 
-      await fetch(proxyUrl, {
+      await authedFetch(url, token, {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: '{"hello":"world"}',
@@ -163,18 +235,16 @@ describe("McpProxyService", () => {
       expect(forwardedHeaderKeys).not.toContain("transfer-encoding");
     });
 
-    it("strips Authorization and Host headers before forwarding", async () => {
-      authServiceMock.authenticatedFetch.mockResolvedValue(
-        new Response('{"ok":true}', {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-      );
+    it("strips Authorization, Host, and the proxy secret before forwarding", async () => {
+      authServiceMock.authenticatedFetch.mockResolvedValue(okJson());
 
       await service.start();
-      const proxyUrl = service.register("alpha", "https://upstream.example");
+      const { url, token } = service.register(
+        "alpha",
+        "https://upstream.example",
+      );
 
-      await fetch(proxyUrl, {
+      await authedFetch(url, token, {
         headers: {
           Authorization: "Bearer leaked",
           "X-Custom": "keep-me",
@@ -188,6 +258,7 @@ describe("McpProxyService", () => {
       expect(forwardedHeaderKeys).not.toContain("authorization");
       expect(forwardedHeaderKeys).not.toContain("host");
       expect(forwardedHeaderKeys).not.toContain("connection");
+      expect(forwardedHeaderKeys).not.toContain(MCP_PROXY_TOKEN_HEADER);
       expect(options.headers["x-custom"]).toBe("keep-me");
     });
 
@@ -200,32 +271,31 @@ describe("McpProxyService", () => {
       );
 
       await service.start();
-      service.register("alpha", "https://upstream.example/inst-2/");
-      const port = new URL(
-        service.register("alpha", "https://upstream.example/inst-2/"),
-      ).port;
+      const { url, token } = service.register(
+        "alpha",
+        "https://upstream.example/inst-2/",
+      );
 
-      await fetch(`http://127.0.0.1:${port}/alpha/tools/list`);
+      await authedFetch(`${url}/tools/list`, token);
 
-      const [url] = authServiceMock.authenticatedFetch.mock.calls.at(-1) ?? [];
-      expect(url).toBe("https://upstream.example/inst-2/tools/list");
+      const [fetchedUrl] =
+        authServiceMock.authenticatedFetch.mock.calls.at(-1) ?? [];
+      expect(fetchedUrl).toBe("https://upstream.example/inst-2/tools/list");
     });
 
     it("preserves the incoming query string on the upstream URL", async () => {
-      authServiceMock.authenticatedFetch.mockResolvedValue(
-        new Response("{}", {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-      );
+      authServiceMock.authenticatedFetch.mockResolvedValue(okJson());
 
       await service.start();
-      const proxyUrl = service.register("alpha", "https://upstream.example");
+      const { url, token } = service.register(
+        "alpha",
+        "https://upstream.example",
+      );
 
-      await fetch(`${proxyUrl}?token=abc&foo=bar`);
+      await authedFetch(`${url}?token=abc&foo=bar`, token);
 
-      const [url] = authServiceMock.authenticatedFetch.mock.calls[0];
-      expect(url).toBe("https://upstream.example?token=abc&foo=bar");
+      const [fetchedUrl] = authServiceMock.authenticatedFetch.mock.calls[0];
+      expect(fetchedUrl).toBe("https://upstream.example?token=abc&foo=bar");
     });
   });
 
@@ -238,17 +308,18 @@ describe("McpProxyService", () => {
             { status: 200, headers: { "content-type": "application/json" } },
           ),
         )
-        .mockResolvedValueOnce(
-          new Response('{"ok":true}', {
-            status: 200,
-            headers: { "content-type": "application/json" },
-          }),
-        );
+        .mockResolvedValueOnce(okJson());
 
       await service.start();
-      const proxyUrl = service.register("alpha", "https://upstream.example");
+      const { url, token } = service.register(
+        "alpha",
+        "https://upstream.example",
+      );
 
-      const res = await fetch(proxyUrl, { method: "POST", body: "payload" });
+      const res = await authedFetch(url, token, {
+        method: "POST",
+        body: "payload",
+      });
 
       expect(res.status).toBe(200);
       expect(await res.text()).toBe('{"ok":true}');
@@ -267,13 +338,16 @@ describe("McpProxyService", () => {
       );
 
       await service.start();
-      const proxyUrl = service.register(
+      const { url, token } = service.register(
         "installation-abc",
         "https://app.posthog.com/api/environments/1/mcp_server_installations/abc/proxy/",
         { credentialOwner: "installation" },
       );
 
-      const res = await fetch(proxyUrl, { method: "POST", body: "payload" });
+      const res = await authedFetch(url, token, {
+        method: "POST",
+        body: "payload",
+      });
 
       expect(res.status).toBe(401);
       expect(await res.text()).toBe('{"error":"Authentication failed"}');
@@ -296,9 +370,15 @@ describe("McpProxyService", () => {
       );
 
       await service.start();
-      const proxyUrl = service.register("alpha", "https://upstream.example");
+      const { url, token } = service.register(
+        "alpha",
+        "https://upstream.example",
+      );
 
-      const res = await fetch(proxyUrl, { method: "POST", body: "payload" });
+      const res = await authedFetch(url, token, {
+        method: "POST",
+        body: "payload",
+      });
 
       expect(res.status).toBe(403);
       expect(authServiceMock.refreshAccessToken).not.toHaveBeenCalled();
@@ -316,9 +396,15 @@ describe("McpProxyService", () => {
       );
 
       await service.start();
-      const proxyUrl = service.register("alpha", "https://upstream.example");
+      const { url, token } = service.register(
+        "alpha",
+        "https://upstream.example",
+      );
 
-      const res = await fetch(proxyUrl, { method: "POST", body: "payload" });
+      const res = await authedFetch(url, token, {
+        method: "POST",
+        body: "payload",
+      });
 
       expect(res.status).toBe(403);
       expect(authServiceMock.refreshAccessToken).not.toHaveBeenCalled();
@@ -326,17 +412,15 @@ describe("McpProxyService", () => {
     });
 
     it("does not retry when the body looks healthy", async () => {
-      authServiceMock.authenticatedFetch.mockResolvedValue(
-        new Response('{"ok":true}', {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-      );
+      authServiceMock.authenticatedFetch.mockResolvedValue(okJson());
 
       await service.start();
-      const proxyUrl = service.register("alpha", "https://upstream.example");
+      const { url, token } = service.register(
+        "alpha",
+        "https://upstream.example",
+      );
 
-      await fetch(proxyUrl);
+      await authedFetch(url, token);
 
       expect(authServiceMock.refreshAccessToken).not.toHaveBeenCalled();
       expect(authServiceMock.authenticatedFetch).toHaveBeenCalledTimes(1);
@@ -354,9 +438,12 @@ describe("McpProxyService", () => {
       );
 
       await service.start();
-      const proxyUrl = service.register("alpha", "https://upstream.example");
+      const { url, token } = service.register(
+        "alpha",
+        "https://upstream.example",
+      );
 
-      const res = await fetch(proxyUrl);
+      const res = await authedFetch(url, token);
 
       expect(res.headers.get("content-type")).toContain("text/event-stream");
       expect(await res.text()).toBe(sseBody);

--- a/products/desktop/packages/workspace-server/src/services/mcp-proxy/mcp-proxy.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/mcp-proxy/mcp-proxy.test.ts
@@ -154,6 +154,26 @@ describe("McpProxyService", () => {
       expect(accepted.status).toBe(200);
     });
 
+    it("rotates the secret when the identity changes, even on the same upstream", async () => {
+      // The forwarded request carries the current user's token, so a secret
+      // issued under one account or project must not outlive a switch.
+      authServiceMock.authenticatedFetch.mockResolvedValue(okJson());
+
+      await service.start();
+      const first = service.register("posthog", "https://mcp.example/mcp", {
+        identity: "https://app.posthog.com#42",
+      });
+      const second = service.register("posthog", "https://mcp.example/mcp", {
+        identity: "https://app.posthog.com#43",
+      });
+
+      const rejected = await authedFetch(first.url, first.token);
+      const accepted = await authedFetch(second.url, second.token);
+
+      expect(rejected.status).toBe(401);
+      expect(accepted.status).toBe(200);
+    });
+
     it("answers the RFC 8414 discovery probe with 404 without a secret", async () => {
       await service.start();
       const { url } = service.register("alpha", "https://upstream.example");

--- a/products/desktop/packages/workspace-server/src/services/mcp-proxy/mcp-proxy.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/mcp-proxy/mcp-proxy.test.ts
@@ -126,12 +126,26 @@ describe("McpProxyService", () => {
       expect(authServiceMock.authenticatedFetch).not.toHaveBeenCalled();
     });
 
-    it("invalidates the old secret when a target is re-registered", async () => {
+    it("keeps the secret when the target is re-registered with the same upstream", async () => {
+      // buildMcpServers runs on every session start and re-registers the same
+      // IDs, while live transports keep sending the token they were built with.
       authServiceMock.authenticatedFetch.mockResolvedValue(okJson());
 
       await service.start();
       const first = service.register("alpha", "https://upstream.example");
       const second = service.register("alpha", "https://upstream.example");
+
+      expect(second.token).toBe(first.token);
+      const res = await authedFetch(first.url, first.token);
+      expect(res.status).toBe(200);
+    });
+
+    it("rotates the secret when the upstream changes", async () => {
+      authServiceMock.authenticatedFetch.mockResolvedValue(okJson());
+
+      await service.start();
+      const first = service.register("alpha", "https://upstream.example");
+      const second = service.register("alpha", "https://other.example");
 
       const rejected = await authedFetch(first.url, first.token);
       const accepted = await authedFetch(second.url, second.token);

--- a/products/desktop/packages/workspace-server/src/services/mcp-proxy/mcp-proxy.ts
+++ b/products/desktop/packages/workspace-server/src/services/mcp-proxy/mcp-proxy.ts
@@ -115,8 +115,9 @@ export class McpProxyService {
   /**
    * Register a target URL under a stable ID. Returns the loopback URL to pass
    * to the MCP transport plus the secret that transport must send on every
-   * request. Subsequent registrations with the same ID overwrite the target
-   * and mint a fresh secret, invalidating any old one.
+   * request. Re-registering the same upstream keeps the secret, because live
+   * transports (open sessions, MCP App connections) still hold it; a changed
+   * upstream rotates it.
    */
   register(
     id: string,
@@ -126,10 +127,17 @@ export class McpProxyService {
     if (!this.port) {
       throw new Error("MCP proxy not started");
     }
-    const token = crypto.randomUUID();
+    const credentialOwner = options.credentialOwner ?? "posthog";
+    const existing = this.targets.get(id);
+    const token =
+      existing &&
+      existing.url === targetUrl &&
+      existing.credentialOwner === credentialOwner
+        ? existing.token
+        : crypto.randomUUID();
     this.targets.set(id, {
       url: targetUrl,
-      credentialOwner: options.credentialOwner ?? "posthog",
+      credentialOwner,
       token,
     });
     return {

--- a/products/desktop/packages/workspace-server/src/services/mcp-proxy/mcp-proxy.ts
+++ b/products/desktop/packages/workspace-server/src/services/mcp-proxy/mcp-proxy.ts
@@ -56,6 +56,7 @@ function isTokenMatch(provided: unknown, expected: string): boolean {
 interface McpProxyTarget {
   url: string;
   credentialOwner: McpProxyCredentialOwner;
+  identity: string;
   token: string;
 }
 
@@ -115,29 +116,36 @@ export class McpProxyService {
   /**
    * Register a target URL under a stable ID. Returns the loopback URL to pass
    * to the MCP transport plus the secret that transport must send on every
-   * request. Re-registering the same upstream keeps the secret, because live
-   * transports (open sessions, MCP App connections) still hold it; a changed
-   * upstream rotates it.
+   * request. Re-registering within the same `identity` keeps the secret,
+   * because live transports (open sessions, MCP App connections) still hold
+   * it. A changed upstream or identity rotates it, so a secret issued under
+   * one account or project cannot outlive a switch to another.
    */
   register(
     id: string,
     targetUrl: string,
-    options: { credentialOwner?: McpProxyCredentialOwner } = {},
+    options: {
+      credentialOwner?: McpProxyCredentialOwner;
+      identity?: string;
+    } = {},
   ): { url: string; token: string } {
     if (!this.port) {
       throw new Error("MCP proxy not started");
     }
     const credentialOwner = options.credentialOwner ?? "posthog";
+    const identity = options.identity ?? "";
     const existing = this.targets.get(id);
     const token =
       existing &&
       existing.url === targetUrl &&
-      existing.credentialOwner === credentialOwner
+      existing.credentialOwner === credentialOwner &&
+      existing.identity === identity
         ? existing.token
         : crypto.randomUUID();
     this.targets.set(id, {
       url: targetUrl,
       credentialOwner,
+      identity,
       token,
     });
     return {

--- a/products/desktop/packages/workspace-server/src/services/mcp-proxy/mcp-proxy.ts
+++ b/products/desktop/packages/workspace-server/src/services/mcp-proxy/mcp-proxy.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import http from "node:http";
 import {
   ROOT_LOGGER,
@@ -26,9 +27,11 @@ function truncateRequestBody(body: RequestInit["body"]): string | undefined {
  * this proxy we would either need to tear the transport down on every token
  * rotation (expensive, racy) or leave it serving stale tokens.
  *
- * The proxy only listens on 127.0.0.1 and strips inbound Authorization headers
- * before forwarding, but any local process can still use it to issue requests
- * on the user's behalf — acceptable for a single-user desktop app.
+ * The proxy only listens on 127.0.0.1, strips inbound Authorization headers
+ * before forwarding, and requires a per-target secret on every request, so a
+ * caller that did not receive the secret from register() (another local
+ * process, or a sandboxed MCP App reaching the loopback port) cannot reach the
+ * upstream with the user's credential attached.
  */
 /**
  * Whose credential an auth failure from a target is about.
@@ -40,9 +43,20 @@ function truncateRequestBody(body: RequestInit["body"]): string | undefined {
  */
 export type McpProxyCredentialOwner = "posthog" | "installation";
 
+export const MCP_PROXY_TOKEN_HEADER = "x-posthog-mcp-proxy-token";
+
+function isTokenMatch(provided: unknown, expected: string): boolean {
+  if (typeof provided !== "string") return false;
+  const providedBuf = Buffer.from(provided, "utf8");
+  const expectedBuf = Buffer.from(expected, "utf8");
+  if (providedBuf.length !== expectedBuf.length) return false;
+  return crypto.timingSafeEqual(providedBuf, expectedBuf);
+}
+
 interface McpProxyTarget {
   url: string;
   credentialOwner: McpProxyCredentialOwner;
+  token: string;
 }
 
 @injectable()
@@ -99,23 +113,29 @@ export class McpProxyService {
   }
 
   /**
-   * Register a target URL under a stable ID. Returns the loopback URL that
-   * should be passed to the MCP transport. Subsequent registrations with the
-   * same ID overwrite the target.
+   * Register a target URL under a stable ID. Returns the loopback URL to pass
+   * to the MCP transport plus the secret that transport must send on every
+   * request. Subsequent registrations with the same ID overwrite the target
+   * and mint a fresh secret, invalidating any old one.
    */
   register(
     id: string,
     targetUrl: string,
     options: { credentialOwner?: McpProxyCredentialOwner } = {},
-  ): string {
+  ): { url: string; token: string } {
     if (!this.port) {
       throw new Error("MCP proxy not started");
     }
+    const token = crypto.randomUUID();
     this.targets.set(id, {
       url: targetUrl,
       credentialOwner: options.credentialOwner ?? "posthog",
+      token,
     });
-    return `http://127.0.0.1:${this.port}/${encodeURIComponent(id)}`;
+    return {
+      url: `http://127.0.0.1:${this.port}/${encodeURIComponent(id)}`,
+      token,
+    };
   }
 
   @preDestroy()
@@ -157,6 +177,17 @@ export class McpProxyService {
       return;
     }
 
+    const providedToken = req.headers[MCP_PROXY_TOKEN_HEADER];
+    if (!isTokenMatch(providedToken, target.token)) {
+      this.log.warn("MCP proxy request rejected without a valid secret", {
+        id,
+        url: req.url,
+      });
+      res.writeHead(401);
+      res.end("Invalid proxy token");
+      return;
+    }
+
     const suffix = rest.join("/");
     const targetBase = target.url.replace(/\/+$/, "");
     const targetUrl =
@@ -165,6 +196,7 @@ export class McpProxyService {
     const strippedHeaders = new Set([
       "authorization",
       "proxy-authorization",
+      MCP_PROXY_TOKEN_HEADER,
       "content-length",
       "transfer-encoding",
     ]);


### PR DESCRIPTION
## Problem

- The desktop app runs a local helper that forwards MCP requests and adds the signed-in PostHog login to each one.
- The helper answered anyone who could reach it. Any other program on the machine could send requests through it in the user's name, and the user would never know.
- The cloud MCP relay already required a secret for the same reason; this helper did not.

## Changes

- Each target the helper serves now gets a random secret, created when it is registered.
- The helper only answers requests that carry the right secret. Everything else gets a 401 and nothing is forwarded.
- Re-registering a target with the same upstream and the same account keeps the secret, so open sessions and MCP App connections stay connected. A changed upstream or account rotates it.
- The helper removes the secret from a request before forwarding it, so it never travels further.
- The connections the app builds for PostHog and for installed MCP servers now include the secret, so all sessions and MCP Apps keep working as before.
- Mechanical: the existing proxy tests now send the secret. Nothing a user sees changes.

## How did you test this code?

- New tests in `mcp-proxy.test.ts` cover: a request without the secret is rejected and never forwarded, a secret from another target is rejected, re-registering with the same upstream keeps the secret while a changed upstream rotates it, and the OAuth discovery probe still gets a 404.
- `auth-adapter.test.ts` now checks that both connection builders attach the secret, and that the PostHog connection still carries no `Authorization` header.
- Ran locally: the affected vitest suites, the TypeScript check for `workspace-server`, and Biome.
- Not run: the database-backed suites. They fail on the base branch here too, this machine has no local database.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal to the desktop host, no documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent: pi coding agent (Claude). The DRI directed the work, chose the proxy-secret approach over a CSP change, and reviewed each step.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`. CodeRabbit local pass is paused, so this PR opened without one.
- Duplicate search: `gh pr list --state open --search "mcp proxy secret token"` found nothing that does this.
- A Greptile review found that re-registering a target rotated its secret and 401'd live transports from earlier sessions; `register()` now keeps the secret while the upstream is unchanged.