### PR TITLE
fix(warehouse-sources): stop retrying Convex document deltas cursor conflicts

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/convex/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/convex/source.py
@@ -127,6 +127,16 @@ You can find your deployment URL and deploy key in your [Convex Dashboard](https
                 "turn off syncing for this table, then re-enable the sync."
             ),
             "StreamingExportNotEnabled": "Streaming export requires the Convex Professional plan. See https://www.convex.dev/plans to upgrade.",
+            # Convex treats a document_deltas/list_snapshot cursor conflict as deterministic, not
+            # transient (it's one of the few codes their own backend classifies as a user error
+            # rather than retryable). It surfaces when a data import or backup restore on the
+            # deployment invalidates the cursor's position in the document log, so every retry
+            # replays the same request against the same now-invalid cursor.
+            "409 Client Error": (
+                "PostHog's sync position for this table no longer matches your Convex deployment. "
+                "This can happen after a data import or backup restore. Trigger a full resync of "
+                "this source to continue syncing."
+            ),
             # Match a stable substring of the raised message, not the `InvalidWindowError` class name:
             # the non-retryable check compares against `str(exception)`, which contains the message
             # but not the class name. The table name in the message is volatile, so it's excluded.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/convex/tests/test_convex.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/convex/tests/test_convex.py
@@ -565,6 +565,11 @@ class TestConvexNonRetryableErrors:
                 "https://x.convex.cloud/api/list_snapshot?tableName=verification&format=json&component=betterAuth",
             ),
             (
+                "cursor_conflict_409",
+                "409 Client Error: Conflict for url: "
+                "https://x.convex.cloud/api/document_deltas?tableName=users&cursor=123&format=json",
+            ),
+            (
                 "invalid_window",
                 "Delta cursor for table 'events' is older than Convex's ~30 day retention window. "
                 "Please trigger a full resync of this source.",
@@ -627,6 +632,7 @@ class TestConvexRetryableErrors:
         [
             ("401", "401 Client Error: Unauthorized for url: https://x.convex.cloud/api/document_deltas"),
             ("403", "403 Client Error: Forbidden for url: https://x.convex.cloud/api/document_deltas"),
+            ("409", "409 Client Error: Conflict for url: https://x.convex.cloud/api/document_deltas"),
             (
                 "invalid_window",
                 "Delta cursor for table 'events' is older than Convex's ~30 day retention window. "


### PR DESCRIPTION
## Problem

A Convex data-warehouse sync fails and keeps retrying identically when the deployment's document_deltas cursor conflicts with the current data. This is reported by [error tracking](https://us.posthog.com/project/2/error_tracking/01a090e9-854a-76b0-9dad-05a4d2faf20c) as an `HTTPError: 409 Client Error: Conflict`, raised from `document_deltas` in `products/warehouse_sources/backend/temporal/data_imports/sources/convex/convex.py`.

Convex returns this 409 when a data import or backup restore on the customer's deployment invalidates the position the sync was reading from. Convex's own backend classifies a Conflict response as deterministic, not transient, so every retry replays the same cursor against the same now-invalid position and fails again.

## Changes

- Add a `"409 Client Error"` entry to `ConvexSource.get_non_retryable_errors`, mirroring the existing 401/403/404 entries, so the sync stops instead of exhausting Temporal's retry budget and tells the customer to trigger a full resync.

## How did you test this code?

- Added `"cursor_conflict_409"` to `TestConvexNonRetryableErrors.test_known_errors_match` and a `"409"` case to `TestConvexRetryableErrors.test_non_retryable_errors_do_not_match`, asserting the new entry is recognised as non-retryable and doesn't collide with the retryable set.
- Ran `products/warehouse_sources/backend/temporal/data_imports/sources/convex/tests/test_convex.py` locally: 84 passed.
- Not run: an end-to-end sync against a real Convex deployment (no test credentials in this environment).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook for a single, first-time occurrence of this error. Investigated the Convex open-source backend (`get-convex/convex-backend`) to confirm 409 maps to Convex's `ErrorCode::Conflict`, which its own error model marks as a deterministic user error, and cross-referenced Convex's streaming-export docs noting that a data import or restore requires resetting the export sync. No open PR (automated or hand-written) already addresses this error. No skills required invocation for this change (no DRF/migration/frontend/dataclass surface touched); `/writing-user-facing-copy` was consulted for the new customer-facing message text.