### PR TITLE
feat(desktop): show prompt image previews

### DIFF
--- a/products/desktop/packages/core/src/sessions/cloudTaskUpdateNotifications.test.ts
+++ b/products/desktop/packages/core/src/sessions/cloudTaskUpdateNotifications.test.ts
@@ -93,7 +93,11 @@ function snapshotUpdate(
   };
 }
 
-function createHarness(isTaskAuthor = true, initialPrompt?: string) {
+function createHarness(
+  isTaskAuthor = true,
+  initialPrompt?: string,
+  initialFilePaths?: string[],
+) {
   const sessions: Record<string, AgentSession> = {};
   const store = {
     getSessions: () => sessions,
@@ -232,7 +236,13 @@ function createHarness(isTaskAuthor = true, initialPrompt?: string) {
   } as unknown as SessionServiceDeps;
 
   const service = new SessionService(deps);
-  if (initialPrompt) service.rememberInitialCloudPrompt(TASK_ID, initialPrompt);
+  if (initialPrompt) {
+    service.rememberInitialCloudPrompt(
+      TASK_ID,
+      initialPrompt,
+      initialFilePaths,
+    );
+  }
   service.watchCloudTask(TASK_ID, RUN_ID, "https://us.posthog.com", 1);
   if (!onUpdate) throw new Error("watchCloudTask did not subscribe");
   const session = sessions[RUN_ID];
@@ -279,6 +289,19 @@ describe("cloud task update notifications", () => {
     );
     expect(harness.session.optimisticItems).toEqual([
       expect.objectContaining({ content: prompt, pinToTop: true }),
+    ]);
+  });
+
+  it("seeds initial cloud prompt attachment metadata", () => {
+    const harness = createHarness(true, "Review the diagram", [
+      "/tmp/diagram.png",
+    ]);
+
+    expect(harness.session.optimisticItems).toEqual([
+      expect.objectContaining({
+        content: "Review the diagram",
+        attachments: [{ id: "/tmp/diagram.png", label: "diagram.png" }],
+      }),
     ]);
   });
 

--- a/products/desktop/packages/core/src/sessions/promptContent.test.ts
+++ b/products/desktop/packages/core/src/sessions/promptContent.test.ts
@@ -71,6 +71,35 @@ describe("promptContent", () => {
     ]);
   });
 
+  it("moves absolute raster image file tags into attachments", () => {
+    const result = extractPromptDisplayContent([
+      {
+        type: "text",
+        text: 'describe this\n<file path="/tmp/diagram.png" />\n<file path="/tmp/notes.txt" />\n<folder path="/tmp/docs" />',
+      },
+    ]);
+
+    expect(result).toEqual({
+      text: 'describe this\n\n<file path="/tmp/notes.txt" />\n<folder path="/tmp/docs" />',
+      attachments: [{ id: "/tmp/diagram.png", label: "diagram.png" }],
+    });
+  });
+
+  it("deduplicates image file tags and ACP resource attachments", () => {
+    const result = extractPromptDisplayContent([
+      { type: "text", text: '<file path="/tmp/diagram.png" />' },
+      {
+        type: "resource_link",
+        uri: "file:///tmp/diagram.png",
+        name: "diagram.png",
+      },
+    ]);
+
+    expect(result.attachments).toEqual([
+      { id: "file:///tmp/diagram.png", label: "diagram.png" },
+    ]);
+  });
+
   it("extracts inline Pi images as previewable attachments", () => {
     const result = extractPromptDisplayContent([
       { type: "text", text: "what is in this image?" },

--- a/products/desktop/packages/core/src/sessions/promptContent.ts
+++ b/products/desktop/packages/core/src/sessions/promptContent.ts
@@ -1,7 +1,13 @@
 import type { ContentBlock } from "@agentclientprotocol/sdk";
-import { getFileName } from "@posthog/shared";
+import {
+  getFileName,
+  isAbsolutePath,
+  isRasterImageFile,
+  unescapeXmlAttr,
+} from "@posthog/shared";
 
 const ATTACHMENT_URI_PREFIX = "attachment://";
+const ABSOLUTE_FILE_TAG_REGEX = /<file\s+path="([^"]+)"\s*\/>/g;
 
 function hashAttachmentPath(filePath: string): string {
   let hash = 2166136261;
@@ -143,31 +149,62 @@ export interface PromptDisplayContent {
   attachments: AttachmentRef[];
 }
 
+function attachmentDedupeKey(attachment: AttachmentRef): string {
+  if (!attachment.id.startsWith("file://")) return attachment.id;
+
+  try {
+    return decodeURIComponent(new URL(attachment.id).pathname);
+  } catch {
+    return attachment.id;
+  }
+}
+
+function stripRasterImageFileTags(
+  text: string,
+  appendAttachment: (attachment: AttachmentRef) => void,
+): string {
+  return text.replaceAll(ABSOLUTE_FILE_TAG_REGEX, (tag, rawPath: string) => {
+    const filePath = unescapeXmlAttr(rawPath);
+    if (!isAbsolutePath(filePath) || !isRasterImageFile(filePath)) {
+      return tag;
+    }
+
+    appendAttachment({ id: filePath, label: getFileName(filePath) });
+    return "";
+  });
+}
+
 export function extractPromptDisplayContent(
   blocks: ContentBlock[],
   options?: { filterHidden?: boolean },
 ): PromptDisplayContent {
   const filterHidden = options?.filterHidden ?? false;
+  const attachmentIndexByKey = new Map<string, number>();
+  const attachments: AttachmentRef[] = [];
+  const appendAttachment = (attachment: AttachmentRef): void => {
+    if (!attachment.id) return;
+    const key = attachmentDedupeKey(attachment);
+    const existingIndex = attachmentIndexByKey.get(key);
+    if (existingIndex !== undefined) {
+      attachments[existingIndex] = attachment;
+      return;
+    }
+    attachmentIndexByKey.set(key, attachments.length);
+    attachments.push(attachment);
+  };
 
   const textParts: string[] = [];
   for (const block of blocks) {
-    if (block.type !== "text") continue;
-    if (filterHidden) {
-      const meta = (block as { _meta?: { ui?: { hidden?: boolean } } })._meta;
-      if (meta?.ui?.hidden) continue;
+    if (block.type === "text") {
+      if (filterHidden) {
+        const meta = (block as { _meta?: { ui?: { hidden?: boolean } } })._meta;
+        if (meta?.ui?.hidden) continue;
+      }
+      textParts.push(stripRasterImageFileTags(block.text, appendAttachment));
     }
-    textParts.push(block.text);
-  }
 
-  const seen = new Set<string>();
-  const attachments: AttachmentRef[] = [];
-  for (const block of blocks) {
-    const ref = getBlockAttachmentRef(block);
-    if (!ref || seen.has(ref.id)) continue;
-    const { id } = ref;
-    if (!id) continue;
-    seen.add(id);
-    attachments.push(ref);
+    const attachment = getBlockAttachmentRef(block);
+    if (attachment) appendAttachment(attachment);
   }
 
   return { text: textParts.join(""), attachments };

--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -31,6 +31,7 @@ import {
   getBackoffDelay,
   getCloudUrlFromRegion,
   getConfigOptionByCategory,
+  getFileName,
   getReasoningEffortOptions,
   isFatalSessionError,
   isJsonRpcNotification,
@@ -45,6 +46,7 @@ import {
   type ModelAccess,
   mergeConfigOptions,
   type OptimisticItem,
+  type OptimisticPromptAttachment,
   type PermissionRequest,
   type QueuedMessage,
   resolveBypassRevertMode,
@@ -114,6 +116,10 @@ import {
   planPermissionResponse,
   resolveAllowAlwaysUpgradeMode,
 } from "./permissionResponse";
+import {
+  type AttachmentRef,
+  extractPromptDisplayContent,
+} from "./promptContent";
 import {
   collapseSupersededToolCallUpdates,
   convertStoredEntriesToEvents,
@@ -275,6 +281,75 @@ type TrpcSubscription = {
 interface CloudHydrationResult {
   historyEntryCount: number;
   liveStreamLineCount: number;
+}
+
+interface InitialCloudOptimisticPrompt {
+  content: string;
+  attachments: OptimisticPromptAttachment[];
+}
+
+interface SendPromptOptions {
+  steer?: boolean;
+  attachments?: OptimisticPromptAttachment[];
+}
+
+interface SendCloudPromptOptions extends SendPromptOptions {
+  skipQueueGuard?: boolean;
+}
+
+function optimisticAttachmentKey(
+  attachment: OptimisticPromptAttachment,
+): string {
+  if (!attachment.id.startsWith("file://")) return attachment.id;
+
+  try {
+    return decodeURIComponent(new URL(attachment.id).pathname);
+  } catch {
+    return attachment.id;
+  }
+}
+
+function mergeOptimisticPromptAttachments(
+  derived: AttachmentRef[],
+  submitted: OptimisticPromptAttachment[] | undefined,
+): OptimisticPromptAttachment[] {
+  const attachments: OptimisticPromptAttachment[] = [];
+  const attachmentIndexByKey = new Map<string, number>();
+  const append = (attachment: OptimisticPromptAttachment): void => {
+    if (!attachment.id) return;
+    const key = optimisticAttachmentKey(attachment);
+    const existingIndex = attachmentIndexByKey.get(key);
+    if (existingIndex === undefined) {
+      attachmentIndexByKey.set(key, attachments.length);
+      attachments.push({
+        id: attachment.id,
+        label: attachment.label,
+        ...(attachment.previewUrl ? { previewUrl: attachment.previewUrl } : {}),
+      });
+      return;
+    }
+    const existing = attachments[existingIndex];
+    attachments[existingIndex] = {
+      id: attachment.id,
+      label: attachment.label,
+      ...(attachment.previewUrl || existing.previewUrl
+        ? { previewUrl: attachment.previewUrl ?? existing.previewUrl }
+        : {}),
+    };
+  };
+
+  for (const attachment of derived) append(attachment);
+  for (const attachment of submitted ?? []) append(attachment);
+  return attachments;
+}
+
+function attachmentsFromFilePaths(
+  filePaths: string[],
+): OptimisticPromptAttachment[] {
+  return filePaths.map((filePath) => ({
+    id: filePath,
+    label: getFileName(filePath),
+  }));
 }
 
 const CLOUD_HYDRATION_MAX_ENTRIES = 100_000;
@@ -1875,13 +1950,16 @@ export class SessionService {
     { promise: Promise<SessionConfigOption[]>; fetchedAt: number }
   >();
   /**
-   * Initial cloud prompt text (user message + any channel CONTEXT.md block),
-   * stashed by task creation keyed by taskId. The cloud sandbox takes seconds to
+   * Initial cloud prompt content and attachment labels, stashed by task
+   * creation keyed by taskId. The cloud sandbox takes seconds to
    * boot and echo this back, so the optimistic placeholder would otherwise show
    * the bare task description with no CONTEXT.md chip until the echo lands. Seed
    * the placeholder with this richer text instead, then drop it once consumed.
    */
-  private initialCloudOptimisticPrompt = new Map<string, string>();
+  private initialCloudOptimisticPrompt = new Map<
+    string,
+    InitialCloudOptimisticPrompt
+  >();
 
   constructor(private readonly d: SessionServiceDeps) {
     this.cloudRunIdleTracker = new CloudRunIdleTracker();
@@ -4149,7 +4227,7 @@ export class SessionService {
   async sendPrompt(
     taskId: string,
     prompt: string | ContentBlock[],
-    options?: { steer?: boolean },
+    options?: SendPromptOptions,
   ): Promise<{ stopReason: string }> {
     if (!this.d.getIsOnline()) {
       throw new Error(
@@ -4178,6 +4256,7 @@ export class SessionService {
     if (options?.steer && session.isPromptPending && !session.isCompacting) {
       if (session.isCloud && session.status === "connected") {
         return this.sendCloudPrompt(session, prompt, {
+          ...options,
           skipQueueGuard: true,
           steer: true,
         });
@@ -4217,7 +4296,7 @@ export class SessionService {
     }
 
     if (session.isCloud) {
-      return this.sendCloudPrompt(session, prompt);
+      return this.sendCloudPrompt(session, prompt, options);
     }
 
     if (session.status !== "connected") {
@@ -4263,7 +4342,7 @@ export class SessionService {
     });
 
     // Show the user's message in the chat immediately, before any respawn
-    this.applyOptimisticPrompt(session.taskRunId, blocks, promptText);
+    this.applyOptimisticPrompt(session.taskRunId, blocks, options?.attachments);
 
     if (promptReferencesAbsoluteFolder(prompt)) {
       const repoPath = this.localRepoPaths.get(taskId);
@@ -4297,6 +4376,7 @@ export class SessionService {
 
     return this.sendLocalPrompt(session, blocks, promptText, {
       optimisticApplied: true,
+      attachments: options?.attachments,
     });
   }
 
@@ -4509,7 +4589,7 @@ export class SessionService {
   private applyOptimisticPrompt(
     taskRunId: string,
     blocks: ContentBlock[],
-    promptText: string,
+    submittedAttachments?: OptimisticPromptAttachment[],
   ): void {
     this.d.store.updateSession(taskRunId, {
       isPromptPending: true,
@@ -4526,10 +4606,18 @@ export class SessionService {
         buttonId: skillButtonId,
       });
     } else {
+      const displayContent = extractPromptDisplayContent(blocks, {
+        filterHidden: true,
+      });
+      const attachments = mergeOptimisticPromptAttachments(
+        displayContent.attachments,
+        submittedAttachments,
+      );
       this.d.store.appendOptimisticItem(taskRunId, {
         type: "user_message",
-        content: promptText,
+        content: displayContent.text,
         timestamp: Date.now(),
+        ...(attachments.length > 0 ? { attachments } : {}),
       });
     }
   }
@@ -4538,10 +4626,18 @@ export class SessionService {
     session: AgentSession,
     blocks: ContentBlock[],
     promptText: string,
-    options: { optimisticApplied?: boolean; isRecoveryResend?: boolean } = {},
+    options: {
+      optimisticApplied?: boolean;
+      isRecoveryResend?: boolean;
+      attachments?: OptimisticPromptAttachment[];
+    } = {},
   ): Promise<{ stopReason: string }> {
     if (!options.optimisticApplied) {
-      this.applyOptimisticPrompt(session.taskRunId, blocks, promptText);
+      this.applyOptimisticPrompt(
+        session.taskRunId,
+        blocks,
+        options.attachments,
+      );
     }
 
     try {
@@ -4588,6 +4684,7 @@ export class SessionService {
             session,
             blocks,
             promptText,
+            options.attachments,
             errorDetails || errorMessage,
           );
           if (resent) {
@@ -4663,6 +4760,7 @@ export class SessionService {
     session: AgentSession,
     blocks: ContentBlock[],
     promptText: string,
+    attachments: OptimisticPromptAttachment[] | undefined,
     reason: string,
   ): Promise<{ stopReason: string } | null> {
     let recovered = false;
@@ -4700,6 +4798,7 @@ export class SessionService {
     });
     return this.sendLocalPrompt(refreshed, blocks, promptText, {
       isRecoveryResend: true,
+      attachments,
     });
   }
 
@@ -4879,10 +4978,14 @@ export class SessionService {
   private async sendCloudPrompt(
     session: AgentSession,
     prompt: string | ContentBlock[],
-    options?: { skipQueueGuard?: boolean; steer?: boolean },
+    options?: SendCloudPromptOptions,
   ): Promise<{ stopReason: string }> {
     const normalizedPrompt = await this.resolveCloudPrompt(prompt);
     const transport = this.d.h.getCloudPromptTransport(normalizedPrompt);
+    const optimisticAttachments = mergeOptimisticPromptAttachments(
+      attachmentsFromFilePaths(transport.filePaths),
+      options?.attachments,
+    );
     if (
       !transport.messageText &&
       transport.filePaths.length === 0 &&
@@ -4919,7 +5022,9 @@ export class SessionService {
             "Cloud run couldn't start. Check that GitHub is connected for this project, then try again.",
         );
       }
-      return this.resumeCloudRun(session, normalizedPrompt);
+      return this.resumeCloudRun(session, normalizedPrompt, {
+        attachments: optimisticAttachments,
+      });
     }
 
     if (session.cloudStatus !== "in_progress") {
@@ -4994,6 +5099,9 @@ export class SessionService {
       content: transport.promptText,
       timestamp: Date.now(),
       pinToTop: false,
+      ...(optimisticAttachments.length > 0
+        ? { attachments: optimisticAttachments }
+        : {}),
     });
 
     const authStatus = await this.getAuthCredentialsStatus().catch((error) => {
@@ -5110,7 +5218,9 @@ export class SessionService {
       if (!result.success) {
         if (result.status === 409 && !options?.steer) {
           this.d.store.clearTailOptimisticItems(session.taskRunId);
-          return this.resumeCloudRun(session, normalizedPrompt);
+          return this.resumeCloudRun(session, normalizedPrompt, {
+            attachments: optimisticAttachments,
+          });
         }
         throw new Error(result.error ?? "Failed to send cloud command");
       }
@@ -5289,6 +5399,7 @@ export class SessionService {
   private async resumeCloudRun(
     session: AgentSession,
     prompt: string | ContentBlock[],
+    options?: Pick<SendPromptOptions, "attachments">,
   ): Promise<{ stopReason: string }> {
     const normalizedPrompt = await this.resolveCloudPrompt(prompt);
     const authStatus = await this.getAuthCredentialsStatus();
@@ -5310,6 +5421,10 @@ export class SessionService {
     }
 
     const transport = this.d.h.getCloudPromptTransport(normalizedPrompt);
+    const optimisticAttachments = mergeOptimisticPromptAttachments(
+      attachmentsFromFilePaths(transport.filePaths),
+      options?.attachments,
+    );
     if (
       !transport.messageText &&
       transport.filePaths.length === 0 &&
@@ -5327,6 +5442,9 @@ export class SessionService {
       content: transport.promptText,
       timestamp: Date.now(),
       pinToTop: false,
+      ...(optimisticAttachments.length > 0
+        ? { attachments: optimisticAttachments }
+        : {}),
     });
 
     const rollbackOptimisticPrompt = () => {
@@ -6857,9 +6975,12 @@ export class SessionService {
       ) {
         this.d.store.appendOptimisticItem(taskRunId, {
           type: "user_message",
-          content: initialPrompt,
+          content: initialPrompt.content,
           timestamp: Date.now(),
           pinToTop: true,
+          ...(initialPrompt.attachments.length > 0
+            ? { attachments: initialPrompt.attachments }
+            : {}),
         });
       }
     } else {
@@ -7068,16 +7189,23 @@ export class SessionService {
   }
 
   /**
-   * Stash the initial cloud prompt (user message plus any channel CONTEXT.md
-   * block) so the optimistic placeholder can render it — and its CONTEXT.md
-   * chip — immediately, instead of waiting for the sandbox to boot and echo it
+   * Stash the initial cloud prompt and attachment labels so the optimistic
+   * placeholder can render them immediately, instead of waiting for the
+   * sandbox to boot and echo it
    * back. Best-effort: lost on reload, where the merge layer dedupes the echo
    * against the bare placeholder instead.
    */
-  rememberInitialCloudPrompt(taskId: string, content: string): void {
+  rememberInitialCloudPrompt(
+    taskId: string,
+    content: string,
+    filePaths?: string[],
+  ): void {
     const trimmed = content.trim();
     if (trimmed) {
-      this.initialCloudOptimisticPrompt.set(taskId, content);
+      this.initialCloudOptimisticPrompt.set(taskId, {
+        content,
+        attachments: attachmentsFromFilePaths(filePaths ?? []),
+      });
     }
   }
 
@@ -7646,7 +7774,12 @@ export class SessionService {
       ? typeof runState?.pending_user_message === "string"
         ? runState.pending_user_message
         : undefined
-      : (this.initialCloudOptimisticPrompt.get(taskId) ?? taskDescription);
+      : (this.initialCloudOptimisticPrompt.get(taskId)?.content ??
+        taskDescription);
+    const initialPrompt = this.initialCloudOptimisticPrompt.get(taskId);
+    const initialAttachments = isResumeRun
+      ? undefined
+      : initialPrompt?.attachments;
     const hasOptimisticUserPrompt = session.optimisticItems.some(
       (item) => item.type === "user_message",
     );
@@ -7665,6 +7798,9 @@ export class SessionService {
         content: seedContent,
         timestamp: Date.now(),
         pinToTop: !isResumeRun,
+        ...(initialAttachments?.length
+          ? { attachments: initialAttachments }
+          : {}),
       });
     }
     if (hasCurrentRunUserPrompt || isTerminalRun) {

--- a/products/desktop/packages/core/src/task-detail/taskCreationSaga.test.ts
+++ b/products/desktop/packages/core/src/task-detail/taskCreationSaga.test.ts
@@ -287,6 +287,7 @@ describe("TaskCreationSaga", () => {
     expect(sessionService.rememberInitialCloudPrompt).toHaveBeenCalledWith(
       "task-123",
       sentMessage,
+      [],
     );
   });
 
@@ -330,6 +331,7 @@ describe("TaskCreationSaga", () => {
     expect(sessionService.rememberInitialCloudPrompt).toHaveBeenCalledWith(
       "task-123",
       sentMessage,
+      [],
     );
   });
 

--- a/products/desktop/packages/core/src/task-detail/taskCreationSaga.ts
+++ b/products/desktop/packages/core/src/task-detail/taskCreationSaga.ts
@@ -329,6 +329,7 @@ export class TaskCreationSaga extends Saga<
         this.deps.sessionService.rememberInitialCloudPrompt(
           task.id,
           warmPayload.pendingUserMessage,
+          warmPayload.transport.filePaths,
         );
       }
       this.deps.track(ANALYTICS_EVENTS.PROMPT_SENT, {
@@ -431,6 +432,7 @@ export class TaskCreationSaga extends Saga<
             this.deps.sessionService.rememberInitialCloudPrompt(
               task.id,
               pendingUserMessage,
+              transport?.filePaths,
             );
           }
           const cloudAdapter = isPiRuntime

--- a/products/desktop/packages/shared/src/index.ts
+++ b/products/desktop/packages/shared/src/index.ts
@@ -321,6 +321,7 @@ export {
   isSelectGroup,
   mergeConfigOptions,
   type OptimisticItem,
+  type OptimisticPromptAttachment,
   type PermissionRequest,
   type QueuedMessage,
   resolveBypassRevertMode,

--- a/products/desktop/packages/shared/src/sessions.ts
+++ b/products/desktop/packages/shared/src/sessions.ts
@@ -29,12 +29,19 @@ export interface QueuedMessage {
   queuedAt: number;
 }
 
+export interface OptimisticPromptAttachment {
+  id: string;
+  label: string;
+  previewUrl?: string;
+}
+
 export type OptimisticItem =
   | {
       type: "user_message";
       id: string;
       content: string;
       timestamp: number;
+      attachments?: OptimisticPromptAttachment[];
       pinToTop?: boolean;
     }
   | {

--- a/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -11,7 +11,11 @@ import {
   FAST_MODE_OPTION_CATEGORY,
 } from "@posthog/core/task-detail/previewConfig";
 import { useService } from "@posthog/di/react";
-import { type AcpMessage, FAST_MODE_FLAG } from "@posthog/shared";
+import {
+  type AcpMessage,
+  FAST_MODE_FLAG,
+  type OptimisticPromptAttachment,
+} from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import {
   spendStopMessage,
@@ -105,7 +109,10 @@ interface SessionViewProps {
   isPromptPending?: boolean | null;
   promptStartedAt?: number | null;
   onBeforeSubmit?: (text: string, clearEditor: () => void) => boolean;
-  onSendPrompt: (text: string) => Promise<boolean>;
+  onSendPrompt: (
+    text: string,
+    attachments?: OptimisticPromptAttachment[],
+  ) => Promise<boolean>;
   onBashCommand?: (command: string) => void;
   onCancelPrompt: () => void;
   repoPath?: string | null;
@@ -409,6 +416,10 @@ export function SessionView({
       const submissionId = ++composerSubmissionRef.current;
       const editor = editorRef.current;
       const submittedContent = editor?.getContent() ?? null;
+      const submittedAttachments: OptimisticPromptAttachment[] | undefined =
+        submittedContent?.attachments?.map((attachment) => ({
+          ...attachment,
+        }));
       if (
         editor &&
         shouldSubmitComposerOptimistically(submittedContent, text)
@@ -416,7 +427,7 @@ export function SessionView({
         const sendPromise = submitComposerPrompt(
           editor,
           submittedContent,
-          () => onSendPrompt(text),
+          () => onSendPrompt(text, submittedAttachments),
           () => submissionId === composerSubmissionRef.current,
         );
         sendInFlightRef.current = false;
@@ -425,7 +436,7 @@ export function SessionView({
       }
 
       try {
-        if (await onSendPrompt(text)) {
+        if (await onSendPrompt(text, submittedAttachments)) {
           const currentEditor = editorRef.current;
           if (
             currentEditor &&

--- a/products/desktop/packages/ui/src/features/sessions/components/UserMessageAttachments.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/UserMessageAttachments.tsx
@@ -81,7 +81,7 @@ function ImageAttachment({
       <Dialog.Trigger>
         <button
           type="button"
-          className="group relative h-16 w-20 overflow-hidden rounded-md border border-gray-6 bg-gray-3"
+          className="group relative h-16 w-20 cursor-zoom-in overflow-hidden rounded-md border border-gray-6 bg-gray-3"
           aria-label={`Preview ${attachment.label}`}
         >
           <img

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -8,6 +8,7 @@ import {
 } from "@phosphor-icons/react";
 import { WorkerPoolContextProvider } from "@pierre/diffs/react";
 import { buildTurnRatingMetric } from "@posthog/core/analytics/aiFeedback";
+import { stripTrailingAttachmentSummary } from "@posthog/core/editor/cloud-prompt";
 import { useService } from "@posthog/di/react";
 import {
   Button,
@@ -535,13 +536,16 @@ function UserBubble({
   attachments?: UserMessageAttachment[];
   keyboardFocused?: boolean;
 }) {
+  const cleanedContent =
+    attachments.length > 0 ? stripTrailingAttachmentSummary(content) : content;
+
   // A message relayed from another agent run renders as an incoming agent
   // message (start-aligned, outlined, provenance chip) instead of masquerading
   // as something this run's user typed. The envelope boilerplate never renders;
   // only the sender-authored body flows into the normal pipeline below.
   const { peerAgentMessage, blocks, displayContent } = useMemo(
-    () => splitUserMessage(content),
-    [content],
+    () => splitUserMessage(cleanedContent),
+    [cleanedContent],
   );
   const visibleBlocks = useVisibleInjectedBlocks(blocks);
   // Provenance is never flag-gated: a peer message must not read as the user's.

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/UserMessageBody.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/UserMessageBody.tsx
@@ -1,4 +1,5 @@
 import { CaretDown } from "@phosphor-icons/react";
+import { stripTrailingAttachmentSummary } from "@posthog/core/editor/cloud-prompt";
 import { cn } from "@posthog/quill";
 import { ChatMarkdown } from "@posthog/ui/features/sessions/components/chat-thread/ChatMarkdown";
 import {
@@ -28,7 +29,9 @@ export function UserMessageBody({
   content: string;
   attachments?: UserMessageAttachment[];
 }) {
-  const containsFileMentions = hasFileMentions(content);
+  const cleanedContent =
+    attachments.length > 0 ? stripTrailingAttachmentSummary(content) : content;
+  const containsFileMentions = hasFileMentions(cleanedContent);
 
   const [isExpanded, setIsExpanded] = useState(false);
   const [isOverflowing, setIsOverflowing] = useState(false);
@@ -48,10 +51,15 @@ export function UserMessageBody({
     );
     observer.observe(el);
     return () => observer.disconnect();
-  }, [content, isExpanded]);
+  }, [cleanedContent, isExpanded]);
 
   return (
     <>
+      {attachments.length > 0 && !containsFileMentions && (
+        <div className={cleanedContent.trim() ? "mb-1.5" : ""}>
+          <UserMessageAttachments attachments={attachments} />
+        </div>
+      )}
       <div
         ref={textRef}
         className={cn(
@@ -66,16 +74,11 @@ export function UserMessageBody({
         )}
       >
         {containsFileMentions ? (
-          parseFileMentions(content)
+          parseFileMentions(cleanedContent)
         ) : (
-          <ChatMarkdown content={content} />
+          <ChatMarkdown content={cleanedContent} />
         )}
       </div>
-      {attachments.length > 0 && !containsFileMentions && (
-        <div className="mt-1.5">
-          <UserMessageAttachments attachments={attachments} />
-        </div>
-      )}
       {isOverflowing && (
         <button
           type="button"

--- a/products/desktop/packages/ui/src/features/sessions/components/mergeConversationItems.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/mergeConversationItems.test.ts
@@ -74,6 +74,48 @@ describe("mergeConversationItems", () => {
     });
   });
 
+  it.each([
+    {
+      name: "keeps optimistic attachments when the echo has none",
+      echoedAttachments: undefined,
+      expectedAttachments: [{ id: "inline-image:1", label: "diagram.png" }],
+    },
+    {
+      name: "replaces optimistic attachments with authoritative echo attachments",
+      echoedAttachments: [
+        { id: "file:///tmp/diagram.png", label: "diagram.png" },
+      ],
+      expectedAttachments: [
+        { id: "file:///tmp/diagram.png", label: "diagram.png" },
+      ],
+    },
+  ])("cloud: $name", ({ echoedAttachments, expectedAttachments }) => {
+    const optimisticAttachments = [
+      { id: "inline-image:1", label: "diagram.png" },
+    ];
+    const result = mergeConversationItems({
+      conversationItems: [
+        {
+          ...userMessage("echo", "review this", undefined, 100),
+          ...(echoedAttachments ? { attachments: echoedAttachments } : {}),
+        },
+      ],
+      optimisticItems: [
+        {
+          ...userMessage("opt", "review this"),
+          attachments: optimisticAttachments,
+        },
+      ],
+      isCloud: true,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: "opt",
+      attachments: expectedAttachments,
+    });
+  });
+
   it("cloud: dedupes the echoed prompt even when it carries an appended channel CONTEXT.md", () => {
     const echoedWithContext =
       'hello\n\n<channel_context channel="bluebird">background</channel_context>';

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/UserMessage.stories.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/UserMessage.stories.tsx
@@ -18,10 +18,26 @@ export default meta;
 type Story = StoryObj<typeof UserMessage>;
 
 const FIXED_TIMESTAMP = Date.parse("2026-07-01T10:30:00Z");
+const IMAGE_PREVIEW_URL =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKAAAABkCAYAAAABtjuPAAAA/ElEQVR42u3SwQ0AEBAAQYXwEF2r072JKi5kHtvAZkrE2lJWxQQBKAAlAAWgBKAAlAAUgBKAAlACUABKAArAW21dAlAACkAABaAABFAACkAABaAABFAACkAABaAABFAACkAABaAABFAACkAA9RjAmEMCUAAKQAAFoAAEUAAKQAAFoAAEUAAKQAAFoAAEUAAKQAAFoAAEUAAKQAAFoAAEUAAKQAAFoAAEUAAKQAAFoAAEUAAKQAAFoAAUgAAKQAEIoAAUgAAKQAEIoAAUgAAKQAEIoAAUgAAKQAEIoAAUgFJSAApAASgBKAAlAAWgBKAAlAAUgBKAAlACUP90AP5EMZdDgPdWAAAAAElFTkSuQmCC";
 
 export const Typed: Story = {
   args: {
     content: "What are our top errors this week?",
+    timestamp: FIXED_TIMESTAMP,
+  },
+};
+
+export const WithImageAttachment: Story = {
+  args: {
+    content: "What does this image show?",
+    attachments: [
+      {
+        id: "inline-image:storybook",
+        label: "screenshot.png",
+        previewUrl: IMAGE_PREVIEW_URL,
+      },
+    ],
     timestamp: FIXED_TIMESTAMP,
   },
 };

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/UserMessage.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/UserMessage.test.tsx
@@ -53,7 +53,7 @@ describe("UserMessage", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
   });
-  it("renders attachment chips for cloud prompts", () => {
+  it("renders attachment chips above cloud prompts", () => {
     renderWithFlags(
       <UserMessage
         content="read this file"
@@ -65,9 +65,38 @@ describe("UserMessage", () => {
       true,
     );
 
-    expect(screen.getByText("read this file")).toBeInTheDocument();
-    expect(screen.getByText("test.txt")).toBeInTheDocument();
+    const prompt = screen.getByText("read this file");
+    const firstAttachment = screen.getByText("test.txt");
+
+    expect(prompt).toBeInTheDocument();
+    expect(firstAttachment).toBeInTheDocument();
     expect(screen.getByText("notes.md")).toBeInTheDocument();
+    expect(
+      firstAttachment.compareDocumentPosition(prompt) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("renders attachment chips without their synthesized trailing summary", () => {
+    renderWithFlags(
+      <UserMessage
+        content={"review this\n\nAttached files: notes.md"}
+        attachments={[{ id: "attachment://notes.md", label: "notes.md" }]}
+      />,
+      true,
+    );
+
+    expect(screen.getByText("review this")).toBeInTheDocument();
+    expect(screen.getByText("notes.md")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Attached files: notes.md"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps attachment-like text when attachment metadata is absent", () => {
+    renderWithFlags(<UserMessage content="Attached files: notes.md" />, true);
+
+    expect(screen.getByText("Attached files: notes.md")).toBeInTheDocument();
   });
 
   it("renders a peer agent message as the body plus a provenance chip, never the raw envelope", () => {

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/UserMessage.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/UserMessage.tsx
@@ -1,4 +1,5 @@
 import { Check, Copy, Robot, SlackLogo } from "@phosphor-icons/react";
+import { stripTrailingAttachmentSummary } from "@posthog/core/editor/cloud-prompt";
 import { Box, IconButton } from "@radix-ui/themes";
 import { motion } from "framer-motion";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -52,12 +53,15 @@ export const UserMessage = memo(function UserMessage({
   taskId,
   keyboardFocused = false,
 }: UserMessageProps) {
+  const cleanedContent =
+    attachments.length > 0 ? stripTrailingAttachmentSummary(content) : content;
+
   // A message relayed from another agent run renders with a provenance chip and
   // neutral accent instead of masquerading as this run's user. The envelope
   // boilerplate never renders; only the sender-authored body flows on.
   const { peerAgentMessage, blocks, displayContent } = useMemo(
-    () => splitUserMessage(content),
-    [content],
+    () => splitUserMessage(cleanedContent),
+    [cleanedContent],
   );
   const visibleBlocks = useVisibleInjectedBlocks(blocks);
 
@@ -91,6 +95,11 @@ export const UserMessage = memo(function UserMessage({
         }}
       >
         <CollapsibleMessageContent contentClassName="font-medium text-[13px] [&_p]:leading-[1.9]">
+          {showAttachmentChips && (
+            <div className={displayContent.trim() ? "mb-1.5" : ""}>
+              <UserMessageAttachments attachments={attachments} />
+            </div>
+          )}
           {containsFileMentions ? (
             parseFileMentions(displayContent)
           ) : (
@@ -107,11 +116,6 @@ export const UserMessage = memo(function UserMessage({
                 />
               )}
               <InjectedBlockChips blocks={visibleBlocks} taskId={taskId} />
-            </div>
-          )}
-          {showAttachmentChips && (
-            <div className={content.trim() ? "mt-1.5" : ""}>
-              <UserMessageAttachments attachments={attachments} />
             </div>
           )}
         </CollapsibleMessageContent>

--- a/products/desktop/packages/ui/src/features/sessions/hooks/useSessionCallbacks.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/hooks/useSessionCallbacks.test.tsx
@@ -218,6 +218,26 @@ describe("useSessionCallbacks.handleSendPrompt", () => {
     expect(toastError).toHaveBeenCalledWith("fetch failed");
   });
 
+  it("forwards non-empty submitted attachments to the session service", async () => {
+    sessionService.sendPrompt.mockResolvedValue({ stopReason: "end_turn" });
+    const attachments = [
+      {
+        id: "inline-image:test",
+        label: "diagram.png",
+        previewUrl: "data:image/png;base64,aW1hZ2U=",
+      },
+    ];
+
+    const { result } = renderCallbacks();
+    await result.current.handleSendPrompt("review this", attachments);
+
+    expect(sessionService.sendPrompt).toHaveBeenCalledWith(
+      TASK,
+      "review this",
+      { steer: false, attachments },
+    );
+  });
+
   it("forwards the steer intent from the messaging mode", async () => {
     messagingMode.value = "steer";
     sessionService.sendPrompt.mockResolvedValue({ stopReason: "steered" });

--- a/products/desktop/packages/ui/src/features/sessions/hooks/useSessionCallbacks.ts
+++ b/products/desktop/packages/ui/src/features/sessions/hooks/useSessionCallbacks.ts
@@ -13,7 +13,10 @@ import {
 } from "@posthog/core/sessions/sessionService";
 import { useService } from "@posthog/di/react";
 import { useHostTRPCClient } from "@posthog/host-router/react";
-import { sessionSupportsSideQuestion } from "@posthog/shared";
+import {
+  type OptimisticPromptAttachment,
+  sessionSupportsSideQuestion,
+} from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import {
   resolveLocalSkillPrompt,
@@ -64,7 +67,10 @@ export function useSessionCallbacks({
   const messagingMode = useMessagingMode(taskId);
 
   const handleSendPrompt = useCallback(
-    async (text: string): Promise<boolean> => {
+    async (
+      text: string,
+      attachments?: OptimisticPromptAttachment[],
+    ): Promise<boolean> => {
       const currentSession = sessionRef.current;
       const currentEvents = currentSession?.events ?? [];
       const handled = await tryExecuteCodeCommand(text, {
@@ -147,6 +153,7 @@ export function useSessionCallbacks({
         markActivity(taskId);
         await sessionService.sendPrompt(taskId, promptText ?? text, {
           steer: messagingMode === "steer",
+          ...(attachments?.length ? { attachments } : {}),
         });
 
         const view = getAppViewSnapshot();

--- a/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -7486,20 +7486,43 @@ describe("SessionService", () => {
       );
     });
 
-    it("sends prompt via tRPC when session is ready", async () => {
+    it("sends a local image prompt with a previewable optimistic attachment", async () => {
       const service = getSessionService();
       mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(
         createMockSession(),
       );
       mockTrpcAgent.prompt.mutate.mockResolvedValue({ stopReason: "end_turn" });
+      const prompt: ContentBlock[] = [
+        { type: "text", text: "Review this image" },
+        {
+          type: "image",
+          data: "aW1hZ2U=",
+          mimeType: "image/png",
+          fileName: "diagram.png",
+        } as ContentBlock,
+      ];
 
-      const result = await service.sendPrompt("task-123", "Hello");
+      const result = await service.sendPrompt("task-123", prompt);
 
       expect(result.stopReason).toBe("end_turn");
       expect(mockTrpcAgent.prompt.mutate).toHaveBeenCalledWith({
         sessionId: "run-123",
-        prompt: [{ type: "text", text: "Hello" }],
+        prompt,
       });
+      expect(mockSessionStoreSetters.appendOptimisticItem).toHaveBeenCalledWith(
+        "run-123",
+        expect.objectContaining({
+          type: "user_message",
+          content: "Review this image",
+          attachments: [
+            {
+              id: expect.stringMatching(/^inline-image:/),
+              label: "diagram.png",
+              previewUrl: "data:image/png;base64,aW1hZ2U=",
+            },
+          ],
+        }),
+      );
     });
 
     it("reuses attachments uploaded before sending cloud follow-ups", async () => {


### PR DESCRIPTION
## Problem

Prompt history does not keep an image preview visible while a message moves from optimistic state to transcript state.

The prompt can show an attachment summary instead of the image preview.

## Changes

- Image attachments render above prompt text in both transcript views.
- Each image opens the existing preview dialog and uses a zoom-in cursor.
- Optimistic messages keep image metadata until the transcript provides an authoritative attachment.
- The renderer removes generated attachment summaries when attachment metadata is available.

| Before | After |
| --- | --- |
| ![Image attachment summary](https://raw.githubusercontent.com/PostHog/pr-assets/fa4bc3563a12b68fc417ecb29ad5459f651c7050/2026/09/fa3814a9-6706-44ef-965a-868f33819b41.png) | ![Image preview above prompt text](https://raw.githubusercontent.com/PostHog/pr-assets/279b26ea6f4a4d8e8f82f8bb2d34da53466f9bb9/2026/09/f7fec13c-6aa0-41be-bb38-c41456e581fa.png) |

The image opens in the existing preview dialog:

![Image preview dialog](https://raw.githubusercontent.com/PostHog/pr-assets/7054cd923f6ddbdf533a22c00fbee71f89db481f/2026/09/22e8c34e-ccaa-4aa2-a19f-06d42aa6b9bb.png)

## How did you test this code?

- Core and UI unit tests cover image extraction, optimistic metadata, summary removal, ordering, and echo reconciliation.
- The full `@posthog/core` and `@posthog/ui` test suites pass.
- The desktop typecheck and the changed-file Biome checks pass.
- A Playwright Storybook check verified the order, cursor, and dialog at 900 px and 520 px widths.
- `hogli ci:preflight --fix` reports no failures against `origin/master`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs change. This change only alters the prompt history presentation.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Pi used Explore, Plan, and General subagents with repository and browser tools.
- Skills used: `/posthog-desktop`, `/writing-ui-components`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, `/reviewing-with-coderabbit`, `/running-ci-preflight`, and `/writing-pr-descriptions`.
- The duplicate pull request search found no matching open pull request.
- The CodeRabbit local pass is paused, so this pull request opened without a local pass.
- The test fixtures use invented file names and generated image data.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*