### PR TITLE
fix(desktop): show active subagents in present tense

### DIFF
--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/ToolCallBlock.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/ToolCallBlock.test.tsx
@@ -230,6 +230,35 @@ describe("ToolCallBlock routing", () => {
     expect(screen.getByText(/Authentication failed/)).toBeInTheDocument();
   });
 
+  it("uses present tense while subagent details report running work", () => {
+    renderBlock({
+      toolCallId: "tc-running-subagents-after-turn",
+      title: "subagent",
+      kind: "other",
+      status: "in_progress",
+      details: {
+        mode: "parallel",
+        results: [
+          {
+            runId: "run-1",
+            agent: "General",
+            task: "Inspect the API routes",
+            state: "running",
+          },
+          {
+            runId: "run-2",
+            agent: "General",
+            task: "Review the interface states",
+            state: "running",
+          },
+        ],
+      },
+    });
+
+    expect(screen.getByText("Running 2 subagents")).toBeInTheDocument();
+    expect(screen.queryByText(/Ran 2 subagents/)).toBeNull();
+  });
+
   it("summarizes a completed workflow while its details are collapsed", () => {
     renderBlock({
       toolCallId: "tc-completed-workflow",

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/piOrchestrationDetails.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/piOrchestrationDetails.ts
@@ -190,6 +190,9 @@ function summarizeSubagentRun(
       ? `Ran ${count}, ${view.counts.failed} failed`
       : `Ran ${count}`;
   }
+  if (view.counts.running > 0) {
+    return `Running ${count}`;
+  }
   return `Ran ${count}, ${formatStoppedCounts(view)}`;
 }
 


### PR DESCRIPTION
## Problem

PostHog Desktop can describe active subagents with past-tense text when the parent turn stops loading.

## Changes

- The summary now uses "Running" while any subagent reports an active state.
- Terminal parent states still use final summaries.
- No screenshot is included because this streamed transition has no stable Storybook state. The component test renders the exact label.

## How did you test this code?

- The `ToolCallBlock` test covers active child states after the parent turn stops loading.
- The scoped UI type check and Biome check passed.
- The CI preflight did not run because this sandbox has no importable `hogli` Python environment.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Desktop used file and shell tools. The work used `/posthog-desktop`, `/writing-user-facing-copy`, `/writing-simplified-technical-english`, `/writing-tests`, `/running-ci-preflight`, `/reviewing-with-coderabbit`, and `/writing-pr-descriptions`.

The CodeRabbit pass is paused. The PR opened without a local pass.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*