### PR TITLE
fix(insights): respect hidden descriptions in exports

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.test.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.test.tsx
@@ -72,11 +72,11 @@ describe('InsightMeta', () => {
         })
     })
 
-    it('always shows description in non-compact mode regardless of showDescription', () => {
+    it('hides description in non-compact mode when showDescription is false', () => {
         const { container } = render(
             <InsightMetaContent title="Test" description={description} compact={false} showDescription={false} />
         )
-        expect(container.querySelector('.CardMeta__description')).toBeInTheDocument()
+        expect(container.querySelector('.CardMeta__description')).toBeNull()
     })
 
     describe('tile.show_description default-to-show mapping', () => {

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -843,7 +843,7 @@ export function InsightMetaContent({
     return (
         <>
             {titleEl}
-            {(!compact || showDescription) && !!description && (
+            {showDescription !== false && !!description && (
                 <LemonMarkdown className="CardMeta__description" lowKeyHeadings>
                     {description}
                 </LemonMarkdown>


### PR DESCRIPTION
## Problem

- Dashboard exports show an insight description that the dashboard owner hid.

## Changes

- Dashboard exports now respect each tile's description visibility setting.
- Other insight layouts keep their current behavior when no setting hides the description.
- Screenshot: Not included. The focused component test verifies the rendered export condition.

## How did you test this code?

- The InsightMeta Jest test covers the non-compact export layout where a hidden description previously appeared.
- The frontend formatter and TypeScript check pass.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No docs update. This fixes existing dashboard export behavior.

## 🤖 Agent context

- **Autonomy:** Human-driven (agent-assisted)
- Agent tools and skills: PostHog product search, `/writing-tests`, and `/writing-pr-descriptions`.
- Duplicate search found no related open PR or issue.
- The PR contains no customer material.
- CodeRabbit local pass is paused.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*