### PR TITLE
fix(signals): restore native command-click on inbox reports

### DIFF
--- a/docs/internal/inbox-report-selection.md
+++ b/docs/internal/inbox-report-selection.md
@@ -3,7 +3,8 @@
 Report cards on the self-driving inbox Reports page do not show selection checkboxes, including on hover or when selected.
 Selected cards keep their accent outline.
 
-Use Cmd+click on macOS or Ctrl+click to select or deselect a report.
+Cmd+click on macOS and Ctrl+click keep the browser's standard link behavior instead of changing the selection.
+This also applies when reports are selected or a bulk action runs.
 Use Shift+click to select a range of reports.
 Press and hold also selects a report.
 Once a selection exists, a plain click selects or deselects a report instead of opening it.

--- a/products/signals/frontend/inbox/components/cards/ReportCard.test.tsx
+++ b/products/signals/frontend/inbox/components/cards/ReportCard.test.tsx
@@ -84,15 +84,27 @@ describe('ReportCard', () => {
         expect(logic.values.selectedReportIds).toEqual([])
     })
 
-    it('selects on cmd-click instead of opening the report', () => {
-        fireEvent.click(cardLink(), { metaKey: true })
+    test.each([
+        ['cmd-click', { metaKey: true }],
+        ['ctrl-click', { ctrlKey: true }],
+        ['cmd-shift-click', { metaKey: true, shiftKey: true }],
+        ['ctrl-shift-click', { ctrlKey: true, shiftKey: true }],
+    ])('leaves %s to the browser with or without a selection', (_name, modifiers) => {
+        expect(fireEvent.click(cardLink(), modifiers)).toBe(true)
+        expect(openedReport()).toBe(false)
+        expect(logic.values.selectedReportIds).toEqual([])
+        expect(lastSelectionEntry()).toBeUndefined()
 
+        act(() => logic.actions.setSelectedReportIds(['r-1']))
+
+        expect(fireEvent.click(cardLink(), modifiers)).toBe(true)
         expect(openedReport()).toBe(false)
         expect(logic.values.selectedReportIds).toEqual(['r-1'])
+        expect(lastSelectionEntry()).toBeUndefined()
     })
 
     it('toggles on a plain click once the list is in selection mode', () => {
-        fireEvent.click(cardLink(), { metaKey: true })
+        act(() => logic.actions.setSelectedReportIds(['r-1']))
         fireEvent.click(cardLink())
 
         expect(openedReport()).toBe(false)
@@ -120,17 +132,14 @@ describe('ReportCard', () => {
         expect(logic.values.selectedReportIds).toEqual([])
     })
 
-    test.each([
-        ['cmd-click', { metaKey: true }, 'meta_click'],
-        ['shift-click', { shiftKey: true }, 'shift_click'],
-    ])('records the entry method when a %s starts the selection', (_name, modifiers, entryMethod) => {
+    it('records the entry method when a shift-click starts the selection', () => {
         // The rendered order, which a shift-range measures itself against.
         logic.actions.setVisibleReportIds(['r-1'])
 
-        fireEvent.click(cardLink(), modifiers)
+        fireEvent.click(cardLink(), { shiftKey: true })
 
         expect(logic.values.selectedReportIds).toEqual(['r-1'])
-        expect(lastSelectionEntry()).toMatchObject({ entry_method: entryMethod })
+        expect(lastSelectionEntry()).toMatchObject({ entry_method: 'shift_click' })
     })
 
     it('leaves a cmd-click on the nested scout link to the browser', () => {
@@ -158,7 +167,7 @@ describe('ReportCard', () => {
         fireEvent.mouseEnter(cardLink())
         expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
 
-        fireEvent.click(cardLink(), { metaKey: true })
+        act(() => logic.actions.setSelectedReportIds(['r-1']))
         expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
 
         expect(logic.values.selectedReportIds).toEqual(['r-1'])
@@ -180,7 +189,9 @@ describe('ReportCard', () => {
             logic.actions.bulkDismiss({ reason: 'other', note: '', correctedRepository: null })
         })
 
-        fireEvent.click(cardLink(), { metaKey: true })
+        expect(fireEvent.click(cardLink(), { metaKey: true })).toBe(true)
+        expect(fireEvent.click(cardLink(), { ctrlKey: true })).toBe(true)
+        expect(fireEvent.click(cardLink())).toBe(false)
         expect(logic.values.selectedReportIds).toEqual(['r-1'])
         setState.mockRestore()
     })

--- a/products/signals/frontend/inbox/components/cards/ReportContextMenu.tsx
+++ b/products/signals/frontend/inbox/components/cards/ReportContextMenu.tsx
@@ -136,7 +136,7 @@ function ReportContextMenuItems({
     const hasOpenPr = hasOpenImplementationPr(report)
     const { isSelected, toggle: toggleSelection } = useReportCardSelection(report.id, true)
 
-    // The row's own affordances (hold, Cmd-click, checkbox) are easy to miss, so the menu names
+    // The row's own selection gestures (hold, Shift-click) are easy to miss, so the menu names
     // the feature outright.
     const selectItem = (
         <ContextMenuItem asChild>

--- a/products/signals/frontend/inbox/components/cards/useReportCardSelection.ts
+++ b/products/signals/frontend/inbox/components/cards/useReportCardSelection.ts
@@ -12,7 +12,7 @@ import {
 
 export interface ReportCardSelection {
     isSelected: boolean
-    /** True once anything is selected: every card then toggles on click. */
+    /** True once anything is selected: every card then toggles on a plain click. */
     selectionMode: boolean
     /** Set while a hold is running, so the card suppresses text selection under the finger. */
     isHolding: boolean
@@ -22,8 +22,7 @@ export interface ReportCardSelection {
     toggle: (method: InboxSelectionEntryMethod) => void
     /**
      * Handlers for the wrapper around the card body. The click is handled in the capture phase,
-     * because the body is a `Link` that answers a Cmd-click itself and never calls a handler
-     * passed to it.
+     * so selection can stop navigation before the body's `Link` handles the click.
      */
     cardHandlers: {
         onClickCapture: (event: MouseEvent) => void
@@ -36,7 +35,7 @@ export interface ReportCardSelection {
 }
 
 /**
- * Multi-select gestures for one report row: press and hold, Cmd / Ctrl-click, shift-range, and the
+ * Multi-select gestures for one report row: press and hold, shift-range, and the
  * gutter checkbox. The selection itself lives in `inboxBulkActionsLogic`; this hook only turns
  * pointer events into its actions, and it does nothing at all on a row the list marks unselectable.
  */
@@ -79,7 +78,7 @@ export function useReportCardSelection(reportId: string, enabled: boolean): Repo
             // A touch that never produces a click would otherwise leave the suppression armed for
             // the next press.
             suppressClickRef.current = false
-            // Only the primary button holds; a modifier click is already a selection of its own.
+            // Only the primary button holds; modified clicks have separate actions.
             if (
                 !enabled ||
                 selectionDisabled ||
@@ -119,7 +118,7 @@ export function useReportCardSelection(reportId: string, enabled: boolean): Repo
 
     const onClick = useCallback(
         (event: MouseEvent): void => {
-            if (!enabled) {
+            if (!enabled || event.metaKey || event.ctrlKey || event.button !== 0) {
                 return
             }
             if (suppressClickRef.current) {
@@ -137,13 +136,8 @@ export function useReportCardSelection(reportId: string, enabled: boolean): Repo
                 }
                 return
             }
-            // A modifier click on a link nested in the row, such as the scout's name, belongs to
-            // that link: Cmd or Ctrl opens it in a new tab. The link cannot keep the click for
-            // itself here, because a capture handler runs before the target's own handlers.
-            if (
-                (event.shiftKey || event.metaKey || event.ctrlKey) &&
-                isNestedControlClick(event.target, event.currentTarget)
-            ) {
+            // A shift-click on a nested link belongs to that link, not the row's selection.
+            if (event.shiftKey && isNestedControlClick(event.target, event.currentTarget)) {
                 return
             }
             const intent = resolveReportCardClickIntent(event, hasSelection)
@@ -162,9 +156,9 @@ export function useReportCardSelection(reportId: string, enabled: boolean): Repo
                 selectRange(reportId)
                 return
             }
-            toggle('meta_click')
+            toggleReportSelection(reportId)
         },
-        [enabled, hasSelection, reportId, selectRange, selectionDisabled, toggle]
+        [enabled, hasSelection, reportId, selectRange, selectionDisabled, toggleReportSelection]
     )
 
     return {

--- a/products/signals/frontend/inbox/components/shell/InboxBulkSelectionBar.tsx
+++ b/products/signals/frontend/inbox/components/shell/InboxBulkSelectionBar.tsx
@@ -30,7 +30,7 @@ export function InboxBulkSelectionBar({ reports }: { reports: SignalReport[] }):
         <div className="flex items-center justify-between gap-3 flex-wrap rounded border border-accent bg-accent-highlight-secondary px-3 py-2">
             <div className="flex items-center gap-2 min-w-0">
                 <span className="font-medium text-sm shrink-0">{selectedCount} selected</span>
-                <span className="text-xs text-muted">Shift-click range · ⌘-click toggle · Esc to clear</span>
+                <span className="text-xs text-muted">Shift-click range · Click to toggle · Esc to clear</span>
             </div>
 
             <div className="flex items-center gap-2 flex-wrap">

--- a/products/signals/frontend/inbox/utils/reportSelection.test.ts
+++ b/products/signals/frontend/inbox/utils/reportSelection.test.ts
@@ -6,10 +6,13 @@ describe('resolveReportCardClickIntent', () => {
     test.each([
         ['plain click with nothing selected opens the report', plain, false, 'open'],
         ['plain click in selection mode toggles instead of opening', plain, true, 'toggle'],
-        ['cmd-click toggles from an empty selection', { ...plain, metaKey: true }, false, 'toggle'],
-        ['ctrl-click toggles from an empty selection', { ...plain, ctrlKey: true }, false, 'toggle'],
+        ['cmd-click opens from an empty selection', { ...plain, metaKey: true }, false, 'open'],
+        ['ctrl-click opens from an empty selection', { ...plain, ctrlKey: true }, false, 'open'],
+        ['cmd-click opens in selection mode', { ...plain, metaKey: true }, true, 'open'],
+        ['ctrl-click opens in selection mode', { ...plain, ctrlKey: true }, true, 'open'],
         ['shift-click ranges', { ...plain, shiftKey: true }, true, 'range'],
-        ['shift wins over cmd', { shiftKey: true, metaKey: true, ctrlKey: false }, true, 'range'],
+        ['cmd wins over shift', { shiftKey: true, metaKey: true, ctrlKey: false }, true, 'open'],
+        ['ctrl wins over shift', { shiftKey: true, metaKey: false, ctrlKey: true }, true, 'open'],
     ])('%s', (_name, modifiers, hasSelection, expected) => {
         expect(resolveReportCardClickIntent(modifiers, hasSelection)).toBe(expected)
     })

--- a/products/signals/frontend/inbox/utils/reportSelection.ts
+++ b/products/signals/frontend/inbox/utils/reportSelection.ts
@@ -9,18 +9,18 @@ export type ReportCardClickIntent = 'open' | 'toggle' | 'range'
 
 /**
  * A plain click opens the report until something is selected; from then on the list is in
- * selection mode and the same click toggles instead. Cmd / Ctrl always toggles, shift always
- * ranges, so a selection can start from an empty list.
+ * selection mode and the same click toggles instead. Cmd / Ctrl keeps browser navigation,
+ * while shift selects a range, so a selection can start from an empty list.
  */
 export function resolveReportCardClickIntent(
     modifiers: { shiftKey: boolean; metaKey: boolean; ctrlKey: boolean },
     hasSelection: boolean
 ): ReportCardClickIntent {
+    if (modifiers.metaKey || modifiers.ctrlKey) {
+        return 'open'
+    }
     if (modifiers.shiftKey) {
         return 'range'
-    }
-    if (modifiers.metaKey || modifiers.ctrlKey) {
-        return 'toggle'
     }
     return hasSelection ? 'toggle' : 'open'
 }


### PR DESCRIPTION
## Problem

Command-click on a report in the self-driving inbox selects it instead of opening a new tab.

**Why:** Report links must keep standard browser navigation without changing the current selection.

## Changes

- Command-click and Ctrl-click keep native link behavior, including during selection and bulk actions.
- Shift-click and press-and-hold still select reports. The toolbar now describes plain-click selection.
- Update selection documentation and remove stale gesture comments.

Report card appearance is unchanged. This Storybook image uses repository fixtures; it does not show the toolbar hint.

![Report cards in Storybook](https://raw.githubusercontent.com/PostHog/pr-assets/9465b3e9623d329ad35cfa449959ecc01e71be7e/2026/09/02a4a7a9-d099-4d68-9db7-d854caf7a20c.png)

## How did you test this code?

- Run the existing `ReportCard` and `reportSelection` Jest suites. Updated cases catch canceled modified clicks, unwanted selection changes, and blocked navigation during bulk actions.
- Frontend lint and formatting pass. Run `hogli ci:preflight --fix` against the changed files.
- Render report cards in Storybook. The full scene and toolbar browser checks did not complete.
- Full TypeScript checking exceeds available memory. A memory-limited retry also cannot complete; CI must run this check.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Update `docs/internal/inbox-report-selection.md`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

No matching open issue or duplicate PR found. The public diff contains no private task data. Human review is required.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1789137346757079?thread_ts=1789137346.757079&cid=C09SK2PAGKF)*
