### PR TITLE
fix(hogql): alias joined subqueries

### DIFF
--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -2254,6 +2254,15 @@ class TestPrinter(BaseTest):
             ),
         )
 
+    @parameterized.expand(
+        [
+            ("select_query", "SELECT 1 FROM events CROSS JOIN (SELECT 1)"),
+            ("select_set_query", "SELECT 1 FROM events CROSS JOIN (SELECT 1 UNION ALL SELECT 2)"),
+        ]
+    )
+    def test_select_cross_join_subquery_uses_generated_alias(self, _name: str, query: str) -> None:
+        self.assertIn("AS __join_1", self._select(query))
+
     def test_left_join_team_id_in_on_clause(self):
         # LEFT JOINs should have team_id in ON clause, not WHERE, to preserve LEFT JOIN semantics
         context = HogQLContext(team_id=self.team.pk, enable_select_queries=True)

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -2263,6 +2263,11 @@ class TestPrinter(BaseTest):
     def test_select_cross_join_subquery_uses_generated_alias(self, _name: str, query: str) -> None:
         self.assertIn("AS __join_1", self._select(query))
 
+    def test_select_cross_join_subquery_avoids_later_alias(self) -> None:
+        printed = self._select("SELECT 1 FROM events CROSS JOIN (SELECT 1) CROSS JOIN events AS __join_1")
+
+        self.assertIn("AS __join_2", printed)
+
     def test_left_join_team_id_in_on_clause(self):
         # LEFT JOINs should have team_id in ON clause, not WHERE, to preserve LEFT JOIN semantics
         context = HogQLContext(team_id=self.team.pk, enable_select_queries=True)

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -1514,8 +1514,11 @@ class Resolver(CloningVisitor):
             if node.constraint and node.constraint.constraint_type == "USING":
                 # visit USING constraint before adding the table to avoid ambiguous names
                 node.constraint = self.visit_join_constraint(node.constraint)
-            if node.alias is None and self._join_chain_has_using(node):
-                node.alias = self._synthesize_using_join_alias(scope)
+            if node.alias is None:
+                if node.join_type is not None:
+                    node.alias = self._synthesize_join_alias(scope)
+                elif self._join_chain_has_using(node):
+                    node.alias = self._synthesize_using_join_alias(scope)
 
             node.table = cast("ast.SelectQuery | ast.SelectSetQuery", super().visit(node.table))
 
@@ -1726,6 +1729,13 @@ class Resolver(CloningVisitor):
         alias = f"__using_join_{index}"
         self._synthetic_using_join_aliases.add(alias)
         return alias
+
+    def _synthesize_join_alias(self, scope: ast.SelectQueryType) -> str:
+        """Alias a joined sub-select because ClickHouse requires a name for it."""
+        index = 1
+        while f"__join_{index}" in scope.tables:
+            index += 1
+        return f"__join_{index}"
 
     def _using_constraint_column_names(self, constraint: ast.JoinConstraint) -> list[str]:
         exprs = constraint.expr.exprs if isinstance(constraint.expr, ast.Tuple) else [constraint.expr]

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -1515,10 +1515,10 @@ class Resolver(CloningVisitor):
                 # visit USING constraint before adding the table to avoid ambiguous names
                 node.constraint = self.visit_join_constraint(node.constraint)
             if node.alias is None:
-                if node.join_type is not None:
-                    node.alias = self._synthesize_join_alias(scope)
-                elif self._join_chain_has_using(node):
+                if self._join_chain_has_using(node):
                     node.alias = self._synthesize_using_join_alias(scope)
+                elif node.join_type is not None:
+                    node.alias = self._synthesize_join_alias(scope)
 
             node.table = cast("ast.SelectQuery | ast.SelectSetQuery", super().visit(node.table))
 

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -1518,7 +1518,7 @@ class Resolver(CloningVisitor):
                 if self._join_chain_has_using(node):
                     node.alias = self._synthesize_using_join_alias(scope)
                 elif node.join_type is not None:
-                    node.alias = self._synthesize_join_alias(scope)
+                    node.alias = self._synthesize_join_alias(scope, node)
 
             node.table = cast("ast.SelectQuery | ast.SelectSetQuery", super().visit(node.table))
 
@@ -1730,10 +1730,17 @@ class Resolver(CloningVisitor):
         self._synthetic_using_join_aliases.add(alias)
         return alias
 
-    def _synthesize_join_alias(self, scope: ast.SelectQueryType) -> str:
+    def _synthesize_join_alias(self, scope: ast.SelectQueryType, node: ast.JoinExpr) -> str:
         """Alias a joined sub-select because ClickHouse requires a name for it."""
+        reserved_aliases = set(scope.tables)
+        next_join = node.next_join
+        while next_join is not None:
+            if next_join.alias is not None:
+                reserved_aliases.add(next_join.alias)
+            next_join = next_join.next_join
+
         index = 1
-        while f"__join_{index}" in scope.tables:
+        while f"__join_{index}" in reserved_aliases:
             index += 1
         return f"__join_{index}"
 


### PR DESCRIPTION
## Problem

People cannot run a HogQL query that joins an un-aliased subquery because ClickHouse requires the joined source to have a name.

## Changes

- Generate a stable alias for un-aliased joined `SELECT` and set-operation subqueries.
- Preserve the existing aliases used when `USING` is rewritten to `ON`.

## How did you test this code?

- `hogli test posthog/hogql/printer/test/test_printer.py -k select_cross_join_subquery_uses_generated_alias` verifies plain and set-operation joined subqueries receive an alias.
- `ruff check` and `ruff format --check` passed for both changed files.
- The focused Semgrep security scan found no findings.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Not needed. This is a printer compatibility fix with no documented workflow change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent: PostHog Slack app.
- Duplicate check: no related open PR or issue found.
- Public artifact: code and tests use generic queries only.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0C0LU050GN/p1789124979664619?thread_ts=1789124979.664619&cid=C0C0LU050GN)*