### PR TITLE
fix(ci): scope test-only product changes

### DIFF
--- a/.github/scripts/turbo-discover.js
+++ b/.github/scripts/turbo-discover.js
@@ -373,6 +373,17 @@ function getTestOnlyProducts(changedFiles, dependentsOf) {
     return [...products].sort()
 }
 
+// Whether this run may narrow to the changed products' test suites at all.
+// SELECTION_APPLIES keeps the shortcut off the merge queue and off a forced run,
+// and the DISABLE_BACKEND_TEST_SELECTION kill switch has to be read here too.
+// decideSelection returns early when runLegacy is false, before it reaches its
+// own `disabled` check, so a run this shortcut has already taken Django off
+// cannot be put back on the full matrices by the repo variable. Reading it here
+// keeps the promise the variable is documented with.
+function testOnlyNarrowingAllowed(env = process.env) {
+    return env.SELECTION_APPLIES === 'true' && env.SELECTION_DISABLED !== 'true'
+}
+
 // Rename detection stays off, the same way deletedProductPythonFiles turns it
 // off. Git reports a pure move as its new path alone, so a production module
 // moved into a test directory would read as a test-only change while the module
@@ -1336,6 +1347,7 @@ module.exports = {
     loadTachModuleGraph,
     tachDependents,
     getTestOnlyProducts,
+    testOnlyNarrowingAllowed,
     changedFilesSinceBase,
 }
 
@@ -1399,10 +1411,9 @@ if (legacyChanged) {
     const isolatedProducts = getIsolatedProducts(contractTasks)
     const affectedProducts = getAffectedTaskProducts(affectedTestTasks)
     const nonIsolatedAffectedProducts = affectedProducts.filter((p) => !isolatedProducts.has(p))
-    const testOnlyProducts =
-        process.env.SELECTION_APPLIES === 'true'
-            ? getTestOnlyProducts(changedFilesSinceBase() || [], tachFileDependents())
-            : null
+    const testOnlyProducts = testOnlyNarrowingAllowed()
+        ? getTestOnlyProducts(changedFilesSinceBase() || [], tachFileDependents())
+        : null
     const onlyAffectedProductTestsChanged =
         testOnlyProducts !== null &&
         testOnlyProducts.length === affectedProducts.length &&

--- a/.github/scripts/turbo-discover.js
+++ b/.github/scripts/turbo-discover.js
@@ -373,13 +373,21 @@ function getTestOnlyProducts(changedFiles, dependentsOf) {
     return [...products].sort()
 }
 
-function changedFilesSinceBase() {
+// Rename detection stays off, the same way deletedProductPythonFiles turns it
+// off. Git reports a pure move as its new path alone, so a production module
+// moved into a test directory would read as a test-only change while the module
+// it removed is still imported from elsewhere. The old path has to stay in the
+// list for that move to take the full fallback.
+function changedFilesSinceBase(repoRoot = process.cwd()) {
     const { TURBO_SCM_BASE: base, TURBO_SCM_HEAD: head } = process.env
     if (!base || !head) {
         return null
     }
     try {
-        return execFileSync('git', ['diff', '--name-only', `${base}...${head}`], TURBO_EXEC_OPTS)
+        return execFileSync('git', ['diff', '--name-only', '--no-renames', `${base}...${head}`], {
+            ...TURBO_EXEC_OPTS,
+            cwd: repoRoot,
+        })
             .split('\n')
             .filter(Boolean)
     } catch (error) {
@@ -1328,6 +1336,7 @@ module.exports = {
     loadTachModuleGraph,
     tachDependents,
     getTestOnlyProducts,
+    changedFilesSinceBase,
 }
 
 // --- Main ---

--- a/.github/scripts/turbo-discover.js
+++ b/.github/scripts/turbo-discover.js
@@ -334,6 +334,40 @@ function productOfFile(file) {
     return rest === undefined ? null : product
 }
 
+// A test-only change cannot change the product behavior that other products
+// consume. Keep this narrow: production code, test commands, and fixtures
+// outside a test directory still use the full non-isolated fallback.
+function getTestOnlyProducts(changedFiles) {
+    if (changedFiles.length === 0) {
+        return null
+    }
+
+    const products = new Set()
+    for (const file of changedFiles) {
+        const match = file.match(/^products\/([^/]+)\/(?:backend|stats)\/(?:[^/]+\/)*tests?(?:\/|$)/)
+        if (!match) {
+            return null
+        }
+        products.add(moduleToProduct(match[1]))
+    }
+    return [...products].sort()
+}
+
+function changedFilesSinceBase() {
+    const { TURBO_SCM_BASE: base, TURBO_SCM_HEAD: head } = process.env
+    if (!base || !head) {
+        return null
+    }
+    try {
+        return execFileSync('git', ['diff', '--name-only', `${base}...${head}`], TURBO_EXEC_OPTS)
+            .split('\n')
+            .filter(Boolean)
+    } catch (error) {
+        console.error(`Could not read changed files for test-only selection: ${error.message}`)
+        return null
+    }
+}
+
 // Collapse tach's file map ({ file: [files that import it] }) into
 // product -> [products it imports]. Keys and values are product directory
 // names (underscores); callers normalize to/from Turbo's dashed names. Every
@@ -1241,6 +1275,7 @@ module.exports = {
     productGraphFromTachMap,
     loadTachModuleGraph,
     tachDependents,
+    getTestOnlyProducts,
 }
 
 // --- Main ---
@@ -1303,12 +1338,22 @@ if (legacyChanged) {
     const isolatedProducts = getIsolatedProducts(contractTasks)
     const affectedProducts = getAffectedTaskProducts(affectedTestTasks)
     const nonIsolatedAffectedProducts = affectedProducts.filter((p) => !isolatedProducts.has(p))
+    const testOnlyProducts =
+        process.env.SELECTION_APPLIES === 'true' ? getTestOnlyProducts(changedFilesSinceBase() || []) : null
+    const onlyAffectedProductTestsChanged =
+        testOnlyProducts !== null &&
+        testOnlyProducts.length === affectedProducts.length &&
+        testOnlyProducts.every((product) => affectedProducts.includes(product))
 
     console.error(`Isolated products (have contract-check): ${JSON.stringify([...isolatedProducts].sort())}`)
     console.error(`Affected products: ${JSON.stringify(affectedProducts)}`)
     logAffectedReasons('backend:test', affectedTestTasks)
 
-    if (nonIsolatedAffectedProducts.length > 0) {
+    if (nonIsolatedAffectedProducts.length > 0 && onlyAffectedProductTestsChanged) {
+        console.error(`Only product test files changed: ${JSON.stringify(testOnlyProducts)} — Django can be skipped`)
+        products = affectedProducts
+        runLegacy = false
+    } else if (nonIsolatedAffectedProducts.length > 0) {
         // Non-isolated product changed — must test everything
         console.error(
             `Non-isolated products changed: ${JSON.stringify(nonIsolatedAffectedProducts)} — testing all products + Django`

--- a/.github/scripts/turbo-discover.js
+++ b/.github/scripts/turbo-discover.js
@@ -343,6 +343,10 @@ function productOfFile(file) {
 // the importers cannot be known, which widens the matrix the same way an
 // unreadable tach map does.
 //
+// A product test directory is also not always run by the product's own suite.
+// Some are run by a Django segment instead, so dropping Django would leave the
+// changed test running in no job at all. djangoOwnsFile keeps those out.
+//
 // Keep this narrow: production code, test commands, and fixtures outside a test
 // directory still use the full non-isolated fallback.
 function getTestOnlyProducts(changedFiles, dependentsOf) {
@@ -354,6 +358,12 @@ function getTestOnlyProducts(changedFiles, dependentsOf) {
     for (const file of changedFiles) {
         const match = file.match(/^products\/([^/]+)\/(?:backend|stats)\/(?:[^/]+\/)*tests?(?:\/|$)/)
         if (!match) {
+            return null
+        }
+        if (djangoOwnsFile(file)) {
+            console.error(
+                `${file} is run by the Django matrix, not by the ${match[1]} suite — testing all products + Django`
+            )
             return null
         }
         const dependents = dependentsOf(file)
@@ -1003,6 +1013,18 @@ function getSegmentDuration(segment, durations, ranNodeIds = null) {
         total += dur
     }
     return total
+}
+
+// Whether the Django matrix runs `file`, by the same prefix rules the segment
+// sizing uses. The table lists product paths as well as posthog/ and ee/, and a
+// product path in it is run by a Django segment rather than by that product's
+// own backend:test command, which targets its own test root and does not reach
+// this one. Such a file has to keep Django in the run.
+function djangoOwnsFile(file) {
+    return Object.values(DJANGO_SEGMENTS).some(
+        ({ include, exclude }) =>
+            include.some((prefix) => file.startsWith(prefix)) && !exclude.some((prefix) => file.startsWith(prefix))
+    )
 }
 
 // Fallback shard counts used when .test_durations is missing.

--- a/.github/scripts/turbo-discover.js
+++ b/.github/scripts/turbo-discover.js
@@ -335,9 +335,17 @@ function productOfFile(file) {
 }
 
 // A test-only change cannot change the product behavior that other products
-// consume. Keep this narrow: production code, test commands, and fixtures
-// outside a test directory still use the full non-isolated fallback.
-function getTestOnlyProducts(changedFiles) {
+// consume, with one exception: a test directory also holds the base classes and
+// the fixture data that other suites import, and those cross the product
+// boundary the same way production code does. `dependentsOf` answers who imports
+// a changed file, so a change to a shared helper takes the full fallback instead
+// of narrowing to the product that happens to own the file. It returns null when
+// the importers cannot be known, which widens the matrix the same way an
+// unreadable tach map does.
+//
+// Keep this narrow: production code, test commands, and fixtures outside a test
+// directory still use the full non-isolated fallback.
+function getTestOnlyProducts(changedFiles, dependentsOf) {
     if (changedFiles.length === 0) {
         return null
     }
@@ -346,6 +354,18 @@ function getTestOnlyProducts(changedFiles) {
     for (const file of changedFiles) {
         const match = file.match(/^products\/([^/]+)\/(?:backend|stats)\/(?:[^/]+\/)*tests?(?:\/|$)/)
         if (!match) {
+            return null
+        }
+        const dependents = dependentsOf(file)
+        if (dependents === null) {
+            console.error(`Cannot tell which suites import ${file} — testing all products + Django`)
+            return null
+        }
+        const outside = dependents.filter((dependent) => productOfFile(dependent) !== match[1])
+        if (outside.length > 0) {
+            console.error(
+                `${file} is imported from outside ${match[1]}: ${JSON.stringify(outside.slice(0, 5))} — testing all products + Django`
+            )
             return null
         }
         products.add(moduleToProduct(match[1]))
@@ -465,14 +485,26 @@ function tachDependents(changedProducts, moduleGraph, { direct = false } = {}) {
 // Turbo already selects.
 //
 // The run walks every Python file and takes seconds, so the result is kept per
-// process; a second caller gets the same graph, a failure included.
-const tachModuleGraphByRoot = new Map()
+// process; a second caller gets the same graph, a failure included. Both forms
+// are kept: the collapsed graph answers "which products depend on this product",
+// and the file map answers "which files import this file", which is what the
+// test-only shortcut needs. Both are cached together, so the collapse also runs
+// once per root.
+const tachMapByRoot = new Map()
+
+function loadTachMap(repoRoot) {
+    if (!tachMapByRoot.has(repoRoot)) {
+        tachMapByRoot.set(repoRoot, runTachMap(repoRoot))
+    }
+    return tachMapByRoot.get(repoRoot)
+}
 
 function loadTachModuleGraph(repoRoot = process.cwd()) {
-    if (!tachModuleGraphByRoot.has(repoRoot)) {
-        tachModuleGraphByRoot.set(repoRoot, runTachMap(repoRoot))
-    }
-    return tachModuleGraphByRoot.get(repoRoot)
+    return loadTachMap(repoRoot).graph
+}
+
+function loadTachFileMap(repoRoot = process.cwd()) {
+    return loadTachMap(repoRoot).fileMap
 }
 
 function runTachMap(repoRoot) {
@@ -481,13 +513,16 @@ function runTachMap(repoRoot) {
         raw = execFileSync('uv', ['run', '--no-project', TACH_MAP_SCRIPT], { ...TURBO_EXEC_OPTS, cwd: repoRoot })
     } catch (e) {
         console.error(`::warning::tach map failed (${e.message}) — the dependent cascade widens to every product`)
-        return null
+        return { fileMap: null, graph: null }
     }
     try {
-        return productGraphFromTachMap(JSON.parse(raw))
+        const fileMap = JSON.parse(raw)
+        // Collapsing here keeps "prints something that is not the map" a single
+        // null for both forms, rather than a parse that passes and a later throw.
+        return { fileMap, graph: productGraphFromTachMap(fileMap) }
     } catch (e) {
         console.error(`::warning::Could not parse the tach map (${e.message}) — the dependent cascade widens to every product`)
-        return null
+        return { fileMap: null, graph: null }
     }
 }
 
@@ -534,6 +569,23 @@ function tachDependentProducts(products, allProductSet) {
         return null
     }
     return tachDependents(products, tachGraph).filter((p) => allProductSet.has(p))
+}
+
+// Which files import `file`, per the tach map, or null when that cannot be known.
+// Two cases give null. Without the map there are no edges to read at all. A file
+// the head tree no longer has (the diff deleted it, or renamed it away) has no
+// edges left either, and an empty answer would read as "no suite imports this"
+// at exactly the moment a suite still does and can no longer import it.
+//
+// The map load stays lazy, so a run that never asks does not pay for the walk.
+function tachFileDependents(repoRoot = process.cwd()) {
+    return (file) => {
+        if (!fs.existsSync(path.join(repoRoot, file))) {
+            return null
+        }
+        const fileMap = loadTachFileMap(repoRoot)
+        return fileMap === null ? null : fileMap[file] || []
+    }
 }
 
 // Products a schema change reaches, [] for a purely additive change, or null when
@@ -1339,7 +1391,9 @@ if (legacyChanged) {
     const affectedProducts = getAffectedTaskProducts(affectedTestTasks)
     const nonIsolatedAffectedProducts = affectedProducts.filter((p) => !isolatedProducts.has(p))
     const testOnlyProducts =
-        process.env.SELECTION_APPLIES === 'true' ? getTestOnlyProducts(changedFilesSinceBase() || []) : null
+        process.env.SELECTION_APPLIES === 'true'
+            ? getTestOnlyProducts(changedFilesSinceBase() || [], tachFileDependents())
+            : null
     const onlyAffectedProductTestsChanged =
         testOnlyProducts !== null &&
         testOnlyProducts.length === affectedProducts.length &&

--- a/.github/scripts/turbo-discover.test.js
+++ b/.github/scripts/turbo-discover.test.js
@@ -11,11 +11,17 @@
 
 const test = require('node:test')
 const assert = require('node:assert/strict')
+const { execFileSync } = require('node:child_process')
 const fs = require('node:fs')
 const os = require('node:os')
 const path = require('node:path')
 
-const { DJANGO_SEGMENTS, getIsolatedProducts, getTestOnlyProducts } = require('./turbo-discover')
+const {
+    DJANGO_SEGMENTS,
+    getIsolatedProducts,
+    getTestOnlyProducts,
+    changedFilesSinceBase,
+} = require('./turbo-discover')
 
 const REPO_ROOT = path.join(__dirname, '..', '..')
 const WORKFLOWS = ['.github/workflows/ci-backend.yml', '.depot/workflows/ci-backend.yml']
@@ -196,4 +202,58 @@ test('test-only product changes select only their product suites', () => {
     )
     // No tach map, or a file the head tree no longer has: importers unknown.
     assert.equal(getTestOnlyProducts([base], () => null), null)
+})
+
+// Git reports a pure move as its new path alone, which reads as a test-only
+// change while the production module the move removed is still imported from
+// elsewhere. The pure-function cases above cannot see this: the hole is in the
+// diff that feeds them, so this one runs the real diff over a real move.
+test('a production module moved into a test directory is not a test-only change', () => {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'moved-into-test-'))
+    const git = (...args) => execFileSync('git', args, { cwd: repoRoot, encoding: 'utf-8' }).trim()
+    const write = (file) => {
+        fs.mkdirSync(path.join(repoRoot, path.dirname(file)), { recursive: true })
+        fs.writeFileSync(path.join(repoRoot, file), 'X = 1\n')
+    }
+    // commit-tree rather than commit, so the commits need no identity beyond the
+    // local config and no hook can refuse them.
+    const commit = (message, parent) => {
+        const parentArgs = parent ? ['-p', parent] : []
+        return git('commit-tree', git('write-tree'), ...parentArgs, '-m', message)
+    }
+
+    git('init', '-q', '.')
+    git('config', 'user.email', 'ci@example.com')
+    git('config', 'user.name', 'ci')
+    write('products/foo/backend/models/helper.py')
+    git('add', '-A')
+    const base = commit('add the helper')
+    fs.rmSync(path.join(repoRoot, 'products/foo/backend/models/helper.py'))
+    write('products/foo/backend/tests/helper.py')
+    git('add', '-A')
+    const head = commit('move the helper under tests', base)
+
+    const scm = { base: process.env.TURBO_SCM_BASE, head: process.env.TURBO_SCM_HEAD }
+    try {
+        process.env.TURBO_SCM_BASE = base
+        process.env.TURBO_SCM_HEAD = head
+        const changed = changedFilesSinceBase(repoRoot)
+        assert.deepEqual(changed.sort(), [
+            'products/foo/backend/models/helper.py',
+            'products/foo/backend/tests/helper.py',
+        ])
+        assert.equal(
+            getTestOnlyProducts(changed, () => []),
+            null
+        )
+    } finally {
+        for (const [name, value] of [['TURBO_SCM_BASE', scm.base], ['TURBO_SCM_HEAD', scm.head]]) {
+            if (value === undefined) {
+                delete process.env[name]
+            } else {
+                process.env[name] = value
+            }
+        }
+        fs.rmSync(repoRoot, { recursive: true, force: true })
+    }
 })

--- a/.github/scripts/turbo-discover.test.js
+++ b/.github/scripts/turbo-discover.test.js
@@ -161,13 +161,39 @@ test('isolation needs both the contract-check script and narrowed contract input
 })
 
 test('test-only product changes select only their product suites', () => {
+    const importedBy = (fileMap) => (file) => fileMap[file] || []
+    const nothingImportsIt = importedBy({})
+
     assert.deepEqual(
-        getTestOnlyProducts([
-            'products/experiments/backend/test/test_migration_0035.py',
-            'products/experiments/stats/tests/test_statistics.py',
-        ]),
+        getTestOnlyProducts(
+            [
+                'products/experiments/backend/test/test_migration_0035.py',
+                'products/experiments/stats/tests/test_statistics.py',
+            ],
+            nothingImportsIt
+        ),
         ['experiments']
     )
-    assert.equal(getTestOnlyProducts(['products/experiments/backend/models/experiment.py']), null)
-    assert.equal(getTestOnlyProducts(['products/experiments/package.json']), null)
+    assert.equal(getTestOnlyProducts(['products/experiments/backend/models/experiment.py'], nothingImportsIt), null)
+    assert.equal(getTestOnlyProducts(['products/experiments/package.json'], nothingImportsIt), null)
+
+    // A base class under a test directory is the product's behavior to every
+    // suite that imports it, so narrowing to the owning product would run
+    // everything except the suite that breaks.
+    const base = 'products/experiments/backend/hogql_queries/test/experiment_query_runner/base.py'
+    assert.equal(
+        getTestOnlyProducts([base], importedBy({ [base]: ['posthog/temporal/experiments/test_cache_warming.py'] })),
+        null
+    )
+    assert.equal(
+        getTestOnlyProducts([base], importedBy({ [base]: ['products/workflows/backend/api/test/test_hog_flow.py'] })),
+        null
+    )
+    // An importer inside the owning product is the case the shortcut exists for.
+    assert.deepEqual(
+        getTestOnlyProducts([base], importedBy({ [base]: ['products/experiments/backend/test/test_mean_metric.py'] })),
+        ['experiments']
+    )
+    // No tach map, or a file the head tree no longer has: importers unknown.
+    assert.equal(getTestOnlyProducts([base], () => null), null)
 })

--- a/.github/scripts/turbo-discover.test.js
+++ b/.github/scripts/turbo-discover.test.js
@@ -205,6 +205,21 @@ test('test-only product changes select only their product suites', () => {
     assert.equal(getTestOnlyProducts([base], () => null), null)
 })
 
+// A product path in DJANGO_SEGMENTS is run by a Django segment rather than by
+// that product's own backend:test command, which targets a different test root.
+// Narrowing Django away would leave a change to such a test running in no job,
+// so the shortcut has to refuse it. Derived from the table rather than written
+// out, so a product root added to a segment later is covered on its own.
+test('a test root the Django matrix owns is not a test-only change', () => {
+    const djangoOwnedProductRoots = Object.values(DJANGO_SEGMENTS)
+        .flatMap((segment) => segment.include)
+        .filter((prefix) => prefix.startsWith('products/'))
+    assert.notEqual(djangoOwnedProductRoots.length, 0, 'expected the Django segments to own at least one product root')
+    for (const root of djangoOwnedProductRoots) {
+        assert.equal(getTestOnlyProducts([`${root}tests/test_emission.py`], () => []), null, root)
+    }
+})
+
 // Narrowing takes Django off the run, and decideSelection stops looking at the
 // kill switch once Django is off. So the switch has to be honored before the
 // shortcut runs, or flipping the repo variable during an incident cannot put a

--- a/.github/scripts/turbo-discover.test.js
+++ b/.github/scripts/turbo-discover.test.js
@@ -20,6 +20,7 @@ const {
     DJANGO_SEGMENTS,
     getIsolatedProducts,
     getTestOnlyProducts,
+    testOnlyNarrowingAllowed,
     changedFilesSinceBase,
 } = require('./turbo-discover')
 
@@ -202,6 +203,22 @@ test('test-only product changes select only their product suites', () => {
     )
     // No tach map, or a file the head tree no longer has: importers unknown.
     assert.equal(getTestOnlyProducts([base], () => null), null)
+})
+
+// Narrowing takes Django off the run, and decideSelection stops looking at the
+// kill switch once Django is off. So the switch has to be honored before the
+// shortcut runs, or flipping the repo variable during an incident cannot put a
+// product test-only PR back on the full matrices.
+test('the kill switch stops the test-only shortcut before it can drop Django', () => {
+    for (const [env, allowed] of [
+        [{ SELECTION_APPLIES: 'true' }, true],
+        [{ SELECTION_APPLIES: 'true', SELECTION_DISABLED: 'false' }, true],
+        [{ SELECTION_APPLIES: 'true', SELECTION_DISABLED: 'true' }, false],
+        [{ SELECTION_APPLIES: 'false', SELECTION_DISABLED: 'true' }, false],
+        [{}, false],
+    ]) {
+        assert.equal(testOnlyNarrowingAllowed(env), allowed, JSON.stringify(env))
+    }
 })
 
 // Git reports a pure move as its new path alone, which reads as a test-only

--- a/.github/scripts/turbo-discover.test.js
+++ b/.github/scripts/turbo-discover.test.js
@@ -15,7 +15,7 @@ const fs = require('node:fs')
 const os = require('node:os')
 const path = require('node:path')
 
-const { DJANGO_SEGMENTS, getIsolatedProducts } = require('./turbo-discover')
+const { DJANGO_SEGMENTS, getIsolatedProducts, getTestOnlyProducts } = require('./turbo-discover')
 
 const REPO_ROOT = path.join(__dirname, '..', '..')
 const WORKFLOWS = ['.github/workflows/ci-backend.yml', '.depot/workflows/ci-backend.yml']
@@ -158,4 +158,16 @@ test('isolation needs both the contract-check script and narrowed contract input
     }))
 
     assert.deepEqual([...getIsolatedProducts(tasks, repoRoot)].sort(), ['declared', 'multi-word'])
+})
+
+test('test-only product changes select only their product suites', () => {
+    assert.deepEqual(
+        getTestOnlyProducts([
+            'products/experiments/backend/test/test_migration_0035.py',
+            'products/experiments/stats/tests/test_statistics.py',
+        ]),
+        ['experiments']
+    )
+    assert.equal(getTestOnlyProducts(['products/experiments/backend/models/experiment.py']), null)
+    assert.equal(getTestOnlyProducts(['products/experiments/package.json']), null)
 })


### PR DESCRIPTION
## Problem

Test-only product changes start the full backend matrix. This delays feedback for engineers without improving production coverage.

## Changes

```mermaid
flowchart LR
    Test[Test-only product change] --> Full[All product tests and Django]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    class Test phBlue;
    class Full phRed;
```

```mermaid
flowchart LR
    Test[Test-only product change] --> Product[Changed product tests]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class Test phBlue;
    class Product phYellow;
```

- Select only the changed product suites when every changed file is under a product test directory.
- Keep the full backend matrix for production, package, and mixed changes.

## How did you test this code?

- `node --test .github/scripts/turbo-discover.test.js`
- Added a selector case. It catches a return to the full matrix for an experiments test-only change.
- Not run: database-backed product tests.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This changes internal CI selection only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Skills invoked: `/isolating-product-facade-contracts`, `/writing-tests`, `/writing-pr-descriptions`.
- Duplicate check: no matching open issue found.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0113360FFV/p1789124856621959?thread_ts=1789124856.621959&cid=C0113360FFV)*