### PR TITLE
fix(posthog-ai): stabilize lazy tool registry test

### DIFF
--- a/products/posthog_ai/frontend/components/tool/toolRegistry.test.tsx
+++ b/products/posthog_ai/frontend/components/tool/toolRegistry.test.tsx
@@ -151,7 +151,7 @@ describe('toolRegistry', () => {
                 />
             )
             expect(screen.getByText('Notebook')).toBeInTheDocument()
-            expect(await screen.findByText('Synthetic notebook')).toBeInTheDocument()
+            expect(await screen.findByText('Synthetic notebook', {}, { timeout: 10000 })).toBeInTheDocument()
             expect(screen.queryByText('Notebook')).not.toBeInTheDocument()
             expect(require.cache[require.resolve('./widgets/CreateNotebookWidget')]).not.toBeUndefined()
         })


### PR DESCRIPTION
## Problem

A slow first load of the notebook tool card can exceed the test's implicit one-second wait and fail CI.

**Why:** The test should wait for the lazy module with the same explicit budget as its sibling test.

Closes #99096

## Changes

- The notebook card test now uses the established lazy-module timeout.
- This is a test-only change. It does not change the product UI.

## How did you test this code?

- Repeated the affected registry test in 50 cold Jest processes.
- Checked the changed file with Oxfmt.
- Ran `uv run --no-sync bin/hogli ci:preflight --strict`.
- Not run: the full frontend test suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Not needed. This is a test-only change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- The PostHog Slack app prepared this focused CI-stability fix.
- Skills invoked: `/fixing-flaky-tests`, `/writing-tests`, `/writing-pr-descriptions`, and `/reviewing-with-coderabbit`.
- The open-PR search found no duplicate. The CodeRabbit pass is paused, so this PR opens without a local pass.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/D0AGC0X66LF/p1789129924949629?thread_ts=1789129924.949629&cid=D0AGC0X66LF)*