### PR TITLE
feat(desktop): show code changes after each turn

### DIFF
--- a/products/desktop/packages/core/src/task-detail/cloudToolChanges.test.ts
+++ b/products/desktop/packages/core/src/task-detail/cloudToolChanges.test.ts
@@ -4,6 +4,7 @@ import {
   cachedDiffStats,
   extractCloudFileContent,
   extractCloudToolChangedFiles,
+  extractCloudToolFileDiffs,
   type ParsedToolCall,
 } from "./cloudToolChanges";
 
@@ -135,6 +136,35 @@ describe("extractCloudToolChangedFiles", () => {
     const recomputed = cachedDiffStats(distinctButEqual);
     expect(recomputed).not.toBe(first);
     expect(recomputed).toEqual(first);
+  });
+});
+
+describe("extractCloudToolFileDiffs", () => {
+  it("combines repeated edits into one diff from the first state to the last state", () => {
+    const calls = makeToolCalls(
+      toolCall({
+        toolCallId: "tc-first",
+        kind: "edit",
+        locations: [{ path: "src/app.ts" }],
+        content: diffContent("src/app.ts", "alpha\nBETA", "alpha\nbeta"),
+      }),
+      toolCall({
+        toolCallId: "tc-second",
+        kind: "edit",
+        locations: [{ path: "src/app.ts" }],
+        content: diffContent("src/app.ts", "alpha\nBETA\ngamma", "alpha\nBETA"),
+      }),
+    );
+
+    expect(extractCloudToolFileDiffs(calls)).toEqual([
+      {
+        path: "src/app.ts",
+        oldText: "alpha\nbeta",
+        newText: "alpha\nBETA\ngamma",
+        linesAdded: 2,
+        linesRemoved: 1,
+      },
+    ]);
   });
 });
 

--- a/products/desktop/packages/core/src/task-detail/cloudToolChanges.ts
+++ b/products/desktop/packages/core/src/task-detail/cloudToolChanges.ts
@@ -121,7 +121,7 @@ function getDiffContent(
  * diff stats with bag of lines, these are computed for every changed file whenever the session events update
  * so we want this to be fast
  */
-function getDiffStats(
+export function getDiffStats(
   oldText: string | null | undefined,
   newText: string | null | undefined,
 ): { added?: number; removed?: number } {
@@ -322,6 +322,40 @@ export function extractCloudToolChangedFiles(
   }
 
   return [...filesByPath.values()];
+}
+
+export interface CloudToolFileDiff {
+  path: string;
+  oldText: string | null;
+  newText: string | null;
+  linesAdded?: number;
+  linesRemoved?: number;
+}
+
+export function extractCloudToolFileDiffs(
+  toolCalls: Map<string, ParsedToolCall>,
+): CloudToolFileDiff[] {
+  const diffs: CloudToolFileDiff[] = [];
+
+  for (const file of extractCloudToolChangedFiles(toolCalls)) {
+    const content = extractCloudFileDiff(toolCalls, file.path);
+    if (!content || (content.oldText === null && content.newText === null)) {
+      continue;
+    }
+
+    const stats = isBinaryFile(file.path)
+      ? {}
+      : getDiffStats(content.oldText, content.newText);
+    diffs.push({
+      path: file.path,
+      oldText: content.oldText,
+      newText: content.newText,
+      linesAdded: stats.added,
+      linesRemoved: stats.removed,
+    });
+  }
+
+  return diffs;
 }
 
 export interface CloudFileContent {

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -62,11 +62,13 @@ import type { PromptRecallHandler } from "@posthog/ui/features/sessions/componen
 import { MessageJumpPicker } from "@posthog/ui/features/sessions/components/chat-thread/MessageJumpPicker";
 import { MessageMinimap } from "@posthog/ui/features/sessions/components/chat-thread/MessageMinimap";
 import { ToolGroup } from "@posthog/ui/features/sessions/components/chat-thread/ToolGroup";
+import { TurnDiffSummary } from "@posthog/ui/features/sessions/components/chat-thread/TurnDiffSummary";
 import { THREAD_HOTKEY_OPTIONS } from "@posthog/ui/features/sessions/components/chat-thread/threadHotkeys";
 import {
   type AgentTurn,
   CHAT_THREAD_VIRTUALIZATION_THRESHOLD,
   completedTurnTimestamp,
+  completedTurnToolCalls,
   completedTurnTraceId,
   countFlatRows,
   type FlatThreadRow,
@@ -781,6 +783,7 @@ const ThreadRow = memo(function ThreadRow({
 }) {
   const { revealed: footerRevealed, rowProps } = useRowReveal(keyboardFocused);
   if (item.type === "agent_turn") {
+    const toolCalls = completedTurnToolCalls(item);
     return (
       <ChatMessageScrollerItem
         messageId={item.id}
@@ -809,6 +812,9 @@ const ThreadRow = memo(function ThreadRow({
               </div>
             ))}
           </div>
+          {toolCalls && (
+            <TurnDiffSummary toolCalls={toolCalls} turnId={item.id} />
+          )}
           <TurnFooter
             turnId={item.id}
             traceId={completedTurnTraceId(item)}
@@ -1189,6 +1195,12 @@ const FlatRowView = memo(
             isTrailing={row.isTrailingInTurn}
             keyboardFocused={keyboardFocused}
           />
+          {row.turnId != null && row.turnToolCalls != null && (
+            <TurnDiffSummary
+              toolCalls={row.turnToolCalls}
+              turnId={row.turnId}
+            />
+          )}
           {row.turnId != null && row.turnTimestamp != null && (
             <TurnFooter
               turnId={row.turnId}
@@ -1207,6 +1219,7 @@ const FlatRowView = memo(
     prev.row.inTurn === next.row.inTurn &&
     prev.row.isTrailingInTurn === next.row.isTrailingInTurn &&
     prev.row.turnTimestamp === next.row.turnTimestamp &&
+    prev.row.turnToolCalls === next.row.turnToolCalls &&
     prev.renderItem === next.renderItem &&
     prev.keyboardFocused === next.keyboardFocused,
 );

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/TurnDiffSummary.stories.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/TurnDiffSummary.stories.tsx
@@ -1,0 +1,74 @@
+import type { ToolCall } from "@posthog/ui/features/sessions/types";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ChatThreadChromeProvider } from "./chatThreadChrome";
+import { TurnDiffSummary } from "./TurnDiffSummary";
+
+const toolCalls = new Map<string, ToolCall>([
+  [
+    "edit-settings",
+    {
+      toolCallId: "edit-settings",
+      title: "Edit src/settings.ts",
+      kind: "edit",
+      status: "completed",
+      content: [
+        {
+          type: "diff",
+          path: "src/settings.ts",
+          oldText: `export const settings = {
+  theme: "light",
+};`,
+          newText: `export const settings = {
+  theme: "system",
+  compactMode: true,
+};`,
+        },
+      ],
+    },
+  ],
+  [
+    "write-preferences",
+    {
+      toolCallId: "write-preferences",
+      title: "Write src/preferences.ts",
+      status: "completed",
+      content: [
+        {
+          type: "diff",
+          path: "src/preferences.ts",
+          oldText: null,
+          newText: `export interface Preferences {
+  compactMode: boolean;
+}`,
+        },
+      ],
+    },
+  ],
+]);
+
+const meta: Meta<typeof TurnDiffSummary> = {
+  title: "Features/Sessions/TurnDiffSummary",
+  component: TurnDiffSummary,
+  decorators: [
+    (Story) => (
+      <ChatThreadChromeProvider value>
+        <div className="max-w-3xl">
+          <Story />
+        </div>
+      </ChatThreadChromeProvider>
+    ),
+  ],
+  parameters: {
+    layout: "padded",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof TurnDiffSummary>;
+
+export const Default: Story = {
+  args: {
+    toolCalls,
+    turnId: "turn-story",
+  },
+};

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/TurnDiffSummary.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/TurnDiffSummary.test.tsx
@@ -1,0 +1,76 @@
+import type { ToolCall } from "@posthog/ui/features/sessions/types";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ChatThreadChromeProvider } from "./chatThreadChrome";
+import { TurnDiffSummary } from "./TurnDiffSummary";
+
+vi.mock(
+  "@posthog/ui/features/sessions/components/session-update/CodePreview",
+  () => ({
+    CodePreview: ({ filePath }: { filePath?: string }) => (
+      <div data-testid="code-preview">{filePath}</div>
+    ),
+  }),
+);
+
+function toolCalls(): Map<string, ToolCall> {
+  return new Map([
+    [
+      "edit-1",
+      {
+        toolCallId: "edit-1",
+        title: "Edit src/app.ts",
+        kind: "edit",
+        status: "completed",
+        content: [
+          {
+            type: "diff",
+            path: "src/app.ts",
+            oldText: "const value = 1;",
+            newText: "const value = 2;\nconst ready = true;",
+          },
+        ],
+      },
+    ],
+    [
+      "edit-2",
+      {
+        toolCallId: "edit-2",
+        title: "Edit src/view.tsx",
+        kind: "edit",
+        status: "completed",
+        content: [
+          {
+            type: "diff",
+            path: "src/view.tsx",
+            oldText: "return null;",
+            newText: "return <main />;",
+          },
+        ],
+      },
+    ],
+  ]);
+}
+
+describe("TurnDiffSummary", () => {
+  it("shows line totals and keeps the turn diff collapsed until the user opens it", () => {
+    render(
+      <ChatThreadChromeProvider value>
+        <TurnDiffSummary toolCalls={toolCalls()} turnId="turn-1" />
+      </ChatThreadChromeProvider>,
+    );
+
+    expect(screen.getByText("2 files changed")).toBeInTheDocument();
+    expect(screen.getByText("+3")).toBeInTheDocument();
+    expect(screen.getByText("-2")).toBeInTheDocument();
+
+    const trigger = screen.getByText("2 files changed").closest("button");
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryAllByTestId("code-preview")).toHaveLength(0);
+
+    fireEvent.click(trigger as HTMLButtonElement);
+
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getAllByTestId("code-preview")).toHaveLength(2);
+  });
+});

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/TurnDiffSummary.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/TurnDiffSummary.tsx
@@ -1,0 +1,58 @@
+import { GitDiff } from "@phosphor-icons/react";
+import { extractCloudToolFileDiffs } from "@posthog/core/task-detail/cloudToolChanges";
+import type { TurnContext } from "@posthog/ui/features/sessions/components/buildConversationItems";
+import { CodePreview } from "@posthog/ui/features/sessions/components/session-update/CodePreview";
+import { ToolRow } from "@posthog/ui/features/sessions/components/session-update/ToolRow";
+import { useMemo } from "react";
+
+interface TurnDiffSummaryProps {
+  toolCalls: TurnContext["toolCalls"];
+  turnId: string;
+}
+
+export function TurnDiffSummary({ toolCalls, turnId }: TurnDiffSummaryProps) {
+  const diffs = useMemo(
+    () => extractCloudToolFileDiffs(toolCalls),
+    [toolCalls],
+  );
+
+  if (diffs.length === 0) return null;
+
+  const linesAdded = diffs.reduce(
+    (total, diff) => total + (diff.linesAdded ?? 0),
+    0,
+  );
+  const linesRemoved = diffs.reduce(
+    (total, diff) => total + (diff.linesRemoved ?? 0),
+    0,
+  );
+  const fileLabel =
+    diffs.length === 1 ? "1 file changed" : `${diffs.length} files changed`;
+
+  return (
+    <ToolRow
+      icon={GitDiff}
+      defaultOpen={false}
+      boxed={false}
+      content={
+        <div className="flex flex-col gap-3">
+          {diffs.map((diff) => (
+            <CodePreview
+              key={diff.path}
+              content={diff.newText ?? ""}
+              filePath={diff.path}
+              showPath
+              oldContent={diff.oldText ?? ""}
+              maxHeight="500px"
+              cacheKey={`${turnId}:${diff.path}`}
+            />
+          ))}
+        </div>
+      }
+    >
+      <span>{fileLabel}</span>
+      <span className="font-mono text-green-11 text-xs">+{linesAdded}</span>
+      <span className="font-mono text-red-11 text-xs">-{linesRemoved}</span>
+    </ToolRow>
+  );
+}

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.test.ts
@@ -28,11 +28,13 @@ function sessionUpdate(
     turnComplete = false,
     timestamp,
     text,
+    toolCalls,
     traceId,
   }: {
     turnComplete?: boolean;
     timestamp?: number;
     text?: string;
+    toolCalls?: SessionUpdateItem["turnContext"]["toolCalls"];
     traceId?: string | null;
   } = {},
 ): SessionUpdateItem {
@@ -44,7 +46,7 @@ function sessionUpdate(
       content: { type: "text", text: text ?? `text ${id}` },
     } as SessionUpdateItem["update"],
     turnContext: {
-      toolCalls: new Map(),
+      toolCalls: toolCalls ?? new Map(),
       childItems: new Map(),
       turnCancelled: false,
       turnComplete,
@@ -168,6 +170,30 @@ describe("flattenTurnRows", () => {
     ]);
     const flat = flattenTurnRows([done]);
     expect(flat.map((r) => r.turnTraceId)).toEqual([undefined, "trace-d"]);
+  });
+
+  it("carries completed turn tool calls on the last row", () => {
+    const toolCalls: SessionUpdateItem["turnContext"]["toolCalls"] = new Map([
+      [
+        "edit-1",
+        {
+          toolCallId: "edit-1",
+          title: "Edit src/app.ts",
+          kind: "edit",
+          status: "completed",
+        },
+      ],
+    ]);
+    const done = agentTurn("d", [
+      sessionUpdate("d1"),
+      sessionUpdate("d2", {
+        turnComplete: true,
+        timestamp: 1234,
+        toolCalls,
+      }),
+    ]);
+    const flat = flattenTurnRows([done]);
+    expect(flat.map((r) => r.turnToolCalls)).toEqual([undefined, toolCalls]);
   });
 
   it("carries the turn's copy text on the same row as its timestamp", () => {

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
@@ -1,4 +1,7 @@
-import type { ConversationItem } from "@posthog/ui/features/sessions/components/buildConversationItems";
+import type {
+  ConversationItem,
+  TurnContext,
+} from "@posthog/ui/features/sessions/components/buildConversationItems";
 import type { ToolGroupItem } from "@posthog/ui/features/sessions/components/chat-thread/ToolGroup";
 import { buildTurnCopyText } from "@posthog/ui/features/sessions/components/chat-thread/turnCopyText";
 
@@ -92,6 +95,7 @@ export interface FlatThreadRow {
   turnTraceId?: string | null;
   /** Set alongside {@link turnTimestamp}: the agent response as plain text, for its copy button. */
   turnCopyText?: string;
+  turnToolCalls?: TurnContext["toolCalls"];
 }
 
 /**
@@ -118,6 +122,15 @@ export function completedTurnTraceId(turn: AgentTurn): string | null {
   return last?.turnContext.turnComplete
     ? (last.turnContext.traceId ?? null)
     : null;
+}
+
+export function completedTurnToolCalls(
+  turn: AgentTurn,
+): TurnContext["toolCalls"] | undefined {
+  const last = lastSessionUpdate(turn);
+  return last?.turnContext.turnComplete
+    ? last.turnContext.toolCalls
+    : undefined;
 }
 
 /** Viewport distance from the top of the loaded window that triggers an older-history page load. */
@@ -179,6 +192,8 @@ export function flattenTurnRows(rows: TurnRow[]): FlatThreadRow[] {
           ? undefined
           : (buildTurnCopyText(row.items) ?? undefined);
       const traceId = timestamp == null ? null : completedTurnTraceId(row);
+      const toolCalls =
+        timestamp == null ? undefined : completedTurnToolCalls(row);
       for (let i = 0; i < row.items.length; i++) {
         const item = row.items[i];
         const isTrailing = i === row.items.length - 1;
@@ -191,6 +206,7 @@ export function flattenTurnRows(rows: TurnRow[]): FlatThreadRow[] {
           turnId: isTrailing ? row.id : undefined,
           turnTraceId: isTrailing ? traceId : undefined,
           turnCopyText: isTrailing ? copyText : undefined,
+          turnToolCalls: isTrailing ? toolCalls : undefined,
         });
       }
       continue;

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/EditToolView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/EditToolView.tsx
@@ -1,5 +1,5 @@
 import { PencilSimple } from "@phosphor-icons/react";
-import { Text } from "@radix-ui/themes";
+import { getDiffStats } from "@posthog/core/task-detail/cloudToolChanges";
 import { useChatThreadChrome } from "../chat-thread/chatThreadChrome";
 import { CodePreview } from "./CodePreview";
 import { FileMentionChip } from "./FileMentionChip";
@@ -9,43 +9,6 @@ import {
   type ToolViewProps,
   useToolCallStatus,
 } from "./toolCallUtils";
-
-function getDiffStats(
-  oldText: string | null | undefined,
-  newText: string | null | undefined,
-): { added: number; removed: number } {
-  const oldLines = oldText ? oldText.split("\n") : [];
-  const newLines = newText ? newText.split("\n") : [];
-
-  if (!oldText) {
-    return { added: newLines.length, removed: 0 };
-  }
-
-  const oldCounts = new Map<string, number>();
-  for (const line of oldLines) {
-    oldCounts.set(line, (oldCounts.get(line) ?? 0) + 1);
-  }
-
-  const newCounts = new Map<string, number>();
-  for (const line of newLines) {
-    newCounts.set(line, (newCounts.get(line) ?? 0) + 1);
-  }
-
-  let added = 0;
-  let removed = 0;
-
-  for (const [line, count] of newCounts) {
-    const oldCount = oldCounts.get(line) ?? 0;
-    if (count > oldCount) added += count - oldCount;
-  }
-
-  for (const [line, count] of oldCounts) {
-    const newCount = newCounts.get(line) ?? 0;
-    if (count > newCount) removed += count - newCount;
-  }
-
-  return { added, removed };
-}
 
 export function EditToolView({
   toolCall,
@@ -93,10 +56,10 @@ export function EditToolView({
     >
       {filePath && <FileMentionChip filePath={filePath} />}
       {diffStats && (
-        <Text className="font-mono text-[13px]">
-          <span className="text-green-11">+{diffStats.added}</span>{" "}
-          <span className="text-red-11">-{diffStats.removed}</span>
-        </Text>
+        <span className="font-mono text-[13px]">
+          <span className="text-green-11">+{diffStats.added ?? 0}</span>{" "}
+          <span className="text-red-11">-{diffStats.removed ?? 0}</span>
+        </span>
       )}
     </ToolRow>
   );


### PR DESCRIPTION
## Problem

Users cannot see a clear summary of the code changes from each agent turn when they return to a session.

## Changes

- Completed agent turns now show a collapsed summary with the changed file count and line totals.
- Expanding the summary shows one cumulative diff per file with the existing diff viewer.
- Repeated edits use the file state before the first edit and the state after the final edit.
- Standard and virtualized chat threads show the same summary.
- The summary uses structured diff output. It does not infer changes from shell commands without diff output.

**Collapsed**

![turn-diff-collapsed](https://raw.githubusercontent.com/PostHog/pr-assets/49f5f7e9405c0f1cb0c54d706e13cced2b0010a0/2026/09/16094910-a9b1-4c1d-87b3-8affd071db9e.png)

**Expanded**

![turn-diff-expanded](https://raw.githubusercontent.com/PostHog/pr-assets/77199d50c934c6c45390814312f61f1dbc2f8d4d/2026/09/c130aabb-2fc0-464e-84fa-177750066e2f.png)

## How did you test this code?

- Added a core test for cumulative diffs across repeated edits to one file.
- Added a UI test for line totals, the collapsed default, and expansion.
- Added a virtualization test that keeps turn changes on the final row.
- Ran the core and UI test suites, the desktop type check, Biome, the host boundary check, and Storybook build.
- Rendered the story at 1000 px and 520 px. The expanded view had no runtime errors or horizontal overflow.
- The full workspace test run stopped in existing Git package tests because this environment blocks unsigned `git commit` calls.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The Storybook story documents the new chat state. No product documentation changed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- The agent used repository tools and read-only Explore subagents.
- The agent used the PostHog Desktop, UI, copy, tests, orchestration, preflight, PR description, and Simplified Technical English skills.
- The open pull request search found no matching implementation.
- The CodeRabbit pass is paused. This PR opened without a local CodeRabbit pass.
- The committed examples use invented file names and content.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

