### PR TITLE
fix(warehouse-sources): stop sending limit on Metronome usage requests

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/metronome/metronome.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/metronome/metronome.py
@@ -255,7 +255,9 @@ def _rest_client(api_key: str) -> RESTClient:
 
 
 def _list_params(config: MetronomeEndpointConfig) -> dict[str, Any]:
-    params: dict[str, Any] = {} if not config.paginated else {"limit": config.page_size}
+    params: dict[str, Any] = {}
+    if config.paginated and config.accepts_page_size:
+        params["limit"] = config.page_size
     params.update(config.extra_params)
     return params
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/metronome/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/metronome/settings.py
@@ -11,7 +11,7 @@ from products.warehouse_sources.backend.types import IncrementalField
 
 METRONOME_BASE_URL = "https://api.metronome.com"
 
-# Every paginated Metronome list endpoint caps `limit` at 100.
+# Metronome caps `limit` at 100 on every list endpoint that accepts it.
 PAGE_SIZE = 100
 
 # List responses share a `{"data": [...], "next_page": "..."}` envelope, and the cursor goes back
@@ -63,12 +63,17 @@ class MetronomeEndpointConfig:
     path: str
     primary_key: list[str]
     method: Literal["get", "post"] = "get"
-    # Filter payload for the POST list endpoints. `limit` and `next_page` stay in the query string
-    # on these; only the filters move into the body.
+    # Filter payload for the POST list endpoints. Only the filters move into the body, and
+    # `next_page` stays in the query string. See `accepts_page_size` for whether `limit` joins it.
     json_body: dict[str, Any] = field(default_factory=dict)
     extra_params: dict[str, Any] = field(default_factory=dict)
     # Endpoints whose response carries a `next_page` cursor; the rest return the whole collection.
     paginated: bool = True
+    # Whether the endpoint takes a `limit` page-size parameter. `POST /v1/usage` follows
+    # `next_page` but rejects `limit`, and answers the whole request with a 400 when it is
+    # present. Following the cursor and setting a page size are separate capabilities, so
+    # `paginated` must not decide both.
+    accepts_page_size: bool = True
     # Server-side lower bound for incremental syncs. Metronome rejects this window when a cursor
     # is also sent, so it only rides the first request of a run.
     incremental_start_param: str | None = None
@@ -182,6 +187,7 @@ METRONOME_ENDPOINTS: dict[str, MetronomeEndpointConfig] = {
         method="post",
         # One aggregate per customer and billable metric — the endpoint carries no row id.
         primary_key=["customer_id", "billable_metric_id"],
+        accepts_page_size=False,
         # `none` returns a single lifetime aggregate per customer/metric over the requested window,
         # which starts at the epoch, so the row count stays bounded by the account. The two tables
         # below carry the same usage split into periods, over a window bounded per table.
@@ -197,6 +203,7 @@ METRONOME_ENDPOINTS: dict[str, MetronomeEndpointConfig] = {
         # lifetime table identifies a row by.
         primary_key=["customer_id", "billable_metric_id", "start_timestamp"],
         partition_key="start_timestamp",
+        accepts_page_size=False,
         window_size="day",
         incremental_fields=[incremental_field("start_timestamp")],
         default_incremental_field="start_timestamp",
@@ -210,6 +217,7 @@ METRONOME_ENDPOINTS: dict[str, MetronomeEndpointConfig] = {
         method="post",
         primary_key=["customer_id", "billable_metric_id", "start_timestamp"],
         partition_key="start_timestamp",
+        accepts_page_size=False,
         window_size="hour",
         incremental_fields=[incremental_field("start_timestamp")],
         default_incremental_field="start_timestamp",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/metronome/tests/test_metronome.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/metronome/tests/test_metronome.py
@@ -150,6 +150,19 @@ class TestMetronomeResources:
         assert resource["endpoint"]["json"] == expected_body
         assert resource["endpoint"]["params"] == {"limit": 100}
 
+    @parameterized.expand([("usage",), ("usage_daily",), ("usage_hourly",)])
+    def test_usage_endpoints_page_by_cursor_and_send_no_page_size(self, endpoint) -> None:
+        # `POST /v1/usage` takes `next_page` in the query string but accepts no `limit`, and it
+        # rejects the whole request when `limit` is present. Answering that by dropping the cursor
+        # instead of the page size would import the first page and report success.
+        resource = cast(
+            dict[str, Any],
+            get_resource(endpoint, should_use_incremental_field=False, window_starting_on=EPOCH_RFC_3339),
+        )
+
+        assert resource["endpoint"]["params"] == {}
+        assert isinstance(resource["endpoint"]["paginator"], MetronomeCursorPaginator)
+
     @parameterized.expand([("invoices",), ("contracts",)])
     def test_get_resource_rejects_fanout_endpoints(self, endpoint) -> None:
         with pytest.raises(ValueError, match="Fan-out endpoint"):


### PR DESCRIPTION
## Problem

Every Metronome source that enables usage gets three permanently broken tables: `usage`, `usage_daily` and `usage_hourly` fail on every run, while the account's other tables sync normally.

- Metronome's `POST /v1/usage` follows a `next_page` cursor but accepts no `limit` parameter, and rejects the whole request with a 400 when one is present.
- `MetronomeEndpointConfig` expressed both capabilities through the single `paginated` flag, so `_list_params` put `limit=100` on every endpoint that follows a cursor.
- All three usage endpoints take that default, which is why they fail together.

The failure is deterministic and account-independent, so it reaches every source that enables these tables, and there is no workaround.

## Changes

- The three usage tables sync again. Their requests carry no `limit`, and they still follow `next_page` to the end of the collection.
- `accepts_page_size` is a new per-endpoint flag that decides whether `limit` rides the query string. `paginated` keeps its single meaning: the response carries a cursor.
- The three usage endpoints set `accepts_page_size=False`. Every other endpoint keeps the default and is unchanged.
- Two comments that asserted `limit` rides every POST list endpoint now say what varies. That claim is what made the bug reachable.

Clearing `paginated` instead is the tempting one-line fix, and it is worse. It drops `limit`, but it also swaps the cursor paginator for `SinglePagePaginator`, so the sync would import the first page and report success. A silent partial import beats a loud failure only until someone trusts the numbers.

Three independent readings of the vendor contract agree that the two capabilities are separate here:

| Source | What it shows |
| --- | --- |
| [Endpoint reference](https://docs.metronome.com/api-reference/usage/get-batched-usage-data) | `next_page` is the only query parameter; no `limit` |
| Generated Python SDK | `list()` sends `query={"next_page": ...}`, page type `SyncCursorPageWithoutLimit` |
| Generated Node SDK | `const { next_page, ...body } = params` into `query: { next_page }`, page type `CursorPageWithoutLimit` |

The sibling `POST /v1/usage/groups` is the control. It is generated from the same spec, in the same SDK file, and it does send `query={"limit": ..., "next_page": ...}`. So the absence of `limit` on `/v1/usage` is the documented contract rather than an omission.

> [!NOTE]
> `window_size` was a second suspect, because both SDKs type it as `'HOUR' | 'DAY' | 'NONE'` while this source sends lowercase. The spec's own enum lists all three casings (`hour`, `day`, `none`, `HOUR`, `DAY`, `NONE`, `Hour`, `Day`, `None`); the SDK generator collapses case-variant members to one canonical form. The narrow SDK type is a generator artifact, not a server constraint, so the lowercase values stay.

No user-visible surface changes, so there is nothing to screenshot.

## How did you test this code?

`test_usage_endpoints_page_by_cursor_and_send_no_page_size` covers the three usage endpoints and catches both failure modes. Against the current code it fails on `{'limit': 100}`. With `paginated=False` substituted for the new flag it fails on `SinglePagePaginator`. Both were run and observed. No existing test asserted anything about the usage endpoints' query parameters.

Not run: nothing was exercised against the live Metronome API, which needs an account API token. The first scheduled sync after deploy is the real confirmation.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior is documented differently; the tables were simply failing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code (Opus 5). Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, `/writing-user-facing-copy`.
- CodeRabbit CLI pass: paused, so this PR opened without a local pass.
- No duplicate: `gh pr list --state open --search "metronome"` returns only #98080, which splits plan-gated 403s from credential failures and does not touch pagination.
- Public artifact: the bug arrived through a support ticket. Nothing from that conversation appears in the code, tests, comments, commit message or this description. The vendor behavior cited here comes from Metronome's public API reference and public SDKs.
- The first design widened `page_size` to `int | None`. That breaks `FanoutEndpointLike`, whose `page_size` is also a row-chunk size for warehouse parents, so a separate boolean is the right shape.
- The `window_size` casing was re-checked against the spec enum after the first pass cited only the SDK types, which conflict with it.
