### PR TITLE
fix(ci): install uv directly in check-migrations

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -1334,7 +1334,7 @@ jobs:
               with:
                   python-version: 3.13.13
                   token: ${{ steps.setup-gh-token.outputs.token || github.token }}
-            # Direct install: the job later checks out the PR head, which may predate the local action, so its post step would fail.
+            # Direct install: The job later checks out the PR head, which may predate the local action, so its post step would fail.
             - name: Install uv
               id: setup-uv
               uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0

--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -1334,9 +1334,15 @@ jobs:
               with:
                   python-version: 3.13.13
                   token: ${{ steps.setup-gh-token.outputs.token || github.token }}
+            # Direct install: the job later checks out the PR head, which may predate the local action, so its post step would fail.
             - name: Install uv
               id: setup-uv
-              uses: ./.depot/actions/setup-uv
+              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              with:
+                  version: '0.12.5'
+                  enable-cache: true
+                  cache-dependency-glob: uv.lock
+                  save-cache: ${{ github.ref == 'refs/heads/master' }}
             - name: Install SAML (python3-saml) dependencies
               if: steps.setup-uv.outputs.cache-hit != 'true'
               run: |

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1558,9 +1558,15 @@ jobs:
                   python-version: 3.13.13
                   token: ${{ steps.setup-gh-token.outputs.token || github.token }}
 
+            # Direct install: the job later checks out the PR head, which may predate the local action, so its post step would fail.
             - name: Install uv
               id: setup-uv
-              uses: ./.github/actions/setup-uv
+              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              with:
+                  version: '0.12.5'
+                  enable-cache: true
+                  cache-dependency-glob: uv.lock
+                  save-cache: ${{ github.ref == 'refs/heads/master' }}
 
             - name: Install SAML (python3-saml) dependencies
               if: steps.setup-uv.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1558,7 +1558,7 @@ jobs:
                   python-version: 3.13.13
                   token: ${{ steps.setup-gh-token.outputs.token || github.token }}
 
-            # Direct install: the job later checks out the PR head, which may predate the local action, so its post step would fail.
+            # Direct install: The job later checks out the PR head, which may predate the local action, so its post step would fail.
             - name: Install uv
               id: setup-uv
               uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0


### PR DESCRIPTION
## Problem

- Backend PRs not rebased past [add shared uv setup action](https://github.com/PostHog/posthog/pull/96867) fail the required Django Tests Pass check.
- The Validate migrations job runs the local `setup-uv` action, then checks out the PR head, which lacks that action.
- The action's post step then fails with `Can't find 'action.yml'` ([example job](https://github.com/PostHog/posthog/actions/runs/34610761235/job/103300464293)).

## Changes

- The Validate migrations job now installs uv 0.12.5 straight from `astral-sh/setup-uv`, with the shared action's cache settings.
- A remote action's post step does not read the workspace, so the PR head checkout cannot break it.
- The `django` and `check-openapi-types` jobs already install uv this way for the same reason.
- The Depot shadow workflow gets the same change.
- CI config only, nothing user-visible.

## How did you test this code?

- Not verified: this PR's own CI cannot hit the failure, because its head already contains the action.
- After merge, watch Validate migrations pass on a backend PR that has not rebased.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None, CI config only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code, directed by the assignee.
- Skills: `/authoring-ci-workflows`, `/writing-code-comments`, `/writing-pr-descriptions`, `/reviewing-with-coderabbit`.
- The CodeRabbit pass is paused, so this PR opened without a local pass.
- A search of open PRs found no existing fix.

https://claude.ai/code/session_01JCn6m1S5Lu9Juj85hRYNB3
