### PR TITLE
fix(aio): bound evaluation report scheduler fan-out

### DIFF
--- a/posthog/temporal/ai_observability/eval_reports/activities.py
+++ b/posthog/temporal/ai_observability/eval_reports/activities.py
@@ -2,6 +2,7 @@
 
 import math
 import time
+import hashlib
 import datetime as dt
 from collections import defaultdict
 from itertools import batched
@@ -70,6 +71,12 @@ class _FetchedDueEvalReports:
     report_ids: list[str]
     oldest_due_at: dt.datetime | None
     has_more: bool
+
+
+def _count_trigger_page_index(poll_number: int, page_count: int) -> int:
+    """Select a deterministic page without aliasing against skipped schedule intervals."""
+    digest = hashlib.blake2s(str(poll_number).encode(), digest_size=8).digest()
+    return int.from_bytes(digest, "big") % page_count
 
 
 @temporalio.activity.defn
@@ -246,7 +253,11 @@ def _fetch_count_triggered_eval_report_candidate_groups(
     page_count = math.ceil(candidate_count / max_reports_per_run)
     poll_time = now or dt.datetime.now(tz=dt.UTC)
     poll_number = int(poll_time.timestamp() // COUNT_TRIGGER_POLL_INTERVAL.total_seconds())
-    page_index = poll_number % page_count
+    # Hashing the absolute poll slot avoids the periodic aliasing produced by a plain
+    # modulo when Temporal skips overlapping ticks (for example, every second tick
+    # with two pages). The activity need not be replay-deterministic, but a stable
+    # mapping keeps selection observable and testable.
+    page_index = _count_trigger_page_index(poll_number, page_count)
     offset = page_index * max_reports_per_run
 
     ids_by_team: dict[int, list[str]] = defaultdict(list)

--- a/posthog/temporal/ai_observability/eval_reports/activities.py
+++ b/posthog/temporal/ai_observability/eval_reports/activities.py
@@ -9,7 +9,7 @@ from itertools import batched
 from typing import TYPE_CHECKING, NamedTuple
 from zoneinfo import ZoneInfo
 
-from django.db.models import F, Q, Window
+from django.db.models import F, Min, Q, Window
 from django.db.models.functions import RowNumber
 
 import temporalio.activity
@@ -39,6 +39,7 @@ from posthog.temporal.ai_observability.eval_reports.targets import (
     target_event_predicate,
 )
 from posthog.temporal.ai_observability.eval_reports.types import (
+    DEFAULT_MAX_COUNT_TRIGGERED_EVAL_REPORT_GROUPS_PER_RUN,
     DEFAULT_MAX_COUNT_TRIGGERED_EVAL_REPORTS_PER_RUN,
     CheckCountTriggeredEvalReportInput,
     CheckCountTriggeredEvalReportOutput,
@@ -73,9 +74,9 @@ class _FetchedDueEvalReports:
     has_more: bool
 
 
-def _count_trigger_page_index(poll_number: int, page_count: int) -> int:
+def _scheduler_page_index(poll_number: int, page_count: int, namespace: str) -> int:
     """Select a deterministic page without aliasing against skipped schedule intervals."""
-    digest = hashlib.blake2s(str(poll_number).encode(), digest_size=8).digest()
+    digest = hashlib.blake2s(f"{namespace}:{poll_number}".encode(), digest_size=8).digest()
     return int.from_bytes(digest, "big") % page_count
 
 
@@ -84,12 +85,13 @@ async def fetch_due_eval_reports_activity(
     inputs: ScheduleAllEvalReportsWorkflowInputs,
 ) -> FetchDueEvalReportsOutput:
     """Return a list of time-based evaluation report IDs that are due for delivery."""
-    now_with_buffer = dt.datetime.now(tz=dt.UTC) + dt.timedelta(minutes=inputs.buffer_minutes)
+    poll_time = dt.datetime.now(tz=dt.UTC)
+    now_with_buffer = poll_time + dt.timedelta(minutes=inputs.buffer_minutes)
 
     fetched = await database_sync_to_async(
         _fetch_due_eval_report_ids,
         thread_sensitive=False,
-    )(now_with_buffer, inputs.max_reports_per_run)
+    )(now_with_buffer, inputs.max_reports_per_run, poll_time=poll_time)
     await logger.ainfo(
         "llma_eval_reports_coordinator_scheduled_poll",
         reports_found=len(fetched.report_ids),
@@ -117,13 +119,15 @@ async def fetch_due_eval_reports_activity(
 def _fetch_due_eval_report_ids(
     now_with_buffer: dt.datetime,
     max_reports_per_run: int,
+    *,
+    poll_time: dt.datetime | None = None,
 ) -> _FetchedDueEvalReports:
     from products.ai_observability.backend.models.evaluation_reports import EvaluationReport
 
     if max_reports_per_run <= 0:
         raise ValueError("max_reports_per_run must be greater than zero")
 
-    rows = list(
+    candidates = (
         EvaluationReport.objects.deliverable()
         .filter(next_delivery_date__lte=now_with_buffer)
         .exclude(frequency=EvaluationReport.Frequency.EVERY_N)
@@ -135,15 +139,28 @@ def _fetch_due_eval_report_ids(
             )
         )
         .order_by("_team_rank", "next_delivery_date", "team_id", "id")
-        .values_list("id", "next_delivery_date")[: max_reports_per_run + 1]
+        .values_list("id", "next_delivery_date")
     )
-    has_more = len(rows) > max_reports_per_run
-    selected_rows = rows[:max_reports_per_run]
-    oldest_due_at = min((next_delivery_date for _, next_delivery_date in selected_rows), default=None)
+    candidate_count = candidates.count()
+    if candidate_count == 0:
+        return _FetchedDueEvalReports(report_ids=[], oldest_due_at=None, has_more=False)
+
+    page_count = math.ceil(candidate_count / max_reports_per_run)
+    effective_poll_time = poll_time or now_with_buffer
+    poll_number = int(effective_poll_time.timestamp() // dt.timedelta(hours=1).total_seconds())
+    page_index = _scheduler_page_index(poll_number, page_count, "scheduled")
+    offset = page_index * max_reports_per_run
+    selected_rows = list(candidates[offset : offset + max_reports_per_run])
+    oldest_due_at = (
+        EvaluationReport.objects.deliverable()
+        .filter(next_delivery_date__lte=now_with_buffer)
+        .exclude(frequency=EvaluationReport.Frequency.EVERY_N)
+        .aggregate(oldest_due_at=Min("next_delivery_date"))["oldest_due_at"]
+    )
     return _FetchedDueEvalReports(
         report_ids=[str(report_id) for report_id, _ in selected_rows],
         oldest_due_at=oldest_due_at,
-        has_more=has_more,
+        has_more=candidate_count > len(selected_rows),
     )
 
 
@@ -158,6 +175,7 @@ async def fetch_count_triggered_eval_report_candidates_activity(
     def get_report_id_groups() -> tuple[list[list[str]], int]:
         return _fetch_count_triggered_eval_report_candidate_groups(
             max_reports_per_run=inputs.max_reports_per_run,
+            max_groups_per_run=inputs.max_groups_per_run,
         )
 
     report_id_groups, candidate_count = await get_report_id_groups()
@@ -168,6 +186,7 @@ async def fetch_count_triggered_eval_report_candidates_activity(
         total_checked=len(report_ids),
         candidate_count=candidate_count,
         max_reports_per_run=inputs.max_reports_per_run,
+        max_groups_per_run=inputs.max_groups_per_run,
         has_more=has_more,
     )
     from posthog.temporal.ai_observability.eval_reports.metrics import (
@@ -220,6 +239,7 @@ async def check_count_triggered_eval_reports_activity(
 
 def _fetch_count_triggered_eval_report_candidate_groups(
     max_reports_per_run: int = DEFAULT_MAX_COUNT_TRIGGERED_EVAL_REPORTS_PER_RUN,
+    max_groups_per_run: int = DEFAULT_MAX_COUNT_TRIGGERED_EVAL_REPORT_GROUPS_PER_RUN,
     now: dt.datetime | None = None,
 ) -> tuple[list[list[str]], int]:
     """Return candidate report ids grouped one team per group, each group at most
@@ -229,6 +249,8 @@ def _fetch_count_triggered_eval_report_candidate_groups(
 
     if max_reports_per_run <= 0:
         raise ValueError("max_reports_per_run must be greater than zero")
+    if max_groups_per_run <= 0:
+        raise ValueError("max_groups_per_run must be greater than zero")
 
     candidates = (
         EvaluationReport.objects.deliverable()
@@ -257,20 +279,19 @@ def _fetch_count_triggered_eval_report_candidate_groups(
     # modulo when Temporal skips overlapping ticks (for example, every second tick
     # with two pages). The activity need not be replay-deterministic, but a stable
     # mapping keeps selection observable and testable.
-    page_index = _count_trigger_page_index(poll_number, page_count)
+    page_index = _scheduler_page_index(poll_number, page_count, "count-reports")
     offset = page_index * max_reports_per_run
 
     ids_by_team: dict[int, list[str]] = defaultdict(list)
     for pk, team_id in candidates[offset : offset + max_reports_per_run]:
         ids_by_team[team_id].append(str(pk))
-    return (
-        [
-            list(chunk)
-            for ids in ids_by_team.values()
-            for chunk in batched(ids, COUNT_TRIGGER_QUERY_WIDTH, strict=False)
-        ],
-        candidate_count,
-    )
+    groups = [
+        list(chunk) for ids in ids_by_team.values() for chunk in batched(ids, COUNT_TRIGGER_QUERY_WIDTH, strict=False)
+    ]
+    group_page_count = math.ceil(len(groups) / max_groups_per_run)
+    group_page_index = _scheduler_page_index(poll_number, group_page_count, "count-groups")
+    group_offset = group_page_index * max_groups_per_run
+    return groups[group_offset : group_offset + max_groups_per_run], candidate_count
 
 
 def _load_count_triggered_report(report_id: str) -> "EvaluationReport | None":

--- a/posthog/temporal/ai_observability/eval_reports/activities.py
+++ b/posthog/temporal/ai_observability/eval_reports/activities.py
@@ -18,6 +18,7 @@ from structlog import get_logger
 from posthog.hogql import ast
 
 from posthog.clickhouse.client.connection import Workload
+from posthog.dataclasses import frozen
 from posthog.exceptions import ClickHouseQueryTimeOut
 from posthog.sync import database_sync_to_async
 from posthog.temporal.ai_observability.eval_reports.constants import (
@@ -64,6 +65,13 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+@frozen
+class _FetchedDueEvalReports:
+    report_ids: list[str]
+    oldest_due_at: dt.datetime | None
+    has_more: bool
+
+
 @temporalio.activity.defn
 async def fetch_due_eval_reports_activity(
     inputs: ScheduleAllEvalReportsWorkflowInputs,
@@ -71,38 +79,38 @@ async def fetch_due_eval_reports_activity(
     """Return a list of time-based evaluation report IDs that are due for delivery."""
     now_with_buffer = dt.datetime.now(tz=dt.UTC) + dt.timedelta(minutes=inputs.buffer_minutes)
 
-    report_ids, oldest_due_at, has_more = await database_sync_to_async(
+    fetched = await database_sync_to_async(
         _fetch_due_eval_report_ids,
         thread_sensitive=False,
     )(now_with_buffer, inputs.max_reports_per_run)
     await logger.ainfo(
         "llma_eval_reports_coordinator_scheduled_poll",
-        reports_found=len(report_ids),
+        reports_found=len(fetched.report_ids),
         max_reports_per_run=inputs.max_reports_per_run,
-        has_more=has_more,
-        oldest_due_at=oldest_due_at,
+        has_more=fetched.has_more,
+        oldest_due_at=fetched.oldest_due_at,
     )
     from posthog.temporal.ai_observability.eval_reports.metrics import (
         record_coordinator_poll,
         record_coordinator_reports_found,
     )
 
-    record_coordinator_reports_found(len(report_ids), "scheduled")
+    record_coordinator_reports_found(len(fetched.report_ids), "scheduled")
     record_coordinator_poll(
-        selected_count=len(report_ids),
+        selected_count=len(fetched.report_ids),
         trigger_type="scheduled",
-        has_more=has_more,
-        oldest_due_at=oldest_due_at,
+        has_more=fetched.has_more,
+        oldest_due_at=fetched.oldest_due_at,
     )
     return FetchDueEvalReportsOutput(
-        report_ids=report_ids,
+        report_ids=fetched.report_ids,
     )
 
 
 def _fetch_due_eval_report_ids(
     now_with_buffer: dt.datetime,
     max_reports_per_run: int,
-) -> tuple[list[str], dt.datetime | None, bool]:
+) -> _FetchedDueEvalReports:
     from products.ai_observability.backend.models.evaluation_reports import EvaluationReport
 
     if max_reports_per_run <= 0:
@@ -125,7 +133,11 @@ def _fetch_due_eval_report_ids(
     has_more = len(rows) > max_reports_per_run
     selected_rows = rows[:max_reports_per_run]
     oldest_due_at = min((next_delivery_date for _, next_delivery_date in selected_rows), default=None)
-    return [str(report_id) for report_id, _ in selected_rows], oldest_due_at, has_more
+    return _FetchedDueEvalReports(
+        report_ids=[str(report_id) for report_id, _ in selected_rows],
+        oldest_due_at=oldest_due_at,
+        has_more=has_more,
+    )
 
 
 @temporalio.activity.defn

--- a/posthog/temporal/ai_observability/eval_reports/activities.py
+++ b/posthog/temporal/ai_observability/eval_reports/activities.py
@@ -1,5 +1,6 @@
 """Activities for evaluation reports workflow."""
 
+import math
 import time
 import datetime as dt
 from collections import defaultdict
@@ -7,7 +8,8 @@ from itertools import batched
 from typing import TYPE_CHECKING, NamedTuple
 from zoneinfo import ZoneInfo
 
-from django.db.models import Q
+from django.db.models import F, Q, Window
+from django.db.models.functions import RowNumber
 
 import temporalio.activity
 from dateutil.rrule import rrulestr
@@ -19,6 +21,7 @@ from posthog.clickhouse.client.connection import Workload
 from posthog.exceptions import ClickHouseQueryTimeOut
 from posthog.sync import database_sync_to_async
 from posthog.temporal.ai_observability.eval_reports.constants import (
+    COUNT_TRIGGER_POLL_INTERVAL,
     COUNT_TRIGGER_QUERY_MAX_EXECUTION_TIME_SECONDS,
     COUNT_TRIGGER_QUERY_MIN_EXECUTION_TIME_SECONDS,
     COUNT_TRIGGER_QUERY_MIN_SPLIT_RANGE,
@@ -34,6 +37,7 @@ from posthog.temporal.ai_observability.eval_reports.targets import (
     target_event_predicate,
 )
 from posthog.temporal.ai_observability.eval_reports.types import (
+    DEFAULT_MAX_COUNT_TRIGGERED_EVAL_REPORTS_PER_RUN,
     CheckCountTriggeredEvalReportInput,
     CheckCountTriggeredEvalReportOutput,
     CheckCountTriggeredEvalReportsBatchInput,
@@ -67,29 +71,61 @@ async def fetch_due_eval_reports_activity(
     """Return a list of time-based evaluation report IDs that are due for delivery."""
     now_with_buffer = dt.datetime.now(tz=dt.UTC) + dt.timedelta(minutes=inputs.buffer_minutes)
 
-    @database_sync_to_async(thread_sensitive=False)
-    def get_report_ids() -> list[str]:
-        from products.ai_observability.backend.models.evaluation_reports import EvaluationReport
-
-        return [
-            str(pk)
-            for pk in EvaluationReport.objects.deliverable()
-            .filter(
-                next_delivery_date__lte=now_with_buffer,
-            )
-            .exclude(frequency=EvaluationReport.Frequency.EVERY_N)
-            .values_list("id", flat=True)
-        ]
-
-    report_ids = await get_report_ids()
+    report_ids, oldest_due_at, has_more = await database_sync_to_async(
+        _fetch_due_eval_report_ids,
+        thread_sensitive=False,
+    )(now_with_buffer, inputs.max_reports_per_run)
     await logger.ainfo(
         "llma_eval_reports_coordinator_scheduled_poll",
         reports_found=len(report_ids),
+        max_reports_per_run=inputs.max_reports_per_run,
+        has_more=has_more,
+        oldest_due_at=oldest_due_at,
     )
-    from posthog.temporal.ai_observability.eval_reports.metrics import record_coordinator_reports_found
+    from posthog.temporal.ai_observability.eval_reports.metrics import (
+        record_coordinator_poll,
+        record_coordinator_reports_found,
+    )
 
     record_coordinator_reports_found(len(report_ids), "scheduled")
-    return FetchDueEvalReportsOutput(report_ids=report_ids)
+    record_coordinator_poll(
+        selected_count=len(report_ids),
+        trigger_type="scheduled",
+        has_more=has_more,
+        oldest_due_at=oldest_due_at,
+    )
+    return FetchDueEvalReportsOutput(
+        report_ids=report_ids,
+    )
+
+
+def _fetch_due_eval_report_ids(
+    now_with_buffer: dt.datetime,
+    max_reports_per_run: int,
+) -> tuple[list[str], dt.datetime | None, bool]:
+    from products.ai_observability.backend.models.evaluation_reports import EvaluationReport
+
+    if max_reports_per_run <= 0:
+        raise ValueError("max_reports_per_run must be greater than zero")
+
+    rows = list(
+        EvaluationReport.objects.deliverable()
+        .filter(next_delivery_date__lte=now_with_buffer)
+        .exclude(frequency=EvaluationReport.Frequency.EVERY_N)
+        .annotate(
+            _team_rank=Window(
+                expression=RowNumber(),
+                partition_by=[F("team_id")],
+                order_by=[F("next_delivery_date").asc(), F("id").asc()],
+            )
+        )
+        .order_by("_team_rank", "next_delivery_date", "team_id", "id")
+        .values_list("id", "next_delivery_date")[: max_reports_per_run + 1]
+    )
+    has_more = len(rows) > max_reports_per_run
+    selected_rows = rows[:max_reports_per_run]
+    oldest_due_at = min((next_delivery_date for _, next_delivery_date in selected_rows), default=None)
+    return [str(report_id) for report_id, _ in selected_rows], oldest_due_at, has_more
 
 
 @temporalio.activity.defn
@@ -100,19 +136,36 @@ async def fetch_count_triggered_eval_report_candidates_activity(
     one team per group so each check activity runs a single shared count query."""
 
     @database_sync_to_async(thread_sensitive=False)
-    def get_report_id_groups() -> list[list[str]]:
-        return _fetch_count_triggered_eval_report_candidate_groups()
+    def get_report_id_groups() -> tuple[list[list[str]], int]:
+        return _fetch_count_triggered_eval_report_candidate_groups(
+            max_reports_per_run=inputs.max_reports_per_run,
+        )
 
-    report_id_groups = await get_report_id_groups()
+    report_id_groups, candidate_count = await get_report_id_groups()
     report_ids = [report_id for group in report_id_groups for report_id in group]
+    has_more = candidate_count > len(report_ids)
     await logger.ainfo(
         "llma_eval_reports_coordinator_count_triggered_candidates_poll",
         total_checked=len(report_ids),
+        candidate_count=candidate_count,
+        max_reports_per_run=inputs.max_reports_per_run,
+        has_more=has_more,
     )
-    from posthog.temporal.ai_observability.eval_reports.metrics import record_coordinator_check_count
+    from posthog.temporal.ai_observability.eval_reports.metrics import (
+        record_coordinator_check_count,
+        record_coordinator_poll,
+    )
 
     record_coordinator_check_count(len(report_ids), "count_triggered")
-    return FetchDueEvalReportsOutput(report_ids=report_ids, report_id_groups=report_id_groups)
+    record_coordinator_poll(
+        selected_count=len(report_ids),
+        trigger_type="count_triggered",
+        has_more=has_more,
+    )
+    return FetchDueEvalReportsOutput(
+        report_ids=report_ids,
+        report_id_groups=report_id_groups,
+    )
 
 
 @temporalio.activity.defn
@@ -146,26 +199,55 @@ async def check_count_triggered_eval_reports_activity(
     return CheckCountTriggeredEvalReportsBatchOutput(results=results)
 
 
-def _fetch_count_triggered_eval_report_candidate_groups() -> list[list[str]]:
+def _fetch_count_triggered_eval_report_candidate_groups(
+    max_reports_per_run: int = DEFAULT_MAX_COUNT_TRIGGERED_EVAL_REPORTS_PER_RUN,
+    now: dt.datetime | None = None,
+) -> tuple[list[list[str]], int]:
     """Return candidate report ids grouped one team per group, each group at most
     COUNT_TRIGGER_QUERY_WIDTH wide, so one check activity runs exactly one ClickHouse
     count query under its own timeout and retry policy."""
     from products.ai_observability.backend.models.evaluation_reports import EvaluationReport
 
-    ids_by_team: dict[int, list[str]] = defaultdict(list)
-    for pk, team_id in (
+    if max_reports_per_run <= 0:
+        raise ValueError("max_reports_per_run must be greater than zero")
+
+    candidates = (
         EvaluationReport.objects.deliverable()
         .filter(
             frequency=EvaluationReport.Frequency.EVERY_N,
             trigger_threshold__isnull=False,
         )
-        .order_by("team_id", "id")
+        .annotate(
+            _team_rank=Window(
+                expression=RowNumber(),
+                partition_by=[F("team_id")],
+                order_by=F("id").asc(),
+            )
+        )
+        .order_by("_team_rank", "team_id", "id")
         .values_list("id", "team_id")
-    ):
+    )
+    candidate_count = candidates.count()
+    if candidate_count == 0:
+        return [], 0
+
+    page_count = math.ceil(candidate_count / max_reports_per_run)
+    poll_time = now or dt.datetime.now(tz=dt.UTC)
+    poll_number = int(poll_time.timestamp() // COUNT_TRIGGER_POLL_INTERVAL.total_seconds())
+    page_index = poll_number % page_count
+    offset = page_index * max_reports_per_run
+
+    ids_by_team: dict[int, list[str]] = defaultdict(list)
+    for pk, team_id in candidates[offset : offset + max_reports_per_run]:
         ids_by_team[team_id].append(str(pk))
-    return [
-        list(chunk) for ids in ids_by_team.values() for chunk in batched(ids, COUNT_TRIGGER_QUERY_WIDTH, strict=False)
-    ]
+    return (
+        [
+            list(chunk)
+            for ids in ids_by_team.values()
+            for chunk in batched(ids, COUNT_TRIGGER_QUERY_WIDTH, strict=False)
+        ],
+        candidate_count,
+    )
 
 
 def _load_count_triggered_report(report_id: str) -> "EvaluationReport | None":

--- a/posthog/temporal/ai_observability/eval_reports/constants.py
+++ b/posthog/temporal/ai_observability/eval_reports/constants.py
@@ -19,11 +19,13 @@ COUNT_TRIGGER_SCHEDULE_ID = "llma-eval-reports-count-triggered-coordinator-sched
 
 # Workflow timeouts
 WORKFLOW_EXECUTION_TIMEOUT = timedelta(minutes=30)
-COORDINATOR_EXECUTION_TIMEOUT = timedelta(hours=2)
+SCHEDULED_COORDINATOR_EXECUTION_TIMEOUT = timedelta(minutes=10)
+COUNT_TRIGGERED_COORDINATOR_EXECUTION_TIMEOUT = timedelta(minutes=30)
 
 # Activity timeouts
 FETCH_ACTIVITY_TIMEOUT = timedelta(seconds=60)
 COUNT_TRIGGER_CHECK_BATCH_SIZE = 5
+COUNT_TRIGGER_POLL_INTERVAL = timedelta(minutes=5)
 # Max number of per-report countIf columns in a single ClickHouse count query. Candidates
 # are grouped one team per group at this width, so one check activity runs exactly one query,
 # and entries are chunked in `since`-sorted order so one stale report's window doesn't widen
@@ -33,6 +35,9 @@ COUNT_TRIGGER_QUERY_WIDTH = 20
 # Max batched check activities in flight at once, capping concurrent count queries at the
 # same ceiling as the legacy per-report path.
 COUNT_TRIGGER_MAX_CONCURRENT_CHECKS = 5
+# Await child starts in bounded groups so Temporal records acceptance without
+# putting the full coordinator page into one Workflow Task completion.
+REPORT_START_BATCH_SIZE = 100
 COUNT_TRIGGER_CHECK_ACTIVITY_TIMEOUT = timedelta(seconds=120)
 # Per-attempt ClickHouse budget. A too-slow count query fails with a catchable
 # ClickHouseQueryTimeOut the activity can split-and-retry, unlike a Temporal activity

--- a/posthog/temporal/ai_observability/eval_reports/metrics.py
+++ b/posthog/temporal/ai_observability/eval_reports/metrics.py
@@ -159,12 +159,14 @@ def record_coordinator_poll(
         "llma_eval_reports_coordinator_selected",
         "Evaluation reports selected for processing by coordinators.",
     ).add(selected_count)
-    if oldest_due_at is not None:
-        get_metric_meter({"trigger_type": trigger_type}).create_histogram_float(
-            "llma_eval_reports_coordinator_oldest_due_age_seconds",
-            "Age of the oldest scheduled evaluation report selected by a coordinator.",
-            "s",
-        ).record(max(0.0, (dt.datetime.now(tz=dt.UTC) - oldest_due_at).total_seconds()))
+    oldest_due_age_seconds = (
+        max(0.0, (dt.datetime.now(tz=dt.UTC) - oldest_due_at).total_seconds()) if oldest_due_at is not None else 0.0
+    )
+    get_metric_meter({"trigger_type": trigger_type}).create_gauge_float(
+        "llma_eval_reports_coordinator_oldest_due_age_seconds",
+        "Age of the oldest scheduled evaluation report selected by a coordinator.",
+        "s",
+    ).set(oldest_due_age_seconds)
     get_metric_meter({"trigger_type": trigger_type}).create_gauge_float(
         "llma_eval_reports_coordinator_last_successful_poll_timestamp_seconds",
         "Unix timestamp of the last successful evaluation report coordinator poll.",

--- a/posthog/temporal/ai_observability/eval_reports/metrics.py
+++ b/posthog/temporal/ai_observability/eval_reports/metrics.py
@@ -5,6 +5,7 @@ Metrics are emitted via Temporal's built-in metric meter (activity/workflow cont
 and scraped by the Prometheus endpoint on the worker pod.
 """
 
+import time
 import typing
 import datetime as dt
 
@@ -135,6 +136,39 @@ def record_coordinator_check_count(count: int, trigger_type: str) -> None:
         "llma_eval_reports_coordinator_checked",
         "Report rows checked by coordinator per poll cycle",
     ).add(count)
+
+
+def record_coordinator_poll(
+    *,
+    selected_count: int,
+    trigger_type: str,
+    has_more: bool,
+    oldest_due_at: dt.datetime | None = None,
+) -> None:
+    """Emit scheduler progress and saturation signals without tenant labels."""
+    if not activity.in_activity():
+        return
+
+    outcome = "saturated" if has_more else "empty" if selected_count == 0 else "partial"
+    meter = get_metric_meter({"trigger_type": trigger_type, "outcome": outcome})
+    meter.create_counter(
+        "llma_eval_reports_coordinator_polls",
+        "Evaluation report coordinator polls by batch saturation.",
+    ).add(1)
+    get_metric_meter({"trigger_type": trigger_type}).create_counter(
+        "llma_eval_reports_coordinator_selected",
+        "Evaluation reports selected for processing by coordinators.",
+    ).add(selected_count)
+    if oldest_due_at is not None:
+        get_metric_meter({"trigger_type": trigger_type}).create_histogram_float(
+            "llma_eval_reports_coordinator_oldest_due_age_seconds",
+            "Age of the oldest scheduled evaluation report selected by a coordinator.",
+            "s",
+        ).record(max(0.0, (dt.datetime.now(tz=dt.UTC) - oldest_due_at).total_seconds()))
+    get_metric_meter({"trigger_type": trigger_type}).create_gauge_float(
+        "llma_eval_reports_coordinator_last_successful_poll_timestamp_seconds",
+        "Unix timestamp of the last successful evaluation report coordinator poll.",
+    ).set(time.time())
 
 
 # ---------------------------------------------------------------------------

--- a/posthog/temporal/ai_observability/eval_reports/schedule.py
+++ b/posthog/temporal/ai_observability/eval_reports/schedule.py
@@ -5,13 +5,24 @@ from datetime import timedelta
 
 from django.conf import settings
 
-from temporalio.client import Client, Schedule, ScheduleActionStartWorkflow, ScheduleIntervalSpec, ScheduleSpec
+from temporalio.client import (
+    Client,
+    Schedule,
+    ScheduleActionStartWorkflow,
+    ScheduleIntervalSpec,
+    ScheduleOverlapPolicy,
+    SchedulePolicy,
+    ScheduleSpec,
+)
 
 from posthog.temporal.ai_observability.eval_reports.constants import (
     CHECK_COUNT_TRIGGERED_REPORTS_WORKFLOW_NAME,
+    COUNT_TRIGGER_POLL_INTERVAL,
     COUNT_TRIGGER_SCHEDULE_ID,
+    COUNT_TRIGGERED_COORDINATOR_EXECUTION_TIMEOUT,
     SCHEDULE_ALL_EVAL_REPORTS_WORKFLOW_NAME,
     SCHEDULE_ID,
+    SCHEDULED_COORDINATOR_EXECUTION_TIMEOUT,
 )
 from posthog.temporal.ai_observability.eval_reports.types import (
     CheckCountTriggeredReportsWorkflowInputs,
@@ -28,8 +39,13 @@ async def create_eval_reports_schedule(client: Client):
             asdict(ScheduleAllEvalReportsWorkflowInputs()),
             id=SCHEDULE_ID,
             task_queue=settings.LLMA_TASK_QUEUE,
+            execution_timeout=SCHEDULED_COORDINATOR_EXECUTION_TIMEOUT,
         ),
         spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(hours=1))]),
+        policy=SchedulePolicy(
+            overlap=ScheduleOverlapPolicy.SKIP,
+            catchup_window=timedelta(hours=1),
+        ),
     )
 
     if await a_schedule_exists(client, SCHEDULE_ID):
@@ -46,8 +62,13 @@ async def create_count_trigger_schedule(client: Client):
             asdict(CheckCountTriggeredReportsWorkflowInputs()),
             id=COUNT_TRIGGER_SCHEDULE_ID,
             task_queue=settings.LLMA_TASK_QUEUE,
+            execution_timeout=COUNT_TRIGGERED_COORDINATOR_EXECUTION_TIMEOUT,
         ),
-        spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(minutes=5))]),
+        spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=COUNT_TRIGGER_POLL_INTERVAL)]),
+        policy=SchedulePolicy(
+            overlap=ScheduleOverlapPolicy.SKIP,
+            catchup_window=timedelta(minutes=5),
+        ),
     )
 
     if await a_schedule_exists(client, COUNT_TRIGGER_SCHEDULE_ID):

--- a/posthog/temporal/ai_observability/eval_reports/test/test_activities.py
+++ b/posthog/temporal/ai_observability/eval_reports/test/test_activities.py
@@ -642,6 +642,30 @@ class TestCountTriggeredReportChecks(BaseTest):
 
         self.assertEqual(selected_ids, report_ids)
 
+    def test_fetch_candidates_caps_and_rotates_query_groups(self):
+        teams = [self.team]
+        teams.extend(Team.objects.create(organization=self.organization, name=f"other-{index}") for index in range(3))
+        report_ids = {str(self._create_report(team=team).id) for team in teams}
+
+        selected_ids: set[str] = set()
+        for group_page_index in range(2):
+            with patch(
+                "posthog.temporal.ai_observability.eval_reports.activities._scheduler_page_index",
+                side_effect=lambda _poll, _pages, namespace, group_page_index=group_page_index: (
+                    0 if namespace == "count-reports" else group_page_index
+                ),
+            ):
+                groups, candidate_count = _fetch_count_triggered_eval_report_candidate_groups(
+                    max_reports_per_run=4,
+                    max_groups_per_run=2,
+                )
+
+            self.assertEqual(candidate_count, 4)
+            self.assertEqual(len(groups), 2)
+            selected_ids.update(report_id for group in groups for report_id in group)
+
+        self.assertEqual(selected_ids, report_ids)
+
     def test_fetch_scheduled_reports_limits_fairly_across_teams(self):
         other_team = Team.objects.create(organization=self.organization, name="other")
         reports = [
@@ -657,7 +681,11 @@ class TestCountTriggeredReportChecks(BaseTest):
         due_at = timezone.now() - dt.timedelta(minutes=30)
         EvaluationReport.objects.filter(id__in=[report.id for report in reports]).update(next_delivery_date=due_at)
 
-        fetched = _fetch_due_eval_report_ids(timezone.now(), max_reports_per_run=2)
+        with patch(
+            "posthog.temporal.ai_observability.eval_reports.activities._scheduler_page_index",
+            return_value=0,
+        ):
+            fetched = _fetch_due_eval_report_ids(timezone.now(), max_reports_per_run=2)
 
         selected_team_ids = set(
             EvaluationReport.objects.filter(id__in=fetched.report_ids).values_list("team_id", flat=True)
@@ -665,6 +693,35 @@ class TestCountTriggeredReportChecks(BaseTest):
         self.assertEqual(selected_team_ids, {self.team.id, other_team.id})
         self.assertEqual(fetched.oldest_due_at, due_at)
         self.assertTrue(fetched.has_more)
+
+    def test_fetch_scheduled_reports_rotates_past_a_stuck_page(self):
+        reports = [
+            self._create_report(
+                frequency=EvaluationReport.Frequency.SCHEDULED,
+                rrule="FREQ=HOURLY",
+                starts_at=timezone.now() - dt.timedelta(hours=5),
+                trigger_threshold=None,
+            )
+            for _ in range(4)
+        ]
+        report_ids = {str(report.id) for report in reports}
+        due_at = timezone.now() - dt.timedelta(minutes=30)
+        EvaluationReport.objects.filter(id__in=report_ids).update(next_delivery_date=due_at)
+
+        selected_ids: set[str] = set()
+        for page_index in range(2):
+            with patch(
+                "posthog.temporal.ai_observability.eval_reports.activities._scheduler_page_index",
+                return_value=page_index,
+            ):
+                fetched = _fetch_due_eval_report_ids(timezone.now(), max_reports_per_run=2)
+
+            self.assertEqual(len(fetched.report_ids), 2)
+            self.assertTrue(fetched.has_more)
+            self.assertEqual(fetched.oldest_due_at, due_at)
+            selected_ids.update(fetched.report_ids)
+
+        self.assertEqual(selected_ids, report_ids)
 
     def test_check_report_returns_due_when_threshold_is_crossed(self):
         report = self._create_report(trigger_threshold=100)

--- a/posthog/temporal/ai_observability/eval_reports/test/test_activities.py
+++ b/posthog/temporal/ai_observability/eval_reports/test/test_activities.py
@@ -627,25 +627,20 @@ class TestCountTriggeredReportChecks(BaseTest):
         self.assertEqual(groups, [team_a_report_ids[:2], team_a_report_ids[2:], [str(team_b_report.id)]])
         self.assertEqual(candidate_count, 4)
 
-    def test_fetch_candidates_rotates_bounded_pages_instead_of_starving_later_reports(self):
-        report_ids = {str(self._create_report().id) for _ in range(4)}
+    def test_fetch_candidates_rotates_bounded_pages_across_skipped_schedule_ticks(self):
+        report_ids = {str(self._create_report().id) for _ in range(8)}
         first_poll = dt.datetime(2026, 9, 11, 12, 0, tzinfo=dt.UTC)
 
-        first_groups, first_count = _fetch_count_triggered_eval_report_candidate_groups(
-            max_reports_per_run=2,
-            now=first_poll,
-        )
-        second_groups, second_count = _fetch_count_triggered_eval_report_candidate_groups(
-            max_reports_per_run=2,
-            now=first_poll + dt.timedelta(minutes=5),
-        )
+        selected_ids: set[str] = set()
+        for skipped_tick_count in range(8):
+            groups, candidate_count = _fetch_count_triggered_eval_report_candidate_groups(
+                max_reports_per_run=2,
+                now=first_poll + skipped_tick_count * dt.timedelta(minutes=10),
+            )
+            self.assertEqual(candidate_count, 8)
+            selected_ids.update(report_id for group in groups for report_id in group)
 
-        first_ids = {report_id for group in first_groups for report_id in group}
-        second_ids = {report_id for group in second_groups for report_id in group}
-        self.assertEqual(first_count, 4)
-        self.assertEqual(second_count, 4)
-        self.assertEqual(first_ids | second_ids, report_ids)
-        self.assertFalse(first_ids & second_ids)
+        self.assertEqual(selected_ids, report_ids)
 
     def test_fetch_scheduled_reports_limits_fairly_across_teams(self):
         other_team = Team.objects.create(organization=self.organization, name="other")
@@ -662,12 +657,14 @@ class TestCountTriggeredReportChecks(BaseTest):
         due_at = timezone.now() - dt.timedelta(minutes=30)
         EvaluationReport.objects.filter(id__in=[report.id for report in reports]).update(next_delivery_date=due_at)
 
-        report_ids, oldest_due_at, has_more = _fetch_due_eval_report_ids(timezone.now(), max_reports_per_run=2)
+        fetched = _fetch_due_eval_report_ids(timezone.now(), max_reports_per_run=2)
 
-        selected_team_ids = set(EvaluationReport.objects.filter(id__in=report_ids).values_list("team_id", flat=True))
+        selected_team_ids = set(
+            EvaluationReport.objects.filter(id__in=fetched.report_ids).values_list("team_id", flat=True)
+        )
         self.assertEqual(selected_team_ids, {self.team.id, other_team.id})
-        self.assertEqual(oldest_due_at, due_at)
-        self.assertTrue(has_more)
+        self.assertEqual(fetched.oldest_due_at, due_at)
+        self.assertTrue(fetched.has_more)
 
     def test_check_report_returns_due_when_threshold_is_crossed(self):
         report = self._create_report(trigger_threshold=100)

--- a/posthog/temporal/ai_observability/eval_reports/test/test_activities.py
+++ b/posthog/temporal/ai_observability/eval_reports/test/test_activities.py
@@ -24,6 +24,7 @@ from posthog.temporal.ai_observability.eval_reports.activities import (
     _count_eval_results_for_reports_with_split_retry,
     _CountEntry,
     _fetch_count_triggered_eval_report_candidate_groups,
+    _fetch_due_eval_report_ids,
     _find_nth_eval_timestamp,
     _load_detector_evaluation_ids,
     _load_evaluation_target,
@@ -607,9 +608,10 @@ class TestCountTriggeredReportChecks(BaseTest):
         )
 
         with patch("posthog.hogql.query.execute_hogql_query") as execute_hogql_query:
-            groups = _fetch_count_triggered_eval_report_candidate_groups()
+            groups, candidate_count = _fetch_count_triggered_eval_report_candidate_groups()
 
         self.assertEqual(groups, [[str(count_triggered_report.id)]])
+        self.assertEqual(candidate_count, 1)
         execute_hogql_query.assert_not_called()
 
     def test_fetch_candidates_groups_by_team_and_chunks_by_width(self):
@@ -620,9 +622,52 @@ class TestCountTriggeredReportChecks(BaseTest):
         team_b_report = self._create_report(team=other_team)
 
         with patch("posthog.temporal.ai_observability.eval_reports.activities.COUNT_TRIGGER_QUERY_WIDTH", 2):
-            groups = _fetch_count_triggered_eval_report_candidate_groups()
+            groups, candidate_count = _fetch_count_triggered_eval_report_candidate_groups()
 
         self.assertEqual(groups, [team_a_report_ids[:2], team_a_report_ids[2:], [str(team_b_report.id)]])
+        self.assertEqual(candidate_count, 4)
+
+    def test_fetch_candidates_rotates_bounded_pages_instead_of_starving_later_reports(self):
+        report_ids = {str(self._create_report().id) for _ in range(4)}
+        first_poll = dt.datetime(2026, 9, 11, 12, 0, tzinfo=dt.UTC)
+
+        first_groups, first_count = _fetch_count_triggered_eval_report_candidate_groups(
+            max_reports_per_run=2,
+            now=first_poll,
+        )
+        second_groups, second_count = _fetch_count_triggered_eval_report_candidate_groups(
+            max_reports_per_run=2,
+            now=first_poll + dt.timedelta(minutes=5),
+        )
+
+        first_ids = {report_id for group in first_groups for report_id in group}
+        second_ids = {report_id for group in second_groups for report_id in group}
+        self.assertEqual(first_count, 4)
+        self.assertEqual(second_count, 4)
+        self.assertEqual(first_ids | second_ids, report_ids)
+        self.assertFalse(first_ids & second_ids)
+
+    def test_fetch_scheduled_reports_limits_fairly_across_teams(self):
+        other_team = Team.objects.create(organization=self.organization, name="other")
+        reports = [
+            self._create_report(
+                team=owner_team,
+                frequency=EvaluationReport.Frequency.SCHEDULED,
+                rrule="FREQ=HOURLY",
+                starts_at=timezone.now() - dt.timedelta(hours=5),
+                trigger_threshold=None,
+            )
+            for owner_team in (self.team, self.team, self.team, other_team)
+        ]
+        due_at = timezone.now() - dt.timedelta(minutes=30)
+        EvaluationReport.objects.filter(id__in=[report.id for report in reports]).update(next_delivery_date=due_at)
+
+        report_ids, oldest_due_at, has_more = _fetch_due_eval_report_ids(timezone.now(), max_reports_per_run=2)
+
+        selected_team_ids = set(EvaluationReport.objects.filter(id__in=report_ids).values_list("team_id", flat=True))
+        self.assertEqual(selected_team_ids, {self.team.id, other_team.id})
+        self.assertEqual(oldest_due_at, due_at)
+        self.assertTrue(has_more)
 
     def test_check_report_returns_due_when_threshold_is_crossed(self):
         report = self._create_report(trigger_threshold=100)

--- a/posthog/temporal/ai_observability/eval_reports/test/test_eval_reports_workflow.py
+++ b/posthog/temporal/ai_observability/eval_reports/test/test_eval_reports_workflow.py
@@ -2,7 +2,7 @@ import asyncio
 from uuid import UUID
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import temporalio.workflow
 
@@ -59,7 +59,11 @@ async def test_scheduled_coordinator_starts_children_without_waiting_for_complet
     ):
         await ScheduleAllEvalReportsWorkflow().run(ScheduleAllEvalReportsWorkflowInputs())
 
-    patched.assert_called_once_with("eval-report-scheduled-fire-and-forget-2026-09")
+    assert patched.call_args_list == [
+        call("eval-report-scheduled-bounded-input-2026-09"),
+        call("eval-report-scheduled-fire-and-forget-2026-09"),
+    ]
+    assert execute_activity.await_args.args[1].max_reports_per_run == 300
     assert start_child.await_count == 2
     execute_child.assert_not_awaited()
     assert all(
@@ -72,11 +76,12 @@ async def test_scheduled_coordinator_starts_children_without_waiting_for_complet
 async def test_scheduled_coordinator_preserves_legacy_child_waits_during_replay() -> None:
     execute_child = AsyncMock(return_value=None)
     start_child = AsyncMock()
+    execute_activity = AsyncMock(return_value=FetchDueEvalReportsOutput(report_ids=["report-1"]))
 
     with (
         patch(
             "posthog.temporal.ai_observability.eval_reports.workflow.temporalio.workflow.execute_activity",
-            new=AsyncMock(return_value=FetchDueEvalReportsOutput(report_ids=["report-1"])),
+            new=execute_activity,
         ),
         patch(
             "posthog.temporal.ai_observability.eval_reports.workflow.temporalio.workflow.start_child_workflow",
@@ -93,6 +98,7 @@ async def test_scheduled_coordinator_preserves_legacy_child_waits_during_replay(
     ):
         await ScheduleAllEvalReportsWorkflow().run(ScheduleAllEvalReportsWorkflowInputs())
 
+    assert execute_activity.await_args.args[1] == {"buffer_minutes": 15}
     execute_child.assert_awaited_once()
     start_child.assert_not_awaited()
 
@@ -128,8 +134,31 @@ async def test_count_coordinator_uses_bounded_input_and_fire_and_forget_dispatch
         await CheckCountTriggeredReportsWorkflow().run(CheckCountTriggeredReportsWorkflowInputs())
 
     assert execute_activity.await_args.args[1].max_reports_per_run == 800
-    patched.assert_called_once_with("eval-report-count-fire-and-forget-2026-09")
+    assert patched.call_args_list == [
+        call("eval-report-count-bounded-input-2026-09"),
+        call("eval-report-count-fire-and-forget-2026-09"),
+    ]
     start_child.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_count_coordinator_preserves_empty_fetch_payload_during_legacy_replay() -> None:
+    execute_activity = AsyncMock(return_value=FetchDueEvalReportsOutput(report_ids=[]))
+
+    with (
+        patch(
+            "posthog.temporal.ai_observability.eval_reports.workflow.temporalio.workflow.execute_activity",
+            new=execute_activity,
+        ),
+        patch(
+            "posthog.temporal.ai_observability.eval_reports.workflow.temporalio.workflow.patched",
+            return_value=False,
+        ) as patched,
+    ):
+        await CheckCountTriggeredReportsWorkflow().run(CheckCountTriggeredReportsWorkflowInputs())
+
+    patched.assert_called_once_with("eval-report-count-bounded-input-2026-09")
+    assert execute_activity.await_args.args[1] == {}
 
 
 @pytest.mark.asyncio

--- a/posthog/temporal/ai_observability/eval_reports/test/test_eval_reports_workflow.py
+++ b/posthog/temporal/ai_observability/eval_reports/test/test_eval_reports_workflow.py
@@ -63,6 +63,7 @@ async def test_scheduled_coordinator_starts_children_without_waiting_for_complet
         call("eval-report-scheduled-bounded-input-2026-09"),
         call("eval-report-scheduled-fire-and-forget-2026-09"),
     ]
+    assert execute_activity.await_args is not None
     assert execute_activity.await_args.args[1].max_reports_per_run == 300
     assert start_child.await_count == 2
     execute_child.assert_not_awaited()
@@ -98,6 +99,7 @@ async def test_scheduled_coordinator_preserves_legacy_child_waits_during_replay(
     ):
         await ScheduleAllEvalReportsWorkflow().run(ScheduleAllEvalReportsWorkflowInputs())
 
+    assert execute_activity.await_args is not None
     assert execute_activity.await_args.args[1] == {"buffer_minutes": 15}
     execute_child.assert_awaited_once()
     start_child.assert_not_awaited()
@@ -133,6 +135,7 @@ async def test_count_coordinator_uses_bounded_input_and_fire_and_forget_dispatch
     ):
         await CheckCountTriggeredReportsWorkflow().run(CheckCountTriggeredReportsWorkflowInputs())
 
+    assert execute_activity.await_args is not None
     assert execute_activity.await_args.args[1].max_reports_per_run == 800
     assert patched.call_args_list == [
         call("eval-report-count-bounded-input-2026-09"),
@@ -158,6 +161,7 @@ async def test_count_coordinator_preserves_empty_fetch_payload_during_legacy_rep
         await CheckCountTriggeredReportsWorkflow().run(CheckCountTriggeredReportsWorkflowInputs())
 
     patched.assert_called_once_with("eval-report-count-bounded-input-2026-09")
+    assert execute_activity.await_args is not None
     assert execute_activity.await_args.args[1] == {}
 
 

--- a/posthog/temporal/ai_observability/eval_reports/test/test_eval_reports_workflow.py
+++ b/posthog/temporal/ai_observability/eval_reports/test/test_eval_reports_workflow.py
@@ -2,7 +2,9 @@ import asyncio
 from uuid import UUID
 
 import pytest
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import temporalio.workflow
 
 from posthog.temporal.ai_observability.eval_reports.activities import (
     deliver_report_activity,
@@ -11,18 +13,123 @@ from posthog.temporal.ai_observability.eval_reports.activities import (
 from posthog.temporal.ai_observability.eval_reports.types import (
     CheckCountTriggeredEvalReportOutput,
     CheckCountTriggeredEvalReportsBatchOutput,
+    CheckCountTriggeredReportsWorkflowInputs,
+    FetchDueEvalReportsOutput,
     GenerateAndDeliverEvalReportWorkflowInput,
     PrepareReportContextOutput,
     RunEvalReportAgentInput,
     RunEvalReportAgentOutput,
+    ScheduleAllEvalReportsWorkflowInputs,
     StoreReportRunOutput,
     UpdateNextDeliveryDateInput,
 )
 from posthog.temporal.ai_observability.eval_reports.workflow import (
+    CheckCountTriggeredReportsWorkflow,
     GenerateAndDeliverEvalReportWorkflow,
+    ScheduleAllEvalReportsWorkflow,
     _check_count_triggered_eval_report_candidates,
     _check_count_triggered_eval_report_candidates_batched,
 )
+
+
+@pytest.mark.asyncio
+async def test_scheduled_coordinator_starts_children_without_waiting_for_completion() -> None:
+    report_ids = ["report-1", "report-2"]
+    execute_activity = AsyncMock(return_value=FetchDueEvalReportsOutput(report_ids=report_ids))
+    start_child = AsyncMock(return_value=MagicMock())
+    execute_child = AsyncMock()
+
+    with (
+        patch(
+            "posthog.temporal.ai_observability.eval_reports.workflow.temporalio.workflow.execute_activity",
+            new=execute_activity,
+        ),
+        patch(
+            "posthog.temporal.ai_observability.eval_reports.workflow.temporalio.workflow.start_child_workflow",
+            new=start_child,
+        ),
+        patch(
+            "posthog.temporal.ai_observability.eval_reports.workflow.temporalio.workflow.execute_child_workflow",
+            new=execute_child,
+        ),
+        patch(
+            "posthog.temporal.ai_observability.eval_reports.workflow.temporalio.workflow.patched",
+            return_value=True,
+        ) as patched,
+    ):
+        await ScheduleAllEvalReportsWorkflow().run(ScheduleAllEvalReportsWorkflowInputs())
+
+    patched.assert_called_once_with("eval-report-scheduled-fire-and-forget-2026-09")
+    assert start_child.await_count == 2
+    execute_child.assert_not_awaited()
+    assert all(
+        call.kwargs["parent_close_policy"] is temporalio.workflow.ParentClosePolicy.ABANDON
+        for call in start_child.await_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_scheduled_coordinator_preserves_legacy_child_waits_during_replay() -> None:
+    execute_child = AsyncMock(return_value=None)
+    start_child = AsyncMock()
+
+    with (
+        patch(
+            "posthog.temporal.ai_observability.eval_reports.workflow.temporalio.workflow.execute_activity",
+            new=AsyncMock(return_value=FetchDueEvalReportsOutput(report_ids=["report-1"])),
+        ),
+        patch(
+            "posthog.temporal.ai_observability.eval_reports.workflow.temporalio.workflow.start_child_workflow",
+            new=start_child,
+        ),
+        patch(
+            "posthog.temporal.ai_observability.eval_reports.workflow.temporalio.workflow.execute_child_workflow",
+            new=execute_child,
+        ),
+        patch(
+            "posthog.temporal.ai_observability.eval_reports.workflow.temporalio.workflow.patched",
+            return_value=False,
+        ),
+    ):
+        await ScheduleAllEvalReportsWorkflow().run(ScheduleAllEvalReportsWorkflowInputs())
+
+    execute_child.assert_awaited_once()
+    start_child.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_count_coordinator_uses_bounded_input_and_fire_and_forget_dispatch() -> None:
+    execute_activity = AsyncMock(
+        return_value=FetchDueEvalReportsOutput(
+            report_ids=["report-1"],
+            report_id_groups=[["report-1"]],
+        )
+    )
+    start_child = AsyncMock(return_value=MagicMock())
+
+    with (
+        patch(
+            "posthog.temporal.ai_observability.eval_reports.workflow.temporalio.workflow.execute_activity",
+            new=execute_activity,
+        ),
+        patch(
+            "posthog.temporal.ai_observability.eval_reports.workflow._check_count_triggered_eval_report_candidates_batched",
+            new=AsyncMock(return_value=["report-1"]),
+        ),
+        patch(
+            "posthog.temporal.ai_observability.eval_reports.workflow.temporalio.workflow.start_child_workflow",
+            new=start_child,
+        ),
+        patch(
+            "posthog.temporal.ai_observability.eval_reports.workflow.temporalio.workflow.patched",
+            return_value=True,
+        ) as patched,
+    ):
+        await CheckCountTriggeredReportsWorkflow().run(CheckCountTriggeredReportsWorkflowInputs())
+
+    assert execute_activity.await_args.args[1].max_reports_per_run == 800
+    patched.assert_called_once_with("eval-report-count-fire-and-forget-2026-09")
+    start_child.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/posthog/temporal/ai_observability/eval_reports/test/test_eval_reports_workflow.py
+++ b/posthog/temporal/ai_observability/eval_reports/test/test_eval_reports_workflow.py
@@ -137,8 +137,10 @@ async def test_count_coordinator_uses_bounded_input_and_fire_and_forget_dispatch
 
     assert execute_activity.await_args is not None
     assert execute_activity.await_args.args[1].max_reports_per_run == 800
+    assert execute_activity.await_args.args[1].max_groups_per_run == 15
     assert patched.call_args_list == [
         call("eval-report-count-bounded-input-2026-09"),
+        call("eval-report-count-group-bounded-input-2026-09"),
         call("eval-report-count-fire-and-forget-2026-09"),
     ]
     start_child.assert_awaited_once()
@@ -163,6 +165,30 @@ async def test_count_coordinator_preserves_empty_fetch_payload_during_legacy_rep
     patched.assert_called_once_with("eval-report-count-bounded-input-2026-09")
     assert execute_activity.await_args is not None
     assert execute_activity.await_args.args[1] == {}
+
+
+@pytest.mark.asyncio
+async def test_count_coordinator_preserves_report_only_bound_during_intermediate_replay() -> None:
+    execute_activity = AsyncMock(return_value=FetchDueEvalReportsOutput(report_ids=[]))
+
+    with (
+        patch(
+            "posthog.temporal.ai_observability.eval_reports.workflow.temporalio.workflow.execute_activity",
+            new=execute_activity,
+        ),
+        patch(
+            "posthog.temporal.ai_observability.eval_reports.workflow.temporalio.workflow.patched",
+            side_effect=[True, False],
+        ) as patched,
+    ):
+        await CheckCountTriggeredReportsWorkflow().run(CheckCountTriggeredReportsWorkflowInputs())
+
+    assert patched.call_args_list == [
+        call("eval-report-count-bounded-input-2026-09"),
+        call("eval-report-count-group-bounded-input-2026-09"),
+    ]
+    assert execute_activity.await_args is not None
+    assert execute_activity.await_args.args[1] == {"max_reports_per_run": 800}
 
 
 @pytest.mark.asyncio

--- a/posthog/temporal/ai_observability/eval_reports/test/test_metrics.py
+++ b/posthog/temporal/ai_observability/eval_reports/test/test_metrics.py
@@ -35,3 +35,5 @@ def test_record_coordinator_poll_emits_saturation_and_progress_signals() -> None
     assert "llma_eval_reports_coordinator_selected" in metric_names
     assert "llma_eval_reports_coordinator_oldest_due_age_seconds" in metric_names
     assert "llma_eval_reports_coordinator_last_successful_poll_timestamp_seconds" in metric_names
+    meter.create_gauge_float.return_value.set.assert_any_call(3_600.0)
+    meter.create_gauge_float.return_value.set.assert_any_call(1_789_128_000.0)

--- a/posthog/temporal/ai_observability/eval_reports/test/test_metrics.py
+++ b/posthog/temporal/ai_observability/eval_reports/test/test_metrics.py
@@ -1,0 +1,37 @@
+import datetime as dt
+
+from unittest.mock import MagicMock, patch
+
+from posthog.temporal.ai_observability.eval_reports.metrics import record_coordinator_poll
+
+
+def test_record_coordinator_poll_emits_saturation_and_progress_signals() -> None:
+    meter = MagicMock()
+    oldest_due_at = dt.datetime(2026, 9, 11, 11, 0, tzinfo=dt.UTC)
+
+    with (
+        patch("posthog.temporal.ai_observability.eval_reports.metrics.activity.in_activity", return_value=True),
+        patch(
+            "posthog.temporal.ai_observability.eval_reports.metrics.get_metric_meter",
+            return_value=meter,
+        ) as get_meter,
+        patch("posthog.temporal.ai_observability.eval_reports.metrics.time.time", return_value=1_789_128_000.0),
+        patch(
+            "posthog.temporal.ai_observability.eval_reports.metrics.dt.datetime",
+            wraps=dt.datetime,
+        ) as datetime_mock,
+    ):
+        datetime_mock.now.return_value = oldest_due_at + dt.timedelta(hours=1)
+        record_coordinator_poll(
+            selected_count=300,
+            trigger_type="scheduled",
+            has_more=True,
+            oldest_due_at=oldest_due_at,
+        )
+
+    assert get_meter.call_args_list[0].args[0] == {"trigger_type": "scheduled", "outcome": "saturated"}
+    metric_names = [call.args[0] for call in meter.method_calls if call[0].startswith("create_")]
+    assert "llma_eval_reports_coordinator_polls" in metric_names
+    assert "llma_eval_reports_coordinator_selected" in metric_names
+    assert "llma_eval_reports_coordinator_oldest_due_age_seconds" in metric_names
+    assert "llma_eval_reports_coordinator_last_successful_poll_timestamp_seconds" in metric_names

--- a/posthog/temporal/ai_observability/eval_reports/test/test_schedule.py
+++ b/posthog/temporal/ai_observability/eval_reports/test/test_schedule.py
@@ -46,6 +46,7 @@ async def test_eval_report_schedules_have_bounded_inputs_and_explicit_policy(
     ):
         await create_schedule(MagicMock())
 
+    assert create.await_args is not None
     schedule = create.await_args.args[2]
     assert schedule.action.args == [expected_args]
     assert schedule.action.execution_timeout == expected_timeout

--- a/posthog/temporal/ai_observability/eval_reports/test/test_schedule.py
+++ b/posthog/temporal/ai_observability/eval_reports/test/test_schedule.py
@@ -23,7 +23,7 @@ from posthog.temporal.ai_observability.eval_reports.schedule import (
         ),
         (
             create_count_trigger_schedule,
-            {"max_reports_per_run": 800},
+            {"max_reports_per_run": 800, "max_groups_per_run": 15},
             timedelta(minutes=30),
             timedelta(minutes=5),
         ),

--- a/posthog/temporal/ai_observability/eval_reports/test/test_schedule.py
+++ b/posthog/temporal/ai_observability/eval_reports/test/test_schedule.py
@@ -1,0 +1,53 @@
+from datetime import timedelta
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from temporalio.client import ScheduleOverlapPolicy
+
+from posthog.temporal.ai_observability.eval_reports.schedule import (
+    create_count_trigger_schedule,
+    create_eval_reports_schedule,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "create_schedule,expected_args,expected_timeout,expected_catchup",
+    [
+        (
+            create_eval_reports_schedule,
+            {"buffer_minutes": 15, "max_reports_per_run": 300},
+            timedelta(minutes=10),
+            timedelta(hours=1),
+        ),
+        (
+            create_count_trigger_schedule,
+            {"max_reports_per_run": 800},
+            timedelta(minutes=30),
+            timedelta(minutes=5),
+        ),
+    ],
+)
+async def test_eval_report_schedules_have_bounded_inputs_and_explicit_policy(
+    create_schedule,
+    expected_args: dict,
+    expected_timeout: timedelta,
+    expected_catchup: timedelta,
+) -> None:
+    create = AsyncMock()
+
+    with (
+        patch(
+            "posthog.temporal.ai_observability.eval_reports.schedule.a_schedule_exists",
+            new=AsyncMock(return_value=False),
+        ),
+        patch("posthog.temporal.ai_observability.eval_reports.schedule.a_create_schedule", new=create),
+    ):
+        await create_schedule(MagicMock())
+
+    schedule = create.await_args.args[2]
+    assert schedule.action.args == [expected_args]
+    assert schedule.action.execution_timeout == expected_timeout
+    assert schedule.policy.overlap is ScheduleOverlapPolicy.SKIP
+    assert schedule.policy.catchup_window == expected_catchup

--- a/posthog/temporal/ai_observability/eval_reports/types.py
+++ b/posthog/temporal/ai_observability/eval_reports/types.py
@@ -9,6 +9,10 @@ DEFAULT_MAX_SCHEDULED_EVAL_REPORTS_PER_RUN = 300
 # Leaves room below Temporal's recommendation of at most 1,000 children per parent
 # while rotating through larger candidate inventories over subsequent polls.
 DEFAULT_MAX_COUNT_TRIGGERED_EVAL_REPORTS_PER_RUN = 800
+# With five groups checked concurrently, 15 groups require at most three serial
+# windows. Even if every activity exhausts its three 120-second attempts and
+# retry backoffs, that leaves useful headroom inside the 30-minute coordinator.
+DEFAULT_MAX_COUNT_TRIGGERED_EVAL_REPORT_GROUPS_PER_RUN = 15
 
 
 @dataclasses.dataclass(frozen=True)
@@ -20,6 +24,7 @@ class ScheduleAllEvalReportsWorkflowInputs:
 @dataclasses.dataclass(frozen=True)
 class CheckCountTriggeredReportsWorkflowInputs:
     max_reports_per_run: int = DEFAULT_MAX_COUNT_TRIGGERED_EVAL_REPORTS_PER_RUN
+    max_groups_per_run: int = DEFAULT_MAX_COUNT_TRIGGERED_EVAL_REPORT_GROUPS_PER_RUN
 
 
 @dataclasses.dataclass

--- a/posthog/temporal/ai_observability/eval_reports/types.py
+++ b/posthog/temporal/ai_observability/eval_reports/types.py
@@ -5,15 +5,21 @@ from typing import Any
 
 from posthog.dataclasses import frozen
 
+DEFAULT_MAX_SCHEDULED_EVAL_REPORTS_PER_RUN = 300
+# Leaves room below Temporal's recommendation of at most 1,000 children per parent
+# while rotating through larger candidate inventories over subsequent polls.
+DEFAULT_MAX_COUNT_TRIGGERED_EVAL_REPORTS_PER_RUN = 800
 
-@dataclasses.dataclass
+
+@dataclasses.dataclass(frozen=True)
 class ScheduleAllEvalReportsWorkflowInputs:
     buffer_minutes: int = 15
+    max_reports_per_run: int = DEFAULT_MAX_SCHEDULED_EVAL_REPORTS_PER_RUN
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class CheckCountTriggeredReportsWorkflowInputs:
-    pass
+    max_reports_per_run: int = DEFAULT_MAX_COUNT_TRIGGERED_EVAL_REPORTS_PER_RUN
 
 
 @dataclasses.dataclass

--- a/posthog/temporal/ai_observability/eval_reports/workflow.py
+++ b/posthog/temporal/ai_observability/eval_reports/workflow.py
@@ -286,13 +286,13 @@ async def _dispatch_report_workflows(
             )
             for report_id in report_ids
         ]
-        results = await asyncio.gather(*tasks, return_exceptions=True)
-        _log_fan_out_failures(kind, report_ids, results)
+        legacy_results = await asyncio.gather(*tasks, return_exceptions=True)
+        _log_fan_out_failures(kind, report_ids, legacy_results)
         return
 
-    results: list[bool | BaseException] = []
+    start_results: list[bool | BaseException] = []
     for report_id_batch in batched(report_ids, REPORT_START_BATCH_SIZE, strict=False):
-        results.extend(
+        start_results.extend(
             await asyncio.gather(
                 *(_start_report_workflow(workflow_id_prefix, report_id) for report_id in report_id_batch),
                 return_exceptions=True,
@@ -301,7 +301,7 @@ async def _dispatch_report_workflows(
 
     already_started = 0
     failures: list[tuple[str, str]] = []
-    for report_id, result in zip(report_ids, results):
+    for report_id, result in zip(report_ids, start_results):
         if isinstance(result, BaseException):
             failures.append((report_id, f"{type(result).__name__}: {result}"))
         elif result is False:

--- a/posthog/temporal/ai_observability/eval_reports/workflow.py
+++ b/posthog/temporal/ai_observability/eval_reports/workflow.py
@@ -129,6 +129,9 @@ class CheckCountTriggeredReportsWorkflow(PostHogWorkflow):
             start_to_close_timeout=FETCH_ACTIVITY_TIMEOUT,
             retry_policy=FETCH_RETRY_POLICY,
         )
+        if not result.report_ids:
+            return
+
         # Batched path: one check activity per team-group, each sharing one ClickHouse
         # count query, instead of one activity per report. Gated on the fetch output so
         # the decision is replay-deterministic: histories recorded before batching (and

--- a/posthog/temporal/ai_observability/eval_reports/workflow.py
+++ b/posthog/temporal/ai_observability/eval_reports/workflow.py
@@ -38,6 +38,7 @@ from posthog.temporal.ai_observability.eval_reports.constants import (
     FETCH_RETRY_POLICY,
     GENERATE_EVAL_REPORT_WORKFLOW_NAME,
     PREPARE_ACTIVITY_TIMEOUT,
+    REPORT_START_BATCH_SIZE,
     SCHEDULE_ALL_EVAL_REPORTS_WORKFLOW_NAME,
     STORE_ACTIVITY_TIMEOUT,
     STORE_RETRY_POLICY,
@@ -90,22 +91,12 @@ class ScheduleAllEvalReportsWorkflow(PostHogWorkflow):
         if not result.report_ids:
             return
 
-        # Fan-out: start child workflow per due report
-        tasks = []
-        for report_id in result.report_ids:
-            task = temporalio.workflow.execute_child_workflow(
-                GenerateAndDeliverEvalReportWorkflow.run,
-                GenerateAndDeliverEvalReportWorkflowInput(report_id=report_id),
-                id=f"eval-report-{report_id}",
-                execution_timeout=WORKFLOW_EXECUTION_TIMEOUT,
-            )
-            tasks.append(task)
-
-        # return_exceptions=True isolates individual report failures — one failing
-        # report shouldn't block the others. Log the offenders so they're visible
-        # in observability even though we don't re-raise.
-        results = await asyncio.gather(*tasks, return_exceptions=True)
-        _log_fan_out_failures("scheduled_eval_report", result.report_ids, results)
+        await _dispatch_report_workflows(
+            "scheduled_eval_report",
+            "eval-report",
+            result.report_ids,
+            patch_id="eval-report-scheduled-fire-and-forget-2026-09",
+        )
 
 
 @temporalio.workflow.defn(name=CHECK_COUNT_TRIGGERED_REPORTS_WORKFLOW_NAME)
@@ -140,18 +131,12 @@ class CheckCountTriggeredReportsWorkflow(PostHogWorkflow):
         if not report_ids:
             return
 
-        tasks = []
-        for report_id in report_ids:
-            task = temporalio.workflow.execute_child_workflow(
-                GenerateAndDeliverEvalReportWorkflow.run,
-                GenerateAndDeliverEvalReportWorkflowInput(report_id=report_id),
-                id=f"eval-report-count-{report_id}",
-                execution_timeout=WORKFLOW_EXECUTION_TIMEOUT,
-            )
-            tasks.append(task)
-
-        results = await asyncio.gather(*tasks, return_exceptions=True)
-        _log_fan_out_failures("count_triggered_eval_report", report_ids, results)
+        await _dispatch_report_workflows(
+            "count_triggered_eval_report",
+            "eval-report-count",
+            report_ids,
+            patch_id="eval-report-count-fire-and-forget-2026-09",
+        )
 
 
 async def _check_count_triggered_eval_report_candidates(report_ids: list[str]) -> list[str]:
@@ -271,6 +256,74 @@ def _log_fan_out_failures(kind: str, report_ids: list[str], results: list) -> No
             f"{kind}.child_workflow_errors",
             extra={"failed_count": len(failed), "failures": failed},
         )
+
+
+async def _dispatch_report_workflows(
+    kind: str,
+    workflow_id_prefix: str,
+    report_ids: list[str],
+    *,
+    patch_id: str,
+) -> None:
+    if not temporalio.workflow.patched(patch_id):
+        tasks = [
+            temporalio.workflow.execute_child_workflow(
+                GenerateAndDeliverEvalReportWorkflow.run,
+                GenerateAndDeliverEvalReportWorkflowInput(report_id=report_id),
+                id=f"{workflow_id_prefix}-{report_id}",
+                execution_timeout=WORKFLOW_EXECUTION_TIMEOUT,
+            )
+            for report_id in report_ids
+        ]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        _log_fan_out_failures(kind, report_ids, results)
+        return
+
+    results: list[bool | BaseException] = []
+    for report_id_batch in batched(report_ids, REPORT_START_BATCH_SIZE, strict=False):
+        results.extend(
+            await asyncio.gather(
+                *(_start_report_workflow(workflow_id_prefix, report_id) for report_id in report_id_batch),
+                return_exceptions=True,
+            )
+        )
+
+    already_started = 0
+    failures: list[tuple[str, str]] = []
+    for report_id, result in zip(report_ids, results):
+        if isinstance(result, BaseException):
+            failures.append((report_id, f"{type(result).__name__}: {result}"))
+        elif result is False:
+            already_started += 1
+
+    if failures:
+        temporalio.workflow.logger.warning(
+            f"{kind}.child_workflow_start_errors",
+            extra={
+                "already_started_count": already_started,
+                "failed_count": len(failures),
+                "failure_samples": failures[:20],
+            },
+        )
+    elif already_started:
+        temporalio.workflow.logger.info(
+            f"{kind}.child_workflow_already_running",
+            extra={"already_started_count": already_started},
+        )
+
+
+async def _start_report_workflow(workflow_id_prefix: str, report_id: str) -> bool:
+    try:
+        await temporalio.workflow.start_child_workflow(
+            GenerateAndDeliverEvalReportWorkflow.run,
+            GenerateAndDeliverEvalReportWorkflowInput(report_id=report_id),
+            id=f"{workflow_id_prefix}-{report_id}",
+            parent_close_policy=temporalio.workflow.ParentClosePolicy.ABANDON,
+            execution_timeout=WORKFLOW_EXECUTION_TIMEOUT,
+        )
+        return True
+    except WorkflowAlreadyStartedError:
+        return False
 
 
 async def _update_report_schedule(inputs: UpdateNextDeliveryDateInput) -> None:

--- a/posthog/temporal/ai_observability/eval_reports/workflow.py
+++ b/posthog/temporal/ai_observability/eval_reports/workflow.py
@@ -4,6 +4,7 @@ import json
 import asyncio
 from datetime import timedelta
 from itertools import batched
+from typing import cast
 
 from django.conf import settings
 
@@ -81,9 +82,14 @@ class ScheduleAllEvalReportsWorkflow(PostHogWorkflow):
 
     @temporalio.workflow.run
     async def run(self, inputs: ScheduleAllEvalReportsWorkflowInputs) -> None:
+        fetch_inputs = (
+            inputs
+            if temporalio.workflow.patched("eval-report-scheduled-bounded-input-2026-09")
+            else cast(ScheduleAllEvalReportsWorkflowInputs, {"buffer_minutes": inputs.buffer_minutes})
+        )
         result = await temporalio.workflow.execute_activity(
             fetch_due_eval_reports_activity,
-            inputs,
+            fetch_inputs,
             start_to_close_timeout=FETCH_ACTIVITY_TIMEOUT,
             retry_policy=FETCH_RETRY_POLICY,
         )
@@ -112,9 +118,14 @@ class CheckCountTriggeredReportsWorkflow(PostHogWorkflow):
 
     @temporalio.workflow.run
     async def run(self, inputs: CheckCountTriggeredReportsWorkflowInputs) -> None:
+        fetch_inputs = (
+            inputs
+            if temporalio.workflow.patched("eval-report-count-bounded-input-2026-09")
+            else cast(CheckCountTriggeredReportsWorkflowInputs, {})
+        )
         result = await temporalio.workflow.execute_activity(
             fetch_count_triggered_eval_report_candidates_activity,
-            inputs,
+            fetch_inputs,
             start_to_close_timeout=FETCH_ACTIVITY_TIMEOUT,
             retry_policy=FETCH_RETRY_POLICY,
         )

--- a/posthog/temporal/ai_observability/eval_reports/workflow.py
+++ b/posthog/temporal/ai_observability/eval_reports/workflow.py
@@ -118,11 +118,17 @@ class CheckCountTriggeredReportsWorkflow(PostHogWorkflow):
 
     @temporalio.workflow.run
     async def run(self, inputs: CheckCountTriggeredReportsWorkflowInputs) -> None:
-        fetch_inputs = (
-            inputs
-            if temporalio.workflow.patched("eval-report-count-bounded-input-2026-09")
-            else cast(CheckCountTriggeredReportsWorkflowInputs, {})
-        )
+        if temporalio.workflow.patched("eval-report-count-bounded-input-2026-09"):
+            fetch_inputs = (
+                inputs
+                if temporalio.workflow.patched("eval-report-count-group-bounded-input-2026-09")
+                else cast(
+                    CheckCountTriggeredReportsWorkflowInputs,
+                    {"max_reports_per_run": inputs.max_reports_per_run},
+                )
+            )
+        else:
+            fetch_inputs = cast(CheckCountTriggeredReportsWorkflowInputs, {})
         result = await temporalio.workflow.execute_activity(
             fetch_count_triggered_eval_report_candidates_activity,
             fetch_inputs,


### PR DESCRIPTION
## Problem

Evaluation reports can be delayed when a coordinator loads every eligible report and waits for every generated child.

Both coordinators grow their Temporal payloads and histories with the report inventory. A fixed first-page limit would protect Temporal but let failed or consistently old reports starve later work. The count-triggered coordinator also needs a bound on query groups, because the workflow consumes five groups at a time in serial windows.

## Changes

- Evaluation reports now make bounded, fair progress through the eligible inventory.
- Scheduled reports select up to 300 rows per run, interleave teams, and rotate pages so a permanently due prefix cannot monopolize the bound.
- Count-triggered reports select from up to 800 rows, rotate report and query-group pages, and process at most 15 groups per run.
- The 15-group default permits three five-way activity windows, leaving headroom inside the 30-minute coordinator timeout even when every activity exhausts its retry budget.
- All limits live in Schedule action inputs, so operators can tune them without changing code.
- Coordinators start children in batches of 100 and return after Temporal accepts each start.
- Abandoned parents no longer cancel accepted children.
- Existing histories preserve their prior command payloads and wait-for-child behavior through Temporal patch markers.
- Schedule policies now define overlap, catch-up, and coordinator timeouts explicitly.
- Metrics expose poll freshness, saturation, selected counts, and oldest due age without tenant labels.

Before:

```mermaid
flowchart TD
    S[Temporal schedule] --> F[Load every eligible report]
    F --> P[One coordinator payload]
    P --> C[Start every child]
    C --> W[Wait for every child result]
    W --> X[Coordinator completes]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class S,X phYellow;
    class F,P phGray;
    class C,W phRed;
```

After:

```mermaid
flowchart TD
    S[Temporal schedule] --> F[Select a bounded rotating page]
    F --> B[Start children in bounded batches]
    B --> A[Temporal accepts child starts]
    A --> X[Coordinator completes]
    A --> C[Children continue independently]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class S,X phYellow;
    class F phGray;
    class B,A phBlue;
    class C phRed;
```

No user interface changes.

## How did you test this code?

- Focused workflow tests cover fire-and-forget starts and both legacy replay boundaries.
- Schedule tests cover configurable default inputs, overlap, catch-up, and timeouts.
- Activity tests cover fair scheduled selection, rotation past a stuck scheduled page, rotating count-triggered report pages, and the query-group cap and rotation.
- Metrics tests cover saturation and freshness signals.
- Ran `./bin/hogli ci:preflight --fix`.
- Ran the focused non-database suite locally.
- Not run locally: database-backed activity tests because this sandbox has no Postgres service. CI is authoritative for those tests.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation change. The `skip-inkeep-docs` label applies.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex Desktop authored the change with the repository `/writing-pr-descriptions` skill. The local CodeRabbit pass is paused per repository guidance.

An open-PR search found no competing evaluation-report scheduler fix. An operational investigation informed the scope; committed tests use invented data and include no private material.
