### PR TITLE
fix(appsflyer): read report bodies through iter_content

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/appsflyer/appsflyer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/appsflyer/appsflyer.py
@@ -1,9 +1,9 @@
 import io
 import re
 import csv
-from collections.abc import Iterable, Iterator
+from collections.abc import Buffer, Iterable, Iterator
 from datetime import UTC, date, datetime, timedelta
-from typing import IO, Any, cast
+from typing import Any
 from urllib.parse import quote, urlencode
 
 import requests
@@ -50,12 +50,44 @@ REQUEST_TIMEOUT_SECONDS = 300
 MAX_RETRY_ATTEMPTS = 5
 # Yield rows in chunks so huge reports don't build one giant list.
 CHUNK_SIZE = 5000
+# Pull the report CSV off the wire in 64 KiB reads.
+REPORT_CHUNK_BYTES = 1 << 16
 
 
 @frozen
 class _ReportWindow:
     start: date
     end: date
+
+
+class _ResponseByteStream(io.RawIOBase):
+    """Read a streaming response body through ``iter_content`` as a binary file.
+
+    Wrapping ``response.raw`` directly crashes once the body is read: urllib3 closes
+    the raw stream as it reads the last byte, and a ``TextIOWrapper`` over the
+    now-closed stream raises ``ValueError: I/O operation on closed file`` instead of
+    reporting EOF. ``iter_content`` also turns a dropped connection into a retryable
+    ``requests`` error mid-stream.
+    """
+
+    def __init__(self, response: requests.Response, chunk_size: int) -> None:
+        self._chunks = response.iter_content(chunk_size=chunk_size)
+        self._buffer = b""
+
+    def readable(self) -> bool:
+        return True
+
+    def readinto(self, target: Buffer) -> int:
+        while not self._buffer:
+            try:
+                self._buffer = next(self._chunks)
+            except StopIteration:
+                return 0
+        view = memoryview(target).cast("B")
+        take = min(len(view), len(self._buffer))
+        view[:take] = self._buffer[:take]
+        self._buffer = self._buffer[take:]
+        return take
 
 
 class AppsFlyerRetryableError(Exception):
@@ -215,10 +247,11 @@ def _iter_report_rows(session: requests.Session, url: str, logger: FilteringBoun
     response = _open_report(session, url, logger)
     try:
         # Read physical lines off the socket rather than buffering the whole body: a raw-data
-        # window can hold a million event rows. Wrapping the stream (instead of `iter_lines`)
+        # window can hold a million event rows. Wrapping the byte stream (instead of `iter_lines`)
         # keeps the line terminators csv needs for quoted multi-line values.
-        response.raw.decode_content = True
-        stream = io.TextIOWrapper(cast(IO[bytes], response.raw), encoding="utf-8", newline="")
+        stream = io.TextIOWrapper(
+            io.BufferedReader(_ResponseByteStream(response, REPORT_CHUNK_BYTES)), encoding="utf-8", newline=""
+        )
         yield from _parse_csv_rows(stream, logger)
     finally:
         response.close()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/appsflyer/tests/test_appsflyer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/appsflyer/tests/test_appsflyer.py
@@ -1,4 +1,5 @@
 import io
+from collections.abc import Iterator
 from datetime import UTC, date, datetime, timedelta
 from urllib.parse import parse_qs, urlparse
 
@@ -41,15 +42,43 @@ _CSV = (
 
 
 class _Raw(io.BytesIO):
-    """Stands in for urllib3's raw stream, which the transport sets `decode_content` on."""
+    """Stands in for urllib3's raw stream, which the transport sets `decode_content` on.
+
+    urllib3 closes the stream on the read that satisfies Content-Length, so anything still
+    holding it open sees a closed file rather than EOF.
+    """
 
     decode_content = False
+
+    def __init__(self, body: bytes) -> None:
+        super().__init__(body)
+        self._length = len(body)
+
+    def read(self, size: int | None = -1) -> bytes:
+        data = super().read(size)
+        if self.tell() >= self._length:
+            self.close()
+        return data
+
+    def read1(self, size: int | None = -1) -> bytes:
+        return self.read(size)
+
+
+def _iter_content(raw: _Raw, chunk_size: int) -> Iterator[bytes]:
+    """Mirrors `Response.iter_content`, which stops once the body is consumed."""
+    while not raw.closed:
+        chunk = raw.read(chunk_size)
+        if not chunk:
+            return
+        yield chunk
 
 
 def _response(text: str, status: int = 200) -> mock.MagicMock:
     resp = mock.MagicMock()
     resp.text = text
-    resp.raw = _Raw(text.encode())
+    raw = _Raw(text.encode())
+    resp.raw = raw
+    resp.iter_content = lambda chunk_size=8192, **kwargs: _iter_content(raw, chunk_size)
     resp.status_code = status
     resp.ok = status < 400
     return resp
@@ -244,6 +273,20 @@ class TestGetRows:
 
         headers = mock_session.call_args.kwargs["headers"]
         assert headers["Accept"] == "text/csv"
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_report_spanning_several_reads_is_returned_whole(self, mock_session):
+        # urllib3 closes the raw stream as it reads the last byte of the body, so reading the
+        # report straight off it lost the report to `I/O operation on closed file` at EOF.
+        header = "Date,Media Source (pid)\n"
+        rows_sent = 4000
+        mock_session.return_value.get.side_effect = _serve(
+            header + "".join(f"2024-01-01,source-{index}\n" for index in range(rows_sent))
+        )
+
+        rows = [row for batch in get_rows("token", "id123", "daily_report", mock.MagicMock()) for row in batch]
+
+        assert [row["media_source_pid"] for row in rows] == [f"source-{index}" for index in range(rows_sent)]
 
     @mock.patch(f"{_MODULE}.make_tracked_session")
     def test_empty_report_yields_nothing(self, mock_session):


### PR DESCRIPTION
## Problem

Every AppsFlyer sync fails with `ValueError: I/O operation on closed file`, so no AppsFlyer table imports any rows.

- The source reads a report CSV through `io.TextIOWrapper(response.raw)`.
- urllib3 closes the raw stream on the read that satisfies `Content-Length`.
- `TextIOWrapper` reports the closed stream as an error rather than as EOF, so the reader raises once it reaches the end of the body.
- Any body with content hits this, including a report that returns only its header row. A zero-byte body is the only one that survives.

Error tracking: [ValueError: I/O operation on closed file](https://us.posthog.com/project/2/error_tracking/01a090f9-fca2-7b80-94af-c3a6d277c9cb), raised in `_parse_csv_rows`.

## Changes

- An AppsFlyer sync now reads a report to the end and imports its rows.
- Report bodies stream through `response.iter_content` behind a small `RawIOBase` adapter, so the CSV reader sees EOF at the end of the body. This is the shape the Gladly source already uses, and it also turns a dropped connection into a `requests` error mid-stream.
- `response.raw.decode_content = True` is gone, because `iter_content` decodes the body itself.
- Nothing about the request, the windowing, or the parsed rows changes. No user-visible surface changes, so there is nothing to screenshot.

## How did you test this code?

- The test stub for urllib3's raw stream now closes itself on the read that satisfies `Content-Length`, the way the real one does. That stub never closed, which is why the suite passed against the bug. With the stub corrected and the fix reverted, 25 cases in `test_appsflyer.py` fail with the production message.
- One case is new: `test_report_spanning_several_reads_is_returned_whole` asserts the full row sequence for a body that spans several chunk reads. No existing case asserts row identity, so silent truncation across a chunk boundary went uncaught.
- Ran locally: `test_appsflyer.py`, `test_appsflyer_source.py`, `ruff check`, `ruff format --check`, `mypy` on both changed files, and `hogli ci:preflight`.
- Not run: the database-backed suites and a real sync against AppsFlyer. The fix was also confirmed against a local HTTP server with the installed urllib3, where the old code failed on every non-empty body and the new code read all rows over both `Content-Length` and chunked encoding.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from the error tracking issue linked above: read the trace to the failing frame, then reproduced the failure against a local HTTP server to confirm it originates in this source rather than in the pipeline around it.

- Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, `/reviewing-with-coderabbit`.
- CodeRabbit CLI pass: paused, so this PR opened without a local pass.
- No duplicate: `gh pr list --state open` searches for the module path, the exception type, and the message phrase found nothing, and no open PR on this source addresses it.
- One alternative was rejected: setting `response.raw.auto_close = False` fixes the crash in one line, but it keeps reading through the raw stream and loses the `requests` error wrapping on a mid-stream disconnect.
- The Gladly source carries an equivalent private adapter with the same docstring, and the Cody and Marketo sources still wrap `response.raw` directly. Consolidating the three onto one shared helper is a follow-up, kept out of this diff.
- Public artifact: no customer data, host, token, or account identifier appears in the diff or this description. The test bodies are invented CSV.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

