### PR TITLE
feat(alerts): expose insight scheduler health metrics

### DIFF
--- a/posthog/temporal/alerts/activities.py
+++ b/posthog/temporal/alerts/activities.py
@@ -15,6 +15,7 @@ from posthog.schema import AlertState
 from posthog.hogql.errors import TableAccessDeniedError
 
 from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
+from posthog.dataclasses import frozen
 from posthog.email import is_email_available
 from posthog.errors import CH_TRANSIENT_ERRORS
 from posthog.exceptions_capture import capture_exception
@@ -72,13 +73,20 @@ logger = structlog.get_logger(__name__)
 _NOTIFICATION_DELIVERY_EXECUTOR = ThreadPoolExecutor(max_workers=10, thread_name_prefix="insight-alert-delivery")
 
 
+@frozen
+class _FetchedDueAlerts:
+    alerts: list[AlertInfo]
+    oldest_due_at: datetime | None
+    has_more: bool
+
+
 @temporalio.activity.defn
 async def retrieve_due_alerts(inputs: ScheduleDueAlertChecksWorkflowInputs | None = None) -> list[AlertInfo]:
     if inputs is None:
         inputs = ScheduleDueAlertChecksWorkflowInputs()
 
     @database_sync_to_async(thread_sensitive=False)
-    def get_alerts() -> tuple[list[AlertInfo], datetime | None, bool]:
+    def get_alerts() -> _FetchedDueAlerts:
         now = datetime.now(UTC)
 
         calculation_interval_order = Case(
@@ -136,19 +144,19 @@ async def retrieve_due_alerts(inputs: ScheduleDueAlertChecksWorkflowInputs | Non
             )
             for a in selected_alerts
         ]
-        return alerts, oldest_due_at, has_more
+        return _FetchedDueAlerts(alerts=alerts, oldest_due_at=oldest_due_at, has_more=has_more)
 
     async with Heartbeater():
-        alerts, oldest_due_at, has_more = await get_alerts()
+        fetched = await get_alerts()
 
     record_scheduler_fetch(
-        selected_count=len(alerts),
+        selected_count=len(fetched.alerts),
         max_alerts_per_run=inputs.max_alerts_per_run,
-        oldest_due_at=oldest_due_at,
+        oldest_due_at=fetched.oldest_due_at,
         now=datetime.now(UTC),
-        has_more=has_more,
+        has_more=fetched.has_more,
     )
-    return alerts
+    return fetched.alerts
 
 
 def _has_active_destinations(alert: AlertConfiguration) -> bool:

--- a/posthog/temporal/alerts/activities.py
+++ b/posthog/temporal/alerts/activities.py
@@ -36,6 +36,7 @@ from posthog.tasks.alerts.utils import (
     skip_because_of_weekend,
 )
 from posthog.temporal.alerts.investigation import claim_investigation_slot, decide_investigation
+from posthog.temporal.alerts.metrics import record_scheduler_fetch
 from posthog.temporal.alerts.types import (
     AlertInfo,
     EvaluateAlertActivityInputs,
@@ -77,7 +78,7 @@ async def retrieve_due_alerts(inputs: ScheduleDueAlertChecksWorkflowInputs | Non
         inputs = ScheduleDueAlertChecksWorkflowInputs()
 
     @database_sync_to_async(thread_sensitive=False)
-    def get_alerts() -> list[AlertInfo]:
+    def get_alerts() -> tuple[list[AlertInfo], datetime | None, bool]:
         now = datetime.now(UTC)
 
         calculation_interval_order = Case(
@@ -89,7 +90,7 @@ async def retrieve_due_alerts(inputs: ScheduleDueAlertChecksWorkflowInputs | Non
             output_field=IntegerField(),
         )
 
-        alerts = (
+        alert_candidates = list(
             AlertConfiguration.objects.filter(
                 Q(enabled=True, next_check_at__lte=now) | Q(enabled=True, next_check_at__isnull=True)
             )
@@ -114,10 +115,18 @@ async def retrieve_due_alerts(inputs: ScheduleDueAlertChecksWorkflowInputs | Non
                 "team_id",
                 "id",
             )
-            .only("id", "team_id", "calculation_interval", "insight_id")[: inputs.max_alerts_per_run]
+            .only("id", "team_id", "calculation_interval", "insight_id", "next_check_at")[
+                : inputs.max_alerts_per_run + 1
+            ]
+        )
+        has_more = len(alert_candidates) > inputs.max_alerts_per_run
+        selected_alerts = alert_candidates[: inputs.max_alerts_per_run]
+        oldest_due_at = min(
+            (alert.next_check_at for alert in selected_alerts if alert.next_check_at is not None),
+            default=None,
         )
 
-        return [
+        alerts = [
             AlertInfo(
                 alert_id=str(a.id),
                 team_id=a.team_id,
@@ -125,11 +134,21 @@ async def retrieve_due_alerts(inputs: ScheduleDueAlertChecksWorkflowInputs | Non
                 calculation_interval=a.calculation_interval,
                 insight_id=a.insight_id,
             )
-            for a in alerts
+            for a in selected_alerts
         ]
+        return alerts, oldest_due_at, has_more
 
     async with Heartbeater():
-        return await get_alerts()
+        alerts, oldest_due_at, has_more = await get_alerts()
+
+    record_scheduler_fetch(
+        selected_count=len(alerts),
+        max_alerts_per_run=inputs.max_alerts_per_run,
+        oldest_due_at=oldest_due_at,
+        now=datetime.now(UTC),
+        has_more=has_more,
+    )
+    return alerts
 
 
 def _has_active_destinations(alert: AlertConfiguration) -> bool:

--- a/posthog/temporal/alerts/metrics.py
+++ b/posthog/temporal/alerts/metrics.py
@@ -1,0 +1,45 @@
+import time
+from datetime import datetime
+
+from posthog.temporal.common.metrics import get_metric_meter
+
+SCHEDULER_RUNS = "insight_alert_scheduler_runs"
+SCHEDULER_SELECTED = "insight_alert_scheduler_selected"
+SCHEDULER_MAX_ALERTS_PER_RUN = "insight_alert_scheduler_max_alerts_per_run"
+SCHEDULER_OLDEST_DUE_AGE_SECONDS = "insight_alert_scheduler_oldest_due_age_seconds"
+SCHEDULER_LAST_SUCCESSFUL_FETCH_TIMESTAMP_SECONDS = "insight_alert_scheduler_last_successful_fetch_timestamp_seconds"
+
+
+def record_scheduler_fetch(
+    *,
+    selected_count: int,
+    max_alerts_per_run: int,
+    oldest_due_at: datetime | None,
+    now: datetime,
+    has_more: bool,
+) -> None:
+    """Record bounded scheduler progress without tenant-level labels."""
+    meter = get_metric_meter()
+    outcome = "saturated" if has_more else "empty" if selected_count == 0 else "partial"
+    meter.with_additional_attributes({"outcome": outcome}).create_counter(
+        SCHEDULER_RUNS,
+        "Insight alert scheduler fetches by whether the configured batch was exhausted.",
+    ).add(1)
+    meter.create_counter(
+        SCHEDULER_SELECTED,
+        "Due insight alerts selected for Temporal child-workflow dispatch.",
+    ).add(selected_count)
+    meter.create_gauge(
+        SCHEDULER_MAX_ALERTS_PER_RUN,
+        "Effective per-run insight alert selection limit.",
+    ).set(max_alerts_per_run)
+    oldest_due_age_seconds = max(0.0, (now - oldest_due_at).total_seconds()) if oldest_due_at is not None else 0.0
+    meter.create_gauge_float(
+        SCHEDULER_OLDEST_DUE_AGE_SECONDS,
+        "Age in seconds of the oldest due insight alert selected by a scheduler run.",
+        "s",
+    ).set(oldest_due_age_seconds)
+    meter.create_gauge_float(
+        SCHEDULER_LAST_SUCCESSFUL_FETCH_TIMESTAMP_SECONDS,
+        "Unix timestamp of the last successful insight alert scheduler fetch.",
+    ).set(time.time())

--- a/posthog/temporal/tests/test_alerts_activities.py
+++ b/posthog/temporal/tests/test_alerts_activities.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 
 import pytest
 import time_machine
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest_asyncio
 from asgiref.sync import sync_to_async
@@ -150,13 +150,22 @@ async def test_retrieve_due_alerts_limits_each_schedule_run_without_starving_oth
     )
     other_alert = await _create_alert(other_team)
 
-    alerts = await ActivityEnvironment().run(
-        retrieve_due_alerts,
-        ScheduleDueAlertChecksWorkflowInputs(max_alerts_per_run=max_alerts_per_run),
-    )
+    with patch("posthog.temporal.alerts.activities.record_scheduler_fetch") as record_scheduler_fetch:
+        alerts = await ActivityEnvironment().run(
+            retrieve_due_alerts,
+            ScheduleDueAlertChecksWorkflowInputs(max_alerts_per_run=max_alerts_per_run),
+        )
 
     assert len(alerts) == max_alerts_per_run
     assert str(other_alert.id) in {alert.alert_id for alert in alerts}
+    record_scheduler_fetch.assert_called_once()
+    assert record_scheduler_fetch.call_args.kwargs == {
+        "selected_count": max_alerts_per_run,
+        "max_alerts_per_run": max_alerts_per_run,
+        "oldest_due_at": None,
+        "now": ANY,
+        "has_more": True,
+    }
 
 
 @pytest_asyncio.fixture

--- a/posthog/temporal/tests/test_alerts_metrics.py
+++ b/posthog/temporal/tests/test_alerts_metrics.py
@@ -1,0 +1,49 @@
+from datetime import UTC, datetime, timedelta
+
+from unittest.mock import MagicMock, patch
+
+from posthog.temporal.alerts.metrics import record_scheduler_fetch
+
+
+def test_record_scheduler_fetch_emits_progress_and_saturation_signals() -> None:
+    meter = MagicMock()
+    now = datetime(2026, 9, 11, 12, 0, tzinfo=UTC)
+
+    with (
+        patch("posthog.temporal.alerts.metrics.get_metric_meter", return_value=meter),
+        patch("posthog.temporal.alerts.metrics.time.time", return_value=1_789_128_000.0),
+    ):
+        record_scheduler_fetch(
+            selected_count=300,
+            max_alerts_per_run=300,
+            oldest_due_at=now - timedelta(minutes=45),
+            now=now,
+            has_more=True,
+        )
+
+    meter.with_additional_attributes.assert_called_once_with({"outcome": "saturated"})
+    run_meter = meter.with_additional_attributes.return_value
+    run_meter.create_counter.return_value.add.assert_called_once_with(1)
+    meter.create_counter.return_value.add.assert_called_once_with(300)
+    meter.create_gauge.return_value.set.assert_any_call(300)
+    meter.create_gauge_float.return_value.set.assert_any_call(2_700.0)
+    meter.create_gauge_float.return_value.set.assert_any_call(1_789_128_000.0)
+
+
+def test_record_scheduler_fetch_resets_oldest_due_age_when_empty() -> None:
+    meter = MagicMock()
+
+    with (
+        patch("posthog.temporal.alerts.metrics.get_metric_meter", return_value=meter),
+        patch("posthog.temporal.alerts.metrics.time.time", return_value=1_789_128_000.0),
+    ):
+        record_scheduler_fetch(
+            selected_count=0,
+            max_alerts_per_run=300,
+            oldest_due_at=None,
+            now=datetime(2026, 9, 11, 12, 0, tzinfo=UTC),
+            has_more=False,
+        )
+
+    meter.with_additional_attributes.assert_called_once_with({"outcome": "empty"})
+    meter.create_gauge_float.return_value.set.assert_any_call(0.0)


### PR DESCRIPTION
## Problem

Operators cannot distinguish a healthy insight-alert scheduler from one that is alive but no longer completing database fetches. This leaves alert-evaluation delays without an independent application-level freshness signal.

## Changes

- Record the timestamp of each successful due-alert fetch.
- Record selected volume, the configured cap, saturation outcome, and oldest selected due age.
- Fetch one extra row so saturation is observable without an additional count query.
- Keep all metrics tenant-agnostic to avoid label-cardinality growth.

## How did you test this code?

- The required commit hooks passed Python lint fixes, formatting, and `ty check`.
- Added focused tests for saturated and empty metric states plus activity integration.
- The local test suite was intentionally not run; CI is the requested test authority for this time-sensitive follow-up.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No user-facing docs change. Apply `skip-inkeep-docs`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used shell inspection and patch tooling with `/using-git-worktrees`, `/test-driven-development`, and `/writing-pr-descriptions`. CodeRabbit CLI review is paused, so this PR opened without a local CodeRabbit pass.

An open-PR search found no existing change providing insight-scheduler fetch freshness and saturation metrics. The diff contains no session-derived customer data or private operational details.