### PR TITLE
fix(desktop): link pull request attribution to its task

### DIFF
--- a/products/desktop/docs/DEEP-LINKS.md
+++ b/products/desktop/docs/DEEP-LINKS.md
@@ -96,6 +96,11 @@ posthog-code://task/abc123?comment=thread-1&scope=desktop_canvas&item=canvas-9
 
 An **https** bridge also exists for links sent outside the app (e.g. comment Slack DMs): `<instance>/code/task/<taskId>` resolves to a web interstitial in PostHog Cloud, which fires this scheme — forwarding the `comment`, `scope`, and `item` params — or offers the desktop-app download.
 
+Pull request attribution links use `<instance>/code/task/<taskId>` when the task and instance are known.
+This applies to agent-created pull requests and the desktop pull request action.
+Slack thread and inbox report links keep their existing destinations.
+The product website remains the fallback when no task link is available.
+
 ### `posthog-code://inbox[/<reportId>]`
 
 Open Self-driving, or a specific report inside it.

--- a/products/desktop/packages/agent/src/pi/task-system-prompt.test.ts
+++ b/products/desktop/packages/agent/src/pi/task-system-prompt.test.ts
@@ -1,7 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { buildTaskSystemPrompt } from "./task-system-prompt";
+import {
+  buildLocalAttributionPrompt,
+  buildTaskSystemPrompt,
+} from "./task-system-prompt";
 
 describe("buildTaskSystemPrompt", () => {
+  it("keeps the product link when the instance is unavailable", () => {
+    expect(buildLocalAttributionPrompt("task-123")).toContain(
+      "*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*",
+    );
+  });
+
   it("builds durable local task instructions", () => {
     const prompt = buildTaskSystemPrompt({
       projectId: 42,
@@ -18,6 +27,9 @@ describe("buildTaskSystemPrompt", () => {
     expect(prompt).toContain("This is task task-123");
     expect(prompt).toContain("Generated-By: PostHog Desktop");
     expect(prompt).toContain("Task-Id: task-123");
+    expect(prompt).toContain(
+      "*Created with [PostHog Desktop](https://us.posthog.com/code/task/task-123)*",
+    );
     expect(prompt).toContain("Keep the patch small.");
     expect(prompt).toContain("<directory>/tmp/a&amp;b</directory>");
     expect(prompt).toContain("<directory>/tmp/&lt;shared&gt;</directory>");
@@ -54,6 +66,9 @@ describe("buildTaskSystemPrompt", () => {
     expect(prompt).toContain("git_signed_commit");
     expect(prompt).toContain("Generated-By: PostHog Desktop");
     expect(prompt).toContain("Task-Id: task-123");
+    expect(prompt).toContain(
+      "*Created with [PostHog Desktop](https://us.posthog.com/code/task/task-123)*",
+    );
     expect(prompt).not.toContain('git commit -m "$(cat');
     expect(prompt).toContain("Use the existing pull request.");
   });

--- a/products/desktop/packages/agent/src/pi/task-system-prompt.ts
+++ b/products/desktop/packages/agent/src/pi/task-system-prompt.ts
@@ -1,3 +1,5 @@
+import { buildTaskShareUrl } from "@posthog/shared";
+
 export interface TaskContextInput {
   taskId: string;
   cwd: string;
@@ -39,7 +41,10 @@ This is task ${taskId}. Keep material provided as task context, including custom
 export function buildAttributionPrompt(
   taskId: string,
   environment: TaskContext["environment"],
+  apiHost?: string,
 ): string {
+  const attributionUrl =
+    buildTaskShareUrl(apiHost, taskId) ?? "https://posthog.com/desktop?ref=pr";
   const commitInstructions =
     environment === "cloud"
       ? `In cloud tasks, call \`git_signed_commit\` to create commits. It automatically adds these trailers:
@@ -70,7 +75,7 @@ When creating new branches, prefix them with \`posthog/\` (e.g. \`posthog/fix-lo
 When creating pull requests, add the following footer at the end of the PR description:
 \`\`\`
 ---
-*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
+*Created with [PostHog Desktop](${attributionUrl})*
 \`\`\``;
 }
 
@@ -152,7 +157,11 @@ export function buildTaskSystemPrompt(
   ];
 
   sections.push(
-    buildAttributionPrompt(context.taskId, context.environment),
+    buildAttributionPrompt(
+      context.taskId,
+      context.environment,
+      context.apiHost,
+    ),
     buildQuestionsPrompt(capabilities.structuredInput === true),
     buildPullRequestLinksPrompt(),
     buildShellEfficiencyPrompt(),

--- a/products/desktop/packages/agent/src/server/agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.test.ts
@@ -11,6 +11,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { type ContentBlock, RequestError } from "@agentclientprotocol/sdk";
+import { readGithubTokenFromEnv } from "@posthog/git/signed-commit";
 import type { Adapter } from "@posthog/shared";
 import { zipSync } from "fflate";
 import jwt from "jsonwebtoken";
@@ -41,6 +42,7 @@ import {
 } from "../test/fixtures/api";
 import { createPostHogHandlers } from "../test/mocks/msw-handlers";
 import type { StoredEntry, TaskRun } from "../types";
+import * as githubToken from "../utils/github-token";
 import {
   AgentServer,
   isTurnCompleteNotification,
@@ -6612,7 +6614,14 @@ describe("AgentServer HTTP Mode", () => {
   });
 
   describe("buildCloudSystemPrompt", () => {
+    beforeEach(() => {
+      vi.spyOn(githubToken, "resolveGithubToken").mockImplementation(() =>
+        readGithubTokenFromEnv(),
+      );
+    });
+
     afterEach(() => {
+      vi.mocked(githubToken.resolveGithubToken).mockRestore();
       vi.unstubAllEnvs();
     });
 
@@ -6764,7 +6773,7 @@ describe("AgentServer HTTP Mode", () => {
         "If the user explicitly asks you to open a pull request",
       );
       expect(prompt).toContain(
-        "*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*",
+        "*Created with [PostHog Desktop](http://localhost:8000/code/task/test-task-id)*",
       );
       expect(prompt).toContain(".github/pull_request_template.md");
       expect(prompt).toContain("gh issue list --search");
@@ -6867,7 +6876,7 @@ describe("AgentServer HTTP Mode", () => {
       expect(prompt).toContain("Task-Id: test-task-id");
       // Slack-origin PRs are attributed to PostHog, not the PostHog Desktop app.
       expect(prompt).toContain(
-        "Created with [PostHog](https://posthog.com?ref=pr)",
+        "Created with [PostHog](http://localhost:8000/code/task/test-task-id)",
       );
       // PR template detection (repo first, org `.github` fallback)
       expect(prompt).toContain(".github/pull_request_template.md");
@@ -6947,7 +6956,7 @@ describe("AgentServer HTTP Mode", () => {
       expect(prompt).not.toContain("stop with local changes ready for review");
       // Manual runs keep the PostHog Desktop attribution.
       expect(prompt).toContain(
-        "Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)",
+        "Created with [PostHog Desktop](http://localhost:8000/code/task/test-task-id)",
       );
     });
 
@@ -7361,7 +7370,7 @@ describe("AgentServer HTTP Mode", () => {
     });
 
     describe("PR body guidance (why context + brevity + footer)", () => {
-      it("instructs Why, brevity, and the plain footer (no Slack link) when auto-creating a Slack PR without a thread URL", () => {
+      it("instructs Why, brevity, and the task footer when auto-creating a Slack PR without a thread URL", () => {
         process.env.POSTHOG_CODE_INTERACTION_ORIGIN = "slack";
         try {
           const prompt = (
@@ -7376,7 +7385,7 @@ describe("AgentServer HTTP Mode", () => {
           expect(prompt).toContain("do NOT enumerate every change");
           // plain footer, no Slack link; Slack-origin PRs are branded "PostHog"
           expect(prompt).toContain(
-            "*Created with [PostHog](https://posthog.com?ref=pr)*",
+            "*Created with [PostHog](http://localhost:8000/code/task/test-task-id)*",
           );
           expect(prompt).not.toContain("from a [Slack thread]");
           expect(prompt).not.toContain("PostHog Desktop](https://posthog.com");
@@ -7442,7 +7451,7 @@ describe("AgentServer HTTP Mode", () => {
         }
       });
 
-      it("instructs Why, brevity, and the plain footer on the non-Slack no-repository path", () => {
+      it("instructs Why, brevity, and the task footer on the non-Slack no-repository path", () => {
         delete process.env.POSTHOG_CODE_INTERACTION_ORIGIN;
         const prompt = (
           createServer({
@@ -7453,7 +7462,7 @@ describe("AgentServer HTTP Mode", () => {
         expect(prompt).toContain("**Why**");
         expect(prompt).toContain("Keep the PR description brief");
         expect(prompt).toContain(
-          "*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*",
+          "*Created with [PostHog Desktop](http://localhost:8000/code/task/test-task-id)*",
         );
         expect(prompt).not.toContain("from a [Slack thread]");
       });

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -22,6 +22,7 @@ import {
   type AcpMcpServer,
   type Adapter,
   buildPrOutput,
+  buildTaskShareUrl,
   getErrorMessage,
   isIgnoredSkillPath,
   isSkillBundleArtifactMetadata,
@@ -4750,9 +4751,13 @@ When you create a non-code file the user should be able to download (such as a r
     // Slack- and inbox-originated PRs are attributed to PostHog, not the
     // PostHog Desktop app — they come from the Slack app / Self-driving
     // inbox, which users know as "PostHog".
+    const taskUrl =
+      !slackThreadUrl && !inboxReportUrl
+        ? buildTaskShareUrl(this.config.apiUrl, this.config.taskId)
+        : null;
     const createdWith = this.isAutomatedOrigin()
-      ? "Created with [PostHog](https://posthog.com?ref=pr)"
-      : "Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)";
+      ? `Created with [PostHog](${taskUrl ?? "https://posthog.com?ref=pr"})`
+      : `Created with [PostHog Desktop](${taskUrl ?? "https://posthog.com/desktop?ref=pr"})`;
     const prFooter = slackThreadUrl
       ? `*${createdWith} from a [Slack thread](${slackThreadUrl})*`
       : inboxReportUrl

--- a/products/desktop/packages/core/src/git/git-host.test.ts
+++ b/products/desktop/packages/core/src/git/git-host.test.ts
@@ -1,0 +1,74 @@
+import type { RootLogger } from "@posthog/di/logger";
+import { describe, expect, it, vi } from "vitest";
+import type { AuthService } from "../auth/auth";
+import type { GitPrService } from "../git-pr/git-pr";
+import type { CreatePrHost, CreatePrInput } from "../git-pr/identifiers";
+import { GitHostService } from "./git-host";
+import type { GitWorkspaceLookup, HostGitWorkspaceClient } from "./host-git";
+
+const logger: RootLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  scope: () => logger,
+};
+
+describe("GitHostService.createPr", () => {
+  it.each([
+    ["us", "task-1", "https://us.posthog.com/code/task/task-1"],
+    ["eu", "task-2", "https://eu.posthog.com/code/task/task-2"],
+    [null, "task-1", undefined],
+    ["us", undefined, undefined],
+  ] as const)(
+    "passes task attribution for %s and %s",
+    async (cloudRegion, taskId, taskUrl) => {
+      const createPrViaGh = vi.fn().mockResolvedValue({
+        success: true,
+        message: "Created",
+        prUrl: "https://github.com/example/repo/pull/1",
+      });
+      const workspace = {
+        git: { createPrViaGh: { mutate: createPrViaGh } },
+      } as unknown as HostGitWorkspaceClient;
+      const prService = {
+        createPr: (input: CreatePrInput, host: CreatePrHost) =>
+          host.createPrViaGh(
+            input.directoryPath,
+            input.prTitle,
+            input.prBody,
+            input.draft,
+          ),
+      } as unknown as GitPrService;
+      const auth = {
+        getState: () => ({ cloudRegion }),
+      } as unknown as AuthService;
+      const service = new GitHostService(
+        workspace,
+        prService,
+        { getSessionEnvForTask: vi.fn().mockResolvedValue({}) },
+        {} as GitWorkspaceLookup,
+        logger,
+        auth,
+      );
+
+      await service.createPr({
+        directoryPath: "/repo",
+        flowId: "flow-1",
+        taskId,
+        prTitle: "Fix a bug",
+        prBody: "Description",
+        draft: true,
+      });
+
+      expect(createPrViaGh).toHaveBeenCalledWith({
+        directoryPath: "/repo",
+        title: "Fix a bug",
+        body: "Description",
+        draft: true,
+        env: undefined,
+        taskUrl,
+      });
+    },
+  );
+});

--- a/products/desktop/packages/core/src/git/git-host.ts
+++ b/products/desktop/packages/core/src/git/git-host.ts
@@ -3,8 +3,14 @@ import {
   type RootLogger,
   type ScopedLogger,
 } from "@posthog/di/logger";
-import { TypedEventEmitter } from "@posthog/shared";
+import {
+  buildTaskShareUrl,
+  getCloudUrlFromRegion,
+  TypedEventEmitter,
+} from "@posthog/shared";
 import { inject, injectable } from "inversify";
+import type { AuthService } from "../auth/auth";
+import { AUTH_SERVICE } from "../auth/auth.module";
 import type { GitPrService } from "../git-pr/git-pr";
 import type { CreatePrHost } from "../git-pr/identifiers";
 import { GIT_PR_SERVICE } from "../git-pr/identifiers";
@@ -41,6 +47,8 @@ export class GitHostService extends TypedEventEmitter<GitServiceEvents> {
     private readonly workspaceLookup: GitWorkspaceLookup,
     @inject(ROOT_LOGGER)
     logger: RootLogger,
+    @inject(AUTH_SERVICE)
+    private readonly authService: AuthService,
   ) {
     super();
     this.log = logger.scope("git-host");
@@ -89,7 +97,7 @@ export class GitHostService extends TypedEventEmitter<GitServiceEvents> {
         taskId: input.taskId,
         conversationContext: input.conversationContext,
       },
-      this.buildCreatePrHost(),
+      this.buildCreatePrHost(input.taskId),
       (step, message, prUrl) => {
         this.emit(GitServiceEvent.CreatePrProgress, {
           flowId,
@@ -147,8 +155,13 @@ export class GitHostService extends TypedEventEmitter<GitServiceEvents> {
     };
   }
 
-  private buildCreatePrHost(): CreatePrHost {
+  private buildCreatePrHost(taskId?: string): CreatePrHost {
     const git = this.git;
+    const region = this.authService.getState().cloudRegion;
+    const taskUrl = buildTaskShareUrl(
+      region ? getCloudUrlFromRegion(region) : null,
+      taskId,
+    );
     return {
       getSessionEnvForTask: (taskId) => this.getSessionEnv(taskId),
       getCurrentBranch: (dir) =>
@@ -182,6 +195,7 @@ export class GitHostService extends TypedEventEmitter<GitServiceEvents> {
           body,
           draft,
           env,
+          taskUrl: taskUrl ?? undefined,
         }),
       linkBranch: (taskId, branch, source) =>
         this.workspaceLookup.linkBranch(taskId, branch, source),

--- a/products/desktop/packages/shared/src/deep-links.test.ts
+++ b/products/desktop/packages/shared/src/deep-links.test.ts
@@ -3,11 +3,39 @@ import {
   buildInboxDeeplink,
   buildLoopDeeplink,
   buildScoutDeeplink,
+  buildTaskShareUrl,
   decodePlanBase64,
   getDeeplinkProtocol,
   isPostHogCodeDeeplink,
   parseGitHubIssueUrl,
 } from "./deep-links";
+
+describe("buildTaskShareUrl", () => {
+  it.each([
+    [
+      "https://us.posthog.com",
+      "task-1",
+      "https://us.posthog.com/code/task/task-1",
+    ],
+    [
+      "https://eu.posthog.com/",
+      "task-2",
+      "https://eu.posthog.com/code/task/task-2",
+    ],
+    [
+      "http://localhost:8000/",
+      "task/3",
+      "http://localhost:8000/code/task/task%2F3",
+    ],
+    [undefined, "task-1", null],
+    ["https://us.posthog.com", undefined, null],
+    ["not a URL", "task-1", null],
+    ["javascript:alert(1)", "task-1", null],
+    ["https://user:secret@example.com", "task-1", null],
+  ])("builds a share link from %s and %s", (apiHost, taskId, expected) => {
+    expect(buildTaskShareUrl(apiHost, taskId)).toBe(expected);
+  });
+});
 
 describe("getDeeplinkProtocol", () => {
   it("returns the dev or production scheme", () => {

--- a/products/desktop/packages/shared/src/deep-links.ts
+++ b/products/desktop/packages/shared/src/deep-links.ts
@@ -2,6 +2,26 @@ const DEEPLINK_PROTOCOL_PRODUCTION = "posthog-code";
 const DEEPLINK_PROTOCOL_DEVELOPMENT = "posthog-code-dev";
 const DEEPLINK_PROTOCOL_TEST = "posthog-code-test";
 
+export function buildTaskShareUrl(
+  apiHost: string | null | undefined,
+  taskId: string | null | undefined,
+): string | null {
+  if (!apiHost || !taskId) return null;
+  try {
+    const base = new URL(apiHost);
+    if (
+      !["https:", "http:"].includes(base.protocol) ||
+      base.username ||
+      base.password
+    ) {
+      return null;
+    }
+    return new URL(`/code/task/${encodeURIComponent(taskId)}`, base).href;
+  } catch {
+    return null;
+  }
+}
+
 // The renderer cannot see app.isPackaged, so the test channel rides in the
 // baked vite env. In plain node (harness, tests) import.meta.env is unset.
 function isTestChannelBuild(): boolean {

--- a/products/desktop/packages/shared/src/index.ts
+++ b/products/desktop/packages/shared/src/index.ts
@@ -106,6 +106,7 @@ export {
 export {
   buildLoopDeeplink,
   buildScoutDeeplink,
+  buildTaskShareUrl,
   decodePlanBase64,
   getDeeplinkProtocol,
   isPostHogCodeDeeplink,

--- a/products/desktop/packages/workspace-server/src/services/git/schemas.ts
+++ b/products/desktop/packages/workspace-server/src/services/git/schemas.ts
@@ -541,6 +541,7 @@ export const resetSoftInput = z.object({
 });
 
 export const createPrViaGhInput = z.object({
+  taskUrl: z.url().optional(),
   directoryPath: z.string(),
   title: z.string().optional(),
   body: z.string().optional(),

--- a/products/desktop/packages/workspace-server/src/services/git/service.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/git/service.test.ts
@@ -21,6 +21,38 @@ describe("GitService", () => {
     execGhMock.mockReset();
   });
 
+  it.each([
+    [
+      "https://eu.posthog.com/code/task/task-1",
+      "https://eu.posthog.com/code/task/task-1",
+    ],
+    [undefined, "https://posthog.com/desktop?ref=pr"],
+  ])("uses %s for pull request attribution", async (taskUrl, expectedUrl) => {
+    execGhMock.mockResolvedValueOnce(
+      ghResult({ stdout: "https://github.com/example/repo/pull/1" }),
+    );
+    await new GitService().createPrViaGh(
+      "/repo",
+      "Fix a bug",
+      "Description",
+      true,
+      undefined,
+      taskUrl,
+    );
+    expect(execGhMock).toHaveBeenCalledWith(
+      [
+        "pr",
+        "create",
+        "--title",
+        "Fix a bug",
+        "--body",
+        `Description\n\n---\n*Created with [PostHog Desktop](${expectedUrl})*`,
+        "--draft",
+      ],
+      { cwd: "/repo", env: undefined },
+    );
+  });
+
   it("returns lifecycle and creator details for a pull request", async () => {
     const details = {
       state: "open",

--- a/products/desktop/packages/workspace-server/src/services/git/service.ts
+++ b/products/desktop/packages/workspace-server/src/services/git/service.ts
@@ -269,9 +269,9 @@ export class GitService extends TypedEventEmitter<GitCloneEvents> {
     body?: string,
     draft?: boolean,
     env?: Record<string, string>,
+    taskUrl?: string,
   ): Promise<{ success: boolean; message: string; prUrl: string | null }> {
-    const prFooter =
-      "\n\n---\n*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*";
+    const prFooter = `\n\n---\n*Created with [PostHog Desktop](${taskUrl ?? "https://posthog.com/desktop?ref=pr"})*`;
     const args = ["pr", "create"];
     if (title) {
       args.push("--title", title);

--- a/products/desktop/packages/workspace-server/src/trpc.ts
+++ b/products/desktop/packages/workspace-server/src/trpc.ts
@@ -735,6 +735,7 @@ export function createAppRouter({
             input.body,
             input.draft,
             input.env,
+            input.taskUrl,
           ),
         ),
 


### PR DESCRIPTION
## Problem

The Desktop attribution link in a pull request opens the product website, so readers cannot return to its task.

**Why:** Reviewers need the task context alongside the code.

## Changes

- Point attribution at the task link when the task ID and instance are available, for both agent-created and desktop-created pull requests.
- Preserve existing Slack thread and inbox report links. Use the task link when neither exists.
- Keep the product website as the fallback when no task link is available.

## How did you test this code?

- Targeted shared, agent, core, and git service tests cover regional URLs, missing context, footer generation, and existing origin links.
- Ran `pnpm typecheck`, `pnpm lint`, core boundary lint, and preflight. Preflight skipped the root Markdown formatter because root dependencies are absent.
- No app layout changes. Browser navigation was not manually checked.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated `products/desktop/docs/DEEP-LINKS.md` with the attribution destinations and fallback.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Slack app used shell tools, GitHub CLI, and the signed-commit tool. Skills: `/posthog-desktop`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`, and `/running-ci-preflight`.

Prompt tests now isolate token lookup from sandbox credentials. The CodeRabbit local pass is paused; this draft has no local pass.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1789128689159709?thread_ts=1789128689.159709&cid=C09G8Q32R6F)*
