### PR TITLE
chore(growth): drop stale durations from product push dag docstring

### DIFF
--- a/products/growth/dags/product_push_campaigns.py
+++ b/products/growth/dags/product_push_campaigns.py
@@ -3,14 +3,14 @@
 Two sequenced phases:
 
 1. Close — evaluate every ACTIVE campaign: close as adopted when the org started
-   using the product, as skipped when the 14-day window expired without adoption.
+   using the product, as skipped when its push window expired without adoption.
 2. Start — start the next campaign for every eligible org (past the signup grace
    period, no active campaign, out of the between-campaigns cooldown, or holding a
    due dated TAM pin).
 
 The start phase depends on the collected close results so a campaign that expires
-today frees its org for cadence evaluation in the same run (the cooldown then
-keeps it quiet for 7 days).
+today frees its org for cadence evaluation in the same run (the between-campaigns
+cooldown then keeps it quiet for COOLDOWN_DAYS).
 
 All business logic lives in products/growth/backend/product_push/; this file only
 orchestrates. Rollout controls (`rollout_percentage`, `max_starts`, `dry_run`)


### PR DESCRIPTION
## Problem

Anyone reading the product push campaign job learns the wrong cadence: the module docstring promises a 14-day campaign window and a 7-day cooldown between campaigns.

- `products/growth/backend/product_push/cadence.py` sets `CAMPAIGN_DURATION_DAYS = 10` and `COOLDOWN_DAYS = 5`.
- The docstring has said 14 and 7 since the job landed in #67968, so every reader since then got both numbers wrong.

## Changes

- The docstring now says "its push window" instead of "the 14-day window".
- It names `COOLDOWN_DAYS` instead of "7 days", so a future change to the constant cannot leave the prose stale again.
- Nothing user-visible changes. The diff is four lines of one docstring.

## How did you test this code?

- No test covers a docstring, and no behavior changes, so this PR adds none.
- The pre-push preflight ran ruff lint and format over the file.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The stale text lives in the module docstring, which this PR fixes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 5) wrote the change after a person asked for the docstring fix. The drift surfaced while reading the job's run summary alongside `cadence.py`.
- Skills invoked: `/writing-code-comments`, `/writing-pr-descriptions`, `/reviewing-with-coderabbit`.
- CodeRabbit CLI pass is paused, so this PR opened without a local pass.
- No duplicate: `gh pr list --state open --search "product_push_campaigns"` returned no open PR touching this file.
- Public artifact: the diff is a docstring correction. Nothing from the session reached the code, the commit message, or this description.
- Naming the constant rather than restating its value was the one judgment call, since the numbers already drifted once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
