### PR TITLE
fix(cdp): route workflow usage by billing category

### DIFF
--- a/nodejs/src/cdp/consumers/cdp-source-webhooks.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-source-webhooks.consumer.test.ts
@@ -560,6 +560,32 @@ describe('SourceWebhooksConsumer', () => {
                 expect(reportBillableInvocation).not.toHaveBeenCalled()
             })
 
+            it('does not report usage when queueing the workflow fails', async () => {
+                const reportBillableInvocation = jest.spyOn(
+                    api['cdpSourceWebhooksConsumer']['cdpUsageReporter'],
+                    'reportBillableInvocation'
+                )
+                mockQueueHogflowInvocationsSpy.mockRejectedValueOnce(new Error('queue unavailable'))
+
+                const res = await doPostRequest({
+                    webhookId: hogFlow.id,
+                    body: {
+                        event: 'my-event',
+                        distinct_id: 'test-distinct-id',
+                    },
+                })
+
+                expect(res.status).toEqual(500)
+                await waitForBackgroundTasks()
+                expect(reportBillableInvocation).not.toHaveBeenCalled()
+                expect(getMetrics()).not.toContainEqual(
+                    expect.objectContaining({
+                        metric_kind: 'billing',
+                        metric_name: 'billable_invocation',
+                    })
+                )
+            })
+
             it('should not capture webhook event to database and should remove execution count property', async () => {
                 // Mock the monitoring service to track what events would be captured
                 const mockQueueInvocationResults = jest.spyOn(

--- a/nodejs/src/cdp/consumers/cdp-source-webhooks.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-source-webhooks.consumer.test.ts
@@ -538,20 +538,14 @@ describe('SourceWebhooksConsumer', () => {
                         metric_name: 'triggered',
                         count: 1,
                     }),
-                    expect.objectContaining({
-                        metric_kind: 'billing',
-                        metric_name: 'billable_invocation',
-                        count: 1,
-                    }),
                 ])
             })
 
-            it('does not report usage when queueing the workflow fails', async () => {
+            it('does not report a workflow trigger as CDP usage', async () => {
                 const reportBillableInvocation = jest.spyOn(
                     api['cdpSourceWebhooksConsumer']['cdpUsageReporter'],
                     'reportBillableInvocation'
                 )
-                mockQueueHogflowInvocationsSpy.mockRejectedValueOnce(new Error('queue unavailable'))
 
                 const res = await doPostRequest({
                     webhookId: hogFlow.id,
@@ -561,15 +555,9 @@ describe('SourceWebhooksConsumer', () => {
                     },
                 })
 
-                expect(res.status).toEqual(500)
+                expect(res.status).toEqual(201)
                 await waitForBackgroundTasks()
                 expect(reportBillableInvocation).not.toHaveBeenCalled()
-                expect(getMetrics()).not.toContainEqual(
-                    expect.objectContaining({
-                        metric_kind: 'billing',
-                        metric_name: 'billable_invocation',
-                    })
-                )
             })
 
             it('should not capture webhook event to database and should remove execution count property', async () => {

--- a/nodejs/src/cdp/consumers/cdp-source-webhooks.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-source-webhooks.consumer.ts
@@ -300,17 +300,6 @@ export class CdpSourceWebhooksConsumer extends CdpConsumerBase<PluginsServerConf
                 })
 
                 await this.hogflowQueue.queueInvocations([hogFlowInvocation])
-
-                addMetric({
-                    metric_kind: 'billing',
-                    metric_name: 'billable_invocation',
-                    count: 1,
-                })
-
-                this.cdpUsageReporter.reportBillableInvocation({
-                    teamId: invocation.teamId,
-                    recordId: `webhook:${invocationId}`,
-                })
             } else {
                 addMetric({
                     metric_kind: 'failure',

--- a/nodejs/src/cdp/services/hog-function-invocation-pipeline.service.ts
+++ b/nodejs/src/cdp/services/hog-function-invocation-pipeline.service.ts
@@ -233,6 +233,7 @@ export class HogFunctionInvocationPipeline {
                     })
                     this.deps.cdpUsageReporter?.reportBillableInvocation({
                         teamId: item.teamId,
+                        usageKey: 'cdp_billable_invocations',
                         recordId: `event:${eventUuid}`,
                     })
                 }

--- a/nodejs/src/cdp/services/hogflows/actions/hog_function.test.ts
+++ b/nodejs/src/cdp/services/hogflows/actions/hog_function.test.ts
@@ -485,9 +485,9 @@ describe('HogFunctionHandler', () => {
     ] as const)(
         'emits a single billable_invocation with %s kind matching the handler billing type',
         async (billingType, usageKey) => {
-            const usageReporter = {
+            const usageReporter: Pick<CdpUsageReporterService, 'reportBillableInvocation'> = {
                 reportBillableInvocation: jest.fn(),
-            } as unknown as CdpUsageReporterService
+            }
             const handler = new HogFunctionHandler(
                 mockHogFlowFunctionsService,
                 mockRecipientPreferencesService,

--- a/nodejs/src/cdp/services/hogflows/actions/hog_function.test.ts
+++ b/nodejs/src/cdp/services/hogflows/actions/hog_function.test.ts
@@ -28,6 +28,7 @@ import { EmailService } from '../../messaging/email.service'
 import { EmailTrackingCodeSigner } from '../../messaging/helpers/tracking-code'
 import { RecipientPreferencesService } from '../../messaging/recipient-preferences.service'
 import { RecipientTokensService } from '../../messaging/recipient-tokens.service'
+import { CdpUsageReporterService } from '../../usage/cdp-usage-reporter.service'
 import { HogFlowFunctionsService } from '../hogflow-functions.service'
 import { findActionByType } from '../hogflow-utils'
 import { HogFunctionHandler } from './hog_function'
@@ -476,14 +477,23 @@ describe('HogFunctionHandler', () => {
     // The billing kind is the whole point of the per-channel handlers: push bills at its own rate
     // (roughly half of email), so a completed invocation must emit exactly one billable_invocation
     // carrying the handler's billing type — never fall back to another channel's kind.
-    it.each(['fetch', 'email', 'push'] as const)(
+    it.each([
+        ['fetch', 'workflow_billable_invocations'],
+        ['email', 'workflow_emails_sent'],
+        ['push', 'workflow_push_sent'],
+        ['sms', 'workflow_sms_sent'],
+    ] as const)(
         'emits a single billable_invocation with %s kind matching the handler billing type',
-        async (billingType) => {
+        async (billingType, usageKey) => {
+            const usageReporter = {
+                reportBillableInvocation: jest.fn(),
+            } as unknown as CdpUsageReporterService
             const handler = new HogFunctionHandler(
                 mockHogFlowFunctionsService,
                 mockRecipientPreferencesService,
                 mockEmailValidationService,
-                billingType
+                billingType,
+                usageReporter
             )
 
             const invocationResult = createInvocationResult<CyclotronJobInvocationHogFlow>(invocation, {
@@ -507,6 +517,9 @@ describe('HogFunctionHandler', () => {
                 metric_name: 'billable_invocation',
                 count: 1,
             })
+            expect(usageReporter.reportBillableInvocation).toHaveBeenCalledWith(
+                expect.objectContaining({ teamId: team.id, usageKey })
+            )
         }
     )
 

--- a/nodejs/src/cdp/services/hogflows/actions/hog_function.ts
+++ b/nodejs/src/cdp/services/hogflows/actions/hog_function.ts
@@ -27,6 +27,14 @@ import { observeMissingVariableReferences } from '../hogflow-variable-usage'
 import { ActionHandler, ActionHandlerOptions, ActionHandlerResult } from './action.interface'
 
 type FunctionActionType = 'function' | 'function_email' | 'function_sms'
+type HogFlowActionBillingType = 'fetch' | 'email' | 'push' | 'sms'
+
+const WORKFLOW_USAGE_KEYS = {
+    fetch: 'workflow_billable_invocations',
+    email: 'workflow_emails_sent',
+    push: 'workflow_push_sent',
+    sms: 'workflow_sms_sent',
+} as const
 
 type Action = Extract<HogFlowAction, { type: FunctionActionType }>
 
@@ -84,7 +92,7 @@ export class HogFunctionHandler implements ActionHandler {
         private hogFlowFunctionsService: HogFlowFunctionsService,
         private recipientPreferencesService: RecipientPreferencesService,
         private emailValidationService: EmailValidationService,
-        private hogFlowActionBillingType: 'fetch' | 'email' | 'push',
+        private hogFlowActionBillingType: HogFlowActionBillingType,
         private usageReporter?: CdpUsageReporterService,
         private options: { awaitedStepsEnabled?: boolean } = {}
     ) {}
@@ -166,6 +174,7 @@ export class HogFunctionHandler implements ActionHandler {
             // actionStepCount holds across a retry of this step but changes on a loop revisit.
             this.usageReporter?.reportBillableInvocation({
                 teamId: invocation.teamId,
+                usageKey: WORKFLOW_USAGE_KEYS[this.hogFlowActionBillingType],
                 recordId: `flow:${invocation.id}:${invocation.state.actionStepCount}:${this.hogFlowActionBillingType}`,
             })
 

--- a/nodejs/src/cdp/services/hogflows/actions/hog_function.ts
+++ b/nodejs/src/cdp/services/hogflows/actions/hog_function.ts
@@ -93,7 +93,7 @@ export class HogFunctionHandler implements ActionHandler {
         private recipientPreferencesService: RecipientPreferencesService,
         private emailValidationService: EmailValidationService,
         private hogFlowActionBillingType: HogFlowActionBillingType,
-        private usageReporter?: CdpUsageReporterService,
+        private usageReporter?: Pick<CdpUsageReporterService, 'reportBillableInvocation'>,
         private options: { awaitedStepsEnabled?: boolean } = {}
     ) {}
 

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
@@ -139,6 +139,14 @@ export class HogFlowExecutorService {
             'email',
             usageReporter
         )
+        const hogFunctionSmsHandler = new HogFunctionHandler(
+            hogFlowFunctionsService,
+            recipientPreferencesService,
+            emailValidationService,
+            'sms',
+            usageReporter,
+            options
+        )
         const hogFunctionPushHandler = new HogFunctionHandler(
             hogFlowFunctionsService,
             recipientPreferencesService,
@@ -155,7 +163,7 @@ export class HogFlowExecutorService {
             wait_until_time_window: new WaitUntilTimeWindowHandler(),
             random_cohort_branch: new RandomCohortBranchHandler(),
             function: hogFunctionHandler,
-            function_sms: hogFunctionHandler,
+            function_sms: hogFunctionSmsHandler,
             function_push: hogFunctionPushHandler,
             function_email: hogFunctionEmailHandler,
             exit: new ExitHandler(),

--- a/nodejs/src/cdp/services/usage/cdp-usage-reporter.service.test.ts
+++ b/nodejs/src/cdp/services/usage/cdp-usage-reporter.service.test.ts
@@ -23,8 +23,8 @@ describe('CdpUsageReporterService', () => {
 
     it('bills a retried invocation once', async () => {
         const reporter = new CdpUsageReporterService(client, () => true)
-        reporter.reportBillableInvocation({ teamId: 1, recordId: 'event:abc' })
-        reporter.reportBillableInvocation({ teamId: 1, recordId: 'event:abc' })
+        reporter.reportBillableInvocation({ teamId: 1, usageKey: 'cdp_billable_invocations', recordId: 'event:abc' })
+        reporter.reportBillableInvocation({ teamId: 1, usageKey: 'cdp_billable_invocations', recordId: 'event:abc' })
         await reporter.flush()
 
         expect(ingested[0]).toEqual([
@@ -39,7 +39,7 @@ describe('CdpUsageReporterService', () => {
 
     it('flushes on its own schedule without a caller flush', async () => {
         const reporter = new CdpUsageReporterService(client, () => true, 1000)
-        reporter.reportBillableInvocation({ teamId: 1, recordId: 'event:abc' })
+        reporter.reportBillableInvocation({ teamId: 1, usageKey: 'cdp_billable_invocations', recordId: 'event:abc' })
 
         expect(client.ingest).not.toHaveBeenCalled()
 
@@ -51,7 +51,7 @@ describe('CdpUsageReporterService', () => {
 
     it('records nothing for a team the matcher excludes', async () => {
         const reporter = new CdpUsageReporterService(client, (teamId) => teamId === 2, 1000)
-        reporter.reportBillableInvocation({ teamId: 1, recordId: 'event:abc' })
+        reporter.reportBillableInvocation({ teamId: 1, usageKey: 'cdp_billable_invocations', recordId: 'event:abc' })
         await reporter.flush()
 
         expect(client.ingest).not.toHaveBeenCalled()

--- a/nodejs/src/cdp/services/usage/cdp-usage-reporter.service.ts
+++ b/nodejs/src/cdp/services/usage/cdp-usage-reporter.service.ts
@@ -3,12 +3,17 @@ import { UsageRecordBatch } from '~/common/usage-ingestion/usage-record-batch'
 import { logger } from '~/common/utils/logger'
 import { ValueMatcher } from '~/types'
 
-const USAGE_KEY = 'cdp_billable_invocations'
 const DEFAULT_FLUSH_INTERVAL_MS = 10_000
 const MAX_PENDING_RECORDS = 2_000
 
 export interface CdpBillableInvocation {
     teamId: number
+    usageKey:
+        | 'cdp_billable_invocations'
+        | 'workflow_billable_invocations'
+        | 'workflow_emails_sent'
+        | 'workflow_push_sent'
+        | 'workflow_sms_sent'
     /** Identity of the billed thing. A replay must produce the same value, or it bills twice. */
     recordId: string
 }
@@ -31,7 +36,7 @@ export class CdpUsageReporterService {
     }
 
     reportBillableInvocation(invocation: CdpBillableInvocation): void {
-        this.batch.add(invocation.teamId, USAGE_KEY, invocation.recordId)
+        this.batch.add(invocation.teamId, invocation.usageKey, invocation.recordId)
         if (this.batch.size >= MAX_PENDING_RECORDS) {
             void this.flush()
             return


### PR DESCRIPTION
## Problem

Billing systems cannot distinguish workflow emails, push notifications, SMS, and destinations in durable usage records.

Workflow actions share the CDP destination key, while webhook triggers emit a separate trigger-level record.

## Changes

- Workflow actions keep the durable usage key for their action category.
- SMS actions use a dedicated billing handler.
- Webhook-triggered workflows now match event-triggered workflows. Only completed actions emit usage.

Before:

```mermaid
flowchart LR
    A[Workflow action] --> C[CDP usage]
    W[Webhook trigger] --> C
    D[CDP destination] --> C
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A,W,D phYellow;
    class C phBlue;
```

After:

```mermaid
flowchart LR
    W[Webhook trigger] --> Q[Queue workflow]
    Q --> A[Workflow action]
    A --> R{Action category}
    R --> E[Workflow email]
    R --> P[Workflow push]
    R --> S[Workflow SMS]
    R --> F[Workflow destination]
    D[CDP destination] --> C[CDP usage]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class W,A,D phYellow;
    class Q,R phGray;
    class E,P,S,F,C phBlue;
```

## How did you test this code?

- `hogli test` covers usage-key routing, retry deduplication, and webhook-trigger parity.
- `pnpm --filter=@posthog/nodejs typescript:check` validates all Node.js callers.
- Manual testing was not run.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No user-facing docs change. This change only affects internal usage routing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used terminal tooling with `/writing-tests`, `/writing-clickhouse-queries`, and `/writing-pr-descriptions`. The CodeRabbit local pass is paused and was not run.

The duplicate search found no matching open PR. No session-only values appear in the public commit or PR.
