### PR TITLE
fix(surveys): stop the launch flow from enabling surveys project-wide

### DIFF
--- a/frontend/src/scenes/surveys/SurveySettings.tsx
+++ b/frontend/src/scenes/surveys/SurveySettings.tsx
@@ -150,7 +150,7 @@ export function SurveySettings({ isModal = false }: { isModal?: boolean }): JSX.
     )
 }
 
-function openSurveysSettingsDialog(): void {
+export function openSurveysSettingsDialog(): void {
     LemonDialog.open({
         title: 'Surveys settings',
         content: <SurveySettings isModal />,

--- a/frontend/src/scenes/surveys/components/LaunchSurveyButton.tsx
+++ b/frontend/src/scenes/surveys/components/LaunchSurveyButton.tsx
@@ -1,30 +1,25 @@
 import { useActions, useValues } from 'kea'
 import { ReactNode } from 'react'
 
-import { IconGear } from '@posthog/icons'
-import { LemonBanner, LemonButton, LemonDialog } from '@posthog/lemon-ui'
+import { LemonButton, LemonDialog } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { HostedSurveyRespondentHint } from 'scenes/surveys/components/HostedSurveyRespondentHint'
 import { SdkVersionWarnings } from 'scenes/surveys/components/SdkVersionWarnings'
 import { SurveyConditionsList } from 'scenes/surveys/components/SurveyConditions'
+import { SurveysDisabledLaunchWarning } from 'scenes/surveys/components/SurveysDisabledLaunchWarning'
 import { getSurveyUrl } from 'scenes/surveys/CopySurveyLink'
 import { surveyLogic } from 'scenes/surveys/surveyLogic'
-import { openSurveysSettingsDialog } from 'scenes/surveys/SurveySettings'
 import { getSurveyDisplayConditionsSummary } from 'scenes/surveys/utils'
-import { teamLogic } from 'scenes/teamLogic'
 
 import { AccessControlLevel, AccessControlResourceType, SurveyType } from '~/types'
 
 export function LaunchSurveyButton({ children = 'Launch' }: { children?: ReactNode }): JSX.Element {
     const { survey, surveyWarnings } = useValues(surveyLogic)
     const { launchSurvey } = useActions(surveyLogic)
-    const { currentTeam } = useValues(teamLogic)
 
     const isHostedSurvey = survey.type === SurveyType.ExternalSurvey
-    // PostHog hosts and renders these surveys, so they do not depend on the project's surveys_opt_in setting.
-    const surveysAreOff = !currentTeam?.surveys_opt_in && !isHostedSurvey
     const conditionsSummary = isHostedSurvey ? [] : getSurveyDisplayConditionsSummary(survey)
 
     return (
@@ -63,20 +58,7 @@ export function LaunchSurveyButton({ children = 'Launch' }: { children?: ReactNo
                                         This survey will be shown to all users.
                                     </div>
                                 )}
-                                {surveysAreOff && (
-                                    <LemonBanner
-                                        type="warning"
-                                        action={{
-                                            type: 'secondary',
-                                            icon: <IconGear />,
-                                            onClick: () => openSurveysSettingsDialog(),
-                                            children: 'Configure',
-                                        }}
-                                    >
-                                        Surveys are off for this project, so your app will not show this survey
-                                        automatically. Launching does not change the setting.
-                                    </LemonBanner>
-                                )}
+                                <SurveysDisabledLaunchWarning surveyType={survey.type} />
                             </div>
                         ),
                         primaryButton: {

--- a/frontend/src/scenes/surveys/components/LaunchSurveyButton.tsx
+++ b/frontend/src/scenes/surveys/components/LaunchSurveyButton.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
-import { ReactNode } from 'react'
+import { ReactNode, useRef } from 'react'
 
-import { LemonButton, LemonDialog } from '@posthog/lemon-ui'
+import { LemonButton, LemonCheckbox, LemonDialog } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
@@ -21,9 +21,11 @@ export function LaunchSurveyButton({ children = 'Launch' }: { children?: ReactNo
     const { currentTeam } = useValues(teamLogic)
     const { updateCurrentTeam } = useActions(teamLogic)
 
-    const needsOptIn = !currentTeam?.surveys_opt_in
     const isHostedSurvey = survey.type === SurveyType.ExternalSurvey
+    // PostHog hosts and renders these surveys, so they do not depend on the project's surveys_opt_in setting.
+    const needsOptIn = !currentTeam?.surveys_opt_in && !isHostedSurvey
     const conditionsSummary = isHostedSurvey ? [] : getSurveyDisplayConditionsSummary(survey)
+    const shouldOptIn = useRef(true)
 
     return (
         <AccessControlAction
@@ -36,6 +38,7 @@ export function LaunchSurveyButton({ children = 'Launch' }: { children?: ReactNo
                 data-attr="launch-survey"
                 size="small"
                 onClick={() => {
+                    shouldOptIn.current = true
                     LemonDialog.open({
                         title: 'Launch this survey?',
                         content: (
@@ -62,7 +65,21 @@ export function LaunchSurveyButton({ children = 'Launch' }: { children?: ReactNo
                                     </div>
                                 )}
                                 {needsOptIn && (
-                                    <div className="text-xs text-muted">This will enable surveys for your project.</div>
+                                    <div className="flex flex-col gap-1">
+                                        <LemonCheckbox
+                                            defaultChecked
+                                            onChange={(checked) => {
+                                                shouldOptIn.current = checked
+                                            }}
+                                            label="Enable surveys for this project"
+                                            data-attr="launch-survey-surveys-opt-in"
+                                            size="small"
+                                        />
+                                        <div className="text-xs text-muted">
+                                            Surveys are off for this project. Your app cannot show any survey until they
+                                            are on.
+                                        </div>
+                                    </div>
                                 )}
                             </div>
                         ),
@@ -70,7 +87,7 @@ export function LaunchSurveyButton({ children = 'Launch' }: { children?: ReactNo
                             children: isHostedSurvey ? 'Launch and copy link' : 'Launch',
                             type: 'primary',
                             onClick: () => {
-                                if (needsOptIn) {
+                                if (needsOptIn && shouldOptIn.current) {
                                     updateCurrentTeam({ surveys_opt_in: true })
                                 }
                                 if (isHostedSurvey) {

--- a/frontend/src/scenes/surveys/components/LaunchSurveyButton.tsx
+++ b/frontend/src/scenes/surveys/components/LaunchSurveyButton.tsx
@@ -1,7 +1,8 @@
 import { useActions, useValues } from 'kea'
-import { ReactNode, useRef } from 'react'
+import { ReactNode } from 'react'
 
-import { LemonButton, LemonCheckbox, LemonDialog } from '@posthog/lemon-ui'
+import { IconGear } from '@posthog/icons'
+import { LemonBanner, LemonButton, LemonDialog } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
@@ -10,6 +11,7 @@ import { SdkVersionWarnings } from 'scenes/surveys/components/SdkVersionWarnings
 import { SurveyConditionsList } from 'scenes/surveys/components/SurveyConditions'
 import { getSurveyUrl } from 'scenes/surveys/CopySurveyLink'
 import { surveyLogic } from 'scenes/surveys/surveyLogic'
+import { openSurveysSettingsDialog } from 'scenes/surveys/SurveySettings'
 import { getSurveyDisplayConditionsSummary } from 'scenes/surveys/utils'
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -19,13 +21,11 @@ export function LaunchSurveyButton({ children = 'Launch' }: { children?: ReactNo
     const { survey, surveyWarnings } = useValues(surveyLogic)
     const { launchSurvey } = useActions(surveyLogic)
     const { currentTeam } = useValues(teamLogic)
-    const { updateCurrentTeam } = useActions(teamLogic)
 
     const isHostedSurvey = survey.type === SurveyType.ExternalSurvey
     // PostHog hosts and renders these surveys, so they do not depend on the project's surveys_opt_in setting.
-    const needsOptIn = !currentTeam?.surveys_opt_in && !isHostedSurvey
+    const surveysAreOff = !currentTeam?.surveys_opt_in && !isHostedSurvey
     const conditionsSummary = isHostedSurvey ? [] : getSurveyDisplayConditionsSummary(survey)
-    const shouldOptIn = useRef(true)
 
     return (
         <AccessControlAction
@@ -38,7 +38,6 @@ export function LaunchSurveyButton({ children = 'Launch' }: { children?: ReactNo
                 data-attr="launch-survey"
                 size="small"
                 onClick={() => {
-                    shouldOptIn.current = true
                     LemonDialog.open({
                         title: 'Launch this survey?',
                         content: (
@@ -64,22 +63,19 @@ export function LaunchSurveyButton({ children = 'Launch' }: { children?: ReactNo
                                         This survey will be shown to all users.
                                     </div>
                                 )}
-                                {needsOptIn && (
-                                    <div className="flex flex-col gap-1">
-                                        <LemonCheckbox
-                                            defaultChecked
-                                            onChange={(checked) => {
-                                                shouldOptIn.current = checked
-                                            }}
-                                            label="Enable surveys for this project"
-                                            data-attr="launch-survey-surveys-opt-in"
-                                            size="small"
-                                        />
-                                        <div className="text-xs text-muted">
-                                            Surveys are off for this project. Your app cannot show any survey until they
-                                            are on.
-                                        </div>
-                                    </div>
+                                {surveysAreOff && (
+                                    <LemonBanner
+                                        type="warning"
+                                        action={{
+                                            type: 'secondary',
+                                            icon: <IconGear />,
+                                            onClick: () => openSurveysSettingsDialog(),
+                                            children: 'Configure',
+                                        }}
+                                    >
+                                        Surveys are off for this project, so your app will not show this survey
+                                        automatically. Launching does not change the setting.
+                                    </LemonBanner>
                                 )}
                             </div>
                         ),
@@ -87,9 +83,6 @@ export function LaunchSurveyButton({ children = 'Launch' }: { children?: ReactNo
                             children: isHostedSurvey ? 'Launch and copy link' : 'Launch',
                             type: 'primary',
                             onClick: () => {
-                                if (needsOptIn && shouldOptIn.current) {
-                                    updateCurrentTeam({ surveys_opt_in: true })
-                                }
                                 if (isHostedSurvey) {
                                     void copyToClipboard(getSurveyUrl(survey.id), 'survey link')
                                 }

--- a/frontend/src/scenes/surveys/components/SurveysDisabledLaunchWarning.tsx
+++ b/frontend/src/scenes/surveys/components/SurveysDisabledLaunchWarning.tsx
@@ -1,0 +1,35 @@
+import { useValues } from 'kea'
+
+import { IconGear } from '@posthog/icons'
+import { LemonBanner } from '@posthog/lemon-ui'
+
+import { openSurveysSettingsDialog } from 'scenes/surveys/SurveySettings'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { SurveyType } from '~/types'
+
+// The launch dialogs snapshot their content, so this component reads the setting live. The
+// Configure button turns surveys on in a dialog above, and the warning must clear when it does.
+export function SurveysDisabledLaunchWarning({ surveyType }: { surveyType: SurveyType }): JSX.Element | null {
+    const { currentTeam } = useValues(teamLogic)
+
+    // PostHog hosts and renders these surveys, so they do not depend on the project's surveys_opt_in setting.
+    if (surveyType === SurveyType.ExternalSurvey || currentTeam?.surveys_opt_in) {
+        return null
+    }
+
+    return (
+        <LemonBanner
+            type="warning"
+            action={{
+                type: 'secondary',
+                icon: <IconGear />,
+                onClick: () => openSurveysSettingsDialog(),
+                children: 'Configure',
+            }}
+        >
+            Surveys are off for this project, so your app will not show this survey automatically. Launching does not
+            change the setting.
+        </LemonBanner>
+    )
+}

--- a/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
+++ b/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
@@ -4,8 +4,8 @@ import { router } from 'kea-router'
 import { getNextSurveyStep } from 'posthog-js/dist/surveys-preview'
 import { useEffect, useState } from 'react'
 
-import { IconArrowLeft, IconChevronLeft, IconChevronRight } from '@posthog/icons'
-import { LemonButton, LemonDialog } from '@posthog/lemon-ui'
+import { IconArrowLeft, IconChevronLeft, IconChevronRight, IconGear } from '@posthog/icons'
+import { LemonBanner, LemonButton, LemonDialog } from '@posthog/lemon-ui'
 
 import { EditableField } from 'lib/components/EditableField/EditableField'
 import { GuidedWizardStep, GuidedWizardStepper } from 'lib/components/GuidedWizard/GuidedWizardStepper'
@@ -27,6 +27,7 @@ import { NewSurvey } from '../constants'
 import { SurveyAppearancePreview } from '../SurveyAppearancePreview'
 import { getEventPropertyFilterCount } from '../SurveyEventTrigger'
 import { surveyLogic } from '../surveyLogic'
+import { openSurveysSettingsDialog } from '../SurveySettings'
 import { surveysLogic } from '../surveysLogic'
 import { getSurveyWithTranslatedContent } from '../surveyTranslationUtils'
 import { canUseSurveyWizard, doesSurveyHaveDisplayConditions, getSurveyAudienceSummaryValue } from '../utils'
@@ -110,7 +111,6 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
     })
 
     const { currentTeam } = useValues(teamLogic)
-    const { updateCurrentTeam } = useActions(teamLogic)
     const { isDarkModeOn } = useValues(themeLogic)
 
     const [previewPageIndex, setPreviewPageIndex] = useState(0)
@@ -255,12 +255,28 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
         const hasConditions = !isHostedSurvey && doesSurveyHaveDisplayConditions(survey)
         const conditionsSummary = isHostedSurvey ? [] : getConditionsSummary()
         const hasAudienceConditions = conditionsSummary.length > 0
+        // PostHog hosts and renders these surveys, so they do not depend on the project's surveys_opt_in setting.
+        const surveysAreOff = !currentTeam?.surveys_opt_in && !isHostedSurvey
 
         LemonDialog.open({
             title: 'Launch this survey?',
             content: (
                 <div className="space-y-2">
                     <SdkVersionWarnings warnings={surveyWarnings} />
+                    {surveysAreOff && (
+                        <LemonBanner
+                            type="warning"
+                            action={{
+                                type: 'secondary',
+                                icon: <IconGear />,
+                                onClick: () => openSurveysSettingsDialog(),
+                                children: 'Configure',
+                            }}
+                        >
+                            Surveys are off for this project, so your app will not show this survey automatically.
+                            Launching does not change the setting.
+                        </LemonBanner>
+                    )}
                     {isHostedSurvey ? (
                         <div className="flex flex-col gap-3">
                             <p className="text-secondary m-0">
@@ -298,31 +314,7 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
     }
 
     const handleLaunchClick = (): void => {
-        if (!currentTeam?.surveys_opt_in) {
-            LemonDialog.open({
-                title: 'Enable surveys?',
-                content: (
-                    <p className="text-secondary">
-                        Surveys are currently disabled for this project. Would you like to enable them and launch your
-                        survey?
-                    </p>
-                ),
-                primaryButton: {
-                    children: 'Enable & continue',
-                    type: 'primary',
-                    onClick: () => {
-                        updateCurrentTeam({ surveys_opt_in: true })
-                        showLaunchConfirmation(launchSurvey)
-                    },
-                },
-                secondaryButton: {
-                    children: 'Cancel',
-                    type: 'tertiary',
-                },
-            })
-        } else {
-            showLaunchConfirmation(launchSurvey)
-        }
+        showLaunchConfirmation(launchSurvey)
     }
 
     const handleSaveClick = (): void => {

--- a/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
+++ b/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
@@ -4,8 +4,8 @@ import { router } from 'kea-router'
 import { getNextSurveyStep } from 'posthog-js/dist/surveys-preview'
 import { useEffect, useState } from 'react'
 
-import { IconArrowLeft, IconChevronLeft, IconChevronRight, IconGear } from '@posthog/icons'
-import { LemonBanner, LemonButton, LemonDialog } from '@posthog/lemon-ui'
+import { IconArrowLeft, IconChevronLeft, IconChevronRight } from '@posthog/icons'
+import { LemonButton, LemonDialog } from '@posthog/lemon-ui'
 
 import { EditableField } from 'lib/components/EditableField/EditableField'
 import { GuidedWizardStep, GuidedWizardStepper } from 'lib/components/GuidedWizard/GuidedWizardStepper'
@@ -14,7 +14,6 @@ import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { featureFlagLogic as enabledFeaturesLogic } from 'lib/logic/featureFlagLogic'
 import { useMaxTool } from 'scenes/max/useMaxTool'
 import { SceneExport } from 'scenes/sceneTypes'
-import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
@@ -23,11 +22,11 @@ import { SurveyMatchType, SurveyQuestionBranchingType, SurveyType } from '~/type
 import { HostedSurveyRespondentHint } from '../components/HostedSurveyRespondentHint'
 import { SdkVersionWarnings } from '../components/SdkVersionWarnings'
 import { SurveyPublicContentNotice } from '../components/SurveyPublicContentNotice'
+import { SurveysDisabledLaunchWarning } from '../components/SurveysDisabledLaunchWarning'
 import { NewSurvey } from '../constants'
 import { SurveyAppearancePreview } from '../SurveyAppearancePreview'
 import { getEventPropertyFilterCount } from '../SurveyEventTrigger'
 import { surveyLogic } from '../surveyLogic'
-import { openSurveysSettingsDialog } from '../SurveySettings'
 import { surveysLogic } from '../surveysLogic'
 import { getSurveyWithTranslatedContent } from '../surveyTranslationUtils'
 import { canUseSurveyWizard, doesSurveyHaveDisplayConditions, getSurveyAudienceSummaryValue } from '../utils'
@@ -110,7 +109,6 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
         },
     })
 
-    const { currentTeam } = useValues(teamLogic)
     const { isDarkModeOn } = useValues(themeLogic)
 
     const [previewPageIndex, setPreviewPageIndex] = useState(0)
@@ -255,28 +253,13 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
         const hasConditions = !isHostedSurvey && doesSurveyHaveDisplayConditions(survey)
         const conditionsSummary = isHostedSurvey ? [] : getConditionsSummary()
         const hasAudienceConditions = conditionsSummary.length > 0
-        // PostHog hosts and renders these surveys, so they do not depend on the project's surveys_opt_in setting.
-        const surveysAreOff = !currentTeam?.surveys_opt_in && !isHostedSurvey
 
         LemonDialog.open({
             title: 'Launch this survey?',
             content: (
                 <div className="space-y-2">
                     <SdkVersionWarnings warnings={surveyWarnings} />
-                    {surveysAreOff && (
-                        <LemonBanner
-                            type="warning"
-                            action={{
-                                type: 'secondary',
-                                icon: <IconGear />,
-                                onClick: () => openSurveysSettingsDialog(),
-                                children: 'Configure',
-                            }}
-                        >
-                            Surveys are off for this project, so your app will not show this survey automatically.
-                            Launching does not change the setting.
-                        </LemonBanner>
-                    )}
+                    <SurveysDisabledLaunchWarning surveyType={survey.type} />
                     {isHostedSurvey ? (
                         <div className="flex flex-col gap-3">
                             <p className="text-secondary m-0">


### PR DESCRIPTION
## Problem

- Launching one survey turned surveys on for the whole project. Every other running survey then started to show in customers' apps, until someone found the setting and turned it off again.
- Teams that trigger surveys from their own code keep "Enable surveys" off on purpose, so that nothing appears on page load. Each launch undid that setup. On the survey page the dialog changed the setting with a line of muted text, and in the wizard the only way forward was "Enable & continue". This came in through support.
- Hosted surveys never needed the setting. PostHog renders them on its own page, and `public_survey_page` does not read `surveys_opt_in`.

## Changes

- Launching a survey makes no change to the "Enable surveys" project setting. A per-survey action no longer changes what every other survey does.
- When surveys are off for the project, both launch dialogs (the survey page and the wizard) show a warning: the app will not show this survey automatically, and launching does not change the setting. The banner carries a "Configure" button that opens the surveys settings, which is the same control the surveys list already uses.
- The wizard no longer asks "Enable surveys?" before the launch confirmation. The warning takes its place.
- Hosted surveys show no warning, because PostHog renders them itself.
- Mechanical: `openSurveysSettingsDialog` is now exported so both dialogs can use it.

> [!NOTE]
> A person can now launch an in-app survey while surveys are off for the project, and see nothing in their app. The warning states this, and the button to turn surveys on sits next to it. Turning surveys on stays a deliberate act in settings, in the quick-create modal, or through onboarding.

No screenshot: the dialogs open on click, no story covers them, and this sandbox has no browser. The visible change is that one line of muted text becomes a warning banner with a "Configure" button, and that the wizard's "Enable surveys?" step disappears.

## How did you test this code?

- No new tests. The change is a dialog banner plus the removal of a settings write, and no test covers these dialogs today.
- Ran `pnpm --filter=@posthog/frontend fix` and `pnpm --filter=@posthog/frontend typescript:check`.
- Not run: the app itself and Storybook.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

- Written by an agent in a PostHog Desktop cloud task, from a support question about surveys that are triggered from code.
- Skills invoked: `/writing-user-facing-copy`, `/writing-ui-components`, `/writing-code-comments`, `/writing-pr-descriptions`.
- The first version of this PR kept a checkbox that enabled surveys by default. A reviewer asked for the simpler rule instead: leave the setting as it is and warn.
- The agent read `posthog-js` to confirm the SDK behavior: with `surveys` false in the remote config, the SDK still builds the survey manager and skips only the automatic display loop, so `posthog.displaySurvey()` keeps working.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
