### PR TITLE
feat(metrics): Grafana-compatible Prometheus read API via Snuffle reverse proxy

### DIFF
--- a/docs/internal/metrics-prometheus-api.md
+++ b/docs/internal/metrics-prometheus-api.md
@@ -1,0 +1,62 @@
+# Metrics Prometheus read API (Grafana datasource)
+
+A thin, authorized reverse proxy in front of [Snuffle](https://github.com/PostHog/snuffle) that lets a Grafana Prometheus datasource read PostHog Metrics. PostHog owns authentication, scope, feature flags, throttling, and team binding; Snuffle is the PromQL engine over ClickHouse and stays user-agnostic.
+
+```
+Grafana --(Authorization: Bearer phx_…)--> Django /api/projects/<id>/metrics/prometheus/api/v1/*
+        --(X-Team-ID: <id>, service Basic creds)--> Snuffle --> ClickHouse
+```
+
+The customer-facing gap this closes: a Metrics alpha customer needs their existing Grafana dashboards to read metrics from PostHog. Today they dual-write (`remote_write` to their Prometheus and to PostHog). This endpoint is the path off that bridge. Snuffle-side support (job/instance aliases, `/api/v1/status/buildinfo`, header-only tenant mode) is in [PostHog/snuffle](https://github.com/PostHog/snuffle).
+
+## Endpoint
+
+`GET|POST /api/projects/<team_id>/metrics/prometheus/api/v1/<path>` — Grafana's datasource URL is the `…/metrics/prometheus` base; it appends `/api/v1/…`.
+
+Auth: a personal API key with the `metrics:read` scope, sent as `Authorization: Bearer phx_…` (Grafana datasource → custom HTTP header). Both feature flags must be on: `metrics` (alpha) and `metrics-prometheus-api`.
+
+## What is proxied
+
+Only read paths Grafana uses; anything else returns a Prometheus `{"status":"error","errorType":"not_found"}` 404.
+
+| Path | Why |
+| --- | --- |
+| `query`, `query_range` | panels, instant, Save & Test |
+| `labels`, `label/<name>/values`, `series`, `metadata` | metric browser, autocomplete, template variables |
+| `status/buildinfo` | Grafana datasource Save & Test |
+| `query_exemplars`, `rules`, `alerts` | stubs / empty in posthog layout |
+
+Blocked: `write` (would bypass the Kafka ingest and series fingerprinting), `read` (remote read — a bulk-export surface with no cost cap, and Grafana does not need it), `admin/*`, `status/*` other than `buildinfo`, `targets`, `format_query`.
+
+## Tenant and credential handling
+
+- The tenant is bound from the URL team and sent to Snuffle as `X-Team-ID: <team.pk>`. A client-supplied `X-Team-ID` header or `team_id`/`tenant` query param is dropped/overridden — Grafana cannot pick a tenant.
+- The upstream call uses `internal_httpx_client` (no env-proxy) with `METRICS_PROMQL_INTERNAL_BASIC_AUTH` as the service ClickHouse credentials, so ClickHouse grants cap the blast radius.
+- Client `Authorization`, `Cookie`, `Accept-Encoding`, hop-by-hop, and `X-Grafana-*` headers are not forwarded.
+- Upstream status (400/422/503) and JSON body pass through verbatim; Grafana renders `error` from the envelope. Connection failure or an unconfigured URL returns `{"status":"error","errorType":"unavailable"}` 503 without leaking the upstream URL.
+
+## Settings
+
+| Env var | Default | Purpose |
+| --- | --- | --- |
+| `METRICS_PROMQL_INTERNAL_URL` | `http://localhost:9091` in DEBUG, else empty | Snuffle base URL |
+| `METRICS_PROMQL_INTERNAL_BASIC_AUTH` | empty | `user:password` for Snuffle's ClickHouse |
+| `METRICS_PROMQL_TIMEOUT_SECONDS` | `60` | Upstream timeout; keep ≥ Snuffle `PROMQL_QUERY_TIMEOUT_SECONDS` |
+
+Set `METRICS_PROMQL_TIMEOUT_SECONDS` at or above Snuffle's query timeout so Snuffle's own timeout envelope reaches Grafana instead of a 503.
+
+## Snuffle deployment (infra, out of this repo)
+
+`CH_SCHEMA_LAYOUT=posthog`, `CH_SAMPLES_TABLE=metrics` (Distributed), `CH_ATTRIBUTE_TABLE=metric_attributes`, `SNUFFLE_TEAM_SOURCE=header`, `SNUFFLE_SELF_SCRAPE_ENABLED=false` (read-only CH user), `SNUFFLE_ALLOW_UNAUTHENTICATED=false`, and `CH_QUERY_SETTINGS=max_bytes_to_read=…,read_overflow_mode=throw,max_execution_time=…`. Dedicated read-only ClickHouse user with SELECT on the four metrics tables and a matching settings profile. Network policy so only Django pods reach Snuffle.
+
+## Local end-to-end
+
+1. `hogli up -d && hogli wait`; seed metrics (`products/metrics/backend/tests/_seeder.py` `seed_metric`, or remote-write to `:8010/i/v1/prometheus/write`).
+2. Run Snuffle in posthog mode against the local `posthog` ClickHouse with `SNUFFLE_TEAM_SOURCE=header`.
+3. `METRICS_PROMQL_INTERNAL_URL=http://localhost:9091`; enable `metrics` + `metrics-prometheus-api`; create a PAK with `metrics:read`.
+4. `curl -H "Authorization: Bearer phx_…" "http://localhost:8010/api/projects/<id>/metrics/prometheus/api/v1/query_range" --data-urlencode 'query=sum by (job) (rate(http_requests_total[5m]))' --data-urlencode start=… --data-urlencode end=… --data-urlencode step=60`.
+5. Grafana in Docker pointed at the same base URL; confirm Save & Test and a panel render.
+
+## Success metric
+
+`metrics prometheus api called` events (endpoint, method, upstream_status, duration_ms, client) per team per day; Snuffle `snuffle_promql_query_duration_seconds` and `snuffle_clickhouse_read_bytes_total`.

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -409,6 +409,7 @@ export const FEATURE_FLAGS = {
     METRICS: 'metrics', // owner: #team-apm (@jonmcwest, @frankh)
     METRICS_ERROR_OVERLAYS: 'metrics-error-overlays', // owner: #team-apm — gates the error-spike overlay PoC on metrics charts
     METRICS_FUNDAMENTALS: 'metrics-fundamentals', // owner: #team-apm (@jonmcwest, @frankh), gates the Fundamentals tab and the explain API behind it, which check the metrics viewer's own reductions
+    METRICS_PROMETHEUS_API: 'metrics-prometheus-api', // owner: #team-apm — gates the Grafana-compatible Prometheus read API
     NEW_TAB_PROJECT_EXPLORER: 'new-tab-project-explorer', // owner: #team-platform-ux
     NEW_TEAM_CORE_EVENTS: 'new-team-core-events', // owner: @jabahamondes #team-web-analytics
     NOTEBOOK_GENERATED_WIDGETS: 'notebook-generated-widgets', // owner: #team-data-tools

--- a/posthog/settings/metrics.py
+++ b/posthog/settings/metrics.py
@@ -1,3 +1,14 @@
 import os
 
+from posthog.settings.utils import get_from_env
+from posthog.utils import str_to_bool
+
 PROMETHEUS_METRICS_EXPORT_PORT = os.getenv("PROMETHEUS_METRICS_EXPORT_PORT", "8001")
+
+# Snuffle (PromQL engine over ClickHouse) the metrics Prometheus read API
+# proxies to. Empty disables the endpoint (503) outside local dev.
+METRICS_PROMQL_INTERNAL_URL = get_from_env(
+    "METRICS_PROMQL_INTERNAL_URL", "http://localhost:9091" if str_to_bool(os.getenv("DEBUG", "False")) else ""
+)
+METRICS_PROMQL_INTERNAL_BASIC_AUTH = os.getenv("METRICS_PROMQL_INTERNAL_BASIC_AUTH", "")
+METRICS_PROMQL_TIMEOUT_SECONDS = float(os.getenv("METRICS_PROMQL_TIMEOUT_SECONDS", "60"))

--- a/products/metrics/backend/facade/api.py
+++ b/products/metrics/backend/facade/api.py
@@ -42,6 +42,12 @@ from products.metrics.backend.metric_event_samples_query_runner import MetricEve
 from products.metrics.backend.metric_names_query_runner import cached_metric_names
 from products.metrics.backend.metric_query_runner import MetricQueryRunner
 from products.metrics.backend.metrics_overview_query_runner import MetricsOverviewQueryRunner
+from products.metrics.backend.prometheus_proxy import forward_prometheus_request, is_allowed_prometheus_path
+
+__all__ = [
+    "forward_prometheus_request",
+    "is_allowed_prometheus_path",
+]
 
 # MetricQueryRunner still speaks the legacy aggregation strings; this shrinks
 # as later PRs teach the runner the remaining MetricAggregation values.

--- a/products/metrics/backend/facade/contracts.py
+++ b/products/metrics/backend/facade/contracts.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 import datetime as dt
 from dataclasses import dataclass
 
+from posthog.dataclasses import frozen
+
 from .enums import AttributeScope, FilterOp, MetricAggregation, MetricType
 
 # Each clause runs its own ClickHouse query on the shared logs cluster, so
@@ -41,6 +43,24 @@ METRICS_ERROR_OVERLAYS_FEATURE_FLAG = "metrics-error-overlays"
 # viewer, not a feature for the teams on the alpha, so it needs a gate of its own
 # on top of METRICS_FEATURE_FLAG.
 METRICS_FUNDAMENTALS_FEATURE_FLAG = "metrics-fundamentals"
+
+# Grafana-facing Prometheus read API, layered on top of METRICS_FEATURE_FLAG.
+# Rolls out to the asking customer first and can be turned off independently if
+# query load from external dashboards is a problem.
+METRICS_PROMETHEUS_API_FEATURE_FLAG = "metrics-prometheus-api"
+
+
+@frozen
+class PrometheusUpstreamResponse:
+    """What Snuffle answered, passed through verbatim to Grafana."""
+
+    status_code: int
+    content: bytes
+    content_type: str
+
+
+class PrometheusUpstreamUnavailable(Exception):
+    """Snuffle is unreachable or not configured; the view maps this to 503."""
 
 
 @dataclass(frozen=True, slots=True)

--- a/products/metrics/backend/presentation/prometheus_api.py
+++ b/products/metrics/backend/presentation/prometheus_api.py
@@ -1,0 +1,138 @@
+"""Grafana-facing Prometheus HTTP API: a thin, authorized reverse proxy to Snuffle.
+
+Grafana's Prometheus datasource speaks the Prometheus wire format, which is not
+PostHog's JSON API. PostHog owns auth, scope, feature flags, throttling and
+team binding here, then forwards the request to Snuffle (the PromQL engine
+over ClickHouse) with the team bound from the URL. Snuffle is user-agnostic and
+runs on a private network; the only tenant it is told is the one from the URL.
+
+Separate from `presentation/api.py` because the Prometheus surface is a foreign
+wire format excluded from OpenAPI/MCP codegen, and `api.py` is already large.
+"""
+
+import json
+import time
+from typing import cast
+
+from django.http import HttpResponse
+
+from drf_spectacular.utils import extend_schema
+from rest_framework import status, viewsets
+from rest_framework.decorators import action
+from rest_framework.permissions import BasePermission
+from rest_framework.request import Request
+from rest_framework.views import APIView
+
+from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
+from posthog.event_usage import report_user_action
+from posthog.models import User
+from posthog.permissions import (
+    FEATURE_FLAG_REQUIRED_ERROR_CODE,
+    PostHogFeatureFlagPermission,
+    posthog_feature_flag_enabled,
+)
+from posthog.rate_limit import ClickHouseBurstRateThrottle, ClickHouseSustainedRateThrottle
+
+from products.metrics.backend.facade.api import forward_prometheus_request, is_allowed_prometheus_path
+from products.metrics.backend.facade.contracts import (
+    METRICS_FEATURE_FLAG,
+    METRICS_PROMETHEUS_API_FEATURE_FLAG,
+    PrometheusUpstreamUnavailable,
+)
+
+__all__ = ["PrometheusMetricsViewSet"]
+
+
+def _envelope(error_type: str, error: str) -> dict:
+    return {"status": "error", "errorType": error_type, "error": error}
+
+
+class _PrometheusApiFeatureFlagPermission(BasePermission):
+    """ANDs the prometheus-api flag on top of the metrics alpha flag.
+
+    PostHogFeatureFlagPermission returns on the first enabled flag, so the two
+    flags cannot be combined in one dict config; this is the second check.
+    """
+
+    code = FEATURE_FLAG_REQUIRED_ERROR_CODE
+
+    def has_permission(self, request: Request, view: APIView) -> bool:
+        team = cast(TeamAndOrgViewSetMixin, view).team
+        return bool(
+            posthog_feature_flag_enabled(
+                METRICS_PROMETHEUS_API_FEATURE_FLAG,
+                str(cast(User, request.user).distinct_id),
+                organization_id=team.organization_id,
+                team_id=team.pk,
+            )
+        )
+
+
+@extend_schema(exclude=True)
+class PrometheusMetricsViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
+    scope_object = "metrics"
+    posthog_feature_flag = METRICS_FEATURE_FLAG
+    permission_classes = [PostHogFeatureFlagPermission, _PrometheusApiFeatureFlagPermission]
+
+    @action(
+        detail=False,
+        methods=["GET", "POST"],
+        url_path=r"api/v1/(?P<upstream_path>.+)",
+        required_scopes=["metrics:read"],
+        throttle_classes=[ClickHouseBurstRateThrottle, ClickHouseSustainedRateThrottle],
+    )
+    def prometheus(self, request: Request, upstream_path: str, *args, **kwargs) -> HttpResponse:
+        tag_queries(product=Product.METRICS, feature=Feature.QUERY)
+        # The router's optional trailing slash sits after the greedy capture.
+        upstream_path = upstream_path.rstrip("/")
+
+        if not is_allowed_prometheus_path(upstream_path):
+            return HttpResponse(
+                _json(_envelope("not_found", f"{upstream_path!r} is not served by the PostHog Prometheus API")),
+                status=status.HTTP_404_NOT_FOUND,
+                content_type="application/json",
+            )
+
+        started = time.monotonic()
+        try:
+            upstream = forward_prometheus_request(
+                team_id=self.team.pk,
+                method=request.method or "GET",
+                upstream_path=upstream_path,
+                # Raw query string and body are forwarded; the proxy strips
+                # tenant params and never touches request.data, so Grafana's
+                # form-encoded POST bodies pass through untouched.
+                query_string=request._request.META.get("QUERY_STRING", ""),
+                body=request._request.body,
+                content_type=request.content_type or "",
+                accept=request.headers.get("Accept", ""),
+            )
+            response = HttpResponse(upstream.content, status=upstream.status_code, content_type=upstream.content_type)
+            upstream_status: int | None = upstream.status_code
+        except PrometheusUpstreamUnavailable as exc:
+            response = HttpResponse(
+                _json(_envelope("unavailable", str(exc))),
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+                content_type="application/json",
+            )
+            upstream_status = None
+
+        report_user_action(
+            request.user,
+            "metrics prometheus api called",
+            {
+                "endpoint": upstream_path,
+                "method": request.method,
+                "upstream_status": upstream_status,
+                "duration_ms": round((time.monotonic() - started) * 1000),
+                "client": "grafana" if request.headers.get("User-Agent", "").startswith("Grafana") else "other",
+            },
+            team=self.team,
+            request=request,
+        )
+        return response
+
+
+def _json(payload: dict) -> bytes:
+    return json.dumps(payload).encode()

--- a/products/metrics/backend/prometheus_proxy.py
+++ b/products/metrics/backend/prometheus_proxy.py
@@ -56,7 +56,13 @@ def _strip_tenant_params(query_string: str) -> str:
     # The tenant is bound by the proxy from the URL team; a client must not
     # also assert one via query param. Snuffle in header mode ignores these
     # anyway, but they are dropped so a misconfigured Snuffle cannot honor one.
-    pairs = [(k, v) for k, v in parse_qsl(query_string, keep_blank_values=True) if k not in ("team_id", "tenant")]
+    # personal_api_key is dropped too — a caller's PostHog key must never leave
+    # PostHog and reach Snuffle.
+    pairs = [
+        (k, v)
+        for k, v in parse_qsl(query_string, keep_blank_values=True)
+        if k not in ("team_id", "tenant", "personal_api_key")
+    ]
     return urlencode(pairs)
 
 
@@ -99,6 +105,12 @@ def forward_prometheus_request(
     except (httpx.ConnectError, httpx.ConnectTimeout, httpx.ReadTimeout, httpx.WriteTimeout, httpx.PoolTimeout) as exc:
         # Do not leak the upstream URL or exception text into the response.
         raise PrometheusUpstreamUnavailable("PromQL backend is unreachable") from exc
+
+    if response.status_code in (401, 403):
+        # Snuffle only rejects the service ClickHouse credential we sent, never
+        # the caller, so this is our misconfiguration — it must not read back as
+        # the caller's own auth failure.
+        raise PrometheusUpstreamUnavailable("PromQL backend rejected the request")
 
     return PrometheusUpstreamResponse(
         status_code=response.status_code,

--- a/products/metrics/backend/prometheus_proxy.py
+++ b/products/metrics/backend/prometheus_proxy.py
@@ -1,0 +1,107 @@
+"""Reverse-proxy forwarding to Snuffle, the PromQL engine over ClickHouse.
+
+Grafana's Prometheus datasource speaks the Prometheus HTTP API. PostHog owns
+authentication, scope, feature flags, throttling and team binding; this module
+forwards an already-authorized, team-scoped request to Snuffle and returns its
+response. Snuffle runs user-agnostic on a private network and is told only the
+team_id, via the X-Team-ID header it is configured to trust
+(SNUFFLE_TEAM_SOURCE=header).
+
+The Prometheus wire format (status/data/errorType envelope, form-encoded POST
+bodies, GET query params) is foreign to PostHog's JSON API, so this forwards
+raw bytes and passes the upstream status through verbatim — Grafana renders
+`error` from the envelope and keys behavior off 400/422/503.
+"""
+
+import re
+import base64
+from urllib.parse import parse_qsl, urlencode
+
+from django.conf import settings
+
+import httpx
+
+from posthog.security.outbound_proxy import internal_httpx_client
+
+from products.metrics.backend.facade.contracts import PrometheusUpstreamResponse, PrometheusUpstreamUnavailable
+
+# Prometheus read paths Grafana may call. `write` is deliberately absent: it
+# would bypass the Kafka ingest and series fingerprinting. `read` (remote
+# read) is a bulk-export surface with no cost cap and Grafana does not need it.
+_ALLOWED_EXACT = frozenset(
+    {
+        "query",
+        "query_range",
+        "series",
+        "labels",
+        "metadata",
+        "status/buildinfo",
+        "query_exemplars",
+        "rules",
+        "alerts",
+    }
+)
+_LABEL_VALUES_RE = re.compile(r"^label/[^/]+/values$")
+
+
+def is_allowed_prometheus_path(path: str) -> bool:
+    """True only for the read-only Prometheus paths Grafana uses."""
+    path = path.strip("/")
+    if not path or ".." in path:
+        return False
+    return path in _ALLOWED_EXACT or bool(_LABEL_VALUES_RE.match(path))
+
+
+def _strip_tenant_params(query_string: str) -> str:
+    # The tenant is bound by the proxy from the URL team; a client must not
+    # also assert one via query param. Snuffle in header mode ignores these
+    # anyway, but they are dropped so a misconfigured Snuffle cannot honor one.
+    pairs = [(k, v) for k, v in parse_qsl(query_string, keep_blank_values=True) if k not in ("team_id", "tenant")]
+    return urlencode(pairs)
+
+
+def forward_prometheus_request(
+    *,
+    team_id: int,
+    method: str,
+    upstream_path: str,
+    query_string: str,
+    body: bytes,
+    content_type: str,
+    accept: str,
+    transport: "httpx.BaseTransport | None" = None,
+) -> PrometheusUpstreamResponse:
+    base_url = settings.METRICS_PROMQL_INTERNAL_URL.rstrip("/")
+    if not base_url:
+        raise PrometheusUpstreamUnavailable("PromQL backend is not configured")
+
+    url = f"{base_url}/api/v1/{upstream_path.strip('/')}"
+    if query_string:
+        url = f"{url}?{_strip_tenant_params(query_string)}"
+
+    headers: dict[str, str] = {"X-Team-ID": str(team_id)}
+    if content_type:
+        headers["Content-Type"] = content_type
+    if accept:
+        headers["Accept"] = accept
+    basic_auth = settings.METRICS_PROMQL_INTERNAL_BASIC_AUTH
+    if basic_auth:
+        headers["Authorization"] = "Basic " + base64.b64encode(basic_auth.encode()).decode()
+
+    timeout = httpx.Timeout(settings.METRICS_PROMQL_TIMEOUT_SECONDS, connect=2.0)
+    client_kwargs: dict = {"timeout": timeout}
+    if transport is not None:
+        client_kwargs["transport"] = transport
+
+    try:
+        with internal_httpx_client(**client_kwargs) as client:
+            response = client.request(method, url, content=body if method in ("POST", "PUT", "PATCH") else None, headers=headers)
+    except (httpx.ConnectError, httpx.ConnectTimeout, httpx.ReadTimeout, httpx.WriteTimeout, httpx.PoolTimeout) as exc:
+        # Do not leak the upstream URL or exception text into the response.
+        raise PrometheusUpstreamUnavailable("PromQL backend is unreachable") from exc
+
+    return PrometheusUpstreamResponse(
+        status_code=response.status_code,
+        content=response.content,
+        content_type=response.headers.get("content-type", "application/json"),
+    )

--- a/products/metrics/backend/routes.py
+++ b/products/metrics/backend/routes.py
@@ -1,7 +1,11 @@
 from posthog.api.routing import RouterRegistry
 
 from products.metrics.backend.presentation.api import MetricsViewSet
+from products.metrics.backend.presentation.prometheus_api import PrometheusMetricsViewSet
 
 
 def register_routes(routers: RouterRegistry) -> None:
     routers.projects.register(r"metrics", MetricsViewSet, "project_metrics", ["team_id"])
+    routers.projects.register(
+        r"metrics/prometheus", PrometheusMetricsViewSet, "project_metrics_prometheus", ["team_id"]
+    )

--- a/products/metrics/backend/tests/test_prometheus_api.py
+++ b/products/metrics/backend/tests/test_prometheus_api.py
@@ -1,0 +1,176 @@
+"""Viewset tests for the Grafana-facing Prometheus reverse proxy.
+
+Snuffle is mocked at the `forward_prometheus_request` seam, so these cover the
+PostHog-side contract: auth, scope, both feature flags, the allowlist, the
+tenant header binding, and the failure envelope.
+"""
+
+import json
+
+from posthog.test.base import APIBaseTest
+from unittest.mock import patch
+
+from parameterized import parameterized
+from rest_framework import status
+
+from posthog.models.personal_api_key import PersonalAPIKey
+from posthog.models.utils import generate_random_token_personal, hash_key_value
+
+from products.metrics.backend.facade.contracts import METRICS_FEATURE_FLAG, METRICS_PROMETHEUS_API_FEATURE_FLAG
+from products.metrics.backend.prometheus_proxy import PrometheusUpstreamResponse, PrometheusUpstreamUnavailable
+
+
+def _flags(prometheus_enabled: bool = True, metrics_enabled: bool = True):
+    def _enabled(flag_key: str, *args: object, **kwargs: object) -> bool:
+        if flag_key == METRICS_PROMETHEUS_API_FEATURE_FLAG:
+            return prometheus_enabled
+        if flag_key == METRICS_FEATURE_FLAG:
+            return metrics_enabled
+        return False
+
+    return _enabled
+
+
+def _upstream(path: str = "query_range", status_code: int = 200):
+    return PrometheusUpstreamResponse(
+        status_code=status_code,
+        content=json.dumps({"status": "success", "data": {"resultType": "matrix", "result": []}}).encode(),
+        content_type="application/json",
+    )
+
+
+def _base_url(team_id: int, path: str = "query_range") -> str:
+    return f"/api/projects/{team_id}/metrics/prometheus/api/v1/{path}"
+
+
+class TestPrometheusApiGate(APIBaseTest):
+    @parameterized.expand(
+        [
+            ("both_on", True, True, status.HTTP_200_OK),
+            ("prometheus_flag_off", False, True, status.HTTP_403_FORBIDDEN),
+            ("metrics_flag_off", True, False, status.HTTP_403_FORBIDDEN),
+            ("both_off", False, False, status.HTTP_403_FORBIDDEN),
+        ]
+    )
+    def test_requires_both_flags(
+        self, _name: str, prometheus_enabled: bool, metrics_enabled: bool, expected: int
+    ) -> None:
+        with (
+            patch("posthoganalytics.feature_enabled", side_effect=_flags(prometheus_enabled, metrics_enabled)),
+            patch(
+                "products.metrics.backend.presentation.prometheus_api.forward_prometheus_request",
+                return_value=_upstream(),
+            ),
+        ):
+            response = self.client.get(_base_url(self.team.id), {"query": "up"})
+        assert response.status_code == expected
+        if expected == status.HTTP_403_FORBIDDEN:
+            assert response.json().get("code") == "feature_flag_required"
+
+    def test_personal_api_key_needs_metrics_read_scope(self) -> None:
+        token = generate_random_token_personal()
+        PersonalAPIKey.objects.create(
+            label="grafana", user=self.user, secure_value=hash_key_value(token), scopes=["error_tracking:read"]
+        )
+        self.client.logout()
+        with patch("posthoganalytics.feature_enabled", side_effect=_flags()):
+            response = self.client.get(_base_url(self.team.id), {"query": "up"}, headers={"authorization": f"Bearer {token}"})
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "metrics:read" in response.json()["detail"]
+
+    def test_personal_api_key_with_metrics_read_scope_passes(self) -> None:
+        token = generate_random_token_personal()
+        PersonalAPIKey.objects.create(
+            label="grafana", user=self.user, secure_value=hash_key_value(token), scopes=["metrics:read"]
+        )
+        self.client.logout()
+        with (
+            patch("posthoganalytics.feature_enabled", side_effect=_flags()),
+            patch(
+                "products.metrics.backend.presentation.prometheus_api.forward_prometheus_request",
+                return_value=_upstream(),
+            ),
+        ):
+            response = self.client.get(_base_url(self.team.id), {"query": "up"}, headers={"authorization": f"Bearer {token}"})
+        assert response.status_code == status.HTTP_200_OK
+
+
+class TestPrometheusApiAllowlist(APIBaseTest):
+    @parameterized.expand([("write",), ("read",), ("admin/tsdb/snapshot",), ("status/config",)])
+    def test_blocked_paths_return_404_envelope(self, path: str) -> None:
+        with (
+            patch("posthoganalytics.feature_enabled", side_effect=_flags()),
+            patch(
+                "products.metrics.backend.presentation.prometheus_api.forward_prometheus_request",
+            ) as forward,
+        ):
+            response = self.client.post(_base_url(self.team.id, path))
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.json()["status"] == "error"
+        assert response.json()["errorType"] == "not_found"
+        forward.assert_not_called()
+
+    def test_buildinfo_is_forwarded(self) -> None:
+        with (
+            patch("posthoganalytics.feature_enabled", side_effect=_flags()),
+            patch(
+                "products.metrics.backend.presentation.prometheus_api.forward_prometheus_request",
+                return_value=_upstream("status/buildinfo"),
+            ) as forward,
+        ):
+            response = self.client.get(_base_url(self.team.id, "status/buildinfo"))
+        assert response.status_code == status.HTTP_200_OK
+        assert forward.call_args.kwargs["upstream_path"] == "status/buildinfo"
+
+    def test_trailing_slash_routes(self) -> None:
+        with (
+            patch("posthoganalytics.feature_enabled", side_effect=_flags()),
+            patch(
+                "products.metrics.backend.presentation.prometheus_api.forward_prometheus_request",
+                return_value=_upstream(),
+            ),
+        ):
+            response = self.client.get(_base_url(self.team.id) + "/", {"query": "up"})
+        assert response.status_code == status.HTTP_200_OK
+
+
+class TestPrometheusApiForwarding(APIBaseTest):
+    def test_team_header_bound_to_url_team(self) -> None:
+        with (
+            patch("posthoganalytics.feature_enabled", side_effect=_flags()),
+            patch(
+                "products.metrics.backend.presentation.prometheus_api.forward_prometheus_request",
+                return_value=_upstream(),
+            ) as forward,
+        ):
+            # A client-asserted X-Team-ID must be overridden by the URL team.
+            self.client.get(_base_url(self.team.id), {"query": "up"}, headers={"X-Team-ID": "9999"})
+        assert forward.call_args.kwargs["team_id"] == self.team.pk
+
+    def test_upstream_status_and_body_pass_through(self) -> None:
+        body = {"status": "error", "errorType": "bad_data", "error": "parse error"}
+        with (
+            patch("posthoganalytics.feature_enabled", side_effect=_flags()),
+            patch(
+                "products.metrics.backend.presentation.prometheus_api.forward_prometheus_request",
+                return_value=PrometheusUpstreamResponse(
+                    status_code=422, content=json.dumps(body).encode(), content_type="application/json"
+                ),
+            ),
+        ):
+            response = self.client.get(_base_url(self.team.id), {"query": "sum(("})
+        assert response.status_code == 422
+        assert response.json() == body
+
+    def test_unconfigured_or_downstream_failure_is_503_envelope(self) -> None:
+        with (
+            patch("posthoganalytics.feature_enabled", side_effect=_flags()),
+            patch(
+                "products.metrics.backend.presentation.prometheus_api.forward_prometheus_request",
+                side_effect=PrometheusUpstreamUnavailable("PromQL backend is not configured"),
+            ),
+        ):
+            response = self.client.get(_base_url(self.team.id), {"query": "up"})
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert response.json()["status"] == "error"
+        assert response.json()["errorType"] == "unavailable"

--- a/products/metrics/backend/tests/test_prometheus_proxy.py
+++ b/products/metrics/backend/tests/test_prometheus_proxy.py
@@ -1,0 +1,179 @@
+"""Forwarding-logic tests for the Prometheus reverse proxy.
+
+No Django client and no live Snuffle: the upstream is an httpx.MockTransport
+that records the request Snuffle would receive, so these assert exactly what
+crosses the wire — the team header, the allowlist, and that client-asserted
+tenant/auth headers never reach Snuffle.
+"""
+
+import json
+
+import pytest
+from unittest.mock import patch
+
+import httpx
+
+from products.metrics.backend.prometheus_proxy import (
+    PrometheusUpstreamUnavailable,
+    forward_prometheus_request,
+    is_allowed_prometheus_path,
+)
+
+BASE = "http://snuffle:9091"
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("query", True),
+        ("query_range", True),
+        ("series", True),
+        ("labels", True),
+        ("label/job/values", True),
+        ("label/__name__/values", True),
+        ("metadata", True),
+        ("status/buildinfo", True),
+        ("query_exemplars", True),
+        ("rules", True),
+        ("alerts", True),
+        # write/read must never be proxied: write bypasses the Kafka ingest and
+        # series fingerprinting, read is a bulk-export surface with no cost cap.
+        ("write", False),
+        ("read", False),
+        ("admin/tsdb/snapshot", False),
+        ("status/config", False),
+        ("status/runtimeinfo", False),
+        ("format_query", False),
+        ("targets", False),
+        ("label//values", False),
+        ("../query", False),
+        ("", False),
+        ("query/evil", False),
+    ],
+)
+def test_is_allowed_prometheus_path(path: str, expected: bool) -> None:
+    assert is_allowed_prometheus_path(path) is expected
+
+
+def _forward(captured: dict, **kwargs) -> httpx.Response:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["request"] = request
+        return kwargs.pop("response")
+
+    transport = httpx.MockTransport(handler)
+    with patch("products.metrics.backend.prometheus_proxy.settings") as mock_settings:
+        mock_settings.METRICS_PROMQL_INTERNAL_URL = BASE
+        mock_settings.METRICS_PROMQL_INTERNAL_BASIC_AUTH = ""
+        mock_settings.METRICS_PROMQL_TIMEOUT_SECONDS = 60.0
+        return forward_prometheus_request(
+            team_id=42,
+            method=kwargs.get("method", "GET"),
+            upstream_path=kwargs.get("upstream_path", "query_range"),
+            query_string=kwargs.get("query_string", "query=up&start=1"),
+            body=kwargs.get("body", b""),
+            content_type=kwargs.get("content_type", ""),
+            accept=kwargs.get("accept", ""),
+            transport=transport,
+        )
+
+
+def test_forward_sets_team_header_and_strips_client_tenant_and_auth() -> None:
+    captured: dict = {}
+    _forward(captured, response=httpx.Response(200, json={"status": "success", "data": {}}))
+    req = captured["request"]
+    assert req.url.path == "/api/v1/query_range"
+    assert req.url.query == b"query=up&start=1"
+    assert req.headers["X-Team-ID"] == "42"
+    # Client-supplied tenant and auth must never reach Snuffle.
+    assert "Authorization" not in req.headers or not req.headers["Authorization"].startswith("Bearer")
+
+
+def test_forward_overrides_client_supplied_team_header() -> None:
+    # A Grafana config that happens to send its own X-Team-ID must not pick a tenant.
+    captured: dict = {}
+    _forward(
+        captured,
+        response=httpx.Response(200, json={}),
+        query_string="query=up&team_id=999",
+    )
+    req = captured["request"]
+    assert req.headers["X-Team-ID"] == "42"
+    assert b"team_id" not in req.url.query
+
+
+def test_forward_post_body_and_content_type() -> None:
+    captured: dict = {}
+    body = b"query=sum%20by%20(job)(rate(x%5B5m%5D))&start=1&end=2&step=60"
+    _forward(
+        captured,
+        response=httpx.Response(200, json={}),
+        method="POST",
+        body=body,
+        content_type="application/x-www-form-urlencoded",
+    )
+    req = captured["request"]
+    assert req.method == "POST"
+    assert req.content == body
+    assert req.headers["Content-Type"] == "application/x-www-form-urlencoded"
+
+
+def test_forward_sends_service_basic_auth_when_configured() -> None:
+    captured: dict = {}
+    with patch("products.metrics.backend.prometheus_proxy.settings") as mock_settings:
+        mock_settings.METRICS_PROMQL_INTERNAL_URL = BASE
+        mock_settings.METRICS_PROMQL_INTERNAL_BASIC_AUTH = "snuffle_ro:secret"
+        mock_settings.METRICS_PROMQL_TIMEOUT_SECONDS = 60.0
+        forward_prometheus_request(
+            team_id=42,
+            method="GET",
+            upstream_path="query",
+            query_string="query=1",
+            body=b"",
+            content_type="",
+            accept="",
+            transport=httpx.MockTransport(lambda r: (captured.update(request=r), httpx.Response(200, json={}))[1]),
+        )
+    assert captured["request"].headers["Authorization"] == "Basic c251ZmZsZV9ybzpzZWNyZXQ="
+
+
+def test_forward_passes_through_upstream_status_and_body() -> None:
+    body = {"status": "error", "errorType": "bad_data", "error": "parse error"}
+    result = _forward({}, response=httpx.Response(422, json=body))
+    assert result.status_code == 422
+    assert json.loads(result.content) == body
+    assert result.content_type.startswith("application/json")
+
+
+def test_upstream_unavailable_maps_to_503() -> None:
+    with patch("products.metrics.backend.prometheus_proxy.settings") as mock_settings:
+        mock_settings.METRICS_PROMQL_INTERNAL_URL = BASE
+        mock_settings.METRICS_PROMQL_INTERNAL_BASIC_AUTH = ""
+        mock_settings.METRICS_PROMQL_TIMEOUT_SECONDS = 60.0
+        with pytest.raises(PrometheusUpstreamUnavailable):
+            forward_prometheus_request(
+                team_id=42,
+                method="GET",
+                upstream_path="query",
+                query_string="query=1",
+                body=b"",
+                content_type="",
+                accept="",
+                transport=httpx.MockTransport(lambda r: (_ for _ in ()).throw(httpx.ConnectError("refused"))),
+            )
+
+
+def test_unconfigured_url_raises_unavailable() -> None:
+    with patch("products.metrics.backend.prometheus_proxy.settings") as mock_settings:
+        mock_settings.METRICS_PROMQL_INTERNAL_URL = ""
+        mock_settings.METRICS_PROMQL_INTERNAL_BASIC_AUTH = ""
+        mock_settings.METRICS_PROMQL_TIMEOUT_SECONDS = 60.0
+        with pytest.raises(PrometheusUpstreamUnavailable):
+            forward_prometheus_request(
+                team_id=42,
+                method="GET",
+                upstream_path="query",
+                query_string="query=1",
+                body=b"",
+                content_type="",
+                accept="",
+            )

--- a/products/metrics/backend/tests/test_prometheus_proxy.py
+++ b/products/metrics/backend/tests/test_prometheus_proxy.py
@@ -101,6 +101,34 @@ def test_forward_overrides_client_supplied_team_header() -> None:
     assert b"team_id" not in req.url.query
 
 
+def test_forward_strips_personal_api_key_from_query_string() -> None:
+    # A personal API key passed as a query param must never reach Snuffle.
+    captured: dict = {}
+    _forward(captured, response=httpx.Response(200, json={}), query_string="query=up&personal_api_key=phx_secret")
+    assert b"personal_api_key" not in captured["request"].url.query
+
+
+def test_upstream_auth_rejection_raises_unavailable() -> None:
+    # Snuffle only rejects the service ClickHouse credential we send, never the
+    # caller, so a 401/403 upstream is our misconfiguration and must surface as
+    # a 503, not the caller's own auth failure.
+    with patch("products.metrics.backend.prometheus_proxy.settings") as mock_settings:
+        mock_settings.METRICS_PROMQL_INTERNAL_URL = BASE
+        mock_settings.METRICS_PROMQL_INTERNAL_BASIC_AUTH = ""
+        mock_settings.METRICS_PROMQL_TIMEOUT_SECONDS = 60.0
+        with pytest.raises(PrometheusUpstreamUnavailable):
+            forward_prometheus_request(
+                team_id=42,
+                method="GET",
+                upstream_path="query",
+                query_string="query=1",
+                body=b"",
+                content_type="",
+                accept="",
+                transport=httpx.MockTransport(lambda r: httpx.Response(401, json={"status": "error"})),
+            )
+
+
 def test_forward_post_body_and_content_type() -> None:
     captured: dict = {}
     body = b"query=sum%20by%20(job)(rate(x%5B5m%5D))&start=1&end=2&step=60"


### PR DESCRIPTION
## Problem

A PostHog Metrics alpha customer wants to point a Grafana Prometheus datasource at PostHog so their existing dashboards keep working — there is no Prometheus-compatible query API over their metrics. Today they dual-write (`remote_write` to their Prometheus and to PostHog); this endpoint is the path off that bridge.

[Snuffle](https://github.com/PostHog/snuffle) translates PromQL to ClickHouse SQL on the logs cluster. Nothing exposes it per project with PostHog auth.

**Alternative implementation of [PostHog/posthog#99207](https://github.com/PostHog/posthog/pull/99207)** (opened concurrently). Same feature; see the comparison below — the two differ mainly in shape, not capability. Requires the Snuffle-side changes in [PostHog/snuffle#2](https://github.com/PostHog/snuffle/pull/2) (job/instance aliases, `/api/v1/status/buildinfo`, header-only tenant mode) to actually serve the target dashboards and pass Grafana's Save & Test.

## Changes

A Prometheus client pointed at `/api/projects/:id/metrics/prometheus` now works: `GET|POST .../metrics/prometheus/api/v1/<path>` proxies to Snuffle with PostHog auth.

- PostHog owns auth, `metrics:read` scope, throttling, and team binding; forwards to Snuffle with `X-Team-ID` from the URL. A caller-asserted `X-Team-ID`/`team_id`/`tenant` is dropped/overridden, and `personal_api_key` is stripped so it never reaches Snuffle.
- Gated on **two** flags: `metrics` (alpha) and new `metrics-prometheus-api` — roll out to the asking customer first, kill independently of the query load.
- Read paths only (`query`, `query_range`, `labels`, `label/:name/values`, `series`, `metadata`, `status/buildinfo`, `query_exemplars`, `rules`, `alerts`). `write`/`read` → 404; `write` would bypass the Kafka ingest.
- Upstream status/body pass through verbatim (Grafana keys off 400/422); upstream connect/timeout or unconfigured URL → `{"status":"error","errorType":"unavailable"}` 503; upstream 401/403 (our service ClickHouse cred) → 503, never the caller's auth failure.
- Raw body bytes forwarded untouched (Grafana form-encoded POSTs); analytics event `metrics prometheus api called` (endpoint/method/status/duration/client, never the query text).
- New settings `METRICS_PROMQL_INTERNAL_URL` / `_BASIC_AUTH` / `_TIMEOUT_SECONDS`. `@extend_schema(exclude=True)` so the foreign wire format stays out of OpenAPI/MCP codegen. Internal doc `docs/internal/metrics-prometheus-api.md`.

**Differences from #99207:** this forwards raw body bytes (his re-encodes form fields), uses `internal_httpx_client`, adds the second flag + analytics, is metrics-only (his also adds the Loki/logs proxy via a shared base viewset). Functionally interchangeable in intent.

## How did you test this code?

Automated (no live Snuffle — upstream mocked at the `forward_prometheus_request` seam with `httpx.MockTransport`):

- `products/metrics/backend/tests/test_prometheus_proxy.py` (31) — allowlist (write/read/admin/format rejected), `X-Team-ID` set from URL team and client tenant/auth/PAK stripped, POST body + content-type forwarded, service Basic auth, upstream 200/422 passthrough, 401/403→unavailable, unreachable/unconfigured→unavailable.
- `products/metrics/backend/tests/test_prometheus_api.py` (15) — both-flag gate (each off → 403 `feature_flag_required`), PAK `metrics:read` required, blocked paths → 404 envelope, buildinfo forwarded, tenant header bound to URL team, upstream 422 body passthrough, 503 envelope.
- Full metrics backend suite (394) green; `ruff`, `mypy`, `lint-imports`, `hogli product:lint metrics` pass; no OpenAPI / `tools.yaml` drift.

Not tested: a real end-to-end request against a deployed Snuffle + Grafana; that needs the infra deploy (Snuffle URL, read-only ClickHouse user) which is out of this repo.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Internal doc added (`docs/internal/metrics-prometheus-api.md`); feature is dark behind flags. `skip-inkeep-docs`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (PostHog Desktop cloud task). Skills read: `/improving-drf-endpoints`, `/writing-tests`, `/writing-pr-descriptions`, `/writing-code-comments`, `/writing-dataclasses`. CodeRabbit local pass is paused; opened without one.
- No duplicate: the duplicate check found [PostHog/posthog#99207](https://github.com/PostHog/posthog/pull/99207) implementing the same proxy. This PR was still opened at the user's direction as an alternative implementation; the tradeoffs vs #99207 are listed in Changes. It is not a duplicate of [PostHog/snuffle#2](https://github.com/PostHog/snuffle/pull/2), which is the Snuffle-side dependency.
- Public artifact: the customer framing is paraphrased from an internal request; committed data is invented.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*