### PR TITLE
fix(warehouse-sources): never create a table on a zero-row run

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/load.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/load.py
@@ -8,7 +8,6 @@ import pyarrow.compute as pc
 import posthoganalytics
 from structlog.types import FilteringBoundLogger
 
-from posthog.dataclasses import frozen
 from posthog.exceptions_capture import capture_exception
 from posthog.sync import database_sync_to_async_pool
 from posthog.temporal.common.logger import get_logger
@@ -302,12 +301,6 @@ async def _run_delta_maintenance(
                 logger.exception(f"Compaction failed: {e}", exc_info=e)
 
 
-@frozen
-class PublishedFiles:
-    folder: str
-    file_count: int
-
-
 async def _publish_queryable_files(
     job: ExternalDataJob,
     schema: ExternalDataSchema,
@@ -315,7 +308,7 @@ async def _publish_queryable_files(
     resource_name: str,
     is_cdc_companion: bool,
     logger: FilteringBoundLogger,
-) -> PublishedFiles:
+) -> str:
     from products.warehouse_sources.backend.temporal.data_imports.pipelines.helpers import build_table_name
 
     if is_cdc_companion:
@@ -357,7 +350,7 @@ async def _publish_queryable_files(
             logger=logger,
             refresh_file_uris=delta_table_ref.get_file_uris,
         )
-    return PublishedFiles(folder=folder, file_count=len(file_uris))
+    return folder
 
 
 async def _finalize_sync_bookkeeping(
@@ -389,7 +382,7 @@ async def _register_table(
     row_count: int,
     table_schema_dict: dict[str, str],
     resource: "Optional[SourceResponse]",
-    published: PublishedFiles,
+    queryable_folder: str,
     logger: FilteringBoundLogger,
 ) -> None:
     from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_sync import (
@@ -404,10 +397,9 @@ async def _register_table(
             schema_id=schema.id,
             table_schema_dict=table_schema_dict,
             row_count=row_count,
-            queryable_folder=published.folder,
+            queryable_folder=queryable_folder,
             table_format=DataWarehouseTable.TableFormat.DeltaS3Wrapper,
             primary_keys=resource.primary_keys if resource is not None else None,
-            published_file_count=published.file_count,
         )
     logger.debug("Finished validating schema and updating table")
 
@@ -669,8 +661,9 @@ async def run_post_load_operations(
 
     await _run_delta_maintenance(schema, delta_table_ref, is_cdc_companion, logger)
 
-    published = await _publish_queryable_files(job, schema, delta_table_ref, resource_name, is_cdc_companion, logger)
-    queryable_folder = published.folder
+    queryable_folder = await _publish_queryable_files(
+        job, schema, delta_table_ref, resource_name, is_cdc_companion, logger
+    )
 
     await _finalize_sync_bookkeeping(job, schema, resource, last_incremental_field_value, logger)
 
@@ -680,7 +673,7 @@ async def run_post_load_operations(
     is_cdc_only_initial = cdc_write_mode is None and is_cdc_schema and schema.cdc_table_mode == "cdc_only"
 
     if not is_cdc_companion and not is_cdc_only_initial:
-        await _register_table(job, schema, row_count, table_schema_dict, resource, published, logger)
+        await _register_table(job, schema, row_count, table_schema_dict, resource, queryable_folder, logger)
 
     if is_cdc_companion or is_cdc_schema:
         await _run_cdc_post_load(

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_load.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_load.py
@@ -15,7 +15,6 @@ from products.warehouse_sources.backend.models.external_data_schema import Exter
 from products.warehouse_sources.backend.temporal.data_imports.external_data_job import Any_Source_Errors
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.common.load import (
     IncrementalFieldMissingFromDataError,
-    PublishedFiles,
     get_incremental_field_value,
     notify_revenue_analytics_that_sync_has_completed,
     run_post_load_operations,
@@ -274,7 +273,7 @@ class TestZeroRowSkip:
         job.created_at = _JOB_CREATED_AT
 
         maintenance = AsyncMock()
-        publish = AsyncMock(return_value=PublishedFiles(folder="folder", file_count=1))
+        publish = AsyncMock(return_value="folder")
         bookkeeping = AsyncMock()
         post_load_step = AsyncMock()
         with (

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_sync.py
@@ -186,7 +186,6 @@ async def validate_schema_and_update_table(
     queryable_folder: str,
     table_schema_dict: Optional[dict[str, str]] = None,
     primary_keys: Optional[list[str]] = None,
-    published_file_count: Optional[int] = None,
 ) -> None:
     """
     Async version of validate_schema_and_update_table_sync.
@@ -201,7 +200,6 @@ async def validate_schema_and_update_table(
         row_count: The count of synced rows
         table_format: The format of the table
         table_schema_dict: The schema of the table
-        published_file_count: Files the publish step just made queryable, when the caller knows.
     """
     logger = LOGGER.bind(team_id=team_id)
 
@@ -263,7 +261,7 @@ async def validate_schema_and_update_table(
             # A reported row_count of 0 does not always mean the run wrote nothing: the v3 consumer
             # can read 0 on a redelivered final batch, and a resumed run counts only its own attempt.
             # A publish step with nothing to make queryable is what an empty first sync looks like.
-            if row_count == 0 and table_created is None and not published_file_count:
+            if row_count == 0 and table_created is None:
                 logger.warning("Skipping table creation: row_count is 0 and no table exists yet")
                 return
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v2/pipeline.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v2/pipeline.py
@@ -446,7 +446,6 @@ class PipelineNonDLT(Generic[ResumableData]):
             row_count=row_count,
             queryable_folder=queryable_folder,
             table_format=DataWarehouseTable.TableFormat.DeltaS3Wrapper,
-            published_file_count=len(new_file_uris),
         )
 
     async def _post_run_operations(self, row_count: int) -> str | None:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
@@ -394,7 +394,6 @@ async def _handle_partial_data_loading(
         queryable_folder=queryable_folder,
         table_format=DataWarehouseTable.TableFormat.DeltaS3Wrapper,
         primary_keys=export_signal.primary_keys,
-        published_file_count=len(new_file_uris),
     )
 
     logger.debug(

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/test_pipeline_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/test_pipeline_sync.py
@@ -404,12 +404,10 @@ class TestValidateSchemaAndUpdateTable:
         # A reported 0 must not zero a table that was just republished.
         assert table.row_count == 150
 
-    # Published files at zero rows mean a resumed or redelivered run counted only its own attempt.
-    # Trusting row_count there left the data in S3 with no table to query it through.
-    @pytest.mark.parametrize("published_file_count,expect_table", [(0, False), (18, True)])
-    def test_zero_row_sync_creates_a_table_only_when_files_were_published(
-        self, team, published_file_count: int, expect_table: bool
-    ):
+    def test_zero_row_sync_creates_no_table(self, team):
+        # The publish step republishes the whole delta table every run, so files being queryable
+        # says nothing about this run writing any. A table born here has no column types to take -
+        # the run wrote no arrow batches - and registers empty, which reads as data loss.
         schema, job = self._schema_and_job(team)
         assert schema.table is None
 
@@ -424,18 +422,11 @@ class TestValidateSchemaAndUpdateTable:
                 row_count=0,
                 table_format=DataWarehouseTableFormat.DeltaS3Wrapper,
                 queryable_folder="s3://bucket/orders",
-                published_file_count=published_file_count,
             )
 
         schema.refresh_from_db()
-        tables = DataWarehouseTable.objects.filter(external_data_source=schema.source, deleted=False)
-        if not expect_table:
-            assert schema.table is None
-            assert not tables.exists()
-        else:
-            assert schema.table_id == tables.get().id
-            # A reported 0 must not register a table full of published files as empty.
-            assert tables.get().row_count == 150
+        assert schema.table is None
+        assert not DataWarehouseTable.objects.filter(external_data_source=schema.source, deleted=False).exists()
 
     def test_relinks_a_table_an_earlier_run_left_unlinked(self, team):
         # An orphan must be adopted and repointed, not left unlinked and not duplicated.
@@ -454,7 +445,6 @@ class TestValidateSchemaAndUpdateTable:
                 row_count=0,
                 table_format=DataWarehouseTableFormat.DeltaS3Wrapper,
                 queryable_folder="s3://bucket/orders_v2",
-                published_file_count=18,
             )
 
         schema.refresh_from_db()
@@ -483,10 +473,9 @@ class TestValidateSchemaAndUpdateTable:
                 run_id=str(sibling_job.id),
                 team_id=team.pk,
                 schema_id=sibling.id,
-                row_count=0,
+                row_count=10,
                 table_format=DataWarehouseTableFormat.DeltaS3Wrapper,
                 queryable_folder="s3://bucket/orders_v2",
-                published_file_count=18,
             )
 
         owner.refresh_from_db()


### PR DESCRIPTION
## Problem

- A customer opens a table the source page reports as synced, with a row count on it, and every query returns nothing. The table has no columns.
- Column types come from the arrow batches a run writes. A run that writes none carries no types, so `merge_columns` drops every column and a table created there registers empty.
- #98676 creates that table. Its guard skips registration only when no files were published, on the understanding that published files meant the run had written some.
- They do not. The publish step republishes the whole delta table every run, so the count says the table is not empty, never that this run added to it. A quiet run over files that already existed creates a table it cannot describe.

## Changes

- A run that writes no rows no longer creates a table, so no table is registered without columns.
- The published file count, the parameter carrying it, both caller arguments and the `PublishedFiles` dataclass go with it. The dataclass existed only to carry that count, so publishing returns the folder again.
- Adopting an orphan is untouched and still runs above the guard, so a quiet run relinks a table an earlier run left unlinked.
- A schema whose files exist but whose table does not now waits for a run that writes rows. That state comes from something else going wrong, not from normal operation.

## How did you test this code?

- `test_zero_row_sync_creates_a_table_only_when_files_were_published` asserted the behavior this PR removes, so it becomes `test_zero_row_sync_creates_no_table`. It pins the case a published folder used to let through.
- The relink test keeps `row_count=0` and still passes, which is the guard against this PR reaching too far: adoption sits above the guard and has to survive it.
- The collision test moves to `row_count=10`. It exists to prove a schema never adopts a table a sibling owns, and that guarantee should not rest on a create path being removed.
- Ran `test_pipeline_sync.py` and `common/test/test_load.py` against an isolated Postgres database with a local Temporal server.
- Not checked: no run against a real source, and no verification in a deployed environment.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 5) in PostHog Desktop, directed by @danielcarletti.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- The CodeRabbit local pass is paused, so this PR opened without one.
- No duplicate: no open PR touches this guard. #99228 proposed typing such a table from ClickHouse introspection instead and was closed in favour of this.
- Found while investigating a support report of a synced table returning nothing, then confirmed against the failing schema's own run logs. Nothing from that session reaches the diff.
- The rejected alternative was to keep creating the table and take its column types from `get_columns()`, which ClickHouse already derives. That repairs the symptom and leaves the case in place; a table nobody can describe should not exist.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
