### PR TITLE
fix(desktop): keep the whole PR number visible in ref chips

### DIFF
--- a/products/desktop/packages/ui/src/features/editor/components/GithubPrRefChip.test.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/GithubPrRefChip.test.tsx
@@ -54,7 +54,7 @@ describe("GithubPrRefChip", () => {
     });
     expect(usePrChecksMock).toHaveBeenCalledWith(null);
 
-    const link = screen.getByText("PostHog/posthog#23985").closest("a");
+    const link = screen.getByText("#23985").closest("a");
     expect(link).not.toBeNull();
     await userEvent.hover(link as HTMLAnchorElement);
 

--- a/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.stories.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.stories.tsx
@@ -37,7 +37,9 @@ export const PullRequestNumberWidth: Story = {
   render: () => (
     <div className="flex flex-col items-start gap-4 text-[13px]">
       <div className="flex flex-col gap-1">
-        <span className="text-(--gray-11)">Before</span>
+        <span className="text-(--gray-11)">
+          Without preservation: the number ellipsizes
+        </span>
         <div className="w-[22ch]">
           <GithubRefChipLink
             href="https://github.com/example-org/example-repo/pull/123456789"
@@ -49,7 +51,9 @@ export const PullRequestNumberWidth: Story = {
         </div>
       </div>
       <div className="flex flex-col gap-1">
-        <span className="text-(--gray-11)">After</span>
+        <span className="text-(--gray-11)">
+          With preservation: the number stays whole
+        </span>
         <div className="w-[22ch]">
           <GithubRefChipLink
             href="https://github.com/example-org/example-repo/pull/123456789"

--- a/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.test.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.test.tsx
@@ -16,8 +16,8 @@ describe("GithubRefChip", () => {
     expect(carrier?.getAttribute(GITHUB_REF_URL_ATTR)).toBe(href);
   });
 
-  it("truncates a pull request label from the start so its number survives", () => {
-    render(
+  it("keeps the whole pull request number outside the truncating span", () => {
+    const { container } = render(
       <GithubRefChip
         href="https://github.com/PostHog/posthog/pull/123456789"
         kind="pr"
@@ -26,10 +26,12 @@ describe("GithubRefChip", () => {
       </GithubRefChip>,
     );
 
-    const label = screen.getByText("PostHog/posthog#123456789");
-    expect(label).toHaveAttribute("dir", "ltr");
-    expect(label.parentElement).toHaveAttribute("dir", "rtl");
-    expect(label.parentElement).toHaveClass("truncate");
+    const label = container.querySelector(".truncate");
+    expect(label).toHaveTextContent("PostHog/posthog");
+    expect(label).not.toHaveAttribute("dir");
+    const number = screen.getByText("#123456789");
+    expect(number).toHaveClass("shrink-0");
+    expect(number.parentElement).not.toHaveAttribute("dir");
   });
 
   it("leaves a label that puts its number first alone", () => {

--- a/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.test.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.test.tsx
@@ -29,9 +29,25 @@ describe("GithubRefChip", () => {
     const label = container.querySelector(".truncate");
     expect(label).toHaveTextContent("PostHog/posthog");
     expect(label).not.toHaveAttribute("dir");
+    expect(label).toHaveStyle({
+      maxWidth: "min(16rem, calc(100% - 1rem - 10ch))",
+    });
     const number = screen.getByText("#123456789");
     expect(number).toHaveClass("shrink-0");
     expect(number.parentElement).not.toHaveAttribute("dir");
+  });
+
+  it("clips the chip so a long preserved number cannot paint past the edge", () => {
+    const { container } = render(
+      <GithubRefChip
+        href="https://github.com/PostHog/posthog/pull/123456789"
+        kind="pr"
+      >
+        PostHog/posthog#123456789
+      </GithubRefChip>,
+    );
+
+    expect(container.querySelector("a")).toHaveClass("overflow-hidden");
   });
 
   it("leaves a label that puts its number first alone", () => {

--- a/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.tsx
@@ -24,12 +24,17 @@ interface GithubRefChipLinkProps
 }
 
 /**
- * Truncation removes the end of a label, which for `owner/repo#number` is the
- * number that tells two pull requests apart. Only labels that end in a number
- * qualify: `#12 - Title` already keeps its number at the front.
+ * Splits `owner/repo#number` into the part that may truncate and the number
+ * that may not, so neither the start nor the end of the number is ellipsized.
+ * Only labels that end in a number qualify: `#12 - Title` already keeps its
+ * number at the front.
  */
-function endsWithRefNumber(label: ReactNode): boolean {
-  return typeof label === "string" && /#\d+$/.test(label);
+function splitRefNumber(label: ReactNode): [string, string] | null {
+  if (typeof label !== "string") {
+    return null;
+  }
+  const match = label.match(/^(.*)(#\d+)$/);
+  return match ? [match[1], match[2]] : null;
 }
 
 /**
@@ -54,11 +59,9 @@ export const GithubRefChipLink = forwardRef<
   },
   ref,
 ) {
-  // A right-to-left box puts the ellipsis at the start, so the trailing number
-  // survives truncation. The inner isolate keeps the text itself left-to-right.
-  // The label stays one text node on purpose: a number in its own flex item
-  // puts a line break into copied text.
-  const ellipsisAtStart = preservePrNumber && endsWithRefNumber(children);
+  // The number lives in its own span that cannot shrink, so a truncating label
+  // keeps the whole number readable instead of ellipsizing one end of it.
+  const split = preservePrNumber ? splitRefNumber(children) : null;
   return (
     <Button
       ref={ref}
@@ -97,10 +100,12 @@ export const GithubRefChipLink = forwardRef<
           "inline-block max-w-[min(16rem,calc(100%-1rem))] truncate align-top",
           toneClass,
         )}
-        dir={ellipsisAtStart ? "rtl" : undefined}
       >
-        {ellipsisAtStart ? <span dir="ltr">{children}</span> : children}
+        {split ? split[0] : children}
       </span>
+      {split && (
+        <span className={cn("shrink-0 align-top", toneClass)}>{split[1]}</span>
+      )}
     </Button>
   );
 });

--- a/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/GithubRefChip.tsx
@@ -34,7 +34,10 @@ function splitRefNumber(label: ReactNode): [string, string] | null {
     return null;
   }
   const match = label.match(/^(.*)(#\d+)$/);
-  return match ? [match[1], match[2]] : null;
+  if (!match) {
+    return null;
+  }
+  return [match[1], match[2]];
 }
 
 /**
@@ -62,6 +65,11 @@ export const GithubRefChipLink = forwardRef<
   // The number lives in its own span that cannot shrink, so a truncating label
   // keeps the whole number readable instead of ellipsizing one end of it.
   const split = preservePrNumber ? splitRefNumber(children) : null;
+  // ch because the unit scales with the label's own font: the preserved number
+  // keeps roughly this many digits readable at any text size, and the label
+  // span's max-width subtracts the same width so a long number cannot push the
+  // chip past its cap.
+  const numberCh = split ? split[1].length : 0;
   return (
     <Button
       ref={ref}
@@ -80,7 +88,10 @@ export const GithubRefChipLink = forwardRef<
       }
       {...buttonProps}
       className={cn(
-        "cli-file-mention focus-visible:-outline-offset-1 mx-0.5 inline-block max-w-full cursor-pointer! select-text whitespace-nowrap pl-1.5 align-baseline leading-[1.375rem] no-underline",
+        // overflow-hidden: nothing in the content box shrinks below its
+        // content size, so a long preserved number would otherwise paint past
+        // the chip edge.
+        "cli-file-mention focus-visible:-outline-offset-1 mx-0.5 inline-block max-w-full cursor-pointer! select-text overflow-hidden whitespace-nowrap pl-1.5 align-baseline leading-[1.375rem] no-underline",
         buttonProps.className,
       )}
     >
@@ -94,12 +105,13 @@ export const GithubRefChipLink = forwardRef<
       />
       <span
         // 1rem is the icon and its margin, which share the chip's content box
-        // with the label. Without that subtraction the label paints past the
-        // chip edge in a narrow panel instead of truncating.
-        className={cn(
-          "inline-block max-w-[min(16rem,calc(100%-1rem))] truncate align-top",
-          toneClass,
-        )}
+        // with the label; numberCh is the preserved number's width. Without
+        // those subtractions the label paints past the chip edge in a narrow
+        // panel instead of truncating.
+        className={cn("inline-block truncate align-top", toneClass)}
+        style={{
+          maxWidth: `min(16rem, calc(100% - 1rem - ${numberCh}ch))`,
+        }}
       >
         {split ? split[0] : children}
       </span>

--- a/products/desktop/packages/ui/src/features/editor/components/PrRefChip.test.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/PrRefChip.test.tsx
@@ -18,7 +18,7 @@ describe("PrRefChip", () => {
   const href = "https://github.com/PostHog/posthog/pull/23985";
 
   async function hoverChip(): Promise<void> {
-    const link = screen.getByText("PostHog/posthog#23985").closest("a");
+    const link = screen.getByText("#23985").closest("a");
     expect(link).not.toBeNull();
     await userEvent.hover(link as HTMLAnchorElement);
   }

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatMarkdown.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatMarkdown.test.tsx
@@ -108,7 +108,8 @@ Verdict: valid.
       <ChatMarkdown content="Review https://github.com/PostHog/posthog/pull/23985" />,
     );
 
-    expect(html).toContain("PostHog/posthog#23985");
+    expect(html).toContain(">PostHog/posthog</span>");
+    expect(html).toContain(">#23985</span>");
     expect(html).toContain('aria-label="Open"');
     expect(html).toContain(
       'data-github-ref-url="https://github.com/PostHog/posthog/pull/23985"',
@@ -120,7 +121,8 @@ Verdict: valid.
       "https://github.com/PostHog/posthog/pull/86811/changes#r3832262653";
     const html = renderStatic(<ChatMarkdown content={href} />);
 
-    expect(html).toContain("Comment on PR #86811");
+    expect(html).toContain(">Comment on PR </span>");
+    expect(html).toContain(">#86811</span>");
     expect(html).toContain(`data-github-ref-url="${href}"`);
   });
 });

--- a/products/desktop/packages/ui/src/features/sessions/components/copyContextMenu.integration.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/copyContextMenu.integration.test.tsx
@@ -73,7 +73,7 @@ describe("conversation context-menu copy (integration)", () => {
     render(<Harness />);
 
     // Right-click the chip label, exactly as a user would.
-    const label = screen.getByText("PostHog/posthog#63995");
+    const label = screen.getByText("#63995");
     fireEvent.contextMenu(label);
 
     const copyItem = await screen.findByText("Copy");


### PR DESCRIPTION
## Problem

Anyone reading a GitHub reference chip (e.g. in session chat) needs the full PR number to tell two pull requests apart. The chip first truncated the end of the label, which cut the number off; a recent change moved the ellipsis to the start instead, but that hides the beginning of the number on long labels. Either way, part of the number is unreadable.

## Changes

- A PR chip label like `owner/repo#123456789` now splits in two: the `owner/repo` part truncates at its end as before, and the `#number` sits in its own span that cannot shrink, so the whole number always stays readable. The start-to-end reading order is unchanged; no RTL flip anymore.
- Mechanical: tests that matched the label as one text node now query the number span or the two spans separately; the storybook panels describe the two modes instead of "Before"/"After".

## How did you test this code?

- Updated `GithubRefChip.test.tsx` to assert the number renders outside the truncating span with no `dir` flip — this catches a regression back to start- or end-truncating the number, which the old test did not cover.
- Ran the five touched suites (GithubRefChip, PrRefChip, GithubPrRefChip, ChatMarkdown, copyContextMenu.integration): all 21 tests pass.
- Ran the wider `src/features` suite: identical results before and after the change (the 35 failing suites fail on clean master too — unbuilt workspace packages in this sandbox — and all 3556 runnable tests pass both ways).
- Not visually verified in a running app; layout is CSS-only and covered by the storybook `PullRequestNumberWidth` panels.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`skip-inkeep-docs` — internal desktop UI polish, nothing docs-worthy.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent: Claude Code (PostHog Desktop session).
- No duplicate: `gh pr list --state open --search "chip truncat"` and `"GithubRefChip"` found no open PR for this.
- Public artifact: the diff contains only repo code; no session material.
- Skills invoked: none of the mandatory repo skills applied (no DRF, migration, or shared-component change); the CodeRabbit local pass is paused, so this PR opened without one.
- The fix was scoped down from a broader approach (CSS middle-truncation) to the simpler label split, which keeps the DOM honest and tests simple.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*