### PR TITLE
fix(warehouse-sources): stop retrying postgres proxy credential rejections

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -128,6 +128,13 @@ _HOST_RESOLUTION_RETRY_MESSAGE = (
 
 PostgresErrors = {
     "password authentication failed for user": _INVALID_CREDENTIALS_VALIDATION_ERROR,
+    # A proxy/pooler in front of some providers rejects bad credentials during its own
+    # database-identification step instead of libpq's "password authentication failed for user",
+    # wrapping the rejection in its own sentence ("Failed to identify your database: Your Postgres
+    # credentials are incorrect. Please check your username and password and try again."). None of
+    # the password keys here substring-match it, so without this key validation falls through to
+    # `capture_exception` and a generic fallback message. Match the stable, self-contained sentence.
+    "Your Postgres credentials are incorrect": _INVALID_CREDENTIALS_VALIDATION_ERROR,
     # The bounded lookup in front of the connect reports a stalled resolver and a "try again"
     # answer as psycopg errors. Neither is a verdict on the host, so validation asks for a retry
     # rather than capturing a self-recovering failure.
@@ -510,6 +517,13 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
             # credential mismatch only the customer can fix. Match the stable, wording-independent
             # fragment shared by both forms.
             "password authentication failed": _INVALID_CREDENTIALS_ERROR,
+            # Twin of the `PostgresErrors` (validation-time) key above: a proxy/pooler in front of
+            # some providers rejects bad credentials during its own database-identification step
+            # instead of libpq's "password authentication failed for user" ("Failed to identify your
+            # database: Your Postgres credentials are incorrect. Please check your username and
+            # password and try again."). None of the password keys above substring-match it, so
+            # without this key Temporal keeps retrying a credential mismatch only the customer can fix.
+            "Your Postgres credentials are incorrect": _INVALID_CREDENTIALS_ERROR,
             # AWS RDS Proxy reports bad credentials with its own wording instead of PostgreSQL's
             # "password authentication failed for user" — it validates against Secrets Manager and
             # returns "The password that was provided for the role <role> is wrong." None of the

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1068,6 +1068,24 @@ class TestPostgresSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # A proxy/pooler in front of some providers rejects bad credentials during its own
+            # database-identification step, wrapping the rejection in its own sentence instead of
+            # libpq's "password authentication failed for user". Host/IP and port are volatile.
+            'connection failed: connection to server at "66.135.14.99", port 5432 failed: '
+            "Failed to identify your database: Your Postgres credentials are incorrect. "
+            "Please check your username and password and try again.",
+        ],
+    )
+    def test_identify_database_credentials_error_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        assert "Your Postgres credentials are incorrect" in non_retryable
+        assert "password authentication failed" not in error_msg
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Proxy credentials rejection should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             'connection to server at "203.0.113.30", port 5432 failed: FATAL:  password authentication failed for user "u"',
             'connection to server at "203.0.113.30", port 5432 failed: FATAL:  password authentication failed\nuser "u"',
             "connection failed: error received from server in SCRAM exchange: Wrong password",
@@ -4567,6 +4585,15 @@ class TestValidateCredentialsErrorMapping:
                 "Your database's connection pooler has temporarily blocked new connections after "
                 'repeated authentication failures ("too many authentication failures"). This usually '
                 "means the username or password is wrong. Check your credentials and try again.",
+            ),
+            # A proxy/pooler in front of some providers rejects bad credentials during its own
+            # database-identification step, wrapping the rejection in its own sentence instead of
+            # libpq's "password authentication failed for user".
+            (
+                'connection failed: connection to server at "66.135.14.99", port 5432 failed: '
+                "Failed to identify your database: Your Postgres credentials are incorrect. "
+                "Please check your username and password and try again.",
+                "The database rejected the username or password. Check the user and password for this source and try again.",
             ),
             (
                 f"{HOST_RESOLUTION_TIMEOUT_ERROR} after 15.0s",


### PR DESCRIPTION
## Problem

A Postgres source behind a proxy/pooler that rejects bad credentials during its own database-identification step keeps retrying instead of telling the customer to fix their username or password.

Surfaced by [error tracking](https://us.posthog.com/project/2/error_tracking/01a09120-dccb-7062-ae2e-a4fafede83ff): `OperationalError` with message `Failed to identify your database: Your Postgres credentials are incorrect. Please check your username and password and try again.` No existing credential-error key recognized this wording.

## Changes

- `validate_credentials` now returns the specific "check the user and password" message for this wording, instead of falling through to `capture_exception` and a generic "check all connection details" message.
- The sync path now stops retrying a sync that hits this rejection mid-stream, instead of burning its retry budget on credentials that won't change.
- Both dicts (`PostgresErrors` for validation, `get_non_retryable_errors` for sync) reuse the existing invalid-credentials messages already shared by other proxy-specific wordings (SASL, PAM, RDS Proxy).

## How did you test this code?

Added one parameterized case to `TestValidateCredentialsErrorMapping::test_operational_errors_map_to_friendly_messages` and one new test, `test_identify_database_credentials_error_is_non_retryable`, next to the existing SASL/PAM non-retryable cases — both guard the exact wording from the error tracking issue.

Ran `products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py`: 715 passed. The remaining 59 errors are pre-existing, unrelated failures from tests that need a live Postgres/ClickHouse connection this sandbox doesn't have (`Connection refused` to `127.0.0.1:5432`).

Ruled out a duplicate: searched open PRs by exception type, message phrase, and author; the closest match ([#98794](https://github.com/PostHog/posthog/pull/98794)) fixes a different Postgres proxy wording (SNI hostname routing), not this credentials message.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no documented workflow changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a live error tracking issue and reproduced the exact failure. Skills invoked: `/writing-tests` (extend the nearest existing test rather than add a new suite), `/writing-pr-descriptions`. No CodeRabbit local pass (paused).