### PR TITLE
feat(metrics): add a minmax index on metric_series2.last_seen

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -302,7 +302,10 @@ jobs:
                     run: pnpm --filter=@posthog/nodejs format:check
 
                   - name: Lint with ESLint
-                    run: pnpm --filter=@posthog/nodejs lint
+                    # Type-aware linting holds the whole TS program in memory and sits right at
+                    # Node's default heap ceiling, so it aborts at random. Same headroom the
+                    # Jest steps in this workflow already give themselves.
+                    run: NODE_OPTIONS='--max_old_space_size=4096' pnpm --filter=@posthog/nodejs lint
 
                   # Guards the cdp/ingestion separation: fails on new lane->lane or shared->lane
                   # imports. Presence-checked so branches without the guard yet are unaffected.

--- a/posthog/clickhouse/hcl/golden/dev/logs.hcl
+++ b/posthog/clickhouse/hcl/golden/dev/logs.hcl
@@ -1252,6 +1252,11 @@ SQL
       type        = "bloom_filter(0.01)"
       granularity = 1
     }
+    index "idx_last_seen_minmax" {
+      expr        = "last_seen"
+      type        = "minmax"
+      granularity = 1
+    }
     engine "replicated_replacing_merge_tree" {
       zoo_path       = "/clickhouse/tables/noshard/posthog.metric_series2"
       replica_name   = "{replica}-{shard}"

--- a/posthog/clickhouse/hcl/golden/local-multi/logs.hcl
+++ b/posthog/clickhouse/hcl/golden/local-multi/logs.hcl
@@ -1816,6 +1816,11 @@ SQL
       type        = "bloom_filter(0.01)"
       granularity = 1
     }
+    index "idx_last_seen_minmax" {
+      expr        = "last_seen"
+      type        = "minmax"
+      granularity = 1
+    }
     engine "replicated_replacing_merge_tree" {
       zoo_path       = "/clickhouse/tables/noshard/posthog.metric_series2"
       replica_name   = "{replica}-{shard}"

--- a/posthog/clickhouse/hcl/golden/local-single/all.hcl
+++ b/posthog/clickhouse/hcl/golden/local-single/all.hcl
@@ -6685,6 +6685,11 @@ SQL
       type        = "bloom_filter(0.01)"
       granularity = 1
     }
+    index "idx_last_seen_minmax" {
+      expr        = "last_seen"
+      type        = "minmax"
+      granularity = 1
+    }
     engine "replicated_replacing_merge_tree" {
       zoo_path       = "/clickhouse/tables/noshard/posthog.metric_series2"
       replica_name   = "{replica}-{shard}"

--- a/posthog/clickhouse/hcl/golden/prod-eu/logs.hcl
+++ b/posthog/clickhouse/hcl/golden/prod-eu/logs.hcl
@@ -1402,6 +1402,11 @@ SQL
       type        = "bloom_filter(0.01)"
       granularity = 1
     }
+    index "idx_last_seen_minmax" {
+      expr        = "last_seen"
+      type        = "minmax"
+      granularity = 1
+    }
     engine "replicated_replacing_merge_tree" {
       zoo_path       = "/clickhouse/tables/noshard/posthog.metric_series2"
       replica_name   = "{replica}-{shard}"

--- a/posthog/clickhouse/hcl/golden/prod-us/logs.hcl
+++ b/posthog/clickhouse/hcl/golden/prod-us/logs.hcl
@@ -1402,6 +1402,11 @@ SQL
       type        = "bloom_filter(0.01)"
       granularity = 1
     }
+    index "idx_last_seen_minmax" {
+      expr        = "last_seen"
+      type        = "minmax"
+      granularity = 1
+    }
     engine "replicated_replacing_merge_tree" {
       zoo_path       = "/clickhouse/tables/noshard/posthog.metric_series2"
       replica_name   = "{replica}-{shard}"

--- a/posthog/clickhouse/hcl/roles/logs/metrics/tables.hcl
+++ b/posthog/clickhouse/hcl/roles/logs/metrics/tables.hcl
@@ -853,6 +853,11 @@ SQL
       type        = "bloom_filter(0.01)"
       granularity = 1
     }
+    index "idx_last_seen_minmax" {
+      expr        = "last_seen"
+      type        = "minmax"
+      granularity = 1
+    }
     engine "replicated_replacing_merge_tree" {
       zoo_path       = "/clickhouse/tables/noshard/posthog.metric_series2"
       replica_name   = "{replica}-{shard}"

--- a/posthog/clickhouse/hcl/sql/dev/logs.sql
+++ b/posthog/clickhouse/hcl/sql/dev/logs.sql
@@ -316,7 +316,8 @@ CREATE TABLE posthog.metric_series2 (
   INDEX idx_service_set service_name TYPE set(1000) GRANULARITY 1,
   INDEX idx_resource_fingerprint resource_fingerprint TYPE bloom_filter(0.01) GRANULARITY 1,
   INDEX idx_attr_keys mapKeys(attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-  INDEX idx_attr_values mapValues(attributes) TYPE bloom_filter(0.01) GRANULARITY 1
+  INDEX idx_attr_values mapValues(attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  INDEX idx_last_seen_minmax last_seen TYPE minmax GRANULARITY 1
 ) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/posthog.metric_series2', '{replica}-{shard}', last_seen) ORDER BY (team_id, metric_name, series_fingerprint) TTL original_expiry_timestamp SETTINGS index_granularity = 8192;
 CREATE TABLE posthog.metric_series_distributed (
   team_id Int32,

--- a/posthog/clickhouse/hcl/sql/local-multi/logs.sql
+++ b/posthog/clickhouse/hcl/sql/local-multi/logs.sql
@@ -429,7 +429,8 @@ CREATE TABLE posthog.metric_series2 (
   INDEX idx_service_set service_name TYPE set(1000) GRANULARITY 1,
   INDEX idx_resource_fingerprint resource_fingerprint TYPE bloom_filter(0.01) GRANULARITY 1,
   INDEX idx_attr_keys mapKeys(attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-  INDEX idx_attr_values mapValues(attributes) TYPE bloom_filter(0.01) GRANULARITY 1
+  INDEX idx_attr_values mapValues(attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  INDEX idx_last_seen_minmax last_seen TYPE minmax GRANULARITY 1
 ) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/posthog.metric_series2', '{replica}-{shard}', last_seen) ORDER BY (team_id, metric_name, series_fingerprint) TTL original_expiry_timestamp SETTINGS index_granularity = 8192;
 CREATE TABLE posthog.metric_series_distributed (
   team_id Int32,

--- a/posthog/clickhouse/hcl/sql/local-single/all.sql
+++ b/posthog/clickhouse/hcl/sql/local-single/all.sql
@@ -1320,7 +1320,8 @@ CREATE TABLE posthog.metric_series2 (
   INDEX idx_service_set service_name TYPE set(1000) GRANULARITY 1,
   INDEX idx_resource_fingerprint resource_fingerprint TYPE bloom_filter(0.01) GRANULARITY 1,
   INDEX idx_attr_keys mapKeys(attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-  INDEX idx_attr_values mapValues(attributes) TYPE bloom_filter(0.01) GRANULARITY 1
+  INDEX idx_attr_values mapValues(attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  INDEX idx_last_seen_minmax last_seen TYPE minmax GRANULARITY 1
 ) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/posthog.metric_series2', '{replica}-{shard}', last_seen) ORDER BY (team_id, metric_name, series_fingerprint) TTL original_expiry_timestamp SETTINGS index_granularity = 8192;
 CREATE TABLE posthog.metric_series_distributed (
   team_id Int32,

--- a/posthog/clickhouse/hcl/sql/prod-eu/logs.sql
+++ b/posthog/clickhouse/hcl/sql/prod-eu/logs.sql
@@ -361,7 +361,8 @@ CREATE TABLE posthog.metric_series2 (
   INDEX idx_service_set service_name TYPE set(1000) GRANULARITY 1,
   INDEX idx_resource_fingerprint resource_fingerprint TYPE bloom_filter(0.01) GRANULARITY 1,
   INDEX idx_attr_keys mapKeys(attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-  INDEX idx_attr_values mapValues(attributes) TYPE bloom_filter(0.01) GRANULARITY 1
+  INDEX idx_attr_values mapValues(attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  INDEX idx_last_seen_minmax last_seen TYPE minmax GRANULARITY 1
 ) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/posthog.metric_series2', '{replica}-{shard}', last_seen) ORDER BY (team_id, metric_name, series_fingerprint) TTL original_expiry_timestamp SETTINGS index_granularity = 8192;
 CREATE TABLE posthog.metric_series_distributed (
   team_id Int32,

--- a/posthog/clickhouse/hcl/sql/prod-us/logs.sql
+++ b/posthog/clickhouse/hcl/sql/prod-us/logs.sql
@@ -361,7 +361,8 @@ CREATE TABLE posthog.metric_series2 (
   INDEX idx_service_set service_name TYPE set(1000) GRANULARITY 1,
   INDEX idx_resource_fingerprint resource_fingerprint TYPE bloom_filter(0.01) GRANULARITY 1,
   INDEX idx_attr_keys mapKeys(attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-  INDEX idx_attr_values mapValues(attributes) TYPE bloom_filter(0.01) GRANULARITY 1
+  INDEX idx_attr_values mapValues(attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  INDEX idx_last_seen_minmax last_seen TYPE minmax GRANULARITY 1
 ) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/posthog.metric_series2', '{replica}-{shard}', last_seen) ORDER BY (team_id, metric_name, series_fingerprint) TTL original_expiry_timestamp SETTINGS index_granularity = 8192;
 CREATE TABLE posthog.metric_series_distributed (
   team_id Int32,

--- a/posthog/clickhouse/metrics/metrics2.py
+++ b/posthog/clickhouse/metrics/metrics2.py
@@ -192,7 +192,8 @@ CREATE TABLE IF NOT EXISTS {_db()}.{METRIC_SERIES2_TABLE_NAME}
     INDEX idx_service_set service_name TYPE set(1000) GRANULARITY 1,
     INDEX idx_resource_fingerprint resource_fingerprint TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_attr_keys mapKeys(attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-    INDEX idx_attr_values mapValues(attributes) TYPE bloom_filter(0.01) GRANULARITY 1
+    INDEX idx_attr_values mapValues(attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_last_seen_minmax last_seen TYPE minmax GRANULARITY 1
 )
 ENGINE = {ReplacingMergeTree(METRIC_SERIES2_TABLE_NAME, replication_scheme=ReplicationScheme.REPLICATED, ver="last_seen")}
 ORDER BY (team_id, metric_name, series_fingerprint)
@@ -343,6 +344,17 @@ def METRICS2_DROP_SERIES_MINUTE_PROJECTION_SQL() -> str:
 
 def METRICS2_DROP_UUID_COLUMN_SQL() -> str:
     return f"ALTER TABLE {_db()}.{METRICS2_TABLE_NAME} DROP COLUMN IF EXISTS uuid"
+
+
+def METRIC_SERIES2_ADD_LAST_SEEN_INDEX_SQL() -> str:
+    return (
+        f"ALTER TABLE {_db()}.{METRIC_SERIES2_TABLE_NAME} "
+        "ADD INDEX IF NOT EXISTS idx_last_seen_minmax last_seen TYPE minmax GRANULARITY 1"
+    )
+
+
+def METRIC_SERIES2_MATERIALIZE_LAST_SEEN_INDEX_SQL() -> str:
+    return f"ALTER TABLE {_db()}.{METRIC_SERIES2_TABLE_NAME} MATERIALIZE INDEX IF EXISTS idx_last_seen_minmax"
 
 
 def METRICS_DISTRIBUTED_DROP_UUID_COLUMN_SQL() -> str:

--- a/posthog/clickhouse/migrations/0320_metric_series2_last_seen_index.py
+++ b/posthog/clickhouse/migrations/0320_metric_series2_last_seen_index.py
@@ -1,0 +1,29 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.clickhouse.metrics.metrics2 import (
+    METRIC_SERIES2_ADD_LAST_SEEN_INDEX_SQL,
+    METRIC_SERIES2_MATERIALIZE_LAST_SEEN_INDEX_SQL,
+)
+
+# The overview and the names picker filter `metric_series2` on `last_seen`, which is not in
+# the sort key, so every load scans the team's whole series table. Rows land in parts by
+# insert time, so a part's `last_seen` range tracks its age and a minmax index lets a
+# one-day window skip the old parts that hold most of the rows.
+#
+# MATERIALIZE is what makes that true for the parts that already exist; without it only
+# parts written after the ADD carry the index, and those are the small recent ones a
+# window would read anyway.
+operations = [
+    run_sql_with_exceptions(
+        METRIC_SERIES2_ADD_LAST_SEEN_INDEX_SQL(),
+        node_roles=[NodeRole.LOGS],
+        sharded=False,
+        is_alter_on_replicated_table=True,
+    ),
+    run_sql_with_exceptions(
+        METRIC_SERIES2_MATERIALIZE_LAST_SEEN_INDEX_SQL(),
+        node_roles=[NodeRole.LOGS],
+        sharded=False,
+        is_alter_on_replicated_table=True,
+    ),
+]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0319_add_data_deletion_request_id_to_adhoc_events_deletion
+0320_metric_series2_last_seen_index

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -4209,7 +4209,8 @@
       INDEX idx_service_set service_name TYPE set(1000) GRANULARITY 1,
       INDEX idx_resource_fingerprint resource_fingerprint TYPE bloom_filter(0.01) GRANULARITY 1,
       INDEX idx_attr_keys mapKeys(attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-      INDEX idx_attr_values mapValues(attributes) TYPE bloom_filter(0.01) GRANULARITY 1
+      INDEX idx_attr_values mapValues(attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+      INDEX idx_last_seen_minmax last_seen TYPE minmax GRANULARITY 1
   )
   ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_noshard/posthog.metric_series2', '{replica}-{shard}', last_seen)
   ORDER BY (team_id, metric_name, series_fingerprint)
@@ -11364,7 +11365,8 @@
       INDEX idx_service_set service_name TYPE set(1000) GRANULARITY 1,
       INDEX idx_resource_fingerprint resource_fingerprint TYPE bloom_filter(0.01) GRANULARITY 1,
       INDEX idx_attr_keys mapKeys(attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-      INDEX idx_attr_values mapValues(attributes) TYPE bloom_filter(0.01) GRANULARITY 1
+      INDEX idx_attr_values mapValues(attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+      INDEX idx_last_seen_minmax last_seen TYPE minmax GRANULARITY 1
   )
   ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_noshard/posthog.metric_series2', '{replica}-{shard}', last_seen)
   ORDER BY (team_id, metric_name, series_fingerprint)


### PR DESCRIPTION
## Problem

The metrics overview and the metric names picker filter `metric_series2` on `last_seen`, which is not in the table's sort key. Every load scans the team's whole series table. On the largest teams that is hundreds of millions of rows for a one-day window, and the scan doubled when reads moved to the metrics2 tables because the new series table holds more unmerged duplicate rows per series.

## Changes

- `metric_series2` gets `INDEX idx_last_seen_minmax last_seen TYPE minmax GRANULARITY 1`, declared in the HCL layer and in the Python DDL, with a migration that adds and materializes it on the logs cluster.
- Mechanical: regenerated `golden/` and `sql/` for every environment, and the schema snapshot.

Why this index: series rows land in parts by insert time, so a part's `last_seen` range tracks its age. On production a one-day window's rows sit in a handful of small recent parts, and the old parts that never touch the window hold most of the rows. A minmax index lets ClickHouse skip those parts without any change to the sort order. The projection on `metrics2` was measured as an alternative and rejected: its sort order puts the hour last, so a time filter reads the whole projection.

`MATERIALIZE INDEX` is the part that makes this apply to existing parts. It is a background mutation over one `DateTime64` column.

No query changes here. The overview totals query still filters inside its aggregates and needs a follow-up to move the window into `WHERE` before it benefits; the services and names queries already filter on `last_seen` in `WHERE` and benefit as soon as the index is materialized.

## How did you test this code?

- `posthog/clickhouse/hcl/check.sh` passes: every node matches its golden, `sql/` is fresh.
- `posthog/clickhouse/test/test_migrations.py` passes. `test_schema.py` snapshots pass; its five `test_person_property_mutation_projection` failures also fail on `master` in this environment and are unrelated.
- Applied locally with `migrate_clickhouse`; `system.data_skipping_indices` shows the index on `metric_series2`.
- Measured on production before writing the migration: on the largest team, the parts that hold rows from the last day contain about a tenth of the table's rows; the rest sit in six old parts the index can skip.
- Not checked: the materialization time on production. It reads one column of the series table.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (PostHog Desktop). Skills invoked: `/clickhouse-migrations`, `/writing-pr-descriptions`. The migration was generated with `hcl/codegen/gen_migration.py --auto` from the HCL edit and then rewritten to route the database name through `_db()` like the neighbouring metrics2 migration, and to add `IF NOT EXISTS` / `IF EXISTS`. Kept migration-only per the ClickHouse migration rules; the query-side changes are in a separate PR.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
