### PR TITLE
chore(ci): bump posthog-cli for sourcemap uploads to 0.18.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,8 +87,8 @@ COPY --from=frontend-build /code/frontend/dist /code/frontend/dist
 # the processed frontend/dist ships in the final image, so the CLI must not be mutable remote code.
 # To upgrade, change POSTHOG_CLI_VERSION and recompute the hash:
 #   curl -LsSf "https://github.com/PostHog/posthog/releases/download/posthog-cli%2Fv<X.Y.Z>/posthog-cli-installer.sh" | sha256sum
-ARG POSTHOG_CLI_VERSION=0.11.2
-ARG POSTHOG_CLI_INSTALLER_SHA256=69ace33b5e153bd7678bea4e1e565f6baa67ca76660e2aca653ed80ea7f6c725
+ARG POSTHOG_CLI_VERSION=0.18.2
+ARG POSTHOG_CLI_INSTALLER_SHA256=TODO-set-after-posthog-cli-v0.18.2-is-released
 # The CLI stamps the release it creates with git metadata (branch, remote, repo name) read from the
 # GitHub Actions environment. Only frontend/dist is copied into this stage, so there is no .git
 # directory to fall back on: without these the release is created with no link back to the code it

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,7 @@ COPY --from=frontend-build /code/frontend/dist /code/frontend/dist
 # To upgrade, change POSTHOG_CLI_VERSION and recompute the hash:
 #   curl -LsSf "https://github.com/PostHog/posthog/releases/download/posthog-cli%2Fv<X.Y.Z>/posthog-cli-installer.sh" | sha256sum
 ARG POSTHOG_CLI_VERSION=0.18.2
-ARG POSTHOG_CLI_INSTALLER_SHA256=TODO-set-after-posthog-cli-v0.18.2-is-released
+ARG POSTHOG_CLI_INSTALLER_SHA256=1ed5ff785ca33f38458efb1677ffd35ed99d935ac59d5e28bfd0d07a4f697f7a
 # The CLI stamps the release it creates with git metadata (branch, remote, repo name) read from the
 # GitHub Actions environment. Only frontend/dist is copied into this stage, so there is no .git
 # directory to fall back on: without these the release is created with no link back to the code it

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -83,7 +83,7 @@ RUN --mount=type=secret,id=SCCACHE_WEBDAV_ENDPOINT,required=false \
 # before execution. To upgrade, change POSTHOG_CLI_VERSION and recompute:
 #   curl -LsSf "https://github.com/PostHog/posthog/releases/download/posthog-cli%2Fv<X.Y.Z>/posthog-cli-installer.sh" | sha256sum
 ARG POSTHOG_CLI_VERSION=0.18.2
-ARG POSTHOG_CLI_INSTALLER_SHA256=TODO-set-after-posthog-cli-v0.18.2-is-released
+ARG POSTHOG_CLI_INSTALLER_SHA256=1ed5ff785ca33f38458efb1677ffd35ed99d935ac59d5e28bfd0d07a4f697f7a
 ARG SYMBOL_UPLOAD_TRIGGER=""
 RUN --mount=type=secret,id=posthog_upload_symbols_cli_api_key \
     --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -82,8 +82,8 @@ RUN --mount=type=secret,id=SCCACHE_WEBDAV_ENDPOINT,required=false \
 # The CLI installer is pinned to an immutable release tag and checksum-verified
 # before execution. To upgrade, change POSTHOG_CLI_VERSION and recompute:
 #   curl -LsSf "https://github.com/PostHog/posthog/releases/download/posthog-cli%2Fv<X.Y.Z>/posthog-cli-installer.sh" | sha256sum
-ARG POSTHOG_CLI_VERSION=0.18.2
-ARG POSTHOG_CLI_INSTALLER_SHA256=1ed5ff785ca33f38458efb1677ffd35ed99d935ac59d5e28bfd0d07a4f697f7a
+ARG POSTHOG_CLI_VERSION=0.8.1
+ARG POSTHOG_CLI_INSTALLER_SHA256=b1f1781a78a37930884db3ad412d9508a9ac015b01339455a7357cd0b23d9c92
 ARG SYMBOL_UPLOAD_TRIGGER=""
 RUN --mount=type=secret,id=posthog_upload_symbols_cli_api_key \
     --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -82,8 +82,8 @@ RUN --mount=type=secret,id=SCCACHE_WEBDAV_ENDPOINT,required=false \
 # The CLI installer is pinned to an immutable release tag and checksum-verified
 # before execution. To upgrade, change POSTHOG_CLI_VERSION and recompute:
 #   curl -LsSf "https://github.com/PostHog/posthog/releases/download/posthog-cli%2Fv<X.Y.Z>/posthog-cli-installer.sh" | sha256sum
-ARG POSTHOG_CLI_VERSION=0.8.1
-ARG POSTHOG_CLI_INSTALLER_SHA256=b1f1781a78a37930884db3ad412d9508a9ac015b01339455a7357cd0b23d9c92
+ARG POSTHOG_CLI_VERSION=0.18.2
+ARG POSTHOG_CLI_INSTALLER_SHA256=TODO-set-after-posthog-cli-v0.18.2-is-released
 ARG SYMBOL_UPLOAD_TRIGGER=""
 RUN --mount=type=secret,id=posthog_upload_symbols_cli_api_key \
     --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \


### PR DESCRIPTION
## Problem

The frontend image build uploads sourcemaps with a posthog-cli that predates #98154. After that PR ships, every master build still makes two API calls per batch of 50 chunks, even when the server already holds every chunk.

- The frontend image pins posthog-cli 0.11.2 for the sourcemap upload.
- The Rust image pins its own posthog-cli for native symbols. This PR leaves it as it is.
- The frontend pin was the latest release when #83034 set it on 2026-08-17. The CLI shipped 17 releases since then.

## Changes

- The frontend image build now installs posthog-cli 0.18.2, the first release that carries #98154.
- The checksum is the SHA256 of the published v0.18.2 installer script.
- Mechanical: two ARG lines change, nothing else.

## How did you test this code?

- Not run: a Docker build. Only the two pinned values change.
- The checksum comes from a local download of the v0.18.2 installer with the command in the Dockerfile comment. No link.
- The flags the stage passes (`--directory`, `--public-path-prefix`, `--release-mode`, `--release-name`, `--release-version`) and the `POSTHOG_CLI_TOKEN` and `POSTHOG_CLI_ENV_ID` variables still exist in the current CLI source.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No doc references the pinned version.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code with Claude Fable 5.1. Skills invoked: /writing-pr-descriptions, /asd-ste100. An open PR search for a CLI version bump found nothing. The first revision also bumped the Rust image pin. The person driving the work asked to keep that change out, so the Rust image stays on its current pin. Nothing in this PR comes from outside the repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHdW7Ruc2SDXyTNzdfpzE5


