### PR TITLE
feat(warehouse-sources): add 3 AppDynamics tables

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/COVERAGE_GAPS_APPENDIX.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/COVERAGE_GAPS_APPENDIX.md
@@ -362,7 +362,7 @@ Note: Reference index (96 slugs) read from the docs nav; each path below confirm
 
 ## Appdynamics — gaps
 
-Today (10): `applications`, `business_transactions`, `events`, `health_rule_violations`, `health_rules`, `metric_data`, `metrics`, `nodes`, `request_snapshots`, `tiers`
+Today (13): `anomalies`, `applications`, `backends`, `business_transactions`, `database_servers`, `events`, `health_rule_violations`, `health_rules`, `metric_data`, `metrics`, `nodes`, `request_snapshots`, `tiers`
 
 Diffed against: <https://help.splunk.com/en/appdynamics-saas/extend-splunk-appdynamics/26.4.0/extend-splunk-appdynamics/splunk-appdynamics-apis>
 
@@ -370,13 +370,20 @@ Diffed against: <https://help.splunk.com/en/appdynamics-saas/extend-splunk-appdy
 - [x] `/controller/alerting/rest/v1/applications/{id}/health-rules` — lookup resolving the health rule IDs/names carried on the health_rule_violations we already sync (high)
 - [x] `/controller/rest/applications/{app}/request-snapshots` — individual slow/error transaction snapshots, the drill-down layer under business_transactions (high)
 - [x] `/controller/rest/applications/{app}/metrics (metric tree browse)` — lookup of available metric paths — without it metric_data has to be hand-configured (high)
-- [ ] `/controller/rest/applications/{app}/backends` — lookup for remote services/databases referenced by tiers and business transactions (high)
-- [ ] `/controller/anomaly/rest/api/v1/applications/{id}/anomalies` — anomaly-detection violations, the ML counterpart to health rule violations (medium)
+- [x] `/controller/rest/applications/{app}/backends` — lookup for remote services/databases referenced by tiers and business transactions (high)
+- [x] `/controller/anomaly/rest/api/v1/applications/{id}/anomalies` — anomaly-detection violations, the ML counterpart to health rule violations (medium)
 - [ ] `/events/query (Analytics Events API, ADQL)` — transaction/log/browser analytics records not exposed by the controller REST API (medium)
-- [ ] `/controller/rest/databases/servers` — database visibility inventory joinable to backends and tiers (medium)
+- [x] `/controller/rest/databases/servers` — database visibility inventory joinable to backends and tiers (medium)
 - [ ] `/controller/rest/databases/servers/healthrule-violations` — database-side violations alongside the APM ones already synced (medium)
 - [ ] `/controller/rest/applications/{app}/metric-data-v2` — v2 metric retrieval with richer rollup semantics than the v1 metric_data we sync (low)
 - [ ] `/controller/ControllerAuditHistory` — who changed what in the controller, for correlating config changes to incidents (low)
+
+Note: `/events/query` is left unticked on purpose. The Analytics Events API is not served by
+the controller: it addresses the Events Service host with its own `X-Events-API-AccountName` /
+`X-Events-API-Key` credentials, and the rows it returns are whatever a user-written ADQL query
+selects, so there is no fixed schema or primary key to sync as a table. Exposing it means new
+credential fields, a query input, and scroll pagination, which is source-shaped work rather than
+one more endpoint in this catalog.
 
 Note: docs.appdynamics.com now serves an SPA shell and presents a broken TLS chain, so the canonical reference is the Splunk help portal; individual API pages (application-model, metric-and-snapshot, alert-and-respond/\*, anomaly-violation, analytics-events, database-visibility, rbac) were fetched and their /controller/... paths extracted.
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/appdynamics/appdynamics.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/appdynamics/appdynamics.py
@@ -20,6 +20,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.appdynamic
     APPLICATIONS_PATH,
     MAX_APPLICATIONS,
     MAX_FANOUT_REQUESTS,
+    MAX_PAGES_PER_TIME_WINDOW,
     MAX_WINDOW_SPLITS,
     METRIC_TREE_MAX_DEPTH,
     METRIC_TREE_MAX_REQUESTS_PER_APPLICATION,
@@ -562,14 +563,23 @@ def _metric_rows(application_id: int, metric: dict[str, Any]) -> list[dict[str, 
     ]
 
 
-def _window_params(start_ms: int, end_ms: int) -> dict[str, Any]:
+def _window_params(config: AppdynamicsEndpointConfig, start_ms: int, end_ms: int) -> dict[str, Any]:
+    if config.uses_epoch_time_params:
+        return {"startTime": start_ms, "endTime": end_ms}
     return {"time-range-type": "BETWEEN_TIMES", "start-time": start_ms, "end-time": end_ms}
 
 
-class SplitAllowance:
-    """Extra requests window bisection may spend, shared by every window in one sync.
+def _rows_from_payload(config: AppdynamicsEndpointConfig, payload: Any) -> list[dict[str, Any]]:
+    """Pull the row list out of a response, unwrapping the endpoint's envelope where it has one."""
+    if config.data_selector:
+        payload = (payload or {}).get(config.data_selector)
+    return payload or []
 
-    Splitting happens per window, but the fan-out limit is per sync. Without a shared
+
+class SplitAllowance:
+    """Extra requests window bisection and paging may spend, shared by every window in one sync.
+
+    Splitting and paging happen per window, but the fan-out limit is per sync. Without a shared
     allowance a controller that returns a full response for every window would multiply an
     already-accepted sync by the per-window split cap, which is how the limit gets bypassed.
     """
@@ -582,6 +592,47 @@ class SplitAllowance:
             return False
         self.remaining -= 1
         return True
+
+
+def _get_paged_window_rows(
+    client: AppdynamicsClient,
+    config: AppdynamicsEndpointConfig,
+    path: str,
+    params: dict[str, Any],
+    application_id: int,
+    split_allowance: SplitAllowance,
+    logger: FilteringBoundLogger,
+) -> Iterator[list[dict[str, Any]]]:
+    """Yield one time window's rows a page at a time, stopping on the first short page."""
+    page_size = config.page_size or 0
+
+    for page_number in range(MAX_PAGES_PER_TIME_WINDOW):
+        # Only the first page of each window is counted by the fan-out estimate, so the rest
+        # draw from the same per-sync allowance window bisection spends from.
+        if page_number > 0 and not split_allowance.take():
+            logger.warning(
+                f"AppDynamics: '{config.name}' stopped paging for application_id={application_id} at the "
+                "per-sync request limit; later pages of that window were not synced."
+            )
+            return
+
+        rows = _rows_from_payload(
+            config,
+            client.get_json(
+                path,
+                {**params, "pageSize": page_size, "pageNumber": page_number},
+                output_json=config.sends_output_json_param,
+            ),
+        )
+        if rows:
+            yield [{**row, "application_id": application_id} for row in rows]
+        if len(rows) < page_size:
+            return
+
+    logger.warning(
+        f"AppDynamics: '{config.name}' hit the {MAX_PAGES_PER_TIME_WINDOW}-page cap for "
+        f"application_id={application_id}; later pages of that window were not synced."
+    )
 
 
 def _get_window_rows(
@@ -606,7 +657,17 @@ def _get_window_rows(
 
     while pending:
         start, end = pending.pop()
-        rows = client.get_json(path, {**base_params, **_window_params(start, end)}) or []
+        window_params = {**base_params, **_window_params(config, start, end)}
+
+        if config.page_size is not None:
+            yield from _get_paged_window_rows(
+                client, config, path, window_params, application_id, split_allowance, logger
+            )
+            continue
+
+        rows = _rows_from_payload(
+            config, client.get_json(path, window_params, output_json=config.sends_output_json_param)
+        )
 
         if config.result_cap is not None and len(rows) >= config.result_cap:
             # `take` spends from the sync-wide allowance, so ask for it last.
@@ -721,7 +782,7 @@ def _get_windowed_application_rows(
 
     for window_start, window_end in _iter_windows(start_ms, end_ms, config.window_chunk_days):
         if config.is_metric_data:
-            window_params = _window_params(window_start, window_end)
+            window_params = _window_params(config, window_start, window_end)
             for metric_path in metric_paths:
                 metrics = client.get_json(path, {**window_params, "metric-path": metric_path, "rollup": "false"})
                 for metric in metrics or []:
@@ -763,7 +824,7 @@ def get_rows(
     client = AppdynamicsClient(base_url, auth, logger)
 
     if not config.fan_out_over_applications:
-        rows = client.get_json(config.path, {})
+        rows = _rows_from_payload(config, client.get_json(config.path, {}, output_json=config.sends_output_json_param))
         if rows:
             yield rows
         return
@@ -844,10 +905,13 @@ def get_rows(
         elif config.is_metric_tree:
             yield from _get_metric_tree_rows(client, config, application_id, logger)
         else:
-            rows = client.get_json(
-                config.path.format(application_id=application_id),
-                {},
-                output_json=config.sends_output_json_param,
+            rows = _rows_from_payload(
+                config,
+                client.get_json(
+                    config.path.format(application_id=application_id),
+                    {},
+                    output_json=config.sends_output_json_param,
+                ),
             )
             if rows:
                 yield [{**row, "application_id": application_id} for row in rows]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/appdynamics/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/appdynamics/canonical_descriptions.py
@@ -60,6 +60,19 @@ CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
             "ipAddresses": "IP addresses registered for the node.",
         },
     },
+    "backends": {
+        "description": "Backends (remote services, databases and message queues) registered in each application, resolving the exit point targets that tiers and business transactions call.",
+        "docs_url": _DOCS_URL,
+        "columns": {
+            "application_id": "Identifier of the application the backend is registered in.",
+            "id": "Unique identifier of the backend within the controller.",
+            "name": "Name of the backend, as shown on the flow map.",
+            "exitPointType": "Type of exit point the backend is called through (e.g. JDBC, JMS, HTTP).",
+            "properties": "Name-value properties identifying the backend, which vary by exit point type (e.g. HOST, PORT, SCHEMA, VENDOR, URL for JDBC).",
+            "tierId": "Identifier of the tier that calls the backend, 0 when it is not tier-specific.",
+            "applicationComponentNodeId": "Identifier of the node that calls the backend, 0 when it is not node-specific.",
+        },
+    },
     "health_rule_violations": {
         "description": "Health rule violations (policy breaches such as slow response times or high error rates) per application, synced by their start time.",
         "docs_url": _DOCS_URL,
@@ -77,6 +90,23 @@ CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
             "affectedEntityDefinition": "Entity (tier, node, business transaction) the violation affects.",
             "triggeredEntityDefinition": "Entity whose metrics triggered the violation.",
             "deepLinkUrl": "Link to the violation in the AppDynamics controller UI.",
+        },
+    },
+    "anomalies": {
+        "description": "Anomaly detection violations, the machine-learning counterpart to health rule violations, synced by their start time.",
+        "docs_url": "https://help.splunk.com/en/appdynamics-saas/extend-splunk-appdynamics/26.4.0/extend-splunk-appdynamics/splunk-appdynamics-apis/anomaly-violation-api",
+        "columns": {
+            "application_id": "Identifier of the application the anomaly was detected in.",
+            "id": "Unique identifier of the anomaly violation within the controller.",
+            "status": "Current status of the anomaly (e.g. OPEN, RESOLVED).",
+            "description": "Summary of what the anomaly detected.",
+            "startTime": "Epoch-ms timestamp when the anomaly started.",
+            "endTime": "Epoch-ms timestamp when the anomaly ended.",
+            "duration": "How long the anomaly lasted, in milliseconds.",
+            "affectedEntityId": "Identifier of the entity the anomaly affects.",
+            "affectedEntityName": "Name of the entity the anomaly affects.",
+            "affectedEntityType": "Type of the affected entity (e.g. BUSINESS_TRANSACTION, APPLICATION_COMPONENT_NODE).",
+            "eventDetailMap": "Events that opened, upgraded or downgraded the anomaly. Empty because suspected causes are not synced.",
         },
     },
     "metric_data": {
@@ -171,6 +201,19 @@ CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
             "name": "Name of the folder or metric.",
             "type": "Whether the item is a 'folder' holding more metrics or a 'leaf' metric.",
             "depth": "How many levels below the metric browser root the item sits.",
+        },
+    },
+    "database_servers": {
+        "description": "Database servers monitored by Database Visibility, the inventory behind the database backends that applications call.",
+        "docs_url": "https://help.splunk.com/en/appdynamics-saas/extend-splunk-appdynamics/26.4.0/extend-splunk-appdynamics/splunk-appdynamics-apis/database-visibility-api",
+        "columns": {
+            "id": "Unique identifier of the monitored database server within the controller.",
+            "name": "Name of the database collector monitoring the server.",
+            "type": "Database type (e.g. ORACLE, MYSQL, MSSQL).",
+            "hostname": "Hostname of the database server.",
+            "port": "Port the collector connects to the database server on.",
+            "enabled": "Whether the collector is currently collecting from the server.",
+            "licensesUsed": "Licenses the collector consumes. Always -1 on controller 21.2 and later, which licenses Database Visibility per infrastructure unit instead.",
         },
     },
 }

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/appdynamics/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/appdynamics/settings.py
@@ -68,6 +68,15 @@ MAX_EVENT_TYPES = 200
 # `severities` is required too, and every severity is wanted for an event history.
 EVENT_SEVERITIES = "INFO,WARN,ERROR"
 
+# `anomalies` pages with `pageSize`/`pageNumber` and documents no default page size, so the
+# stream always sends one and walks pages until one comes back short — relying on an omitted
+# param to return everything would silently drop rows if the Controller applies its own default.
+ANOMALIES_PAGE_SIZE = 500
+
+# Pages one time window may fetch before the stream gives up on it, so a window holding an
+# unexpectedly large number of anomalies cannot loop a worker indefinitely.
+MAX_PAGES_PER_TIME_WINDOW = 64
+
 # `/metrics` returns only the immediate children of a path, so browsing the tree costs one
 # request per folder. The hierarchy is unbounded (a folder per tier, node and business
 # transaction), so bound both how deep the walk goes and what it may spend per application.
@@ -111,6 +120,12 @@ class AppdynamicsEndpointConfig:
     """Events requests carry the required `event-types` list configured on the source."""
     is_metric_tree: bool = False
     """Walk the metric hierarchy folder by folder instead of reading one list response."""
+    uses_epoch_time_params: bool = False
+    """Window bounds ride as bare epoch-ms `startTime`/`endTime` instead of the `time-range-type` triple."""
+    data_selector: str | None = None
+    """Key holding the row list, for endpoints that wrap it in an object instead of returning an array."""
+    page_size: int | None = None
+    """Page rows with `pageSize`/`pageNumber` instead of reading a whole window in one response."""
     result_cap: int | None = None
     """Rows the endpoint returns per request at most. A window at the cap is bisected."""
     extra_params: dict[str, Any] = field(default_factory=dict)
@@ -148,6 +163,16 @@ APPDYNAMICS_ENDPOINTS: dict[str, AppdynamicsEndpointConfig] = {
         primary_keys=["application_id", "id"],
         fan_out_over_applications=True,
     ),
+    "backends": AppdynamicsEndpointConfig(
+        name="backends",
+        path="/controller/rest/applications/{application_id}/backends",
+        primary_keys=["application_id", "id"],
+        fan_out_over_applications=True,
+        description=(
+            "Backends (remote services, databases and message queues) that each application's "
+            "tiers and business transactions call."
+        ),
+    ),
     "health_rule_violations": AppdynamicsEndpointConfig(
         name="health_rule_violations",
         path="/controller/rest/applications/{application_id}/problems/healthrule-violations",
@@ -161,6 +186,28 @@ APPDYNAMICS_ENDPOINTS: dict[str, AppdynamicsEndpointConfig] = {
             "Health rule violations are synced by their start time. Status changes to previously "
             "synced violations (e.g. a violation resolving) are only picked up on a full refresh. "
             "Only syncs the last 30 days on initial sync."
+        ),
+    ),
+    "anomalies": AppdynamicsEndpointConfig(
+        name="anomalies",
+        path="/controller/anomaly/rest/api/v1/applications/{application_id}/anomalies",
+        primary_keys=["application_id", "id"],
+        fan_out_over_applications=True,
+        time_windowed=True,
+        uses_epoch_time_params=True,
+        sends_output_json_param=False,
+        data_selector="violationListItem",
+        page_size=ANOMALIES_PAGE_SIZE,
+        incremental_fields=time_window_incremental_fields("startTime"),
+        extra_params={"fetchSuspectedCause": "false"},
+        default_lookback_days=30,
+        window_chunk_days=7,
+        description=(
+            "Anomaly detection violations, the machine-learning counterpart to health rule "
+            "violations, synced by their start time. Suspected causes are not synced. Status "
+            "changes to previously synced anomalies are only picked up on a full refresh. "
+            "Only syncs the last 30 days on initial sync. Requires anomaly detection to be "
+            "enabled on the controller."
         ),
     ),
     "metric_data": AppdynamicsEndpointConfig(
@@ -232,6 +279,15 @@ APPDYNAMICS_ENDPOINTS: dict[str, AppdynamicsEndpointConfig] = {
             "Metric paths available in each application's metric browser, one row per folder "
             "or metric. Use a path from here in the source's metric paths setting to sync its "
             "time series into metric_data."
+        ),
+    ),
+    "database_servers": AppdynamicsEndpointConfig(
+        name="database_servers",
+        path="/controller/rest/databases/servers",
+        primary_keys=["id"],
+        description=(
+            "Database servers monitored by AppDynamics Database Visibility. Joins to the "
+            "database backends that applications call."
         ),
     ),
 }

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/appdynamics/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/appdynamics/source.py
@@ -62,7 +62,7 @@ class AppdynamicsSource(ResumableSource[AppdynamicsSourceConfig, AppdynamicsResu
             label="Splunk AppDynamics (Cisco)",
             releaseStatus=ReleaseStatus.ALPHA,
             keywords=["appdynamics", "cisco", "splunk", "apm"],
-            caption="""Sync your Splunk AppDynamics (Cisco) APM data (applications, business transactions, tiers, nodes, events, transaction snapshots, health rules, health rule violations, metric paths, and metric time series) into the PostHog Data warehouse.
+            caption="""Sync your Splunk AppDynamics (Cisco) APM data (applications, business transactions, tiers, nodes, backends, events, transaction snapshots, health rules, health rule violations, anomalies, metric paths, metric time series, and monitored database servers) into the PostHog Data warehouse.
 
 Enter your controller URL (e.g. `https://mycompany.saas.appdynamics.com`) and your account name, then authenticate with an OAuth API client (recommended) or a username and password.
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/appdynamics/tests/test_appdynamics.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/appdynamics/tests/test_appdynamics.py
@@ -26,6 +26,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.appdynamic
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.appdynamics.settings import (
+    ANOMALIES_PAGE_SIZE,
     APPDYNAMICS_ENDPOINTS,
     MAX_METRIC_PATHS,
     MAX_ROWS_PER_TIME_WINDOW,
@@ -415,14 +416,21 @@ def _application_list_responder(tree: dict[str, Any], application_ids: list[int]
 
 
 class TestGetRows:
-    def test_applications_yields_rows_without_state(self) -> None:
+    @parameterized.expand(
+        [
+            ("applications", "/controller/rest/applications"),
+            ("database_servers", "/controller/rest/databases/servers"),
+        ]
+    )
+    def test_account_level_endpoint_is_read_without_fanning_out(self, endpoint: str, expected_path: str) -> None:
         manager = FakeResumeManager()
-        batches, _ = _run_get_rows(
-            lambda path, params: FakeResponse(json_data=[{"id": 1, "name": "app"}]),
-            "applications",
+        batches, session = _run_get_rows(
+            lambda path, params: FakeResponse(json_data=[{"id": 1, "name": "thing"}]),
+            endpoint,
             manager,
         )
-        assert batches == [[{"id": 1, "name": "app"}]]
+        assert batches == [[{"id": 1, "name": "thing"}]]
+        assert [path for path, _, _ in session.get_calls] == [expected_path]
         assert manager.saved == []
 
     def test_too_many_applications_is_rejected(self) -> None:
@@ -703,6 +711,7 @@ class TestGetRows:
         [
             ("events", {"event-types": "APPLICATION_DEPLOYMENT,APP_SERVER_RESTART", "severities": "INFO,WARN,ERROR"}),
             ("request_snapshots", {"maximum-results": MAX_ROWS_PER_TIME_WINDOW}),
+            ("anomalies", {"fetchSuspectedCause": "false"}),
         ]
     )
     @time_machine.travel("2024-01-31T00:00:00Z", tick=False)
@@ -737,6 +746,84 @@ class TestGetRows:
         assert list_params["output"] == "JSON"
         assert rules_path == "/controller/alerting/rest/v1/applications/7/health-rules"
         assert "output" not in rules_params
+
+    @time_machine.travel("2024-01-31T00:00:00Z", tick=False)
+    def test_anomalies_sends_epoch_window_bounds_and_unwraps_the_response(self) -> None:
+        # The anomaly API takes bare epoch-ms bounds instead of the Controller REST
+        # `time-range-type` triple, serves JSON with no `output` param, and returns its rows
+        # wrapped in an object rather than as a bare array.
+        watermark = FROZEN_NOW_MS - MILLIS_PER_DAY
+
+        def responder(path: str, params: dict[str, Any]) -> FakeResponse:
+            if path == "/controller/rest/applications":
+                return FakeResponse(json_data=[{"id": 3}])
+            return FakeResponse(json_data={"violationListItem": [{"id": 9, "startTime": params["startTime"]}]})
+
+        batches, session = _run_get_rows(
+            responder,
+            "anomalies",
+            FakeResumeManager(),
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=watermark,
+        )
+
+        path, params, _ = session.get_calls[1]
+        assert path == "/controller/anomaly/rest/api/v1/applications/3/anomalies"
+        assert params["startTime"] == watermark + 1
+        assert params["endTime"] == FROZEN_NOW_MS
+        assert "time-range-type" not in params
+        assert "output" not in params
+        assert batches == [[{"id": 9, "startTime": watermark + 1, "application_id": 3}]]
+
+    @time_machine.travel("2024-01-31T00:00:00Z", tick=False)
+    def test_anomalies_walks_pages_until_one_comes_back_short(self) -> None:
+        # A full page means anomalies are still waiting, and the API documents no default page
+        # size, so the stream sends one and pages on rather than trusting a single response.
+        pages: dict[int, list[dict[str, Any]]] = {
+            0: [{"id": index} for index in range(ANOMALIES_PAGE_SIZE)],
+            1: [{"id": 999}],
+        }
+
+        def responder(path: str, params: dict[str, Any]) -> FakeResponse:
+            if path == "/controller/rest/applications":
+                return FakeResponse(json_data=[{"id": 1}])
+            return FakeResponse(json_data={"violationListItem": pages.get(params["pageNumber"], [])})
+
+        batches, session = _run_get_rows(
+            responder,
+            "anomalies",
+            FakeResumeManager(),
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=FROZEN_NOW_MS - MILLIS_PER_DAY,
+        )
+
+        assert [params["pageNumber"] for _, params, _ in session.get_calls[1:]] == [0, 1]
+        assert all(params["pageSize"] == ANOMALIES_PAGE_SIZE for _, params, _ in session.get_calls[1:])
+        assert [row["id"] for batch in batches for row in batch][-1] == 999
+
+    @time_machine.travel("2024-01-31T00:00:00Z", tick=False)
+    def test_anomalies_paging_draws_from_the_sync_wide_request_allowance(self) -> None:
+        # Paging is per window but the fan-out limit is per sync, so a controller that returns
+        # a full page every time can't multiply an accepted sync by the per-window page cap.
+        def responder(path: str, params: dict[str, Any]) -> FakeResponse:
+            if path == "/controller/rest/applications":
+                return FakeResponse(json_data=[{"id": 1}])
+            return FakeResponse(json_data={"violationListItem": [{"id": n} for n in range(ANOMALIES_PAGE_SIZE)]})
+
+        logger = mock.MagicMock()
+        # One window is estimated, so an allowance of one leaves room for a single extra page.
+        with mock.patch.object(appdynamics_module, "MAX_FANOUT_REQUESTS", 2):
+            _, session = _run_get_rows(
+                responder,
+                "anomalies",
+                FakeResumeManager(),
+                logger=logger,
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=FROZEN_NOW_MS - MILLIS_PER_DAY,
+            )
+
+        assert [params["pageNumber"] for _, params, _ in session.get_calls[1:]] == [0, 1]
+        assert logger.warning.call_count == 1
 
     def test_metric_tree_walk_builds_reusable_paths_and_skips_leaves(self) -> None:
         tree = {

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/appdynamics/tests/test_appdynamics_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/appdynamics/tests/test_appdynamics_source.py
@@ -72,6 +72,7 @@ class TestAppdynamicsSource:
         }
         assert cursors == {
             "health_rule_violations": {"startTimeInMillis"},
+            "anomalies": {"startTime"},
             "metric_data": {"startTimeInMillis"},
             "events": {"eventTime"},
             "request_snapshots": {"serverStartTime"},


### PR DESCRIPTION
## Problem

An AppDynamics user cannot see what their applications call, what anomaly detection found, or which databases AppDynamics monitors. The source syncs 10 tables and skips those three endpoints.

- `backends` is the lookup that resolves the exit point targets on tiers and business transactions, both of which we already sync.
- `anomalies` is the machine-learning counterpart to `health_rule_violations`, so today only half the alerting surface lands in the warehouse.
- `database_servers` is the Database Visibility inventory that joins to those backends.

Long-standing gaps from `COVERAGE_GAPS_APPENDIX.md`, not a new vendor release.

## Changes

- The table picker now offers `backends`, `anomalies` and `database_servers`. Each is selectable on a new or existing AppDynamics source.
- `anomalies` supports incremental sync on `startTime`. The other two are full refresh, because neither endpoint takes a time filter.
- `AppdynamicsEndpointConfig` gains three fields, because the anomaly API is not Controller REST: `uses_epoch_time_params` (bare `startTime`/`endTime` instead of the `time-range-type` triple), `data_selector` (rows arrive wrapped in `violationListItem`), and `page_size`.
- `anomalies` pages explicitly with `pageSize` and `pageNumber`, and stops on the first short page. The vendor documents no default page size, so omitting the param risks a silent truncation if the Controller applies one of its own.
- Pages past the first draw from the same per-sync request allowance that window bisection spends from, so a controller returning a full page every time cannot multiply an accepted sync by the per-window page cap.
- `fetchSuspectedCause` stays `false`. Suspected causes come back as a map keyed by event id holding nested per-metric bands, which has no stable column shape.
- Canonical descriptions cover the three tables from the vendor API reference.
- Mechanical: the source caption lists the new tables, and the coverage appendix ticks the three endpoints.

### Endpoint skipped

`/events/query` (Analytics Events API, ADQL) is real but not a table for this catalog. It addresses the Events Service host rather than the controller, authenticates with its own `X-Events-API-AccountName` and `X-Events-API-Key` pair, and returns whatever a user-written ADQL query selects, so there is no fixed schema or primary key. Wiring it means new credential fields, a query input and scroll pagination, which is source-shaped work.

## How did you test this code?

Automated tests only. No AppDynamics controller was available in this session, so none of the three endpoints was called against a live account. The request and response shapes come from the vendor reference: [Application Model API](https://help.splunk.com/en/appdynamics-saas/extend-splunk-appdynamics/26.4.0/extend-splunk-appdynamics/splunk-appdynamics-apis/application-model-api), [Anomaly Violation API](https://help.splunk.com/en/appdynamics-saas/extend-splunk-appdynamics/25.11.0/extend-splunk-appdynamics/splunk-appdynamics-apis/anomaly-violation-api), [Database Visibility API](https://help.splunk.com/en/appdynamics-saas/extend-splunk-appdynamics/26.4.0/extend-splunk-appdynamics/splunk-appdynamics-apis/database-visibility-api).

New cases in `tests/test_appdynamics.py`:

- Anomaly window request shape. Catches a regression that sends `time-range-type` or an `output` param to the anomaly API, or reads its rows as a bare array and yields nothing.
- Page walking. Catches a stream that reads one page and drops the rest of a window.
- Page allowance. Catches paging that ignores the per-sync request limit.
- A `database_servers` case on the existing account-level test. Catches a regression that fans the endpoint out over applications and requests a per-application path.

No new test covers `backends`: it takes the existing fan-out path, which the `business_transactions` tests already exercise.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The posthog.com doc renders its table list from `public_source_configs`, so the three tables and their descriptions appear there without a doc edit.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude Opus 5 in PostHog Desktop. Skills invoked: `/implementing-warehouse-sources`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`. The CodeRabbit local pass is paused, so this PR opened without one.

No duplicate: `gh pr list --state open --search appdynamics` found nothing, and no open PR from the maintainer touches this source.

Each of the four audited endpoints was checked against the vendor reference before building. Three survived. The audit note for `backends` calls it a lookup for "remote services/databases", which the reference confirms, and the endpoint takes no time filter, so it ships as full refresh rather than incremental. The anomaly path in the audit was accurate, including the unusual `/controller/anomaly/rest/api/v1/` prefix.

Public artifact: everything in this diff comes from the repo and the public vendor docs linked above.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
