### PR TITLE
feat(mcp): keep every openai-mcp surface on the cli default

### DIFF
--- a/services/mcp/README.md
+++ b/services/mcp/README.md
@@ -345,7 +345,8 @@ The example above exposes all flag tools plus `dashboard-get`.
 
 The MCP server can register either every PostHog tool individually (**tools** mode) or wrap them all behind a single `posthog` CLI-like tool (**cli** mode).
 **cli is the default for all clients.**
-When the caller does not pin a mode, the server only auto-selects tools mode for a short allow-list of clients that are better served by the full per-tool roster — currently Cursor (matched by its self-reported client name or its `Cursor/…` User-Agent) and ChatGPT (matched by its `openai-mcp … (ChatGPT)` User-Agent).
+When the caller does not pin a mode, the server only auto-selects tools mode for a short allow-list of clients that are better served by the full per-tool roster — currently Cursor (matched by its self-reported client name or its `Cursor/…` User-Agent).
+Every OpenAI surface (ChatGPT, Codex, Agent Builder, Responses API) gets the cli default. OpenAI's `openai-mcp` client caches the roster it captures for a published plugin and serves that snapshot to every user of the plugin, so the mode a plugin listing should run in is pinned on the URL submitted to OpenAI rather than inferred from a User-Agent label.
 
 You can pin the choice yourself with either a query parameter or a header. Only `tools` and `cli` are accepted:
 

--- a/services/mcp/src/hono/request-state-resolver.ts
+++ b/services/mcp/src/hono/request-state-resolver.ts
@@ -84,9 +84,9 @@ export function resolveMode(args: { mode: McpMode | undefined; clientProfile: MC
     useSingleExec: boolean
 } {
     const { mode, clientProfile } = args
-    // CLI (single-exec) is the default; only allow-listed clients (Cursor,
-    // ChatGPT) keep the full per-tool roster, and an explicit ?mode= /
-    // x-posthog-mcp-mode header always wins over auto-detection.
+    // CLI (single-exec) is the default; only allow-listed clients (Cursor) keep
+    // the full per-tool roster, and an explicit ?mode= / x-posthog-mcp-mode
+    // header always wins over auto-detection.
     const resolved: McpMode = mode ?? (clientProfile.isToolsModeClient() ? 'tools' : 'cli')
     return { mode: resolved, useSingleExec: resolved === 'cli' }
 }

--- a/services/mcp/src/lib/client-detection.ts
+++ b/services/mcp/src/lib/client-detection.ts
@@ -115,12 +115,13 @@ export const LEGACY_DIALECT_ONLY_CLIENT_NAME_FRAGMENTS = ['antigravity'] as cons
 //   the full roster serves it better than the exec wrapper. Some older Cursor
 //   builds omit `clientInfo.name` and are only identifiable by their
 //   `Cursor/x.y.z (...)` User-Agent, hence the UA fragment too.
-// - ChatGPT connects through OpenAI's shared `openai-mcp` client whose
-//   `clientInfo.name` is generic; the surface only shows up in the User-Agent
-//   parenthetical (`openai-mcp/1.0.0 (ChatGPT)`). Other openai-mcp surfaces
-//   (Codex, Agent Builder, Responses API) stay on the CLI default.
-export const TOOLS_MODE_CLIENT_NAME_FRAGMENTS = ['cursor', 'chatgpt'] as const
-export const TOOLS_MODE_USER_AGENT_FRAGMENTS = ['cursor', 'chatgpt'] as const
+// - Every OpenAI surface (ChatGPT, Codex, Agent Builder, Responses API) stays
+//   on the CLI default. OpenAI's shared `openai-mcp` client caches the roster it
+//   captures for a published plugin and serves that snapshot to every user, so
+//   the plugin listing pins its mode explicitly with `?mode=` instead of relying
+//   on a User-Agent label that only some of its requests carry.
+export const TOOLS_MODE_CLIENT_NAME_FRAGMENTS = ['cursor'] as const
+export const TOOLS_MODE_USER_AGENT_FRAGMENTS = ['cursor'] as const
 
 // Known `x-anthropic-client` (`vendorClient`) header values. Anthropic pools
 // MCP transports across all its products and reports the live one in this
@@ -270,9 +271,9 @@ export class MCPClientProfile {
     isToolsModeClient(): boolean {
         // The only clients that auto-select the full per-tool roster; everyone
         // else defaults to CLI (single-exec) mode — see `resolveMode`. Matched on
-        // the self-reported `clientInfo.name` and the User-Agent (ChatGPT's
-        // surface only appears in the UA parenthetical); never on the vendor
-        // header, so Anthropic pooled transports can't land in tools mode.
+        // the self-reported `clientInfo.name` and the User-Agent (older Cursor
+        // builds identify only through the UA); never on the vendor header, so
+        // Anthropic pooled transports can't land in tools mode.
         return (
             matchesAnyFragment(this.clientName, TOOLS_MODE_CLIENT_NAME_FRAGMENTS) ||
             matchesAnyFragment(this.userAgent, TOOLS_MODE_USER_AGENT_FRAGMENTS)

--- a/services/mcp/src/lib/utils.ts
+++ b/services/mcp/src/lib/utils.ts
@@ -84,7 +84,7 @@ export type McpMode = 'tools' | 'cli'
 // Caller-supplied selection between the tool-based MCP (each PostHog tool registered
 // individually) and the CLI-based MCP (a single `posthog` CLI-like tool that wraps
 // all tools). Anything other than `tools` or `cli` returns undefined and lets
-// `resolveMode` pick: cli by default, tools for allow-listed clients (Cursor, ChatGPT).
+// `resolveMode` pick: cli by default, tools for allow-listed clients (Cursor).
 export function parseMcpMode(raw: string | null | undefined): McpMode | undefined {
     const value = raw?.trim().toLowerCase()
     return value === 'tools' ? 'tools' : value === 'cli' ? 'cli' : undefined

--- a/services/mcp/tests/hono/request-state-resolver.test.ts
+++ b/services/mcp/tests/hono/request-state-resolver.test.ts
@@ -174,14 +174,22 @@ describe('RequestStateResolver MCP client contexts', () => {
         expect(result.clientProfile.clientName).toBe('cursor')
     })
 
-    it('auto-selects tools mode from the ChatGPT user-agent', async () => {
-        // ChatGPT's clientInfo.name is generic; the surface only shows up in the
+    it('auto-selects tools mode from a name-less Cursor user-agent', async () => {
+        // Older Cursor builds omit clientInfo.name and identify only through the
         // User-Agent. Guards the `userAgent: props.clientUserAgent` profile plumbing.
-        const props = makeProps({ mcpClientName: undefined, clientUserAgent: 'openai-mcp/1.0.0 (ChatGPT)' })
+        const props = makeProps({ mcpClientName: undefined, clientUserAgent: 'Cursor/3.1.15 (darwin arm64)' })
         const result = await makeResolver().resolve(props)
 
         expect(result.useSingleExec).toBe(false)
         expect(props.mode).toBe('tools')
+    })
+
+    it('keeps the labeled ChatGPT user-agent on the cli default', async () => {
+        const props = makeProps({ mcpClientName: undefined, clientUserAgent: 'openai-mcp/1.0.0 (ChatGPT)' })
+        const result = await makeResolver().resolve(props)
+
+        expect(result.useSingleExec).toBe(true)
+        expect(props.mode).toBe('cli')
     })
 
     it('defaults to cli mode when no client hints are present', async () => {

--- a/services/mcp/tests/unit/client-detection.test.ts
+++ b/services/mcp/tests/unit/client-detection.test.ts
@@ -212,21 +212,22 @@ describe('isToolsModeClient', () => {
         }
     )
 
-    it.each([
-        // ChatGPT never self-reports a client name; the surface is UA-only.
-        ['openai-mcp/1.0.0 (ChatGPT)'],
-        // Older Cursor builds omit clientInfo.name and identify only via UA.
-        ['Cursor/3.1.15 (darwin arm64)'],
-    ])('returns true for the name-less user-agent %s', (userAgent) => {
-        expect(isToolsModeClient(undefined, userAgent)).toBe(true)
+    // Older Cursor builds omit clientInfo.name and identify only via UA.
+    it('returns true for the name-less Cursor user-agent', () => {
+        expect(isToolsModeClient(undefined, 'Cursor/3.1.15 (darwin arm64)')).toBe(true)
     })
 
-    it.each([['openai-mcp/1.0.0'], ['openai-mcp/1.0.0 (Codex)'], ['openai-mcp/1.0.0 (Agent Builder)']])(
-        'returns false for the non-ChatGPT openai-mcp surface %s',
-        (userAgent) => {
-            expect(isToolsModeClient(undefined, userAgent)).toBe(false)
-        }
-    )
+    // OpenAI's proxy caches the roster it captures for a published plugin, so a
+    // labeled ChatGPT request landing in tools mode would freeze the full roster
+    // for every plugin user. Every openai-mcp surface stays on the cli default.
+    it.each([
+        ['openai-mcp/1.0.0'],
+        ['openai-mcp/1.0.0 (ChatGPT)'],
+        ['openai-mcp/1.0.0 (Codex)'],
+        ['openai-mcp/1.0.0 (Agent Builder)'],
+    ])('returns false for the openai-mcp surface %s', (userAgent) => {
+        expect(isToolsModeClient(undefined, userAgent)).toBe(false)
+    })
 
     it.each([['claude-code'], ['mcp-inspector'], ['some-random-tool'], [''], [undefined]])(
         'returns false for client name %s',

--- a/services/mcp/tests/unit/protocol-types.test.ts
+++ b/services/mcp/tests/unit/protocol-types.test.ts
@@ -26,7 +26,7 @@ describe('resolveMode', () => {
 
     it.each([
         ['Cursor client name', profile({ clientName: 'cursor' })],
-        ['ChatGPT user-agent', profile({ clientName: undefined, userAgent: 'openai-mcp/1.0.0 (ChatGPT)' })],
+        ['name-less Cursor user-agent', profile({ clientName: undefined, userAgent: 'Cursor/3.1.15 (darwin arm64)' })],
     ])('auto-selects tools mode for the %s', (_label, clientProfile) => {
         expect(resolveMode({ mode: undefined, clientProfile })).toEqual({ mode: 'tools', useSingleExec: false })
     })


### PR DESCRIPTION
## Problem

- ChatGPT plugin users could get either the full per-tool roster or the single `exec` tool, depending on which User-Agent label OpenAI's proxy happened to send.
- The `chatgpt` allow-list fragment only matches a labeled `openai-mcp/1.0.0 (ChatGPT)` request. Production tool calls from ChatGPT arrive as a bare `openai-mcp/1.0.0`, and only the roster captures for a plugin submission carry the label.
- OpenAI's proxy captures the roster once for a published plugin version and calls tools by name from that snapshot. It almost never calls `tools/list` again, so the mode returned to the capture request decides what every plugin user runs on.
- Open PR #92738 proposes the opposite fix, matching the bare UA into tools mode. This PR resolves the ambiguity the other way: no OpenAI surface auto-selects tools mode, and a plugin listing pins its mode explicitly.

## Changes

- A labeled ChatGPT request now resolves to cli, the same as Codex, Agent Builder and the Responses API. `TOOLS_MODE_CLIENT_NAME_FRAGMENTS` and `TOOLS_MODE_USER_AGENT_FRAGMENTS` keep only `cursor`.
- A plugin listing that wants the full roster pins `?mode=tools` on the URL it submits to OpenAI. An explicit mode already wins over auto-detection, so nothing else changes.
- Cursor detection is unchanged, and the render-ui gate is untouched.
- Mechanical: the stale "Cursor, ChatGPT" comments in `resolveMode` and `parseMcpMode`, and the README mode section.

> [!NOTE]
> Existing plugin users keep the roster OpenAI captured for the current published version. They move to `exec` only when OpenAI re-captures the roster for a new plugin version, so this PR changes nothing for them on its own.

## How did you test this code?

- `isToolsModeClient` test: the labeled `(ChatGPT)` UA moved into the "returns false" cases next to the other `openai-mcp` surfaces. It catches the regression where the fragment is re-added and a plugin capture lands in tools mode.
- Resolver test: the name-less UA plumbing case now uses a `Cursor/…` UA, so it still guards `userAgent: props.clientUserAgent`. A new case asserts the labeled ChatGPT UA resolves to cli through the resolver.
- `resolveMode` table in `protocol-types.test.ts`: the ChatGPT row became a name-less Cursor row.
- Ran locally: `tests/unit/client-detection.test.ts`, `tests/unit/protocol-types.test.ts`, `tests/hono/request-state-resolver.test.ts`, and `pnpm run typecheck` in `services/mcp`.
- Not run: the rest of the MCP suite, and no manual check against ChatGPT.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`services/mcp/README.md` server-mode section updated in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Fable 5.1). Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, `/reviewing-with-coderabbit` (paused, so the PR opened without a local pass).

The session started as a risk assessment of exec mode for ChatGPT. Production `$mcp_tool_call` events showed that OpenAI's proxy bypasses `exec` and calls tools by name with no session, and that its `tools/list` requests are rare, which is what pointed at a cached per-plugin roster. That finding is described in the Problem section without the underlying numbers. Origin thread: https://posthog.slack.com/archives/C09SK2PAGKF/p1789133857884849. Related: #92709.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
