### PR TITLE
feat(desktop): warn before local tasks use dirty folders

### DIFF
--- a/products/desktop/packages/core/src/git/router-schemas.ts
+++ b/products/desktop/packages/core/src/git/router-schemas.ts
@@ -102,7 +102,9 @@ export const cloneProgressPayload = z.object({
 
 export type CloneProgressPayload = z.infer<typeof cloneProgressPayload>;
 
-export const getChangedFilesHeadInput = directoryPathInput;
+export const getChangedFilesHeadInput = directoryPathInput.extend({
+  includeAgentFiles: z.boolean().optional(),
+});
 export const getChangedFilesHeadOutput = z.array(changedFileSchema);
 
 export const getFileAtHeadInput = z.object({

--- a/products/desktop/packages/git/src/queries.ts
+++ b/products/desktop/packages/git/src/queries.ts
@@ -507,6 +507,7 @@ export interface ChangedFileInfo {
 
 export interface GetChangedFilesDetailedOptions extends CreateGitClientOptions {
   excludePatterns?: string[];
+  throwOnError?: boolean;
 }
 
 function matchesExcludePattern(filePath: string, patterns: string[]): boolean {
@@ -579,7 +580,7 @@ export async function getChangedFilesDetailed(
   baseDir: string,
   options?: GetChangedFilesDetailedOptions,
 ): Promise<ChangedFileInfo[]> {
-  const { excludePatterns, ...gitOptions } = options ?? {};
+  const { excludePatterns, throwOnError, ...gitOptions } = options ?? {};
   const manager = getGitOperationManager();
 
   return manager.executeRead(
@@ -673,7 +674,8 @@ export async function getChangedFilesDetailed(
         }
 
         return files;
-      } catch {
+      } catch (error) {
+        if (throwOnError) throw error;
         return [];
       }
     },

--- a/products/desktop/packages/host-router/src/routers/git.router.ts
+++ b/products/desktop/packages/host-router/src/routers/git.router.ts
@@ -235,7 +235,10 @@ export const gitRouter = router({
     .output(getChangedFilesHeadOutput)
     .query(({ ctx, input, signal }) =>
       getWorkspaceClient(ctx.container).git.getChangedFilesHead.query(
-        { directoryPath: input.directoryPath },
+        {
+          directoryPath: input.directoryPath,
+          includeAgentFiles: input.includeAgentFiles,
+        },
         { signal },
       ),
     ),

--- a/products/desktop/packages/shared/src/analytics-events.ts
+++ b/products/desktop/packages/shared/src/analytics-events.ts
@@ -115,6 +115,14 @@ export interface TaskCreateProperties {
   space_context_mode: SpaceContextMode;
 }
 
+export interface LocalChangesWarningActionProperties {
+  action: "cancel" | "continue" | "stash_and_continue";
+  result?: "success" | "failure";
+  staged_file_count: number;
+  unstaged_file_count: number;
+  untracked_file_count: number;
+}
+
 export interface TaskViewProperties {
   task_id: string;
 }
@@ -1545,6 +1553,7 @@ export const ANALYTICS_EVENTS = {
   TASK_RUN_STOPPED: "Task run stopped",
   PROMPT_SENT: "Prompt sent",
   AGENT_TURN_FEEDBACK: "Agent turn feedback",
+  LOCAL_CHANGES_WARNING_ACTION: "Local changes warning action",
 
   // Claude Code session import
   CLAUDE_SESSIONS_SHOWN: "Claude Code sessions shown",
@@ -1761,6 +1770,7 @@ export type EventPropertyMap = {
   [ANALYTICS_EVENTS.TASK_RUN_STOPPED]: TaskRunStoppedProperties;
   [ANALYTICS_EVENTS.PROMPT_SENT]: PromptSentProperties;
   [ANALYTICS_EVENTS.AGENT_TURN_FEEDBACK]: AgentTurnFeedbackProperties;
+  [ANALYTICS_EVENTS.LOCAL_CHANGES_WARNING_ACTION]: LocalChangesWarningActionProperties;
 
   // Claude Code session import
   [ANALYTICS_EVENTS.CLAUDE_SESSIONS_SHOWN]: ClaudeSessionsShownProperties;

--- a/products/desktop/packages/ui/src/features/task-detail/components/LocalChangesDialog.stories.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/LocalChangesDialog.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { LocalChangesDialog } from "./LocalChangesDialog";
+
+const meta: Meta<typeof LocalChangesDialog> = {
+  title: "Task detail/Local changes dialog",
+  component: LocalChangesDialog,
+  parameters: { layout: "centered" },
+  args: {
+    open: true,
+    stagedFiles: ["packages/ui/src/features/tasks/TaskList.tsx"],
+    unstagedFiles: ["packages/core/src/tasks/taskService.ts"],
+    untrackedFiles: ["packages/ui/src/features/tasks/NewTask.tsx"],
+    isStashing: false,
+    stashError: null,
+    onOpenChange: () => {},
+    onCancel: () => {},
+    onContinue: () => {},
+    onStashAndContinue: () => {},
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof LocalChangesDialog>;
+
+export const Default: Story = {};
+
+export const StashFailed: Story = {
+  args: {
+    stashError: "Could not stash local changes. Check Git, then try again.",
+  },
+};

--- a/products/desktop/packages/ui/src/features/task-detail/components/LocalChangesDialog.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/LocalChangesDialog.tsx
@@ -1,0 +1,119 @@
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Button,
+  DialogBody,
+} from "@posthog/quill";
+
+export interface LocalChangesDialogProps {
+  open: boolean;
+  stagedFiles: string[];
+  unstagedFiles: string[];
+  untrackedFiles: string[];
+  isStashing: boolean;
+  stashError: string | null;
+  onOpenChange: (open: boolean) => void;
+  onCancel: () => void;
+  onContinue: () => void;
+  onStashAndContinue: () => void;
+}
+
+function renderFileGroup(
+  title: string,
+  files: string[],
+): React.JSX.Element | null {
+  if (files.length === 0) return null;
+
+  return (
+    <section className="flex flex-col gap-1.5">
+      <h3 className="font-medium text-sm">
+        {title} ({files.length})
+      </h3>
+      <ul className="max-h-28 overflow-y-auto rounded-md border border-border bg-muted/30 px-3 py-2 font-mono text-muted-foreground text-xs">
+        {files.map((file) => (
+          <li key={file} className="truncate">
+            {file}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export function LocalChangesDialog({
+  open,
+  stagedFiles,
+  unstagedFiles,
+  untrackedFiles,
+  isStashing,
+  stashError,
+  onOpenChange,
+  onCancel,
+  onContinue,
+  onStashAndContinue,
+}: LocalChangesDialogProps): React.JSX.Element {
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && !isStashing) onOpenChange(next);
+      }}
+    >
+      <AlertDialogContent className="max-w-md">
+        <AlertDialogHeader>
+          <AlertDialogTitle>Local changes found</AlertDialogTitle>
+          <AlertDialogDescription>
+            This folder has local changes. A local task can mix its work with
+            these changes. Stashed changes stay in Git until you restore them.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <DialogBody>
+          <div className="flex flex-col gap-3">
+            {renderFileGroup("Staged", stagedFiles)}
+            {renderFileGroup("Unstaged", unstagedFiles)}
+            {renderFileGroup("Untracked", untrackedFiles)}
+            {stashError ? (
+              <p className="text-destructive text-sm" role="alert">
+                {stashError}
+              </p>
+            ) : null}
+          </div>
+        </DialogBody>
+        <AlertDialogFooter>
+          <Button
+            variant="outline"
+            size="sm"
+            data-attr="task-local-changes-cancel"
+            disabled={isStashing}
+            onClick={onCancel}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            data-attr="task-local-changes-continue"
+            disabled={isStashing}
+            onClick={onContinue}
+          >
+            Continue
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            data-attr="task-local-changes-stash-and-continue"
+            disabled={isStashing}
+            loading={isStashing}
+            onClick={onStashAndContinue}
+          >
+            Stash and continue
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/products/desktop/packages/ui/src/features/task-detail/components/LocalChangesDialogHost.test.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/LocalChangesDialogHost.test.tsx
@@ -1,0 +1,117 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useLocalChangesConfirmStore } from "../stores/localChangesConfirmStore";
+import { LocalChangesDialogHost } from "./LocalChangesDialogHost";
+
+const stashMock = vi.hoisted(() => vi.fn());
+const trackMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@posthog/host-router/react", () => ({
+  useHostTRPC: () => ({
+    focus: {
+      stash: {
+        mutationOptions: () => ({ mutationFn: stashMock }),
+      },
+    },
+  }),
+}));
+vi.mock("../../../shell/analytics", () => ({ track: trackMock }));
+
+function wrapper({ children }: { children: ReactNode }): React.JSX.Element {
+  return (
+    <QueryClientProvider client={new QueryClient()}>
+      {children}
+    </QueryClientProvider>
+  );
+}
+
+describe("LocalChangesDialogHost", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useLocalChangesConfirmStore.setState({
+      isOpen: false,
+      repoPath: "",
+      stagedFiles: [],
+      unstagedFiles: [],
+      untrackedFiles: [],
+      resolve: null,
+    });
+  });
+
+  it("stashes local changes before continuing", async () => {
+    let resolveStash!: (result: { success: boolean }) => void;
+    stashMock.mockImplementation(
+      () =>
+        new Promise<{ success: boolean }>((resolve) => {
+          resolveStash = resolve;
+        }),
+    );
+    const user = userEvent.setup();
+    render(<LocalChangesDialogHost />, { wrapper });
+
+    let confirmation!: Promise<string>;
+    act(() => {
+      confirmation = useLocalChangesConfirmStore.getState().confirm({
+        repoPath: "/repo",
+        stagedFiles: ["staged.ts"],
+        unstagedFiles: [],
+        untrackedFiles: ["new.ts"],
+      });
+    });
+
+    await user.click(
+      await screen.findByRole("button", { name: "Stash and continue" }),
+    );
+
+    await waitFor(() => {
+      for (const action of ["cancel", "continue", "stash-and-continue"]) {
+        expect(
+          document.querySelector(`[data-attr="task-local-changes-${action}"]`),
+        ).toHaveAttribute("aria-disabled", "true");
+      }
+    });
+    await act(async () => {
+      resolveStash({ success: true });
+      await expect(confirmation).resolves.toBe("stash-and-continue");
+    });
+    expect(stashMock.mock.calls[0][0]).toEqual({
+      repoPath: "/repo",
+      message: "PostHog Desktop: local changes before task creation",
+    });
+  });
+
+  it("keeps the dialog open when stashing fails", async () => {
+    stashMock.mockResolvedValue({ success: false });
+    const user = userEvent.setup();
+    render(<LocalChangesDialogHost />, { wrapper });
+
+    let confirmation!: Promise<string>;
+    act(() => {
+      confirmation = useLocalChangesConfirmStore.getState().confirm({
+        repoPath: "/repo",
+        stagedFiles: [],
+        unstagedFiles: ["unstaged.ts"],
+        untrackedFiles: [],
+      });
+    });
+
+    await user.click(
+      await screen.findByRole("button", { name: "Stash and continue" }),
+    );
+
+    expect(
+      await screen.findByText(
+        "Could not stash local changes. Check Git, then try again.",
+      ),
+    ).toBeInTheDocument();
+    expect(useLocalChangesConfirmStore.getState().isOpen).toBe(true);
+
+    await act(async () => {
+      useLocalChangesConfirmStore.getState().cancel();
+      await expect(confirmation).resolves.toBe("cancel");
+    });
+  });
+});

--- a/products/desktop/packages/ui/src/features/task-detail/components/LocalChangesDialogHost.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/LocalChangesDialogHost.tsx
@@ -1,0 +1,105 @@
+import { useHostTRPC } from "@posthog/host-router/react";
+import { ANALYTICS_EVENTS } from "@posthog/shared";
+import { useMutation } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { track } from "../../../shell/analytics";
+import { useLocalChangesConfirmStore } from "../stores/localChangesConfirmStore";
+import { LocalChangesDialog } from "./LocalChangesDialog";
+
+const STASH_MESSAGE = "PostHog Desktop: local changes before task creation";
+const STASH_ERROR = "Could not stash local changes. Check Git, then try again.";
+
+export function LocalChangesDialogHost(): React.JSX.Element {
+  const trpc = useHostTRPC();
+  const isOpen = useLocalChangesConfirmStore((state) => state.isOpen);
+  const repoPath = useLocalChangesConfirmStore((state) => state.repoPath);
+  const stagedFiles = useLocalChangesConfirmStore((state) => state.stagedFiles);
+  const unstagedFiles = useLocalChangesConfirmStore(
+    (state) => state.unstagedFiles,
+  );
+  const untrackedFiles = useLocalChangesConfirmStore(
+    (state) => state.untrackedFiles,
+  );
+  const cancel = useLocalChangesConfirmStore((state) => state.cancel);
+  const continueTask = useLocalChangesConfirmStore((state) => state.continue);
+  const stashAndContinue = useLocalChangesConfirmStore(
+    (state) => state.stashAndContinue,
+  );
+  const [stashError, setStashError] = useState<string | null>(null);
+  const stashMutation = useMutation(trpc.focus.stash.mutationOptions());
+
+  useEffect(() => {
+    if (!isOpen) setStashError(null);
+  }, [isOpen]);
+
+  const eventProperties = {
+    staged_file_count: stagedFiles.length,
+    unstaged_file_count: unstagedFiles.length,
+    untracked_file_count: untrackedFiles.length,
+  };
+
+  const handleCancel = (): void => {
+    track(ANALYTICS_EVENTS.LOCAL_CHANGES_WARNING_ACTION, {
+      action: "cancel",
+      ...eventProperties,
+    });
+    cancel();
+  };
+
+  const handleContinue = (): void => {
+    track(ANALYTICS_EVENTS.LOCAL_CHANGES_WARNING_ACTION, {
+      action: "continue",
+      ...eventProperties,
+    });
+    continueTask();
+  };
+
+  const handleStashAndContinue = async (): Promise<void> => {
+    setStashError(null);
+    try {
+      const result = await stashMutation.mutateAsync({
+        repoPath,
+        message: STASH_MESSAGE,
+      });
+      if (!result.success) {
+        track(ANALYTICS_EVENTS.LOCAL_CHANGES_WARNING_ACTION, {
+          action: "stash_and_continue",
+          result: "failure",
+          ...eventProperties,
+        });
+        setStashError(STASH_ERROR);
+        return;
+      }
+      track(ANALYTICS_EVENTS.LOCAL_CHANGES_WARNING_ACTION, {
+        action: "stash_and_continue",
+        result: "success",
+        ...eventProperties,
+      });
+      stashAndContinue();
+    } catch {
+      track(ANALYTICS_EVENTS.LOCAL_CHANGES_WARNING_ACTION, {
+        action: "stash_and_continue",
+        result: "failure",
+        ...eventProperties,
+      });
+      setStashError(STASH_ERROR);
+    }
+  };
+
+  return (
+    <LocalChangesDialog
+      open={isOpen}
+      stagedFiles={stagedFiles}
+      unstagedFiles={unstagedFiles}
+      untrackedFiles={untrackedFiles}
+      isStashing={stashMutation.isPending}
+      stashError={stashError}
+      onOpenChange={(open) => {
+        if (!open) handleCancel();
+      }}
+      onCancel={handleCancel}
+      onContinue={handleContinue}
+      onStashAndContinue={() => void handleStashAndContinue()}
+    />
+  );
+}

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/useTaskCreation.test.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/useTaskCreation.test.tsx
@@ -11,14 +11,17 @@ import {
   usePendingTaskPromptStore,
 } from "@posthog/ui/shell/pendingTaskPromptStore";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useLocalChangesConfirmStore } from "../stores/localChangesConfirmStore";
 
 const createTaskMock = vi.hoisted(() => vi.fn());
 const invalidateTasksMock = vi.hoisted(() => vi.fn());
 const openTaskMock = vi.hoisted(() => vi.fn());
 const trackMock = vi.hoisted(() => vi.fn());
+const validateRepoMock = vi.hoisted(() => vi.fn());
+const getChangedFilesHeadMock = vi.hoisted(() => vi.fn());
 const cloudSubscription = vi.hoisted(() => ({
   cloudSubscriptionOn: false,
   cloudFlagEnabled: true,
@@ -42,6 +45,10 @@ vi.mock("@posthog/host-router/react", () => ({
   }),
   useHostTRPCClient: () => ({
     workspace: { getWorktreeFileUsage: { query: vi.fn() } },
+    git: {
+      validateRepo: { query: validateRepoMock },
+      getChangedFilesHead: { query: getChangedFilesHeadMock },
+    },
   }),
 }));
 vi.mock("@posthog/ui/features/canvas/hooks/useTaskChannels", () => ({
@@ -170,8 +177,99 @@ describe("useTaskCreation prompt records", () => {
     vi.clearAllMocks();
     createTaskMock.mockReset();
     cloudSubscription.cloudSubscriptionOn = false;
+    validateRepoMock.mockResolvedValue(true);
+    getChangedFilesHeadMock.mockResolvedValue([]);
+    useLocalChangesConfirmStore.setState({
+      isOpen: false,
+      repoPath: "",
+      stagedFiles: [],
+      unstagedFiles: [],
+      untrackedFiles: [],
+      resolve: null,
+    });
     usePendingTaskPromptStore.setState({ byKey: {}, _hasHydrated: true });
     useTaskInputPrefillStore.setState({ prefill: {} });
+  });
+
+  it("cancels local task creation when local changes are not accepted", async () => {
+    getChangedFilesHeadMock.mockResolvedValue([
+      { path: "staged.ts", status: "modified", staged: true },
+    ]);
+    const { result } = renderTaskCreation(textToContent("Check the build"));
+
+    let submission!: Promise<boolean>;
+    act(() => {
+      submission = result.current.handleSubmit();
+    });
+    await waitFor(() =>
+      expect(useLocalChangesConfirmStore.getState().isOpen).toBe(true),
+    );
+    act(() => useLocalChangesConfirmStore.getState().cancel());
+
+    await act(async () => {
+      await expect(submission).resolves.toBe(false);
+    });
+    expect(createTaskMock).not.toHaveBeenCalled();
+  });
+
+  it("creates a local task after local changes are accepted", async () => {
+    getChangedFilesHeadMock.mockResolvedValue([
+      { path: "unstaged.ts", status: "modified", staged: false },
+    ]);
+    createTaskMock.mockResolvedValueOnce({
+      success: true,
+      data: { task: fakeTask(), workspace: null },
+    });
+    const { result } = renderTaskCreation(textToContent("Check the build"));
+
+    let submission!: Promise<boolean>;
+    act(() => {
+      submission = result.current.handleSubmit();
+    });
+    await waitFor(() =>
+      expect(useLocalChangesConfirmStore.getState().isOpen).toBe(true),
+    );
+    act(() => useLocalChangesConfirmStore.getState().continue());
+
+    await act(async () => {
+      await expect(submission).resolves.toBe(true);
+    });
+    expect(getChangedFilesHeadMock).toHaveBeenCalledWith({
+      directoryPath: "/repo",
+      includeAgentFiles: true,
+    });
+    expect(createTaskMock).toHaveBeenCalledOnce();
+  });
+
+  it("creates a local task without a Git preflight for a non-Git folder", async () => {
+    validateRepoMock.mockResolvedValue(false);
+    createTaskMock.mockResolvedValueOnce({
+      success: true,
+      data: { task: fakeTask(), workspace: null },
+    });
+    const { result } = renderTaskCreation(textToContent("Check the build"));
+
+    await act(async () => {
+      await expect(result.current.handleSubmit()).resolves.toBe(true);
+    });
+
+    expect(getChangedFilesHeadMock).not.toHaveBeenCalled();
+    expect(createTaskMock).toHaveBeenCalledOnce();
+  });
+
+  it("does not create a local task when the Git change check fails", async () => {
+    getChangedFilesHeadMock.mockRejectedValue(new Error("Git failed"));
+    const { result } = renderTaskCreation(textToContent("Check the build"));
+
+    await act(async () => {
+      await expect(result.current.handleSubmit()).resolves.toBe(false);
+    });
+
+    expect(createTaskMock).not.toHaveBeenCalled();
+    expect(trackMock).toHaveBeenCalledWith(
+      "Task creation failed",
+      expect.objectContaining({ error_type: "local_changes_check_failed" }),
+    );
   });
 
   it("omits subscription billing when Pi is selected", async () => {

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
@@ -1,4 +1,5 @@
 import { buildTaskSpaceContextProps } from "@posthog/core/canvas/canvasAnalytics";
+import type { ChangedFile } from "@posthog/core/git/router-schemas";
 import { partitionLocalMcpServersForRun } from "@posthog/core/local-mcp/localMcpImport";
 import {
   getErrorTitle,
@@ -72,9 +73,28 @@ import { useTasks } from "../../tasks/useTasks";
 import { useTourStore } from "../../tour/tourStore";
 import { createFirstTaskTour } from "../../tour/tours/createFirstTaskTour";
 import { useExistingWorktreeConfirmStore } from "../stores/existingWorktreeConfirmStore";
+import { useLocalChangesConfirmStore } from "../stores/localChangesConfirmStore";
 import { useRemoteBranchConfirmStore } from "../stores/remoteBranchConfirmStore";
 
 const log = logger.scope("task-creation");
+
+function groupLocalChanges(files: ChangedFile[]): {
+  stagedFiles: string[];
+  unstagedFiles: string[];
+  untrackedFiles: string[];
+} {
+  return {
+    stagedFiles: files
+      .filter((file) => file.status !== "untracked" && file.staged)
+      .map((file) => file.path),
+    unstagedFiles: files
+      .filter((file) => file.status !== "untracked" && !file.staged)
+      .map((file) => file.path),
+    untrackedFiles: files
+      .filter((file) => file.status === "untracked")
+      .map((file) => file.path),
+  };
+}
 
 interface UseTaskCreationOptions {
   editorRef: React.RefObject<EditorHandle | null>;
@@ -358,6 +378,53 @@ export function useTaskCreation({
             description: "Try again in a moment.",
           });
           return false;
+        }
+
+        if (workspaceMode === "local" && selectedDirectory) {
+          let isGitRepository: boolean;
+          try {
+            isGitRepository = await hostClient.git.validateRepo.query({
+              directoryPath: selectedDirectory,
+            });
+          } catch (error) {
+            log.warn("Failed to validate local repository", { error });
+            track(ANALYTICS_EVENTS.TASK_CREATION_FAILED, {
+              error_type: "local_changes_check_failed",
+            });
+            toast.error("Cannot check this Git repository", {
+              description: "Try again before creating a task.",
+            });
+            return false;
+          }
+
+          if (isGitRepository) {
+            let changedFiles: ChangedFile[];
+            try {
+              changedFiles = await hostClient.git.getChangedFilesHead.query({
+                directoryPath: selectedDirectory,
+                includeAgentFiles: true,
+              });
+            } catch (error) {
+              log.warn("Failed to read local repository changes", { error });
+              track(ANALYTICS_EVENTS.TASK_CREATION_FAILED, {
+                error_type: "local_changes_check_failed",
+              });
+              toast.error("Cannot check local changes", {
+                description: "Try again before creating a task.",
+              });
+              return false;
+            }
+
+            if (changedFiles.length > 0) {
+              const action = await useLocalChangesConfirmStore
+                .getState()
+                .confirm({
+                  repoPath: selectedDirectory,
+                  ...groupLocalChanges(changedFiles),
+                });
+              if (action === "cancel") return false;
+            }
+          }
         }
 
         // Confirm a couple of worktree branch situations before starting the

--- a/products/desktop/packages/ui/src/features/task-detail/stores/localChangesConfirmStore.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/stores/localChangesConfirmStore.ts
@@ -1,0 +1,58 @@
+import { create } from "zustand";
+
+export type LocalChangesDialogAction =
+  | "cancel"
+  | "continue"
+  | "stash-and-continue";
+
+export interface LocalChanges {
+  repoPath: string;
+  stagedFiles: string[];
+  unstagedFiles: string[];
+  untrackedFiles: string[];
+}
+
+interface LocalChangesConfirmState extends LocalChanges {
+  isOpen: boolean;
+  resolve: ((action: LocalChangesDialogAction) => void) | null;
+}
+
+interface LocalChangesConfirmActions {
+  confirm: (changes: LocalChanges) => Promise<LocalChangesDialogAction>;
+  cancel: () => void;
+  continue: () => void;
+  stashAndContinue: () => void;
+}
+
+type LocalChangesConfirmStore = LocalChangesConfirmState &
+  LocalChangesConfirmActions;
+
+const initialState: LocalChangesConfirmState = {
+  isOpen: false,
+  repoPath: "",
+  stagedFiles: [],
+  unstagedFiles: [],
+  untrackedFiles: [],
+  resolve: null,
+};
+
+export const useLocalChangesConfirmStore = create<LocalChangesConfirmStore>()(
+  (set, get) => {
+    const resolve = (action: LocalChangesDialogAction): void => {
+      get().resolve?.(action);
+      set(initialState);
+    };
+
+    return {
+      ...initialState,
+      confirm: (changes) =>
+        new Promise<LocalChangesDialogAction>((resolveCurrent) => {
+          get().resolve?.("cancel");
+          set({ ...changes, isOpen: true, resolve: resolveCurrent });
+        }),
+      cancel: () => resolve("cancel"),
+      continue: () => resolve("continue"),
+      stashAndContinue: () => resolve("stash-and-continue"),
+    };
+  },
+);

--- a/products/desktop/packages/ui/src/router/routes/__root.tsx
+++ b/products/desktop/packages/ui/src/router/routes/__root.tsx
@@ -62,6 +62,7 @@ import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
 import { useSidebarData } from "@posthog/ui/features/sidebar/useSidebarData";
 import { useVisualTaskOrder } from "@posthog/ui/features/sidebar/useVisualTaskOrder";
 import { ExistingWorktreeDialog } from "@posthog/ui/features/task-detail/components/ExistingWorktreeDialog";
+import { LocalChangesDialogHost } from "@posthog/ui/features/task-detail/components/LocalChangesDialogHost";
 import { RemoteBranchCheckoutDialog } from "@posthog/ui/features/task-detail/components/RemoteBranchCheckoutDialog";
 import { useTasks } from "@posthog/ui/features/tasks/useTasks";
 import { TourOverlay } from "@posthog/ui/features/tour/components/TourOverlay";
@@ -511,6 +512,7 @@ function RootLayout() {
           onFinished={handleFeedbackFinished}
         />
         <ExistingWorktreeDialog />
+        <LocalChangesDialogHost />
         <CanvasConnectorPermissionDialog />
         <HedgehogMode />
       </Flex>

--- a/products/desktop/packages/workspace-server/src/services/git/git.integration.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/git/git.integration.test.ts
@@ -149,6 +149,27 @@ describe("GitService integration (git-read + git-mutate)", () => {
   });
 
   describe("staging mutation", () => {
+    it.each([
+      { includeAgentFiles: false, expected: false },
+      { includeAgentFiles: true, expected: true },
+    ])(
+      "getChangedFilesHead returns agent files: $expected",
+      async ({ includeAgentFiles, expected }) => {
+        await fs.mkdir(path.join(repo, ".claude"));
+        await fs.writeFile(path.join(repo, ".claude", "settings.json"), "{}");
+        await fs.writeFile(path.join(repo, "CLAUDE.local.md"), "local\n");
+
+        const files = await git.getChangedFilesHead(
+          repo,
+          includeAgentFiles ? { includeAgentFiles: true } : undefined,
+        );
+        const paths = files.map((file) => file.path);
+
+        expect(paths.includes(".claude/settings.json")).toBe(expected);
+        expect(paths.includes("CLAUDE.local.md")).toBe(expected);
+      },
+    );
+
     it("getChangedFilesHead lists a new untracked file", async () => {
       await fs.writeFile(path.join(repo, "new.txt"), "hello\n");
       const files = await git.getChangedFilesHead(repo);

--- a/products/desktop/packages/workspace-server/src/services/git/schemas.ts
+++ b/products/desktop/packages/workspace-server/src/services/git/schemas.ts
@@ -2,6 +2,10 @@ import { z } from "zod";
 
 export const directoryPathInput = z.object({ directoryPath: z.string() });
 
+export const getChangedFilesHeadInput = directoryPathInput.extend({
+  includeAgentFiles: z.boolean().optional(),
+});
+
 export const diffStatsInput = z.object({ directoryPath: z.string().min(1) });
 
 export const diffStatsSchema = z.object({

--- a/products/desktop/packages/workspace-server/src/services/git/service.ts
+++ b/products/desktop/packages/workspace-server/src/services/git/service.ts
@@ -373,11 +373,14 @@ export class GitService extends TypedEventEmitter<GitCloneEvents> {
 
   async getChangedFilesHead(
     directoryPath: string,
-    signal?: AbortSignal,
+    options?: { includeAgentFiles?: boolean; signal?: AbortSignal },
   ): Promise<ChangedFile[]> {
     const files = await getChangedFilesDetailed(directoryPath, {
-      excludePatterns: [".claude", "CLAUDE.local.md"],
-      abortSignal: signal,
+      excludePatterns: options?.includeAgentFiles
+        ? undefined
+        : [".claude", "CLAUDE.local.md"],
+      throwOnError: options?.includeAgentFiles,
+      abortSignal: options?.signal,
     });
     type HeadChangedFile = Omit<ChangedFile, "patch">;
     const filteredFiles: Array<HeadChangedFile | null> = await Promise.all(

--- a/products/desktop/packages/workspace-server/src/trpc.ts
+++ b/products/desktop/packages/workspace-server/src/trpc.ts
@@ -65,6 +65,7 @@ import {
   discardFileChangesOutput,
   filePathInput,
   getBranchChangedFilesInput,
+  getChangedFilesHeadInput,
   getCommitChangedFilesInput,
   getCommitConventionsInput,
   getCommitConventionsOutput,
@@ -336,10 +337,13 @@ export function createAppRouter({
         ),
 
       getChangedFilesHead: t.procedure
-        .input(directoryPathInput)
+        .input(getChangedFilesHeadInput)
         .output(changedFilesOutput)
         .query(({ input, signal }) =>
-          gitService().getChangedFilesHead(input.directoryPath, signal),
+          gitService().getChangedFilesHead(input.directoryPath, {
+            includeAgentFiles: input.includeAgentFiles,
+            signal,
+          }),
         ),
 
       getFileAtHead: t.procedure


### PR DESCRIPTION
## Problem

A local task can start in a folder with existing Git changes and mix unrelated work.
The app does not show which files already changed.

## Changes

- The local task form checks staged, unstaged, and untracked files before task creation.
- A warning lists the files and lets the user cancel, continue, or stash them.
- The stash action stops task creation if Git cannot stash the changes.
- The warning does not link another task because a shared folder does not prove who made each change.
- The action event records the choice and file counts. It does not record file paths.

Before:

```mermaid
flowchart LR
    A[Start local task] --> B[Create task]
    B --> C[Agent uses selected folder]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A,C phYellow;
    class B phBlue;
```

After:

```mermaid
flowchart TD
    A[Start local task] --> B[Check Git changes]
    B -->|Clean| C[Create task]
    B -->|Changes found| D[Show warning]
    D -->|Cancel| E[Keep task draft]
    D -->|Continue| C
    D -->|Stash| F[Stash changes]
    F --> C
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A,E phYellow;
    class C,F phBlue;
    class B,D phGray;
```

![Local changes warning](https://raw.githubusercontent.com/PostHog/pr-assets/e2222d5885c7fb6f256bb452575512bd38311dbf/2026/09/2c8ba319-d5a8-4e42-b91b-267f7ded9b90.png)

## How did you test this code?

- `pnpm run typecheck`
- Full `@posthog/ui`, `@posthog/core`, and `@posthog/workspace-server` test suites
- Focused task creation, dialog host, and Git integration tests
- Storybook build and browser checks at 520 px and 1000 px widths
- `hogli ci:preflight --fix`
- The full `@posthog/git` suite has one unrelated failure. Its permission test expects `EACCES`, but this sandbox runs as root.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update. The warning explains the new choice in the task flow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Pi used Explore and General subagents.
- Invoked skills: `/posthog-desktop`, `/subagent-orchestration`, `/writing-simplified-technical-english`, `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-tests`, `/instrument-product-analytics`, `/storybook-stories`, `/test-electron-app`, `/running-ci-preflight`, `/reviewing-with-coderabbit`, and `/writing-pr-descriptions`.
- The CodeRabbit local pass is paused. The PR opened without a local pass.
- The duplicate PR search found no matching change.
- The diff contains no private task material.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
