### PR TITLE
fix(warehouse-sources): type columns from ClickHouse when a run wrote none

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_sync.py
@@ -30,7 +30,7 @@ from products.warehouse_sources.backend.models.external_data_schema import (
     mark_initial_sync_complete,
     update_sync_type_config_keys,
 )
-from products.warehouse_sources.backend.models.table import DataWarehouseTable
+from products.warehouse_sources.backend.models.table import DataWarehouseTable, DataWarehouseTableIntrospectedColumns
 from products.warehouse_sources.backend.temporal.data_imports.naming_convention import NamingConvention
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.common.db_retry import (
     retry_on_operational_error,
@@ -49,6 +49,19 @@ from products.warehouse_sources.backend.types import (
 )
 
 LOGGER = get_logger(__name__)
+
+
+def hogql_types_with_introspection_floor(
+    raw_db_columns: DataWarehouseTableIntrospectedColumns, table_schema_dict: dict[str, str] | None
+) -> dict[str, str]:
+    """HogQL type per column, falling back to the one ClickHouse introspection derived.
+
+    table_schema_dict is built from the arrow batches a run wrote, so a run that wrote none carries
+    no types at all and merge_columns drops every column it cannot type. The source-derived type
+    still wins where it exists, because only it can tell a JSON string from a plain one.
+    """
+    introspected = {name: column["hogql"] for name, column in raw_db_columns.items() if column.get("hogql")}
+    return {**introspected, **(table_schema_dict or {})}
 
 
 def merge_columns(
@@ -310,6 +323,7 @@ async def validate_schema_and_update_table(
             # instead of the generic, user-facing Exception get_columns() raises by default.
             raw_db_columns = table_created.get_columns(safe_expose_ch_error=False)
             db_columns = {key: str(column.get("clickhouse", "")) for key, column in raw_db_columns.items()}
+            column_types = hogql_types_with_introspection_floor(raw_db_columns, table_schema_dict)
 
             def _persist_columns() -> None:
                 with transaction.atomic():
@@ -320,7 +334,7 @@ async def validate_schema_and_update_table(
                     # its nullable LEFT JOINs are rejected by Postgres under FOR UPDATE.
                     table_for_update = DataWarehouseTable.raw_objects.select_for_update().get(id=table_created.id)
                     existing_columns = table_for_update.columns or {}
-                    columns = merge_columns(db_columns, table_schema_dict or {}, existing_columns)
+                    columns = merge_columns(db_columns, column_types, existing_columns)
                     # Project to enabled_columns so disabled columns the user already deselected don't
                     # creep back into HogQL via the Delta schema (which still contains them historically).
                     # Prefer source-detected PKs (always present) over the schema model's PKs (only set
@@ -463,7 +477,9 @@ async def register_cdc_companion_table(
             raw_db_columns = companion_table.get_columns()
             db_columns = {key: str(column.get("clickhouse", "")) for key, column in raw_db_columns.items()}
             existing_columns = companion_table.columns or {}
-            columns = merge_columns(db_columns, table_schema_dict or {}, existing_columns)
+            columns = merge_columns(
+                db_columns, hogql_types_with_introspection_floor(raw_db_columns, table_schema_dict), existing_columns
+            )
 
             def _persist_columns() -> None:
                 with transaction.atomic():

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/test_pipeline_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/test_pipeline_sync.py
@@ -405,16 +405,22 @@ class TestValidateSchemaAndUpdateTable:
         assert table.row_count == 150
 
     # Published files at zero rows mean a resumed or redelivered run counted only its own attempt.
-    # Trusting row_count there left the data in S3 with no table to query it through.
+    # Trusting row_count there left the data in S3 with no table to query it through. The run wrote
+    # no arrow batches, so it carries no table_schema_dict and the columns can only come from
+    # introspection - without them the table registers empty and still queries as nothing.
     @pytest.mark.parametrize("published_file_count,expect_table", [(0, False), (18, True)])
     def test_zero_row_sync_creates_a_table_only_when_files_were_published(
         self, team, published_file_count: int, expect_table: bool
     ):
         schema, job = self._schema_and_job(team)
         assert schema.table is None
+        introspected = {
+            "id": {"hogql": "StringDatabaseField", "clickhouse": "String", "valid": True},
+            "created": {"hogql": "DateTimeDatabaseField", "clickhouse": "DateTime64(3)", "valid": True},
+        }
 
         with (
-            patch.object(DataWarehouseTable, "get_columns", return_value={}),
+            patch.object(DataWarehouseTable, "get_columns", return_value=introspected),
             patch.object(DataWarehouseTable, "get_count", return_value=150),
         ):
             async_to_sync(validate_schema_and_update_table)(
@@ -436,6 +442,7 @@ class TestValidateSchemaAndUpdateTable:
             assert schema.table_id == tables.get().id
             # A reported 0 must not register a table full of published files as empty.
             assert tables.get().row_count == 150
+            assert set(tables.get().columns or {}) == {"id", "created"}
 
     def test_relinks_a_table_an_earlier_run_left_unlinked(self, team):
         # An orphan must be adopted and repointed, not left unlinked and not duplicated.


### PR DESCRIPTION
## Problem

- A customer opens a table the sync reports as synced, sees a row count on it, and every query returns nothing. The table has no columns at all.
- `table_schema_dict` carries the HogQL type of each column, and it is built from the arrow batches a run writes. A run that writes none carries an empty map.
- `merge_columns` drops every column it cannot type, and a table created on that run has no earlier columns to fall back on, so it registers empty.
- #98676 made this reachable for a schema whose files already exist, because a zero-row run now creates the table over them. Tables in this state also predate that PR, from other paths that register against an empty type map.

## Changes

- Registration types a column from ClickHouse introspection when the run carries no type for it, so a table created by a zero-row run is queryable from the start.
- `get_columns()` already derives a HogQL type per column through `CLICKHOUSE_HOGQL_MAPPING`. Registration kept only the ClickHouse half of that result and discarded the rest.
- The source-derived type still wins where it exists. Only the arrow batches distinguish a JSON string from a plain one, which `merge_columns` needs for `StringJSONDatabaseField`.
- The CDC companion registration takes the same floor. It had the same shape.
- Existing tables with no columns do not recover from this alone. A linked table sends a later zero-row run down the fast path that skips registration, so they need a run that writes rows, or a backfill.

## How did you test this code?

- `test_zero_row_sync_creates_a_table_only_when_files_were_published` patched `get_columns` to return `{}`, so a table that registered with no columns looked identical to one that registered correctly. That is why the gap shipped. It now returns two introspected columns and asserts both reach the table.
- On the unfixed code that case fails with `assert equals failed` on the column set. It is the only test covering a registration whose run carries no type map.
- Ran `test_pipeline_sync.py` against an isolated Postgres database with a local Temporal server.
- Not checked: no run against a real source, and no verification in a deployed environment.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 5) in PostHog Desktop, directed by @danielcarletti.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- The CodeRabbit local pass is paused, so this PR opened without one.
- No duplicate: `gh pr list --state open --search "warehouse_sources columns hogql introspection"` returned nothing covering this. #94289 touches S3 JSON inference and is unrelated.
- Found while investigating a support report of a synced table returning nothing. Nothing from that session reaches the diff: the test's introspected columns are invented, and the fixtures build their own source, schema and job.
- The rejected alternative was to leave the column dropped and refuse to link a table that registers with none, so the orphan path would retry it. That keeps the schema unlinked and hides a table whose files are readable, which is a worse outcome than typing it from the column definitions ClickHouse already returned.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
