### PR TITLE
fix(logs): bound alert coordinator fan-out

### DIFF
--- a/posthog/temporal/logs_alerting/schedule.py
+++ b/posthog/temporal/logs_alerting/schedule.py
@@ -1,6 +1,7 @@
 """Schedule registration for the logs alert check workflow."""
 
 from dataclasses import asdict
+from datetime import timedelta
 
 from django.conf import settings
 
@@ -26,9 +27,13 @@ async def create_logs_alert_check_schedule(client: Client) -> None:
             asdict(CheckAlertsInput()),
             id=SCHEDULE_ID,
             task_queue=settings.LOGS_ALERTING_TASK_QUEUE,
+            execution_timeout=timedelta(minutes=10),
         ),
         spec=ScheduleSpec(cron_expressions=[SCHEDULE_CRON]),
-        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
+        policy=SchedulePolicy(
+            overlap=ScheduleOverlapPolicy.SKIP,
+            catchup_window=timedelta(minutes=1),
+        ),
     )
 
     if await a_schedule_exists(client, SCHEDULE_ID):

--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -12,6 +12,8 @@ from itertools import batched
 from uuid import UUID
 
 from django.db import transaction
+from django.db.models import F, Window
+from django.db.models.functions import RowNumber
 from django.db.utils import IntegrityError
 
 import structlog
@@ -70,6 +72,8 @@ from products.logs.backend.alert_utils import (
 from products.logs.backend.logs_url_params import build_logs_url_params
 from products.logs.backend.models import LogsAlertConfiguration, LogsAlertEvent
 from products.logs.backend.temporal.constants import (
+    DEFAULT_MAX_ALERTS_PER_RUN,
+    DEFAULT_MAX_CONCURRENT_BATCHES,
     EMIT_SIGNAL_CONCURRENCY,
     MAX_ALERT_COHORT_SIZE,
     MAX_COHORTS_PER_BATCH,
@@ -92,6 +96,7 @@ from products.logs.backend.temporal.metrics import (
     record_cohort_save_duration,
     record_cohort_size,
     record_cohort_update_duration,
+    record_coordinator_poll,
     record_scheduler_lag,
     record_worker_memory_snapshot,
 )
@@ -175,7 +180,8 @@ def _derive_breaches(
 
 @dataclasses.dataclass(frozen=True)
 class CheckAlertsInput:
-    pass
+    max_alerts_per_run: int = DEFAULT_MAX_ALERTS_PER_RUN
+    max_concurrent_batches: int = DEFAULT_MAX_CONCURRENT_BATCHES
 
 
 @dataclasses.dataclass(frozen=True)
@@ -319,7 +325,7 @@ class CheckAlertsOutput:
 
 @dataclasses.dataclass(frozen=True)
 class DiscoverCohortsInput:
-    pass
+    max_alerts_per_run: int = DEFAULT_MAX_ALERTS_PER_RUN
 
 
 @dataclasses.dataclass(frozen=True)
@@ -367,13 +373,31 @@ async def discover_cohorts_activity(input: DiscoverCohortsInput) -> DiscoverCoho
     full `select_related('team')` would OOM. Team objects are loaded later, only
     inside `evaluate_cohort_batch_activity`, scoped to a small batch.
     """
-    return await database_sync_to_async_pool(_discover_cohorts_sync)()
+    return await database_sync_to_async_pool(_discover_cohorts_sync)(input)
 
 
-def _discover_cohorts_sync() -> DiscoverCohortsOutput:
+def _discover_cohorts_sync(input: DiscoverCohortsInput | None = None) -> DiscoverCohortsOutput:
+    input = input or DiscoverCohortsInput()
+    if input.max_alerts_per_run <= 0:
+        raise ValueError("max_alerts_per_run must be greater than zero")
+
     now = datetime.now(UTC)
-    rows = list(
-        _due_alerts_qs(now).values(
+    candidate_rows = list(
+        _due_alerts_qs(now)
+        .annotate(
+            _team_rank=Window(
+                expression=RowNumber(),
+                partition_by=[F("team_id")],
+                order_by=[F("next_check_at").asc(nulls_first=True), F("id").asc()],
+            )
+        )
+        .order_by(
+            "_team_rank",
+            F("next_check_at").asc(nulls_first=True),
+            "team_id",
+            "id",
+        )
+        .values(
             "id",
             "team_id",
             "window_minutes",
@@ -382,7 +406,14 @@ def _discover_cohorts_sync() -> DiscoverCohortsOutput:
             "filters",
             "next_check_at",
             "schedule_restriction",
-        )
+        )[: input.max_alerts_per_run + 1]
+    )
+    has_more = len(candidate_rows) > input.max_alerts_per_run
+    rows = candidate_rows[: input.max_alerts_per_run]
+    selected_count = len(rows)
+    oldest_due_at = min(
+        (row["next_check_at"] for row in rows if row["next_check_at"] is not None),
+        default=None,
     )
     rescheduled_alert_ids = _reschedule_due_alerts_in_quiet_hours(rows, now)
     rows = [row for row in rows if row["id"] not in rescheduled_alert_ids]
@@ -417,6 +448,14 @@ def _discover_cohorts_sync() -> DiscoverCohortsOutput:
     # Read MAX_COHORTS_PER_BATCH inside the activity, not in workflow code:
     # module-level env reads are non-deterministic on replay because Temporal's
     # sandbox re-imports the workflow module each time.
+    _safe_record(
+        "coordinator poll",
+        record_coordinator_poll,
+        selected_count=selected_count,
+        max_alerts_per_run=input.max_alerts_per_run,
+        has_more=has_more,
+        oldest_due_at=oldest_due_at,
+    )
     return DiscoverCohortsOutput(manifests=manifests, batch_size=MAX_COHORTS_PER_BATCH)
 
 

--- a/products/logs/backend/temporal/constants.py
+++ b/products/logs/backend/temporal/constants.py
@@ -9,6 +9,8 @@ WORKFLOW_NAME = "logs-alert-check"
 # Schedule
 SCHEDULE_ID = "logs-alert-check-schedule"
 SCHEDULE_CRON = "* * * * *"
+DEFAULT_MAX_ALERTS_PER_RUN = 300
+DEFAULT_MAX_CONCURRENT_BATCHES = 5
 
 # Activity
 ACTIVITY_TIMEOUT = timedelta(minutes=5)

--- a/products/logs/backend/temporal/metrics.py
+++ b/products/logs/backend/temporal/metrics.py
@@ -177,7 +177,7 @@ def record_coordinator_poll(
     unlabelled_meter.create_gauge(
         "logs_alerting_coordinator_last_successful_poll_timestamp_seconds",
         "Unix timestamp of the last successful logs alert coordinator poll",
-    ).set(time.time())
+    ).set(int(time.time()))
 
 
 def record_checkpoint_lag(now: dt.datetime, checkpoint: dt.datetime) -> None:

--- a/products/logs/backend/temporal/metrics.py
+++ b/products/logs/backend/temporal/metrics.py
@@ -143,6 +143,43 @@ def record_alerts_active(count: int) -> None:
     gauge.set(count)
 
 
+def record_coordinator_poll(
+    *,
+    selected_count: int,
+    max_alerts_per_run: int,
+    has_more: bool,
+    oldest_due_at: dt.datetime | None,
+) -> None:
+    """Record bounded coordinator progress without tenant-level labels."""
+    outcome = "saturated" if has_more else "empty" if selected_count == 0 else "partial"
+    meter = get_metric_meter({"outcome": outcome})
+    meter.create_counter(
+        "logs_alerting_coordinator_polls_total",
+        "Logs alert coordinator polls by batch saturation",
+    ).add(1)
+
+    unlabelled_meter = get_metric_meter()
+    unlabelled_meter.create_counter(
+        "logs_alerting_coordinator_selected_total",
+        "Logs alerts selected by the coordinator",
+    ).add(selected_count)
+    unlabelled_meter.create_gauge(
+        "logs_alerting_coordinator_max_alerts_per_run",
+        "Effective per-run logs alert selection limit",
+    ).set(max_alerts_per_run)
+    oldest_due_age_seconds = (
+        max(0, int((dt.datetime.now(tz=dt.UTC) - oldest_due_at).total_seconds())) if oldest_due_at is not None else 0
+    )
+    unlabelled_meter.create_gauge(
+        "logs_alerting_coordinator_oldest_due_age_seconds",
+        "Wall-clock age of the oldest due logs alert selected by the coordinator",
+    ).set(oldest_due_age_seconds)
+    unlabelled_meter.create_gauge(
+        "logs_alerting_coordinator_last_successful_poll_timestamp_seconds",
+        "Unix timestamp of the last successful logs alert coordinator poll",
+    ).set(time.time())
+
+
 def record_checkpoint_lag(now: dt.datetime, checkpoint: dt.datetime) -> None:
     meter = get_metric_meter()
     gauge = meter.create_gauge(

--- a/products/logs/backend/temporal/workflow.py
+++ b/products/logs/backend/temporal/workflow.py
@@ -1,7 +1,9 @@
 """Temporal workflow for logs alert checking — two-phase fan-out."""
 
+import json
 import asyncio
 from itertools import batched
+from typing import cast
 
 import temporalio
 from temporalio import workflow
@@ -42,20 +44,33 @@ class LogsAlertCheckWorkflow(PostHogWorkflow):
 
     Workflows can't do I/O; the discovery activity owns the Postgres query and
     returns serialisable manifests recorded in workflow history. The workflow
-    then deterministically chunks the manifests into batches and dispatches one
-    activity per batch via `asyncio.gather` — Temporal spreads them across
+    then deterministically chunks the manifests into batches and dispatches a
+    bounded window of activities at a time. Temporal spreads each window across
     available worker pods.
     """
 
     @staticmethod
     def parse_inputs(inputs: list[str]) -> CheckAlertsInput:
-        return CheckAlertsInput()
+        if not inputs:
+            return CheckAlertsInput()
+        return CheckAlertsInput(**json.loads(inputs[0]))
 
     @temporalio.workflow.run
     async def run(self, input: CheckAlertsInput) -> CheckAlertsOutput:
+        if input.max_alerts_per_run <= 0:
+            raise ValueError("max_alerts_per_run must be greater than zero")
+        if input.max_concurrent_batches <= 0:
+            raise ValueError("max_concurrent_batches must be greater than zero")
+
+        bounded_coordinator = workflow.patched("logs-alert-coordinator-bounds-2026-09")
+        discovery_input = (
+            DiscoverCohortsInput(max_alerts_per_run=input.max_alerts_per_run)
+            if bounded_coordinator
+            else cast(DiscoverCohortsInput, {})
+        )
         discovery: DiscoverCohortsOutput = await workflow.execute_activity(
             discover_cohorts_activity,
-            DiscoverCohortsInput(),
+            discovery_input,
             start_to_close_timeout=ACTIVITY_TIMEOUT,
             retry_policy=ACTIVITY_RETRY_POLICY,
         )
@@ -70,44 +85,46 @@ class LogsAlertCheckWorkflow(PostHogWorkflow):
             for chunk in batched(discovery.manifests, discovery.batch_size, strict=False)
         ]
 
-        # `return_exceptions=True` isolates per-batch retry-exhaustion: one
-        # batch's `ActivityError` doesn't abort the cycle.
-        results: list[EvaluateCohortBatchOutput | BaseException] = await asyncio.gather(
-            *(
-                workflow.execute_activity(
-                    evaluate_cohort_batch_activity,
-                    batch,
-                    start_to_close_timeout=ACTIVITY_TIMEOUT,
-                    retry_policy=ACTIVITY_RETRY_POLICY,
-                )
-                for batch in batches
-            ),
-            return_exceptions=True,
-        )
-
         alerts_checked = 0
         alerts_fired = 0
         alerts_resolved = 0
         alerts_errored = 0
         notified: list[NotifiedAlert] = []
-        for batch, result in zip(batches, results):
-            if isinstance(result, ActivityError):
-                # Batch's retries exhausted — count its alerts as errored, keep going.
-                workflow.logger.warning(
-                    "Cohort batch activity failed; counting batch alerts as errored",
-                    extra={"cohort_count": len(batch.manifests)},
-                )
-                alerts_errored += sum(len(m.alert_ids) for m in batch.manifests)
-            elif isinstance(result, BaseException):
-                # Unexpected exception type — re-raise so the workflow fails loudly
-                # rather than silently masking a bug.
-                raise result
-            else:
-                alerts_checked += result.alerts_checked
-                alerts_fired += result.alerts_fired
-                alerts_resolved += result.alerts_resolved
-                alerts_errored += result.alerts_errored
-                notified.extend(result.notified)
+        batch_window_size = input.max_concurrent_batches if bounded_coordinator else max(1, len(batches))
+        for batch_window in batched(batches, batch_window_size, strict=False):
+            # `return_exceptions=True` isolates per-batch retry-exhaustion: one
+            # batch's `ActivityError` doesn't abort the cycle.
+            results: list[EvaluateCohortBatchOutput | BaseException] = await asyncio.gather(
+                *(
+                    workflow.execute_activity(
+                        evaluate_cohort_batch_activity,
+                        batch,
+                        start_to_close_timeout=ACTIVITY_TIMEOUT,
+                        retry_policy=ACTIVITY_RETRY_POLICY,
+                    )
+                    for batch in batch_window
+                ),
+                return_exceptions=True,
+            )
+
+            for batch, result in zip(batch_window, results):
+                if isinstance(result, ActivityError):
+                    # Batch's retries exhausted — count its alerts as errored, keep going.
+                    workflow.logger.warning(
+                        "Cohort batch activity failed; counting batch alerts as errored",
+                        extra={"cohort_count": len(batch.manifests)},
+                    )
+                    alerts_errored += sum(len(m.alert_ids) for m in batch.manifests)
+                elif isinstance(result, BaseException):
+                    # Unexpected exception type — re-raise so the workflow fails loudly
+                    # rather than silently masking a bug.
+                    raise result
+                else:
+                    alerts_checked += result.alerts_checked
+                    alerts_fired += result.alerts_fired
+                    alerts_resolved += result.alerts_resolved
+                    alerts_errored += result.alerts_errored
+                    notified.extend(result.notified)
 
         # Off the eval critical path. Best-effort: signal emission must never fail
         # the alert cycle, so retry-exhaustion is swallowed. Chunked because the

--- a/products/logs/backend/test/test_logs_alerting_activities.py
+++ b/products/logs/backend/test/test_logs_alerting_activities.py
@@ -2045,6 +2045,32 @@ class TestCohortManifest(unittest.TestCase):
 class TestDiscoverCohortsActivity(NonAtomicBaseTest):
     CLASS_DATA_LEVEL_SETUP = False
 
+    @time_machine.travel("2026-05-05T10:00:00Z", tick=False)
+    def test_limits_due_alerts_without_one_team_monopolizing_the_page(self):
+        from posthog.models import Team
+
+        from products.logs.backend.temporal.activities import DiscoverCohortsInput, discover_cohorts_activity
+
+        other_team = Team.objects.create(organization=self.organization, name="other")
+        for index, team in enumerate((self.team, self.team, self.team, other_team)):
+            LogsAlertConfiguration.objects.create(
+                team=team,
+                name=f"due_{index}",
+                threshold_count=1,
+                threshold_operator="above",
+                window_minutes=5,
+                evaluation_periods=1,
+                filters={"serviceNames": [f"svc_{index}"]},
+                enabled=True,
+                next_check_at=datetime(2026, 5, 5, 9, 55, tzinfo=UTC),
+            )
+
+        result = asyncio.run(discover_cohorts_activity(DiscoverCohortsInput(max_alerts_per_run=2)))
+
+        selected = [(manifest.team_id, alert_id) for manifest in result.manifests for alert_id in manifest.alert_ids]
+        assert len(selected) == 2
+        assert {team_id for team_id, _ in selected} == {self.team.id, other_team.id}
+
     @time_machine.travel("2026-05-05T23:00:00Z", tick=False)
     def test_skips_alert_with_invalid_quiet_hours_and_discovers_healthy_alerts(self):
         from products.logs.backend.temporal.activities import DiscoverCohortsInput, discover_cohorts_activity

--- a/products/logs/backend/test/test_logs_alerting_metrics.py
+++ b/products/logs/backend/test/test_logs_alerting_metrics.py
@@ -3,7 +3,38 @@ import datetime as dt
 import pytest
 from unittest.mock import MagicMock, patch
 
-from products.logs.backend.temporal.metrics import ExecutionTimeRecorder, record_checkpoint_lag
+from products.logs.backend.temporal.metrics import ExecutionTimeRecorder, record_checkpoint_lag, record_coordinator_poll
+
+
+def test_record_coordinator_poll_exposes_saturation_and_freshness() -> None:
+    meter = MagicMock()
+    counters: dict[str, MagicMock] = {}
+    gauges: dict[str, MagicMock] = {}
+    meter.create_counter.side_effect = lambda name, _description: counters.setdefault(name, MagicMock())
+    meter.create_gauge.side_effect = lambda name, _description: gauges.setdefault(name, MagicMock())
+    oldest_due_at = dt.datetime(2026, 9, 11, 10, 0, tzinfo=dt.UTC)
+
+    with (
+        patch("products.logs.backend.temporal.metrics.get_metric_meter", return_value=meter) as get_meter,
+        patch("products.logs.backend.temporal.metrics.time.time", return_value=1_789_128_000.0),
+        patch("products.logs.backend.temporal.metrics.dt.datetime", wraps=dt.datetime) as datetime_mock,
+    ):
+        datetime_mock.now.return_value = oldest_due_at + dt.timedelta(hours=1)
+        record_coordinator_poll(
+            selected_count=300,
+            max_alerts_per_run=300,
+            has_more=True,
+            oldest_due_at=oldest_due_at,
+        )
+
+    assert get_meter.call_args_list[0].args[0] == {"outcome": "saturated"}
+    counters["logs_alerting_coordinator_polls_total"].add.assert_called_once_with(1)
+    counters["logs_alerting_coordinator_selected_total"].add.assert_called_once_with(300)
+    gauges["logs_alerting_coordinator_max_alerts_per_run"].set.assert_called_once_with(300)
+    gauges["logs_alerting_coordinator_oldest_due_age_seconds"].set.assert_called_once_with(3600)
+    gauges["logs_alerting_coordinator_last_successful_poll_timestamp_seconds"].set.assert_called_once_with(
+        1_789_128_000.0
+    )
 
 
 class TestRecordCheckpointLag:

--- a/products/logs/backend/test/test_logs_alerting_schedule.py
+++ b/products/logs/backend/test/test_logs_alerting_schedule.py
@@ -1,0 +1,28 @@
+from datetime import timedelta
+
+import pytest
+from unittest import mock
+
+from temporalio.client import ScheduleActionStartWorkflow, ScheduleOverlapPolicy
+
+from posthog.temporal.logs_alerting.schedule import create_logs_alert_check_schedule
+
+
+@pytest.mark.asyncio
+async def test_logs_alert_schedule_bounds_each_run_and_limits_catchup() -> None:
+    captured = []
+    with (
+        mock.patch("posthog.temporal.logs_alerting.schedule.a_schedule_exists", new=mock.AsyncMock(return_value=False)),
+        mock.patch(
+            "posthog.temporal.logs_alerting.schedule.a_create_schedule",
+            new=mock.AsyncMock(side_effect=lambda client, schedule_id, schedule, **kwargs: captured.append(schedule)),
+        ),
+    ):
+        await create_logs_alert_check_schedule(mock.MagicMock())
+
+    schedule = captured[0]
+    assert isinstance(schedule.action, ScheduleActionStartWorkflow)
+    assert schedule.action.args == [{"max_alerts_per_run": 300, "max_concurrent_batches": 5}]
+    assert schedule.action.execution_timeout == timedelta(minutes=10)
+    assert schedule.policy.overlap is ScheduleOverlapPolicy.SKIP
+    assert schedule.policy.catchup_window == timedelta(minutes=1)

--- a/products/logs/backend/test/test_logs_alerting_workflow.py
+++ b/products/logs/backend/test/test_logs_alerting_workflow.py
@@ -6,8 +6,10 @@ the sandbox doesn't trip on Django imports inside `activities.py`.
 """
 
 import uuid
+import asyncio
 
 import pytest
+from unittest.mock import patch
 
 from temporalio import activity
 from temporalio.exceptions import ApplicationError
@@ -24,10 +26,90 @@ from products.logs.backend.temporal.activities import (
     EmitAlertSignalsInput,
     EvaluateCohortBatchInput,
     EvaluateCohortBatchOutput,
+    discover_cohorts_activity,
+    evaluate_cohort_batch_activity,
 )
 from products.logs.backend.temporal.workflow import LogsAlertCheckWorkflow
 
 TASK_QUEUE = "logs-alerting-test"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "workflow_input,error",
+    [
+        (CheckAlertsInput(max_alerts_per_run=0), "max_alerts_per_run"),
+        (CheckAlertsInput(max_concurrent_batches=0), "max_concurrent_batches"),
+    ],
+)
+async def test_workflow_rejects_non_positive_coordinator_bounds(workflow_input: CheckAlertsInput, error: str) -> None:
+    with pytest.raises(ValueError, match=error):
+        await LogsAlertCheckWorkflow().run(workflow_input)
+
+
+@pytest.mark.asyncio
+async def test_workflow_limits_batch_activity_concurrency() -> None:
+    manifests = [
+        CohortManifest(
+            team_id=1,
+            projection_eligible=True,
+            date_to_iso="2026-05-05T10:05:00+00:00",
+            alert_ids=[f"alert-{index}"],
+        )
+        for index in range(6)
+    ]
+    active = 0
+    max_active = 0
+
+    async def fake_execute_activity(activity_fn, activity_input, **_kwargs):
+        nonlocal active, max_active
+        if activity_fn is discover_cohorts_activity:
+            return DiscoverCohortsOutput(manifests=manifests, batch_size=1)
+        if activity_fn is evaluate_cohort_batch_activity:
+            active += 1
+            max_active = max(max_active, active)
+            await asyncio.sleep(0.01)
+            active -= 1
+            return EvaluateCohortBatchOutput(
+                alerts_checked=len(activity_input.manifests),
+                alerts_fired=0,
+                alerts_resolved=0,
+                alerts_errored=0,
+            )
+        raise AssertionError(f"Unexpected activity: {activity_fn}")
+
+    workflow_input = CheckAlertsInput(max_alerts_per_run=300, max_concurrent_batches=2)
+
+    with (
+        patch(
+            "products.logs.backend.temporal.workflow.workflow.execute_activity",
+            side_effect=fake_execute_activity,
+        ),
+        patch("products.logs.backend.temporal.workflow.workflow.patched", return_value=True),
+    ):
+        result = await LogsAlertCheckWorkflow().run(workflow_input)
+
+    assert result.alerts_checked == 6
+    assert max_active == 2
+
+
+@pytest.mark.asyncio
+async def test_workflow_preserves_empty_discovery_payload_for_legacy_replay() -> None:
+    async def fake_execute_activity(activity_fn, activity_input, **_kwargs):
+        assert activity_fn is discover_cohorts_activity
+        assert activity_input == {}
+        return DiscoverCohortsOutput(manifests=[], batch_size=20)
+
+    with (
+        patch(
+            "products.logs.backend.temporal.workflow.workflow.execute_activity",
+            side_effect=fake_execute_activity,
+        ),
+        patch("products.logs.backend.temporal.workflow.workflow.patched", return_value=False),
+    ):
+        result = await LogsAlertCheckWorkflow().run(CheckAlertsInput())
+
+    assert result.alerts_checked == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

People relying on logs alerts can receive late evaluations when one coordinator run discovers an unbounded backlog and fills the shared activity queue.

The coordinator also lacked an end-to-end freshness signal for successful discovery.

## Changes

- Logs alert recovery now selects 300 due alerts by default, with fair interleaving across teams.
- Schedule inputs can override the selection and concurrency defaults without a code change.
- The workflow dispatches at most five batch activities concurrently, which preserves queue headroom for unrelated work.
- A Temporal patch preserves the original activity payload and fan-out for existing workflow replays.
- Coordinator metrics expose saturation, throughput, oldest due age, configured limits, and successful poll freshness.
- The schedule now skips overlaps, limits catchup to one minute, and caps each workflow run at ten minutes.

Before:

```mermaid
flowchart LR
    A[Every minute] --> B[Discover all due alerts]
    B --> C[Create every batch]
    C --> D[Dispatch all batches concurrently]
    D --> E[Shared activity queue]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A,E phYellow;
    class B,C,D phBlue;
```

After:

```mermaid
flowchart LR
    A[Every minute] --> B[Select a fair bounded page]
    B --> C[Create bounded batches]
    C --> D[Dispatch five batches at a time]
    D --> E[Shared activity queue]
    B --> F[Record backlog and freshness metrics]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A,E phYellow;
    class B,C,D phBlue;
    class F phGray;
```

## How did you test this code?

- Added a workflow regression test that fails if concurrent batch activities exceed the configured window.
- Added a replay regression test that requires the legacy discovery activity payload to remain empty.
- Added database coverage for bounded, fair selection across teams.
- Added schedule and metric contract tests for defaults, policy, saturation, lag, and freshness.
- Ran `hogli ci:preflight --fix` with no failures.
- CI is the authoritative test run. The local database suite was unavailable, and the final local collection stalled during environment initialization.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation update is required because this changes internal scheduling and telemetry.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used shell and GitHub CLI tooling. Repository guidance for PR descriptions and tests, plus the public test-driven development skill, shaped the change.

The design deliberately avoids a generic scheduler framework, database claims, and a hard upper bound. Operators retain control through Temporal schedule input.

The duplicate search found no open PR for `logs-alert-check`. CodeRabbit CLI review is paused under repository policy, so this PR opened without a local CodeRabbit pass.