### PR TITLE
feat(marketing): add acquisition overview to the new dashboard

### DIFF
--- a/docs/internal/marketing-analytics-configuration-writes.md
+++ b/docs/internal/marketing-analytics-configuration-writes.md
@@ -11,3 +11,7 @@ Suggestion review, dismissal, restoration, batch review, capability filters, res
 `marketing analytics setup change submitted`, `change completed` and `change failed` share the same prefix and report operation types, counts, source and whether the change is an undo. Completed reports the server's applied count, which may be zero.
 `marketing analytics setup sync retry completed` reports requested and failed counts; it measures scheduling retries, not completed syncs.
 Payloads exclude suggestion IDs, titles, evidence, goal names and UTM values. Source navigation measures entry into connection flows; existing warehouse connection events measure their completion.
+
+## Acquisition preview
+
+With `new-marketing-analytics-dashboard` enabled, the dashboard shows visitors, sessions and pageviews using the existing Web Overview query and metric cards. The date range, comparison and saved test-account filter apply to both the summary and channel table. Reload summary refreshes only the summary. The legacy dashboard remains available when the flag is off.

--- a/frontend/src/scenes/marketing-analytics/NewMarketingAnalyticsDashboard.tsx
+++ b/frontend/src/scenes/marketing-analytics/NewMarketingAnalyticsDashboard.tsx
@@ -1,13 +1,25 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
+
+import { CompareFilter } from 'lib/components/CompareFilter/CompareFilter'
+import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { MARKETING_ANALYTICS_DEFAULT_QUERY_TAGS } from 'scenes/web-analytics/common'
+import { marketingAnalyticsLogic } from 'scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsLogic'
 import { MarketingAnalyticsCell } from 'scenes/web-analytics/tabs/marketing-analytics/frontend/shared'
 import { webAnalyticsDataTableQueryContext } from 'scenes/web-analytics/tiles/WebAnalyticsTile'
 
+import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
+import { OverviewMetricCardGrid } from '~/queries/nodes/OverviewGrid/OverviewMetricCardGrid'
+import { labelFromKey } from '~/queries/nodes/WebOverview/WebOverview'
 import { Query } from '~/queries/Query/Query'
 import {
     DataTableNode,
     MarketingAnalyticsBaseColumns,
     MarketingAnalyticsDrillDownLevel,
     NodeKind,
+    WebOverviewQuery,
+    WebOverviewQueryResponse,
 } from '~/queries/schema/schema-general'
 import { QueryContext, QueryContextColumn } from '~/queries/types'
 
@@ -67,9 +79,62 @@ const QUERY_CONTEXT: QueryContext = {
 // Scaffold for the redesigned marketing analytics dashboard, gated behind the
 // `new-marketing-analytics-dashboard` feature flag.
 export function NewMarketingAnalyticsDashboard(): JSX.Element {
+    const { dateFilter, compareFilter, shouldFilterTestAccounts } = useValues(marketingAnalyticsLogic)
+    const { setDates, setCompareFilter } = useActions(marketingAnalyticsLogic)
+    const dateRange = { date_from: dateFilter.dateFrom, date_to: dateFilter.dateTo }
+    const query: WebOverviewQuery = {
+        kind: NodeKind.WebOverviewQuery,
+        dateRange,
+        compareFilter,
+        filterTestAccounts: shouldFilterTestAccounts,
+        properties: [],
+        tags: MARKETING_ANALYTICS_DEFAULT_QUERY_TAGS,
+    }
+    const overviewLogic = dataNodeLogic({ query, key: 'marketing-acquisition-overview' })
+    const { response, responseLoading, responseError } = useValues(overviewLogic)
+    const { loadData } = useActions(overviewLogic)
+    const overview = response as WebOverviewQueryResponse | undefined
+    const items = ['visitors', 'sessions', 'views'].flatMap((key) =>
+        (overview?.results?.filter((item) => item.key === key) ?? []).map((item) => ({ ...item, value: item.value }))
+    )
+
     return (
-        <div className="mt-4">
-            <Query query={CHANNEL_SOURCE_BREAKDOWN} context={QUERY_CONTEXT} readOnly />
+        <div className="mt-4 flex flex-col gap-4">
+            <div className="flex flex-wrap items-center gap-2">
+                <DateFilter dateFrom={dateFilter.dateFrom} dateTo={dateFilter.dateTo} onChange={setDates} />
+                <CompareFilter compareFilter={compareFilter} updateCompareFilter={setCompareFilter} />
+                <LemonButton size="small" loading={responseLoading} onClick={() => loadData('force_async')}>
+                    Reload summary
+                </LemonButton>
+            </div>
+            <h2 className="mb-0">Acquisition</h2>
+            {responseError ? (
+                <LemonBanner type="error" action={{ children: 'Retry', onClick: () => loadData('force_async') }}>
+                    Could not load acquisition metrics. Try again.
+                </LemonBanner>
+            ) : (
+                <OverviewMetricCardGrid
+                    items={items}
+                    loading={responseLoading}
+                    numSkeletons={3}
+                    samplingRate={overview?.samplingRate}
+                    preComputeStrategy={overview?.preComputeStrategy}
+                    labelFromKey={labelFromKey}
+                />
+            )}
+            <Query
+                query={{
+                    ...CHANNEL_SOURCE_BREAKDOWN,
+                    source: {
+                        ...CHANNEL_SOURCE_BREAKDOWN.source,
+                        dateRange,
+                        compareFilter,
+                        filterTestAccounts: shouldFilterTestAccounts,
+                    },
+                }}
+                context={QUERY_CONTEXT}
+                readOnly
+            />
         </div>
     )
 }


### PR DESCRIPTION
## Problem

The new Marketing dashboard shows a channel table without an acquisition summary and uses a fixed 30-day range.

## Changes

Add Visitors, Sessions and Page views using existing Web Overview queries and metric cards. Date and comparison controls also update the channel table. The existing dashboard flag gates this surface; the legacy dashboard code is unchanged.

![Acquisition with synthetic demo traffic](https://raw.githubusercontent.com/PostHog/pr-assets/36d4a12e8024b2d8597e0fc722a65a7b301a203d/2026/09/9adbd7a3-78c2-4cab-baba-cec8e77b4458.png)

## How did you test this code?

- Browser: switched between 7 and 30 days and enabled/disabled comparison with synthetic traffic. Verified the summary without pageviews.
- Ran scoped Oxlint, formatting, diff checks and `hogli ci:preflight --against HEAD`.
- Full TypeScript check fails on dependencies elsewhere in the checkout, including `@posthog/quill-primitives`; no errors reference the changed component.
- Pending before release: flag-off browser verification, error/retry checks and session-count parity between Web Overview and the existing channel table.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Added acquisition behavior to `docs/internal/marketing-analytics-configuration-writes.md`.

## 🤖 Agent context

Human-directed, Codex-assisted implementation using shell, GitHub CLI and browser UI checks. Skills: writing-ui-components, writing-kea-logics, writing-user-facing-copy, run-posthog, running-ci-preflight and writing-pr-descriptions.

The open-PR title search found no duplicate acquisition PR. No local CodeRabbit pass. The screenshot contains synthetic demo traffic only.
