### PR TITLE
fix(feature-flags): store numeric comparison values as strings

### DIFF
--- a/posthog/management/migration_analysis/atomic_false_acknowledged_migrations.txt
+++ b/posthog/management/migration_analysis/atomic_false_acknowledged_migrations.txt
@@ -35,3 +35,7 @@ feature_flags.0015_clamp_rollout_percentages_over_100
 # Backfills one search row per canvas in batches, so a long run does not hold one transaction open.
 # Re-running is a no-op: bulk_create passes ignore_conflicts, and the unique key is (team, kind, source_key).
 tasks.0120_backfill_canvas_search_documents
+# Same shape as 0014 and 0015: scans every flag but writes only the few that hold a numeric
+# comparison value, each as its own compare-and-swap. Re-running is a no-op, since a value
+# already stored as a string is skipped.
+feature_flags.0021_stringify_numeric_comparison_values

--- a/products/feature_flags/backend/migrations/0021_stringify_numeric_comparison_values.py
+++ b/products/feature_flags/backend/migrations/0021_stringify_numeric_comparison_values.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django.db import migrations
 
 import structlog
@@ -12,7 +14,7 @@ BATCH_SIZE = 500
 NUMERIC_COMPARISON_OPERATORS = frozenset({"gt", "gte", "lt", "lte"})
 
 
-def _stringified_value(value):
+def _stringified_value(value: Any) -> str | None:
     """The stored value as a string, or None when the property needs no change.
 
     Booleans are excluded because `bool` is a subclass of `int`: "True" is not a number, so

--- a/products/feature_flags/backend/migrations/0021_stringify_numeric_comparison_values.py
+++ b/products/feature_flags/backend/migrations/0021_stringify_numeric_comparison_values.py
@@ -1,0 +1,135 @@
+from django.db import migrations
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+BATCH_SIZE = 500
+
+# Frozen copy of the operators filters_validation.py requires a string value for, narrowed to
+# the numeric comparisons. Migrations must stay self-contained, so a later edit to that set
+# cannot change what this one already did.
+NUMERIC_COMPARISON_OPERATORS = frozenset({"gt", "gte", "lt", "lte"})
+
+
+def _stringified_value(value):
+    """The stored value as a string, or None when the property needs no change.
+
+    Booleans are excluded because `bool` is a subclass of `int`: "True" is not a number, so
+    writing it would turn a comparison that fails today into one that fails differently.
+    """
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    return repr(value) if isinstance(value, float) else str(value)
+
+
+def _stringify_filters(filters: dict) -> dict | None:
+    """Rewrite numeric comparison values as strings, or None when nothing changes.
+
+    The Rust evaluator and the Python SDK parse either form to the same float, so this is a
+    no-op for them. The .NET SDK reads a JSON number through its cohort-id constructor, which
+    leaves the value it compares against unset, and every gt/gte/lt/lte then matches
+    regardless of the person's property. A string restores the comparison there.
+    """
+    groups = filters.get("groups")
+    if not isinstance(groups, list):
+        return None
+
+    changed = False
+    new_groups = []
+    for group in groups:
+        if not isinstance(group, dict):
+            new_groups.append(group)
+            continue
+        properties = group.get("properties")
+        if not isinstance(properties, list):
+            new_groups.append(group)
+            continue
+
+        new_properties = []
+        for prop in properties:
+            if not isinstance(prop, dict) or prop.get("operator") not in NUMERIC_COMPARISON_OPERATORS:
+                new_properties.append(prop)
+                continue
+            as_string = _stringified_value(prop.get("value"))
+            if as_string is None:
+                new_properties.append(prop)
+                continue
+            new_properties.append({**prop, "value": as_string})
+            changed = True
+
+        new_group = dict(group)
+        new_group["properties"] = new_properties
+        new_groups.append(new_group)
+
+    if not changed:
+        return None
+    new_filters = dict(filters)
+    new_filters["groups"] = new_groups
+    return new_filters
+
+
+def stringify_numeric_comparison_values(apps, schema_editor):
+    """One-time fix for #50084's operator_requires_string_value rule on gt/gte/lt/lte.
+
+    Only the numeric comparisons are in scope. The same rule covers icontains and regex, where
+    the stored value is a list rather than a number, and picking one entry from a list changes
+    who the flag targets. That belongs with the flag's owner, not here.
+
+    Property values live in nested arrays that jsonb prefilters can't select cheaply, so this
+    scans all flags read-only and writes only the ones that change. Soft-deleted and inactive
+    flags included: their filters are blanked in the cached payload, but restoring or
+    re-enabling a flag would put the stored value straight back in play.
+    """
+    FeatureFlag = apps.get_model("feature_flags", "FeatureFlag")
+
+    updated_rows = 0
+    skipped_concurrent = 0
+
+    # Keyset pagination instead of .iterator(): server-side cursors are disabled when migrations
+    # run through pgbouncer (DISABLE_SERVER_SIDE_CURSORS), which would make .iterator() buffer the
+    # whole table client-side. id-range batches are memory-bounded however the connection is pooled.
+    last_id = 0
+    while True:
+        # _base_manager documents that soft-deleted rows are in scope (a historical model's
+        # manager is plain anyway). Nothing here touches payloads, so encrypted flags are in scope.
+        rows = list(FeatureFlag._base_manager.filter(id__gt=last_id).order_by("id").only("id", "filters")[:BATCH_SIZE])
+        if not rows:
+            break
+        last_id = rows[-1].id
+
+        for flag in rows:
+            if not isinstance(flag.filters, dict):
+                continue
+            new_filters = _stringify_filters(flag.filters)
+            if new_filters is None:
+                continue
+            # Compare-and-swap on the value we read: a flag edited between the batch select and
+            # this write keeps the newer filters instead of being reverted to our snapshot.
+            written = FeatureFlag._base_manager.filter(id=flag.id, filters=flag.filters).update(filters=new_filters)
+            if not written:
+                skipped_concurrent += 1
+                continue
+            updated_rows += 1
+
+    logger.info(
+        "stringified_numeric_comparison_values",
+        updated_rows=updated_rows,
+        skipped_concurrent=skipped_concurrent,
+    )
+
+
+class Migration(migrations.Migration):
+    # Non-atomic so each row's UPDATE commits as it goes. The default wrapping transaction would
+    # stay open across the whole scan, holding an xmin autovacuum cannot advance past on the table
+    # the flags API writes to. Safe to resume: every compare-and-swap is independently correct and
+    # the transform is idempotent, since a value already stored as a string is skipped.
+    atomic = False
+
+    dependencies = [
+        ("feature_flags", "0020_alter_featureflag_created_by_alter_featureflag_team_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(stringify_numeric_comparison_values, migrations.RunPython.noop, elidable=True),
+    ]

--- a/products/feature_flags/backend/migrations/0021_stringify_numeric_comparison_values.py
+++ b/products/feature_flags/backend/migrations/0021_stringify_numeric_comparison_values.py
@@ -76,6 +76,10 @@ def stringify_numeric_comparison_values(apps, schema_editor):
     the stored value is a list rather than a number, and picking one entry from a list changes
     who the flag targets. That belongs with the flag's owner, not here.
 
+    `.update()` fires no post_save, so the flag-definitions cache keeps serving the number
+    until the hourly verification task repairs the drift. Local evaluation reads that cache,
+    so a .NET caller keeps matching everyone for up to an hour after this runs.
+
     Property values live in nested arrays that jsonb prefilters can't select cheaply, so this
     scans all flags read-only and writes only the ones that change. Soft-deleted and inactive
     flags included: their filters are blanked in the cached payload, but restoring or

--- a/products/feature_flags/backend/migrations/max_migration.txt
+++ b/products/feature_flags/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0020_alter_featureflag_created_by_alter_featureflag_team_and_more
+0021_stringify_numeric_comparison_values

--- a/products/feature_flags/backend/test/test_migration_0021_stringify_numeric_values.py
+++ b/products/feature_flags/backend/test/test_migration_0021_stringify_numeric_values.py
@@ -1,0 +1,85 @@
+from typing import Any
+
+from posthog.test.base import TestMigrations
+
+
+def prop(operator: str, value: Any) -> dict:
+    return {"key": "version", "type": "person", "operator": operator, "value": value}
+
+
+def group(*properties: dict) -> dict:
+    return {"properties": list(properties), "rollout_percentage": 100, "variant": None}
+
+
+class StringifyNumericComparisonValuesMigrationTest(TestMigrations):
+    migrate_from = "0020_alter_featureflag_created_by_alter_featureflag_team_and_more"
+    migrate_to = "0021_stringify_numeric_comparison_values"
+
+    CLASS_DATA_LEVEL_SETUP = False
+
+    @property
+    def app(self) -> str:
+        return "feature_flags"
+
+    def setUpBeforeMigration(self, apps: Any) -> None:
+        Organization = apps.get_model("posthog", "Organization")
+        Project = apps.get_model("posthog", "Project")
+        Team = apps.get_model("posthog", "Team")
+        FeatureFlag = apps.get_model("feature_flags", "FeatureFlag")
+
+        org = Organization.objects.create(name="Test Organization")
+        project = Project.objects.create(id=999994, organization=org, name="Test Project")
+        team = Team.objects.create(organization=org, project=project, name="Test Team")
+
+        def make_flag(key: str, filters: dict, **kwargs: Any) -> Any:
+            return FeatureFlag.objects.create(team=team, created_by=None, key=key, filters=filters, **kwargs)
+
+        self.int_id = make_flag("int-value", {"groups": [group(prop("gte", 5))]}).id
+        self.float_id = make_flag("float-value", {"groups": [group(prop("lt", 1.5))]}).id
+        self.every_operator_id = make_flag(
+            "every-operator",
+            {"groups": [group(prop("gt", 1), prop("gte", 2), prop("lt", 3), prop("lte", 4))]},
+        ).id
+        self.already_string_id = make_flag("already-string", {"groups": [group(prop("gte", "5"))]}).id
+        # bool subclasses int, and "True" is not a number the evaluators can compare.
+        self.bool_id = make_flag("bool-value", {"groups": [group(prop("gte", True))]}).id
+        # The same rule covers these, but picking one entry from a list changes who is targeted.
+        self.list_icontains_id = make_flag("list-icontains", {"groups": [group(prop("icontains", ["a", "b"]))]}).id
+        self.number_on_other_operator_id = make_flag("number-on-exact", {"groups": [group(prop("exact", 5))]}).id
+        self.soft_deleted_id = make_flag("soft-deleted", {"groups": [group(prop("gte", 7))]}, deleted=True).id
+
+        self.junk_ids = [
+            make_flag("junk-groups", {"groups": {}}).id,
+            make_flag("junk-group-entry", {"groups": ["nope"]}).id,
+            make_flag("junk-properties", {"groups": [{"properties": "nope"}]}).id,
+            make_flag("junk-property-entry", {"groups": [{"properties": ["nope"]}]}).id,
+        ]
+
+    def _properties(self, flag_id: int) -> list[dict]:
+        assert self.apps is not None
+        FeatureFlag = self.apps.get_model("feature_flags", "FeatureFlag")
+        return FeatureFlag.objects.get(id=flag_id).filters["groups"][0]["properties"]
+
+    def test_rewrites_numbers_as_strings(self) -> None:
+        assert self._properties(self.int_id)[0]["value"] == "5"
+        assert self._properties(self.float_id)[0]["value"] == "1.5"
+
+    def test_covers_every_numeric_comparison_operator(self) -> None:
+        assert [p["value"] for p in self._properties(self.every_operator_id)] == ["1", "2", "3", "4"]
+
+    def test_leaves_values_it_must_not_change(self) -> None:
+        assert self._properties(self.already_string_id)[0]["value"] == "5"
+        assert self._properties(self.bool_id)[0]["value"] is True
+        assert self._properties(self.list_icontains_id)[0]["value"] == ["a", "b"]
+        assert self._properties(self.number_on_other_operator_id)[0]["value"] == 5
+
+    def test_covers_soft_deleted_flags(self) -> None:
+        assert self._properties(self.soft_deleted_id)[0]["value"] == "7"
+
+    def test_skips_malformed_filters_without_raising(self) -> None:
+        assert self.apps is not None
+        FeatureFlag = self.apps.get_model("feature_flags", "FeatureFlag")
+        assert FeatureFlag.objects.get(id=self.junk_ids[0]).filters == {"groups": {}}
+        assert FeatureFlag.objects.get(id=self.junk_ids[1]).filters == {"groups": ["nope"]}
+        assert FeatureFlag.objects.get(id=self.junk_ids[2]).filters["groups"][0]["properties"] == "nope"
+        assert FeatureFlag.objects.get(id=self.junk_ids[3]).filters["groups"][0]["properties"] == ["nope"]


### PR DESCRIPTION
## Problem

A flag condition like `version >= 5` is evaluated wrongly by two SDKs, in opposite directions, depending on whether the value is stored as a number or a string.

The API reports a number here as a violation of `cross_field.operator_requires_string_value`, but only logs it, so both forms are in the database today: 77 stored as numbers, the rest as strings.

This PR converts the numbers to strings. **It should not merge as written** — see the finding below.

Part of #50084.

## What the SDKs actually do

Checked on `main` of each repo, by reading the comparison path for `gt`, `gte`, `lt` and `lte`.

| SDK | number | string | evaluates locally |
|---|---|---|---|
| Rust (server) | works | works | — |
| Python | works | works | yes |
| Node / core | works | works | yes |
| Ruby | works | works | yes |
| PHP | works | works | yes |
| **.NET** | **matches everyone** | works | yes |
| **Go** | works | **falls back to the API** | yes |
| Java | — | — | no |

Four of the six that evaluate locally accept either form. Only .NET and Go are exclusive, and in opposite directions.

**.NET** reads a JSON number through its cohort-id constructor (`PropertyFilterValue.cs`, `JsonValueKind.Number => new PropertyFilterValue(jsonElement.GetInt64())`). The value it compares against is never set, so every comparison passes and the condition matches everyone.

**Go** has no `case string` in `interfaceToFloat` (`featureflags.go`). A string returns `argument not orderable`, which is not an `InconclusiveMatchError`, so it does not try other conditions and falls back to the API.

**Java** no longer evaluates locally at all, so it cannot be affected.

## Why this PR is wrong as written

The scale is lopsided. The rule requires a string, so most stored values already are one.

- .NET is wrong on the 77 flags that hold a number.
- Go falls back on every other flag using these operators, which is the majority.

Converting numbers to strings fixes 77 flags for .NET and adds 77 more to what Go cannot evaluate. It makes the larger problem larger.

## What should happen instead

Two small SDK changes, each making its SDK accept both forms, matching what Python, Node, Ruby and PHP already do:

- **Go**: add a `string` case to `interfaceToFloat`.
- **.NET**: stop routing `JsonValueKind.Number` through the cohort-id constructor.

Once both accept either form, the stored value stops mattering and this migration is probably unnecessary. Go is the more urgent of the two, by volume.

No SDK changes are in this PR. It is left open as the write-up of the finding.

## Related

This is the second bug of this shape in this area. An earlier one changed a whole rollout percentage from `100` to `100.0`, and .NET and Java rejected the entire local evaluation payload and fell back to remote. That failed loudly, through a jump in flag requests. The .NET bug here fails silently, with a wrong result.

## How did you test this code?

Five tests over the migration, covering each operator and the values it must not touch. Also checked the migration output against the validator: for an int, a float, a negative, a zero and a large float, the rule reports a violation before and none after, and a second pass changes nothing.

Verified the tests fail for the right reason. Removing the boolean guard turns `True` into `"True"` and the test catches it.

Not tested: no SDK was executed. Every SDK claim above comes from reading the comparison path on `main`. Three of the checkouts were on stale branches when first read, and the Go and .NET findings were re-confirmed on `main` afterwards.
