### PR TITLE
fix(data-modeling): separate lineage and materialization resolution metrics

### DIFF
--- a/posthog/temporal/data_modeling/metrics.py
+++ b/posthog/temporal/data_modeling/metrics.py
@@ -28,16 +28,6 @@ DATA_MODELING_LATENCY_HISTOGRAM_BUCKETS = [
 ]
 
 
-def get_data_modeling_finished_metric(status: str) -> MetricCounter:
-    return (
-        workflow.metric_meter()
-        .with_additional_attributes({"status": status})
-        .create_counter(
-            "data_modeling_finished", "Number of data modeling runs finished, for any reason (including failure)."
-        )
-    )
-
-
 def get_node_suspended_metric(engine: str) -> MetricCounter:
     return (
         activity.metric_meter()

--- a/products/data_modeling/backend/facade/modeling.py
+++ b/products/data_modeling/backend/facade/modeling.py
@@ -10,6 +10,8 @@ module level (modeling's heavy deps are deferred inside its methods).
 from products.data_modeling.backend.models.modeling import (
     DEFAULT_RESOLUTION_DEADLINE_SECONDS,
     DEFAULT_RESOLUTION_MAX_VIEW_DEPTH,
+    RESOLUTION_SOURCE_LINEAGE,
+    RESOLUTION_SOURCE_MATERIALIZATION,
     BoundedResolver,
     DataWarehouseModelPath,
     LabelTreeField,
@@ -24,6 +26,8 @@ from products.data_modeling.backend.models.modeling import (
 __all__ = [
     "DEFAULT_RESOLUTION_DEADLINE_SECONDS",
     "DEFAULT_RESOLUTION_MAX_VIEW_DEPTH",
+    "RESOLUTION_SOURCE_LINEAGE",
+    "RESOLUTION_SOURCE_MATERIALIZATION",
     "BoundedResolver",
     "DataWarehouseModelPath",
     "LabelTreeField",

--- a/products/data_modeling/backend/models/modeling.py
+++ b/products/data_modeling/backend/models/modeling.py
@@ -99,24 +99,37 @@ class ResolutionTimeoutError(BoundedResolverError):
         self.deadline_seconds = deadline_seconds
 
 
+# `source` separates the two jobs the resolver does, which fail differently and are read
+# differently: a `materialization` failure fails a customer's model on a scheduled run, while
+# `lineage` resolves a query's parents at save time to maintain DAG edges and view metadata.
+# Lineage runs orders of magnitude more often, so unlabelled they share one series and the
+# rarer, costlier one becomes unreadable. Anything under `other` is a caller added without
+# saying which of the two it is.
+RESOLUTION_SOURCE_MATERIALIZATION = "materialization"
+RESOLUTION_SOURCE_LINEAGE = "lineage"
+RESOLUTION_SOURCE_OTHER = "other"
+
 DAG_RESOLUTION_TOTAL = Counter(
     "data_modeling_dag_resolution_total",
-    "Total HogQL view-dependency resolutions performed, labelled by terminal status.",
-    labelnames=["status"],  # ok | cycle | depth_exceeded | timeout | error
+    "Total HogQL view-dependency resolutions performed, by calling path and terminal status.",
+    labelnames=["source", "status"],  # ok | cycle | depth_exceeded | timeout | error
 )
 DAG_RESOLUTION_DURATION_SECONDS = Histogram(
     "data_modeling_dag_resolution_duration_seconds",
-    "Wall-clock time spent resolving HogQL view dependencies.",
+    "Wall-clock time spent resolving HogQL view dependencies, by calling path.",
+    labelnames=["source"],
     buckets=(0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0),
 )
 DAG_RESOLUTION_VIEW_DEPTH = Histogram(
     "data_modeling_dag_resolution_view_depth",
-    "Maximum nested view depth observed on successful HogQL dependency resolution.",
+    "Maximum nested view depth observed on successful HogQL dependency resolution, by calling path.",
+    labelnames=["source"],
     buckets=(1, 2, 4, 8, 16, 25, 50, 100),
 )
 DAG_RESOLUTION_DEADLINE_VIOLATIONS = Counter(
     "data_modeling_dag_resolution_deadline_violations_total",
     "Resolutions where the deadline elapsed; in soft mode this is observed without raising.",
+    labelnames=["source"],
 )
 
 
@@ -156,9 +169,11 @@ class BoundedResolver(Resolver):
         deadline_seconds: float | None = DEFAULT_RESOLUTION_DEADLINE_SECONDS,
         enforce_bounds: bool = True,
         deadline_anchor: float | None = None,
+        source: str = RESOLUTION_SOURCE_OTHER,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
+        self.source = source
         self.initial_view_name = initial_view_name
         # views whose bodies are currently being visited; seeded with the current view name so
         # it counts as "visited" for cycle detection
@@ -200,12 +215,12 @@ class BoundedResolver(Resolver):
             status = "error"
             raise
         finally:
-            DAG_RESOLUTION_TOTAL.labels(status=status).inc()
-            DAG_RESOLUTION_DURATION_SECONDS.observe(time.monotonic() - start_time)
+            DAG_RESOLUTION_TOTAL.labels(source=self.source, status=status).inc()
+            DAG_RESOLUTION_DURATION_SECONDS.labels(source=self.source).observe(time.monotonic() - start_time)
             if status == "ok":
-                DAG_RESOLUTION_VIEW_DEPTH.observe(self.max_view_depth_observed)
+                DAG_RESOLUTION_VIEW_DEPTH.labels(source=self.source).observe(self.max_view_depth_observed)
             if self.deadline_violated:
-                DAG_RESOLUTION_DEADLINE_VIOLATIONS.inc()
+                DAG_RESOLUTION_DEADLINE_VIOLATIONS.labels(source=self.source).inc()
 
     def _check_deadline(self) -> None:
         if self.deadline_seconds is None:
@@ -309,6 +324,7 @@ def bounded_resolver_factory_for_view(
     max_view_depth: int = DEFAULT_RESOLUTION_MAX_VIEW_DEPTH,
     deadline_seconds: float | None = DEFAULT_RESOLUTION_DEADLINE_SECONDS,
     enforce_bounds: bool = True,
+    source: str = RESOLUTION_SOURCE_MATERIALIZATION,
 ) -> ResolverFactory:
     """Build a ResolverFactory bound to a specific saved-query view.
 
@@ -341,6 +357,7 @@ def bounded_resolver_factory_for_view(
             deadline_seconds=deadline_seconds,
             enforce_bounds=enforce_bounds,
             deadline_anchor=anchor,
+            source=source,
         )
 
     return factory
@@ -497,7 +514,9 @@ def get_parents_from_model_query(
             allowed_system_tables=DATA_MODELING_ALLOWED_SYSTEM_TABLES,
         )
 
-    resolver = BoundedResolver(context=context, dialect="hogql", initial_view_name=model_name)
+    resolver = BoundedResolver(
+        context=context, dialect="hogql", initial_view_name=model_name, source=RESOLUTION_SOURCE_LINEAGE
+    )
     prepared_ast = resolver.visit(hogql_query)
 
     if prepared_ast is None:

--- a/products/data_warehouse/backend/models/test/test_modeling.py
+++ b/products/data_warehouse/backend/models/test/test_modeling.py
@@ -12,6 +12,8 @@ from posthog.hogql.parser import parse_select
 from products.data_modeling.backend.facade.modeling import (
     DEFAULT_RESOLUTION_DEADLINE_SECONDS,
     DEFAULT_RESOLUTION_MAX_VIEW_DEPTH,
+    RESOLUTION_SOURCE_LINEAGE,
+    RESOLUTION_SOURCE_MATERIALIZATION,
     BoundedResolver,
     DataWarehouseModelPath,
     NodeType,
@@ -780,8 +782,15 @@ class TestBoundedResolver(BaseTest):
 
 
 class TestResolutionMetrics(BaseTest):
-    def _counter(self, status: str) -> float:
-        return REGISTRY.get_sample_value("data_modeling_dag_resolution_total", {"status": status}) or 0.0
+    def _counter(self, status: str, source: str = RESOLUTION_SOURCE_LINEAGE) -> float:
+        return (
+            REGISTRY.get_sample_value("data_modeling_dag_resolution_total", {"status": status, "source": source}) or 0.0
+        )
+
+    def _duration_count(self, source: str = RESOLUTION_SOURCE_LINEAGE) -> float:
+        return (
+            REGISTRY.get_sample_value("data_modeling_dag_resolution_duration_seconds_count", {"source": source}) or 0.0
+        )
 
     def test_ok_path_increments_counter_and_records_depth(self):
         DataWarehouseSavedQuery.objects.create(
@@ -790,15 +799,17 @@ class TestResolutionMetrics(BaseTest):
             query={"query": "select event from events"},
         )
         before_ok = self._counter("ok")
-        before_count = REGISTRY.get_sample_value("data_modeling_dag_resolution_duration_seconds_count") or 0.0
+        before_count = self._duration_count()
+        before_materialization_ok = self._counter("ok", RESOLUTION_SOURCE_MATERIALIZATION)
 
         parents = get_parents_from_model_query(self.team, "caller", "select * from leaf")
 
         assert parents == {"leaf"}
         assert self._counter("ok") - before_ok == 1.0
-        assert (
-            REGISTRY.get_sample_value("data_modeling_dag_resolution_duration_seconds_count") or 0.0
-        ) - before_count == 1.0
+        assert self._duration_count() - before_count == 1.0
+        # Lineage resolution runs on every saved-query write; materialization runs a few thousand
+        # times a day. One shared series hides the rarer one, so the label has to separate them.
+        assert self._counter("ok", RESOLUTION_SOURCE_MATERIALIZATION) - before_materialization_ok == 0.0
 
     def test_cycle_increments_cycle_status(self):
         DataWarehouseSavedQuery.objects.create(


### PR DESCRIPTION
## Problem

A materialization that fails dependency resolution is invisible on the data modeling dashboard. `data_modeling_dag_resolution_total` mixes two unrelated callers into one series, and the loud one buries the other.

- `BoundedResolver` runs once per materialization, and also once per saved-query write and per AI lineage enrichment.
- The lineage callers dominate: they run orders of magnitude more resolutions than materialization does.
- A resolution error rate panel therefore tracks lineage health and says nothing about whether models can materialize.

Separately, `data_modeling_finished` has had no emitter since the v1 workflow was retired. Two dashboard panels query it and render empty.

## Changes

- Resolution metrics carry a `source` label: `materialization` or `lineage`. A dashboard can now chart materialization failures on their own.
- `bounded_resolver_factory_for_view` labels `materialization`; `get_parents_from_model_query` labels `lineage`. Both serve real callers today.
- The label defaults to `other`, so a future caller that forgets to pass one is visible rather than silently merged into an existing bucket.
- Delete `get_data_modeling_finished_metric`. Mechanical: nothing imported it.

`source` sits on all four resolution metrics (`_total`, `_duration_seconds`, `_view_depth`, `_deadline_violations_total`) so a slice holds across the whole set.

Existing dashboard queries keep working: an unlabelled series and a `materialization` series both match `source!="lineage"`.

## How did you test this code?

- `pytest products/data_warehouse/backend/models/test/test_modeling.py` — 52 passed.
- `TestResolutionMetrics` asserts the two sources increment separate counters. That catches a regression where a new caller reuses the wrong constant and re-merges the series, which no existing test covered.
- `hogli product:lint --all` clean.
- Not checked: the emitted label in a running environment. The change is a label addition on an existing counter, verified by test only.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tools: Claude Code. Skills invoked: `/writing-pr-descriptions`, `/writing-tests`, `/writing-code-comments`. CodeRabbit CLI pass is paused, so this PR opened without a local review pass.

This fell out of an audit of the data modeling Grafana dashboard. The dashboard's resolution panels were unreadable because of the merged series, and two panels queried a dead metric. A companion dashboard PR in the grafana-dashboards repo consumes the new label.

One decision worth flagging: the second source was first named `dag_sync` after its nearest caller, then renamed `lineage` once it became clear the same function also backs AI lineage enrichment. The name describes what the resolution is for, not which module called it.

No duplicate: `gh pr list --state open --search "data_modeling_dag_resolution OR data_modeling_finished"` found nothing touching these metrics.

Public artifact: the diff carries no session material. Metric names and code paths are all in this repository.

