### PR TITLE
fix(tasks): refuse log appends when the per-log lock is unavailable

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -2991,7 +2991,7 @@ def append_task_run_log(
     run = _get_visible_run(run_id, task_id, team_id)
     if run is None:
         return None
-    run.append_log(entries)
+    run.append_log(entries, lock_attempts=1)
     run.clear_echoed_followup_messages(entries)
     run.heartbeat_workflow(agent_active=_entries_show_agent_activity(entries))
     return _task_run_detail_to_dto(run)

--- a/products/tasks/backend/facade/contracts.py
+++ b/products/tasks/backend/facade/contracts.py
@@ -402,6 +402,10 @@ class TaskAnalysisError(Exception):
     """A task analysis could not be created or recorded; ``message`` is safe to surface."""
 
 
+class TaskRunLogAppendUnserialized(Exception):
+    """The per-log append lock could not be taken; the caller should retry the append."""
+
+
 @dataclass(frozen=True)
 class TaskValidationError:
     """A structured validation-error payload the presentation layer renders as a 400/404.

--- a/products/tasks/backend/metrics.py
+++ b/products/tasks/backend/metrics.py
@@ -141,8 +141,9 @@ RUN_LOG_MIRROR_OTLP_BATCHES_TOTAL = Counter(
 
 LOG_APPEND_UNSERIALIZED_TOTAL = Counter(
     "posthog_tasks_log_append_unserialized_total",
-    "Task-run log appends that ran without the per-object lock (redis unavailable, or contention "
-    "past the blocking timeout), where a concurrent append can still drop entries.",
+    "Task-run log appends that did not hold the per-object lock: refused on contention past the wait "
+    "(the agent retries them) or run unserialized while redis is unavailable.",
+    labelnames=["reason"],
 )
 
 PREWARMED_ACTIVATED_TOTAL = Counter(

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -2647,18 +2647,20 @@ class TaskRun(models.Model):
     # expiry — user history must not silently vanish after 30 days.
     DEFAULT_LOG_TTL_DAYS = 30
 
-    def append_log(self, entries: list[dict], *, ttl_days: int | None = DEFAULT_LOG_TTL_DAYS):
+    def append_log(self, entries: list[dict], *, ttl_days: int | None = DEFAULT_LOG_TTL_DAYS, lock_attempts: int = 3):
         """Append log entries to S3 storage.
 
         `ttl_days` tags a newly-created log file for expiry; pass `None` to write a log that is
         never auto-expired. The tag is only applied on
         first write — re-tagging an existing log would not change a TTL already in flight.
+        `lock_attempts` is how often to wait for the per-log append lock before raising
+        TaskRunLogAppendUnserialized; a caller that retries the append itself passes 1.
         """
         entries = [e for e in entries if not self._is_agent_message_chunk(e)]
         if not entries:
             return
 
-        is_new_file = append_jsonl_object(self.log_url, entries)
+        is_new_file = append_jsonl_object(self.log_url, entries, lock_attempts=lock_attempts)
 
         self._mirror_logs_to_posthog_logs(entries)
 

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -78,7 +78,7 @@ from products.tasks.backend.facade.access import (
 from products.tasks.backend.facade.billing import TaskTokenUsageUnavailable, get_task_usage
 from products.tasks.backend.facade.client_provenance import get_task_client_provenance, is_sandbox_oauth_request
 from products.tasks.backend.facade.compute_quota import ComputeBillingLimitExceeded
-from products.tasks.backend.facade.contracts import TaskAnalysisError
+from products.tasks.backend.facade.contracts import TaskAnalysisError, TaskRunLogAppendUnserialized
 from products.tasks.backend.facade.metrics import (
     StreamConnectionOutcome,
     observe_stream_backlog_bytes,
@@ -1491,6 +1491,15 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     def get_serializer_context(self):
         return {**super().get_serializer_context(), "team": self.team, "team_id": self.team.id}
 
+    def handle_exception(self, exc):
+        if isinstance(exc, TaskRunLogAppendUnserialized):
+            return Response(
+                TaskRunErrorResponseSerializer({"error": "Log append busy"}).data,
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+                headers={"Retry-After": "2"},
+            )
+        return super().handle_exception(exc)
+
     def _task_id(self) -> str:
         task_id = self.kwargs.get("parent_lookup_task_id")
         if not task_id:
@@ -1882,6 +1891,9 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             200: OpenApiResponse(response=TaskRunDetailSerializer, description="Run with updated log"),
             400: OpenApiResponse(response=TaskRunErrorResponseSerializer, description="Invalid log entries"),
             404: OpenApiResponse(description="Run not found"),
+            503: OpenApiResponse(
+                response=TaskRunErrorResponseSerializer, description="Log is locked by another append; retry"
+            ),
         },
         summary="Append log entries",
         description="Append one or more log entries to the task run log array",
@@ -1914,6 +1926,9 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             404: OpenApiResponse(description="Run not found"),
             409: OpenApiResponse(
                 response=TaskRunErrorResponseSerializer, description="Run is still active; send /clear to its agent"
+            ),
+            503: OpenApiResponse(
+                response=TaskRunErrorResponseSerializer, description="Log is locked by another append; retry"
             ),
         },
         summary="Clear conversation history",

--- a/products/tasks/backend/storage.py
+++ b/products/tasks/backend/storage.py
@@ -9,48 +9,55 @@ import structlog
 from posthog.redis import get_client
 from posthog.storage import object_storage
 
+from products.tasks.backend.facade.contracts import TaskRunLogAppendUnserialized
 from products.tasks.backend.metrics import LOG_APPEND_UNSERIALIZED_TOTAL
 
 logger = structlog.get_logger(__name__)
 
-# Must outlive read + write, each bounded by botocore's 60s default read_timeout.
+# Must outlive the whole-object read + write below.
 _APPEND_LOCK_TTL_SECONDS = 3 * 60
-_APPEND_LOCK_WAIT_SECONDS = 15
+_APPEND_LOCK_WAIT_SECONDS = 5
 
 
 @contextlib.contextmanager
-def _append_lock(object_storage_key: str) -> Iterator[None]:
-    """Serialize the read-modify-write below; fails open so redis can't break the agent's flush."""
-    lock = None
-    acquired = False
+def _append_lock(object_storage_key: str, attempts: int) -> Iterator[None]:
+    """Serialize the read-modify-write below.
 
+    Contention past the attempts is refused so a concurrent batch is never overwritten;
+    callers without their own retry loop ask for more attempts. Redis being unavailable
+    proceeds unserialized instead, since refusing every append for the whole outage would
+    lose far more than the rare overlapping pair.
+    """
     try:
         lock = get_client().lock(
             f"tasks:log_append:{object_storage_key}",
             timeout=_APPEND_LOCK_TTL_SECONDS,
             blocking_timeout=_APPEND_LOCK_WAIT_SECONDS,
         )
-        acquired = bool(lock.acquire())
+        acquired = any(lock.acquire() for _ in range(attempts))
     except redis.exceptions.RedisError:
         logger.warning("task_log_append_lock_unavailable", object_storage_key=object_storage_key, exc_info=True)
+        LOG_APPEND_UNSERIALIZED_TOTAL.labels(reason="redis_unavailable").inc()
+        yield
+        return
 
     if not acquired:
-        LOG_APPEND_UNSERIALIZED_TOTAL.inc()
+        LOG_APPEND_UNSERIALIZED_TOTAL.labels(reason="contended").inc()
+        raise TaskRunLogAppendUnserialized()
 
     try:
         yield
     finally:
-        if acquired and lock is not None:
-            try:
-                lock.release()
-            except redis.exceptions.RedisError:
-                logger.warning(
-                    "task_log_append_lock_release_failed", object_storage_key=object_storage_key, exc_info=True
-                )
+        try:
+            lock.release()
+        except redis.exceptions.LockNotOwnedError:
+            logger.warning("task_log_append_lock_expired", object_storage_key=object_storage_key)
+        except redis.exceptions.RedisError:
+            logger.warning("task_log_append_lock_release_failed", object_storage_key=object_storage_key, exc_info=True)
 
 
-def append_jsonl_object(object_storage_key: str, entries: list[dict[str, Any]]) -> bool:
-    with _append_lock(object_storage_key):
+def append_jsonl_object(object_storage_key: str, entries: list[dict[str, Any]], *, lock_attempts: int = 1) -> bool:
+    with _append_lock(object_storage_key, lock_attempts):
         existing_content = object_storage.read(object_storage_key, missing_ok=True) or ""
         is_new_object = not existing_content
         new_lines = "\n".join(json.dumps(entry) for entry in entries)

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -6730,6 +6730,28 @@ class TestTaskRunAPI(BaseTaskAPITest):
 
         mock_heartbeat.assert_called_once_with(agent_active=True)
 
+    @parameterized.expand(
+        [
+            ("append_log", TaskRun.Status.IN_PROGRESS, {"entries": [{"type": "info", "message": "hello"}]}),
+            ("clear_conversation", TaskRun.Status.COMPLETED, None),
+        ]
+    )
+    @patch("products.tasks.backend.models.TaskRun.heartbeat_workflow")
+    @patch("products.tasks.backend.storage.get_client")
+    def test_log_write_refused_while_lock_contended(self, action, run_status, body, mock_get_client, mock_heartbeat):
+        task = self.create_task()
+        run = TaskRun.objects.create(task=task, team=self.team, status=run_status)
+        mock_get_client.return_value.lock.return_value.acquire.return_value = False
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/{action}/", body, format="json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        self.assertEqual(response["Retry-After"], "2")
+        self.assertEqual(response.json(), {"error": "Log append busy"})
+        mock_heartbeat.assert_not_called()
+
     @patch("posthog.storage.object_storage.write")
     @patch("posthog.storage.object_storage.tag")
     def test_upload_artifacts(self, mock_tag, mock_write):

--- a/products/tasks/backend/tests/test_storage.py
+++ b/products/tasks/backend/tests/test_storage.py
@@ -9,10 +9,46 @@ from django.test import SimpleTestCase
 import redis
 from parameterized import parameterized
 
+from products.tasks.backend.facade.contracts import TaskRunLogAppendUnserialized
 from products.tasks.backend.storage import append_jsonl_object
 
 
 class TestAppendJsonlObject(SimpleTestCase):
+    @patch("products.tasks.backend.storage.get_client")
+    @patch("products.tasks.backend.storage.object_storage.write")
+    @patch("products.tasks.backend.storage.object_storage.read")
+    def test_refuses_append_when_lock_contended(
+        self,
+        mock_read: MagicMock,
+        mock_write: MagicMock,
+        mock_get_client: MagicMock,
+    ) -> None:
+        mock_get_client.return_value.lock.return_value.acquire.return_value = False
+
+        with self.assertRaises(TaskRunLogAppendUnserialized):
+            append_jsonl_object("sessions/example.jsonl", [{"type": "session"}])
+
+        mock_read.assert_not_called()
+        mock_write.assert_not_called()
+
+    @patch("products.tasks.backend.storage.get_client")
+    @patch("products.tasks.backend.storage.object_storage.write")
+    @patch("products.tasks.backend.storage.object_storage.read")
+    def test_waits_for_the_lock_again_when_asked(
+        self,
+        mock_read: MagicMock,
+        mock_write: MagicMock,
+        mock_get_client: MagicMock,
+    ) -> None:
+        mock_read.return_value = ""
+        lock = mock_get_client.return_value.lock.return_value
+        lock.acquire.side_effect = [False, True]
+
+        append_jsonl_object("sessions/example.jsonl", [{"type": "session"}], lock_attempts=2)
+
+        self.assertEqual(lock.acquire.call_count, 2)
+        mock_write.assert_called_once_with("sessions/example.jsonl", '{"type": "session"}')
+
     @parameterized.expand(
         [
             ("", True, '{"type": "session"}'),
@@ -81,25 +117,21 @@ class TestAppendJsonlObject(SimpleTestCase):
 
         self.assertEqual(sorted(stored.split("\n")), sorted(json.dumps({"n": n}) for n in range(8)))
 
+    @parameterized.expand([("acquire",), ("release",)])
     @patch("products.tasks.backend.storage.get_client")
     @patch("products.tasks.backend.storage.object_storage.write")
     @patch("products.tasks.backend.storage.object_storage.read")
-    def test_fails_open_when_lock_release_raises_connection_error(
+    def test_fails_open_when_redis_is_unavailable(
         self,
+        failing_call: str,
         mock_read: MagicMock,
         mock_write: MagicMock,
         mock_get_client: MagicMock,
     ) -> None:
         mock_read.return_value = ""
-
-        class _ReleaseFails:
-            def acquire(self) -> bool:
-                return True
-
-            def release(self) -> None:
-                raise redis.exceptions.ConnectionError("redis down")
-
-        mock_get_client.return_value.lock.return_value = _ReleaseFails()
+        lock = mock_get_client.return_value.lock.return_value
+        lock.acquire.return_value = True
+        getattr(lock, failing_call).side_effect = redis.exceptions.ConnectionError("redis down")
 
         is_new = append_jsonl_object("sessions/example.jsonl", [{"type": "session"}])
 


### PR DESCRIPTION
## Problem

- A task run's durable log could silently lose a batch of entries, so history later replayed from the log had holes.
- The log append is a whole-object read-modify-write on S3, serialized by a per-log Redis lock.
- That lock failed open: a Redis error, or 15 seconds of contention, let the append proceed unserialized.
- Two unserialized appends interleave, and the second write overwrites the first batch.

## Changes

- An append that cannot take the lock is refused with `503 Service Unavailable` and `Retry-After: 2` instead of running unserialized. The agent already retries failed flushes, so the batch lands on the next attempt.
- `TaskRunLogAppendUnserialized` is raised from `_append_lock` and mapped in the `append_log` view; the endpoint schema documents the 503.
- `posthog_tasks_log_append_unserialized_total` now counts refused appends; its name is unchanged so existing panels keep working.
- Mechanical: a lock release failure after a successful write still logs and returns success, as before.