### PR TITLE
feat(desktop): show sent images above user messages

### DIFF
--- a/products/desktop/packages/core/src/editor/cloud-prompt.ts
+++ b/products/desktop/packages/core/src/editor/cloud-prompt.ts
@@ -52,7 +52,7 @@ export function hasProseBeyondAttachments(content: EditorContent): boolean {
   );
 }
 
-const ABSOLUTE_FILE_TAG_REGEX = /<file\s+path="([^"]+)"\s*\/>/g;
+export const ABSOLUTE_FILE_TAG_REGEX = /<file\s+path="([^"]+)"\s*\/>/g;
 const FOLDER_TAG_REGEX = /<folder\s+path="[^"]+"\s*\/>/g;
 const FOLDER_TAG_PATH_REGEX = /<folder\s+path="([^"]+)"\s*\/>/g;
 const TEXT_EXTENSIONS = new Set([
@@ -134,7 +134,7 @@ function unique<T>(values: T[]): T[] {
   return Array.from(new Set(values));
 }
 
-function normalizePromptText(prompt: string): string {
+export function normalizePromptText(prompt: string): string {
   return prompt.replace(/\n{3,}/g, "\n\n").trim();
 }
 
@@ -179,6 +179,22 @@ const TRAILING_ATTACHMENT_SUMMARY_REGEX = new RegExp(
 
 export function stripTrailingAttachmentSummary(text: string): string {
   return text.replace(TRAILING_ATTACHMENT_SUMMARY_REGEX, "").trim();
+}
+
+/** Strips the trailing attachment summary only when every file it names is in `labels`. */
+export function stripAttachmentSummaryOf(
+  text: string,
+  labels: ReadonlySet<string>,
+): string {
+  const summary = text.match(TRAILING_ATTACHMENT_SUMMARY_REGEX)?.[0];
+  if (!summary) return text;
+  const names = summary
+    .trim()
+    .slice(ATTACHMENT_SUMMARY_PREFIX.length)
+    .split(", ");
+  return names.every((name) => labels.has(name))
+    ? stripTrailingAttachmentSummary(text)
+    : text;
 }
 
 export function buildCloudTaskDescription(

--- a/products/desktop/packages/core/src/sessions/promptContent.test.ts
+++ b/products/desktop/packages/core/src/sessions/promptContent.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  extractImageFileTags,
   extractPromptDisplayContent,
   makeAttachmentUri,
   parseAttachmentUri,
@@ -104,5 +105,31 @@ describe("promptContent", () => {
     expect(result.attachments).toEqual([
       { id: fileUri, label: "screenshot.png" },
     ]);
+  });
+
+  it.each([
+    {
+      name: "lifts an absolute image tag out of the text",
+      text: 'look at this <file path="/tmp/attachment-abc/clipboard.png" />',
+      expected: {
+        text: "look at this",
+        attachments: [
+          {
+            id: "file:///tmp/attachment-abc/clipboard.png",
+            label: "clipboard.png",
+          },
+        ],
+      },
+    },
+    {
+      name: "keeps relative and non-image file mentions inline",
+      text: 'see <file path="src/logo.png" /> and <file path="/tmp/notes.md" />',
+      expected: {
+        text: 'see <file path="src/logo.png" /> and <file path="/tmp/notes.md" />',
+        attachments: [],
+      },
+    },
+  ])("extractImageFileTags $name", ({ text, expected }) => {
+    expect(extractImageFileTags(text)).toEqual(expected);
   });
 });

--- a/products/desktop/packages/core/src/sessions/promptContent.test.ts
+++ b/products/desktop/packages/core/src/sessions/promptContent.test.ts
@@ -109,23 +109,31 @@ describe("promptContent", () => {
 
   it.each([
     {
-      name: "lifts an absolute image tag out of the text",
-      text: 'look at this <file path="/tmp/attachment-abc/clipboard.png" />',
+      name: "lifts a composer image tag out of the text",
+      text: 'look at this <file path="/tmp/posthog-code-clipboard/attachment-abc/clipboard.png" />',
       expected: {
         text: "look at this",
         attachments: [
           {
-            id: "file:///tmp/attachment-abc/clipboard.png",
+            id: "file:///tmp/posthog-code-clipboard/attachment-abc/clipboard.png",
             label: "clipboard.png",
           },
         ],
       },
     },
     {
-      name: "keeps relative and non-image file mentions inline",
-      text: 'see <file path="src/logo.png" /> and <file path="/tmp/notes.md" />',
+      name: "keeps images outside the composer folder inline",
+      text: 'see <file path="/Users/me/Pictures/secret.png" /> and <file path="src/logo.png" />',
       expected: {
-        text: 'see <file path="src/logo.png" /> and <file path="/tmp/notes.md" />',
+        text: 'see <file path="/Users/me/Pictures/secret.png" /> and <file path="src/logo.png" />',
+        attachments: [],
+      },
+    },
+    {
+      name: "keeps non-image composer files inline",
+      text: 'see <file path="/tmp/posthog-code-clipboard/attachment-abc/notes.md" />',
+      expected: {
+        text: 'see <file path="/tmp/posthog-code-clipboard/attachment-abc/notes.md" />',
         attachments: [],
       },
     },

--- a/products/desktop/packages/core/src/sessions/promptContent.test.ts
+++ b/products/desktop/packages/core/src/sessions/promptContent.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
-  extractImageFileTags,
   extractPromptDisplayContent,
   makeAttachmentUri,
   parseAttachmentUri,
+  resolveMessageAttachments,
 } from "./promptContent";
 
 describe("promptContent", () => {
@@ -107,37 +107,61 @@ describe("promptContent", () => {
     ]);
   });
 
+  const clipboardImage = {
+    id: "file:///tmp/posthog-code-clipboard/attachment-abc/clipboard.png",
+    label: "clipboard.png",
+  };
+
   it.each([
     {
       name: "lifts a composer image tag out of the text",
       text: 'look at this <file path="/tmp/posthog-code-clipboard/attachment-abc/clipboard.png" />',
-      expected: {
-        text: "look at this",
-        attachments: [
-          {
-            id: "file:///tmp/posthog-code-clipboard/attachment-abc/clipboard.png",
-            label: "clipboard.png",
-          },
-        ],
-      },
+      given: [],
+      expected: { text: "look at this", attachments: [clipboardImage] },
     },
     {
       name: "keeps images outside the composer folder inline",
-      text: 'see <file path="/Users/me/Pictures/secret.png" /> and <file path="src/logo.png" />',
+      text: 'see <file path="/Users/me/Pictures/secret.png" />',
+      given: [],
       expected: {
-        text: 'see <file path="/Users/me/Pictures/secret.png" /> and <file path="src/logo.png" />',
+        text: 'see <file path="/Users/me/Pictures/secret.png" />',
+        attachments: [],
+      },
+    },
+    {
+      name: "keeps network share paths inline",
+      text: 'see <file path="\\\\host\\share\\posthog-code-clipboard\\attachment-a\\x.png" />',
+      given: [],
+      expected: {
+        text: 'see <file path="\\\\host\\share\\posthog-code-clipboard\\attachment-a\\x.png" />',
         attachments: [],
       },
     },
     {
       name: "keeps non-image composer files inline",
       text: 'see <file path="/tmp/posthog-code-clipboard/attachment-abc/notes.md" />',
+      given: [],
       expected: {
         text: 'see <file path="/tmp/posthog-code-clipboard/attachment-abc/notes.md" />',
         attachments: [],
       },
     },
-  ])("extractImageFileTags $name", ({ text, expected }) => {
-    expect(extractImageFileTags(text)).toEqual(expected);
+    {
+      name: "drops a summary that names only the shown files",
+      text: "Attached files: clipboard.png",
+      given: [clipboardImage],
+      expected: { text: "", attachments: [clipboardImage] },
+    },
+    {
+      name: "keeps a summary that names a file it does not show",
+      text: "hello\n\nAttached files: other.png",
+      given: [clipboardImage],
+      expected: {
+        text: "hello\n\nAttached files: other.png",
+        attachments: [clipboardImage],
+      },
+    },
+  ])("resolveMessageAttachments $name", ({ text, given, expected }) => {
+    expect(resolveMessageAttachments(text, given)).toEqual(expected);
   });
 });

--- a/products/desktop/packages/core/src/sessions/promptContent.ts
+++ b/products/desktop/packages/core/src/sessions/promptContent.ts
@@ -6,6 +6,11 @@ import {
   pathToFileUri,
   unescapeXmlAttr,
 } from "@posthog/shared";
+import {
+  ABSOLUTE_FILE_TAG_REGEX,
+  normalizePromptText,
+  stripAttachmentSummaryOf,
+} from "../editor/cloud-prompt";
 
 const ATTACHMENT_URI_PREFIX = "attachment://";
 
@@ -179,30 +184,56 @@ export function extractPromptDisplayContent(
   return { text: textParts.join(""), attachments };
 }
 
-const FILE_TAG_REGEX = /<file\s+path="([^"]+)"\s*\/>/g;
+const MENTION_TAG_TEST =
+  /<(?:file\s+path|folder\s+path|github_issue\s+number|github_pr\s+number|error_context\s+label)="[^"]+"/;
+export const SLASH_COMMAND_START = /^\/([a-zA-Z][\w-]*)(?=\s|$)/;
 
-export function extractImageFileTags(text: string): PromptDisplayContent {
-  const attachments: AttachmentRef[] = [];
-  const stripped = text.replace(FILE_TAG_REGEX, (tag, rawPath: string) => {
-    const filePath = unescapeXmlAttr(rawPath);
-    const label = getFileName(filePath);
-    // Message text is not trusted: only files the composer saved may be read from disk.
-    if (!isClipboardAttachmentPath(filePath) || !isRasterImageFile(label)) {
-      return tag;
-    }
-    const id = pathToFileUri(filePath);
-    if (!attachments.some((attachment) => attachment.id === id)) {
-      attachments.push({ id, label });
-    }
-    return "";
-  });
-  if (attachments.length === 0) return { text, attachments };
+export function hasMentionTags(content: string): boolean {
+  return MENTION_TAG_TEST.test(content) || SLASH_COMMAND_START.test(content);
+}
 
+export function resolveMessageAttachments(
+  text: string,
+  attachments: AttachmentRef[],
+): PromptDisplayContent {
+  const lifted = extractImageFileTags(text);
+  // contentToXml folds every attachment into a <file /> mention, so text that
+  // still carries one already lists the message's attachments inline.
+  const visible = hasMentionTags(lifted.text)
+    ? lifted.attachments
+    : [
+        ...attachments,
+        ...lifted.attachments.filter(
+          (image) => !attachments.some(({ id }) => id === image.id),
+        ),
+      ];
   return {
-    text: stripped
-      .replace(/[ \t]+$/gm, "")
-      .replace(/\n{3,}/g, "\n\n")
-      .trim(),
-    attachments,
+    text: stripAttachmentSummaryOf(
+      lifted.text,
+      new Set(visible.map(({ label }) => label)),
+    ),
+    attachments: visible,
   };
+}
+
+function extractImageFileTags(text: string): PromptDisplayContent {
+  const attachments: AttachmentRef[] = [];
+  const stripped = text.replace(
+    ABSOLUTE_FILE_TAG_REGEX,
+    (tag, rawPath: string) => {
+      const filePath = unescapeXmlAttr(rawPath);
+      const label = getFileName(filePath);
+      // Message text is not trusted: only files the composer saved may be read from disk.
+      if (!isClipboardAttachmentPath(filePath) || !isRasterImageFile(label)) {
+        return tag;
+      }
+      const id = pathToFileUri(filePath);
+      if (!attachments.some((attachment) => attachment.id === id)) {
+        attachments.push({ id, label });
+      }
+      return "";
+    },
+  );
+  if (attachments.length === 0) return { text, attachments };
+  return { text: normalizePromptText(stripped), attachments };
 }

--- a/products/desktop/packages/core/src/sessions/promptContent.ts
+++ b/products/desktop/packages/core/src/sessions/promptContent.ts
@@ -1,7 +1,7 @@
 import type { ContentBlock } from "@agentclientprotocol/sdk";
 import {
   getFileName,
-  isAbsolutePath,
+  isClipboardAttachmentPath,
   isRasterImageFile,
   pathToFileUri,
   unescapeXmlAttr,
@@ -186,7 +186,10 @@ export function extractImageFileTags(text: string): PromptDisplayContent {
   const stripped = text.replace(FILE_TAG_REGEX, (tag, rawPath: string) => {
     const filePath = unescapeXmlAttr(rawPath);
     const label = getFileName(filePath);
-    if (!isAbsolutePath(filePath) || !isRasterImageFile(label)) return tag;
+    // Message text is not trusted: only files the composer saved may be read from disk.
+    if (!isClipboardAttachmentPath(filePath) || !isRasterImageFile(label)) {
+      return tag;
+    }
     const id = pathToFileUri(filePath);
     if (!attachments.some((attachment) => attachment.id === id)) {
       attachments.push({ id, label });

--- a/products/desktop/packages/core/src/sessions/promptContent.ts
+++ b/products/desktop/packages/core/src/sessions/promptContent.ts
@@ -1,5 +1,11 @@
 import type { ContentBlock } from "@agentclientprotocol/sdk";
-import { getFileName } from "@posthog/shared";
+import {
+  getFileName,
+  isAbsolutePath,
+  isRasterImageFile,
+  pathToFileUri,
+  unescapeXmlAttr,
+} from "@posthog/shared";
 
 const ATTACHMENT_URI_PREFIX = "attachment://";
 
@@ -171,4 +177,29 @@ export function extractPromptDisplayContent(
   }
 
   return { text: textParts.join(""), attachments };
+}
+
+const FILE_TAG_REGEX = /<file\s+path="([^"]+)"\s*\/>/g;
+
+export function extractImageFileTags(text: string): PromptDisplayContent {
+  const attachments: AttachmentRef[] = [];
+  const stripped = text.replace(FILE_TAG_REGEX, (tag, rawPath: string) => {
+    const filePath = unescapeXmlAttr(rawPath);
+    const label = getFileName(filePath);
+    if (!isAbsolutePath(filePath) || !isRasterImageFile(label)) return tag;
+    const id = pathToFileUri(filePath);
+    if (!attachments.some((attachment) => attachment.id === id)) {
+      attachments.push({ id, label });
+    }
+    return "";
+  });
+  if (attachments.length === 0) return { text, attachments };
+
+  return {
+    text: stripped
+      .replace(/[ \t]+$/gm, "")
+      .replace(/\n{3,}/g, "\n\n")
+      .trim(),
+    attachments,
+  };
 }

--- a/products/desktop/packages/shared/src/index.ts
+++ b/products/desktop/packages/shared/src/index.ts
@@ -253,11 +253,14 @@ export {
   workflowAgentStateSchema,
 } from "./orchestration";
 export {
+  CLIPBOARD_ATTACHMENT_DIR_NAME,
+  CLIPBOARD_ATTACHMENT_PREFIX,
   compactHomePath,
   expandTildePath,
   getFileExtension,
   getFileName,
   isAbsolutePath,
+  isClipboardAttachmentPath,
   pathToFileUri,
   toRelativePath,
 } from "./path";

--- a/products/desktop/packages/shared/src/path.ts
+++ b/products/desktop/packages/shared/src/path.ts
@@ -55,6 +55,22 @@ export function getFileExtension(filePath: string): string {
   return lastDot >= 0 ? name.slice(lastDot + 1).toLowerCase() : "";
 }
 
+export const CLIPBOARD_ATTACHMENT_DIR_NAME = "posthog-code-clipboard";
+export const CLIPBOARD_ATTACHMENT_PREFIX = "attachment-";
+
+const CLIPBOARD_ATTACHMENT_PATH_REGEX = new RegExp(
+  `[\\\\/]${CLIPBOARD_ATTACHMENT_DIR_NAME}[\\\\/]${CLIPBOARD_ATTACHMENT_PREFIX}[^\\\\/]+[\\\\/][^\\\\/]+$`,
+);
+
+/** True for a file the composer saved, at `<tmp>/posthog-code-clipboard/attachment-*\/<name>`. */
+export function isClipboardAttachmentPath(filePath: string): boolean {
+  return (
+    isAbsolutePath(filePath) &&
+    CLIPBOARD_ATTACHMENT_PATH_REGEX.test(filePath) &&
+    !filePath.split(/[\\/]/).includes("..")
+  );
+}
+
 /**
  * Convert a local file path to a `file://` URI.
  * Renderer-safe (no `node:*` imports) and supports Windows drive and UNC paths.

--- a/products/desktop/packages/shared/src/path.ts
+++ b/products/desktop/packages/shared/src/path.ts
@@ -58,16 +58,19 @@ export function getFileExtension(filePath: string): string {
 export const CLIPBOARD_ATTACHMENT_DIR_NAME = "posthog-code-clipboard";
 export const CLIPBOARD_ATTACHMENT_PREFIX = "attachment-";
 
-const CLIPBOARD_ATTACHMENT_PATH_REGEX = new RegExp(
-  `[\\\\/]${CLIPBOARD_ATTACHMENT_DIR_NAME}[\\\\/]${CLIPBOARD_ATTACHMENT_PREFIX}[^\\\\/]+[\\\\/][^\\\\/]+$`,
-);
-
-/** True for a file the composer saved, at `<tmp>/posthog-code-clipboard/attachment-*\/<name>`. */
+/** True for a path shaped like a composer-saved file: `<dir>/posthog-code-clipboard/attachment-*\/<name>`. */
 export function isClipboardAttachmentPath(filePath: string): boolean {
+  const normalized = filePath.replaceAll("\\", "/");
+  if (!isAbsolutePath(filePath) || normalized.startsWith("//")) return false;
+  const segments = normalized.split("/");
+  const [dir, folder, name] = segments.slice(-3);
   return (
-    isAbsolutePath(filePath) &&
-    CLIPBOARD_ATTACHMENT_PATH_REGEX.test(filePath) &&
-    !filePath.split(/[\\/]/).includes("..")
+    dir === CLIPBOARD_ATTACHMENT_DIR_NAME &&
+    folder !== undefined &&
+    folder.length > CLIPBOARD_ATTACHMENT_PREFIX.length &&
+    folder.startsWith(CLIPBOARD_ATTACHMENT_PREFIX) &&
+    !!name &&
+    !segments.includes("..")
   );
 }
 

--- a/products/desktop/packages/ui/src/features/sessions/components/UserMessageAttachments.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/UserMessageAttachments.tsx
@@ -81,13 +81,13 @@ function ImageAttachment({
       <Dialog.Trigger>
         <button
           type="button"
-          className="group relative h-16 w-20 overflow-hidden rounded-md border border-gray-6 bg-gray-3"
+          className="group relative block max-w-full overflow-hidden rounded-md border border-gray-6 bg-gray-3"
           aria-label={`Preview ${attachment.label}`}
         >
           <img
             src={previewUrl}
             alt={attachment.label}
-            className="size-full object-cover transition-transform group-hover:scale-105"
+            className="block h-auto max-h-48 w-auto max-w-64 transition-transform group-hover:scale-105"
           />
           <span className="absolute inset-x-0 bottom-0 truncate bg-black/60 px-1.5 py-0.5 text-left text-[10px] text-white">
             {attachment.label}

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -121,7 +121,10 @@ import {
   useTurnFeedback,
 } from "@posthog/ui/features/sessions/sessionViewStore";
 import { useThreadScrollRequest } from "@posthog/ui/features/sessions/threadNavigationStore";
-import type { UserMessageAttachment } from "@posthog/ui/features/sessions/userMessageTypes";
+import {
+  NO_ATTACHMENTS,
+  type UserMessageAttachment,
+} from "@posthog/ui/features/sessions/userMessageTypes";
 import {
   SessionTaskIdProvider,
   useSessionTaskId,
@@ -154,8 +157,6 @@ import {
 import { useHotkeys } from "react-hotkeys-hook";
 
 type SessionUpdateItem = Extract<ConversationItem, { type: "session_update" }>;
-
-const NO_ATTACHMENTS: UserMessageAttachment[] = [];
 
 function isToolCallItem(item: ConversationItem): item is SessionUpdateItem {
   return (

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -155,6 +155,8 @@ import { useHotkeys } from "react-hotkeys-hook";
 
 type SessionUpdateItem = Extract<ConversationItem, { type: "session_update" }>;
 
+const NO_ATTACHMENTS: UserMessageAttachment[] = [];
+
 function isToolCallItem(item: ConversationItem): item is SessionUpdateItem {
   return (
     item.type === "session_update" && item.update.sessionUpdate === "tool_call"
@@ -528,7 +530,7 @@ function CopyButton({ value, label }: { value: string; label: string }) {
 function UserBubble({
   content,
   timestamp,
-  attachments = [],
+  attachments = NO_ATTACHMENTS,
   keyboardFocused = false,
 }: {
   content: string;

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -102,6 +102,7 @@ import { isShowActionsItem } from "@posthog/ui/features/sessions/components/sess
 import { UserShellExecuteView } from "@posthog/ui/features/sessions/components/session-update/UserShellExecuteView";
 import { splitUserMessage } from "@posthog/ui/features/sessions/components/session-update/userMessageDisplay";
 import { useVisibleInjectedBlocks } from "@posthog/ui/features/sessions/components/session-update/useVisibleInjectedBlocks";
+import { UserMessageAttachments } from "@posthog/ui/features/sessions/components/UserMessageAttachments";
 import {
   CHAT_CONTENT_MAX_WIDTH,
   CHAT_CONTENT_PADDING_INLINE,
@@ -539,9 +540,14 @@ function UserBubble({
   // message (start-aligned, outlined, provenance chip) instead of masquerading
   // as something this run's user typed. The envelope boilerplate never renders;
   // only the sender-authored body flows into the normal pipeline below.
-  const { peerAgentMessage, blocks, displayContent } = useMemo(
-    () => splitUserMessage(content),
-    [content],
+  const {
+    peerAgentMessage,
+    blocks,
+    displayContent,
+    attachments: visibleAttachments,
+  } = useMemo(
+    () => splitUserMessage(content, attachments),
+    [content, attachments],
   );
   const visibleBlocks = useVisibleInjectedBlocks(blocks);
   // Provenance is never flag-gated: a peer message must not read as the user's.
@@ -555,7 +561,7 @@ function UserBubble({
       <ChatMessage align={peerAgentMessage ? "start" : "end"} className="group">
         <ChatMessageContent className="gap-1">
           {showHeaderChips && (
-            <ChatMessageHeader className="flex-wrap gap-1">
+            <ChatMessageHeader className="flex-wrap gap-1 px-0">
               {peerAgentMessage && (
                 <MentionChip
                   icon={<Robot size={12} />}
@@ -565,8 +571,13 @@ function UserBubble({
               <InjectedBlockChips blocks={visibleBlocks} taskId={taskId} />
             </ChatMessageHeader>
           )}
+          {visibleAttachments.length > 0 && (
+            <div className={peerAgentMessage ? "self-start" : "self-end"}>
+              <UserMessageAttachments attachments={visibleAttachments} />
+            </div>
+          )}
           {/* The brief is the whole message, so stripping it leaves nothing to put in a bubble. */}
-          {(!!displayContent || attachments.length > 0) && (
+          {!!displayContent && (
             <ChatBubble
               align={peerAgentMessage ? "start" : "end"}
               variant={peerAgentMessage ? "outline" : "default"}
@@ -576,10 +587,7 @@ function UserBubble({
               )}
             >
               <ChatBubbleContent>
-                <UserMessageBody
-                  content={displayContent}
-                  attachments={attachments}
-                />
+                <UserMessageBody content={displayContent} />
               </ChatBubbleContent>
             </ChatBubble>
           )}

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/UserMessageBody.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/UserMessageBody.tsx
@@ -5,8 +5,6 @@ import {
   hasFileMentions,
   parseFileMentions,
 } from "@posthog/ui/features/sessions/components/session-update/parseFileMentions";
-import { UserMessageAttachments } from "@posthog/ui/features/sessions/components/UserMessageAttachments";
-import type { UserMessageAttachment } from "@posthog/ui/features/sessions/userMessageTypes";
 import { useEffect, useRef, useState } from "react";
 
 /**
@@ -15,19 +13,10 @@ import { useEffect, useRef, useState } from "react";
  * identically in the live transcript and in views that precede it. Plain
  * content renders as markdown.
  *
- * Attachments hide when the content carries file mentions: contentToXml folds
- * every attachment into a <file /> tag, so showing both would list it twice.
- *
  * Long content clamps to five lines with a Show more toggle, so a bubble in a
  * pre-transcript view never grows past what the live bubble would show.
  */
-export function UserMessageBody({
-  content,
-  attachments = [],
-}: {
-  content: string;
-  attachments?: UserMessageAttachment[];
-}) {
+export function UserMessageBody({ content }: { content: string }) {
   const containsFileMentions = hasFileMentions(content);
 
   const [isExpanded, setIsExpanded] = useState(false);
@@ -71,11 +60,6 @@ export function UserMessageBody({
           <ChatMarkdown content={content} />
         )}
       </div>
-      {attachments.length > 0 && !containsFileMentions && (
-        <div className="mt-1.5">
-          <UserMessageAttachments attachments={attachments} />
-        </div>
-      )}
       {isOverflowing && (
         <button
           type="button"

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/UserMessage.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/UserMessage.tsx
@@ -27,6 +27,8 @@ interface UserMessageProps {
   keyboardFocused?: boolean;
 }
 
+const NO_ATTACHMENTS: UserMessageAttachment[] = [];
+
 function formatTimestamp(ts: number): string {
   return new Date(ts).toLocaleString([], {
     month: "short",
@@ -47,7 +49,7 @@ export const UserMessage = memo(function UserMessage({
   content,
   timestamp,
   sourceUrl,
-  attachments = [],
+  attachments = NO_ATTACHMENTS,
   animate = true,
   taskId,
   keyboardFocused = false,

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/UserMessage.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/UserMessage.tsx
@@ -4,7 +4,10 @@ import { motion } from "framer-motion";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Tooltip } from "../../../../primitives/Tooltip";
 import { MarkdownRenderer } from "../../../editor/components/MarkdownRenderer";
-import type { UserMessageAttachment } from "../../userMessageTypes";
+import {
+  NO_ATTACHMENTS,
+  type UserMessageAttachment,
+} from "../../userMessageTypes";
 import { UserMessageAttachments } from "../UserMessageAttachments";
 import { CollapsibleMessageContent } from "./CollapsibleMessageContent";
 import { InjectedBlockChips } from "./InjectedBlockChips";
@@ -26,8 +29,6 @@ interface UserMessageProps {
   taskId?: string;
   keyboardFocused?: boolean;
 }
-
-const NO_ATTACHMENTS: UserMessageAttachment[] = [];
 
 function formatTimestamp(ts: number): string {
   return new Date(ts).toLocaleString([], {

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/UserMessage.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/UserMessage.tsx
@@ -55,14 +55,18 @@ export const UserMessage = memo(function UserMessage({
   // A message relayed from another agent run renders with a provenance chip and
   // neutral accent instead of masquerading as this run's user. The envelope
   // boilerplate never renders; only the sender-authored body flows on.
-  const { peerAgentMessage, blocks, displayContent } = useMemo(
-    () => splitUserMessage(content),
-    [content],
+  const {
+    peerAgentMessage,
+    blocks,
+    displayContent,
+    attachments: visibleAttachments,
+  } = useMemo(
+    () => splitUserMessage(content, attachments),
+    [content, attachments],
   );
   const visibleBlocks = useVisibleInjectedBlocks(blocks);
 
   const containsFileMentions = hasFileMentions(displayContent);
-  const showAttachmentChips = attachments.length > 0 && !containsFileMentions;
   const [copied, setCopied] = useState(false);
 
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
@@ -91,6 +95,11 @@ export const UserMessage = memo(function UserMessage({
         }}
       >
         <CollapsibleMessageContent contentClassName="font-medium text-[13px] [&_p]:leading-[1.9]">
+          {visibleAttachments.length > 0 && (
+            <div className={displayContent ? "mb-1.5" : ""}>
+              <UserMessageAttachments attachments={visibleAttachments} />
+            </div>
+          )}
           {containsFileMentions ? (
             parseFileMentions(displayContent)
           ) : (
@@ -107,11 +116,6 @@ export const UserMessage = memo(function UserMessage({
                 />
               )}
               <InjectedBlockChips blocks={visibleBlocks} taskId={taskId} />
-            </div>
-          )}
-          {showAttachmentChips && (
-            <div className={content.trim() ? "mt-1.5" : ""}>
-              <UserMessageAttachments attachments={attachments} />
             </div>
           )}
         </CollapsibleMessageContent>

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/parseFileMentions.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/parseFileMentions.tsx
@@ -1,4 +1,8 @@
 import { File, Folder, Warning } from "@phosphor-icons/react";
+import {
+  hasMentionTags,
+  SLASH_COMMAND_START,
+} from "@posthog/core/sessions/promptContent";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@posthog/quill";
 import { unescapeXmlAttr } from "@posthog/shared";
 import { Text } from "@radix-ui/themes";
@@ -14,9 +18,6 @@ import {
 
 const MENTION_TAG_REGEX =
   /<file\s+path="([^"]+)"\s*\/>|<(github_issue|github_pr)\s+number="([^"]+)"(?:\s+title="([^"]*)")?(?:\s+url="([^"]*)")?\s*\/>|<error_context\s+label="([^"]*)">[\s\S]*?<\/error_context>|<folder\s+path="([^"]+)"\s*\/>/g;
-const MENTION_TAG_TEST =
-  /<(?:file\s+path|folder\s+path|github_issue\s+number|github_pr\s+number|error_context\s+label)="[^"]+"/;
-const SLASH_COMMAND_START = /^\/([a-zA-Z][\w-]*)(?=\s|$)/;
 
 const inlineComponents: Components = {
   ...baseComponents,
@@ -41,10 +42,6 @@ const InlineMarkdown = memo(function InlineMarkdown({
     </ReactMarkdown>
   );
 });
-
-function hasMentionTags(content: string): boolean {
-  return MENTION_TAG_TEST.test(content) || SLASH_COMMAND_START.test(content);
-}
 
 export const hasFileMentions = hasMentionTags;
 

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/userMessageDisplay.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/userMessageDisplay.ts
@@ -1,11 +1,9 @@
-import { stripTrailingAttachmentSummary } from "@posthog/core/editor/cloud-prompt";
 import {
   type InjectedBlock,
   splitInjectedBlocks,
 } from "@posthog/core/editor/injectedBlocks";
-import { extractImageFileTags } from "@posthog/core/sessions/promptContent";
+import { resolveMessageAttachments } from "@posthog/core/sessions/promptContent";
 import type { UserMessageAttachment } from "@posthog/ui/features/sessions/userMessageTypes";
-import { hasFileMentions } from "./parseFileMentions";
 import {
   extractPeerAgentMessage,
   type PeerAgentMessage,
@@ -27,27 +25,15 @@ export function splitUserMessage(
   const { blocks, text } = splitInjectedBlocks(
     peerAgentMessage ? peerAgentMessage.body : content,
   );
-  const { text: displayText, attachments: imageAttachments } =
-    extractImageFileTags(collapsePiSkillInvocation(text));
-  // contentToXml folds every attachment into a <file /> mention, so text that
-  // still carries one already lists the message's attachments inline.
-  const visibleAttachments = hasFileMentions(displayText)
-    ? imageAttachments
-    : [
-        ...attachments,
-        ...imageAttachments.filter(
-          (image) => !attachments.some(({ id }) => id === image.id),
-        ),
-      ];
+  const resolved = resolveMessageAttachments(
+    collapsePiSkillInvocation(text),
+    attachments,
+  );
   return {
     peerAgentMessage,
     blocks,
-    // The "Attached files: …" summary only stands in for attachments we cannot draw.
-    displayContent:
-      visibleAttachments.length > 0
-        ? stripTrailingAttachmentSummary(displayText)
-        : displayText,
-    attachments: visibleAttachments,
+    displayContent: resolved.text,
+    attachments: resolved.attachments,
   };
 }
 

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/userMessageDisplay.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/userMessageDisplay.ts
@@ -1,7 +1,11 @@
+import { stripTrailingAttachmentSummary } from "@posthog/core/editor/cloud-prompt";
 import {
   type InjectedBlock,
   splitInjectedBlocks,
 } from "@posthog/core/editor/injectedBlocks";
+import { extractImageFileTags } from "@posthog/core/sessions/promptContent";
+import type { UserMessageAttachment } from "@posthog/ui/features/sessions/userMessageTypes";
+import { hasFileMentions } from "./parseFileMentions";
 import {
   extractPeerAgentMessage,
   type PeerAgentMessage,
@@ -12,17 +16,38 @@ export interface UserMessageParts {
   peerAgentMessage: PeerAgentMessage | null;
   blocks: InjectedBlock[];
   displayContent: string;
+  attachments: UserMessageAttachment[];
 }
 
-export function splitUserMessage(content: string): UserMessageParts {
+export function splitUserMessage(
+  content: string,
+  attachments: UserMessageAttachment[] = [],
+): UserMessageParts {
   const peerAgentMessage = extractPeerAgentMessage(content);
   const { blocks, text } = splitInjectedBlocks(
     peerAgentMessage ? peerAgentMessage.body : content,
   );
+  const { text: displayText, attachments: imageAttachments } =
+    extractImageFileTags(collapsePiSkillInvocation(text));
+  // contentToXml folds every attachment into a <file /> mention, so text that
+  // still carries one already lists the message's attachments inline.
+  const visibleAttachments = hasFileMentions(displayText)
+    ? imageAttachments
+    : [
+        ...attachments,
+        ...imageAttachments.filter(
+          (image) => !attachments.some(({ id }) => id === image.id),
+        ),
+      ];
   return {
     peerAgentMessage,
     blocks,
-    displayContent: collapsePiSkillInvocation(text),
+    // The "Attached files: …" summary only stands in for attachments we cannot draw.
+    displayContent:
+      visibleAttachments.length > 0
+        ? stripTrailingAttachmentSummary(displayText)
+        : displayText,
+    attachments: visibleAttachments,
   };
 }
 

--- a/products/desktop/packages/ui/src/features/sessions/userMessageTypes.ts
+++ b/products/desktop/packages/ui/src/features/sessions/userMessageTypes.ts
@@ -1,3 +1,5 @@
 import type { AttachmentRef } from "@posthog/core/sessions/promptContent";
 
 export type UserMessageAttachment = AttachmentRef;
+
+export const NO_ATTACHMENTS: UserMessageAttachment[] = [];

--- a/products/desktop/packages/workspace-server/src/services/os/os.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/os/os.test.ts
@@ -625,3 +625,44 @@ describe("OsService.getClaudePermissions", () => {
     });
   });
 });
+
+describe("OsService.readFileAsDataUrl", () => {
+  const clipboardFile = path.join(
+    os.tmpdir(),
+    "posthog-code-clipboard",
+    "attachment-a",
+    "shot.png",
+  );
+  const lookAlike = "/work/repo/posthog-code-clipboard/attachment-a/shot.png";
+
+  it.each([
+    {
+      name: "reads an image the composer saved",
+      requested: clipboardFile,
+      resolvesTo: clipboardFile,
+      expected: "data:image/png;base64,aW1n",
+    },
+    {
+      name: "rejects a look-alike folder outside the temp dir",
+      requested: lookAlike,
+      resolvesTo: lookAlike,
+      expected: null,
+    },
+    {
+      name: "rejects a clipboard file that links elsewhere",
+      requested: clipboardFile,
+      resolvesTo: "/Users/me/secret.png",
+      expected: null,
+    },
+  ])("$name", async ({ requested, resolvesTo, expected }) => {
+    mockRealpath.mockImplementation(async (p: string) =>
+      p === requested ? resolvesTo : p,
+    );
+    mockStat.mockResolvedValue({ size: 3 });
+    mockReadFile.mockResolvedValue(Buffer.from("img"));
+    const { service } = createService();
+
+    expect(await service.readFileAsDataUrl(requested, 1024)).toBe(expected);
+    expect(mockReadFile).toHaveBeenCalledTimes(expected ? 1 : 0);
+  });
+});

--- a/products/desktop/packages/workspace-server/src/services/os/os.ts
+++ b/products/desktop/packages/workspace-server/src/services/os/os.ts
@@ -29,6 +29,7 @@ import {
   CLIPBOARD_ATTACHMENT_DIR_NAME,
   CLIPBOARD_ATTACHMENT_PREFIX,
   IMAGE_MIME_TYPES,
+  isClipboardAttachmentPath,
   isRasterImageFile,
 } from "@posthog/shared";
 import { inject, injectable } from "inversify";
@@ -54,6 +55,17 @@ const CLIPBOARD_TEMP_DIR = path.join(
   CLIPBOARD_ATTACHMENT_DIR_NAME,
 );
 const claudeSettingsPath = path.join(os.homedir(), ".claude", "settings.json");
+
+async function isInsideClipboardTempDir(filePath: string): Promise<boolean> {
+  const [realFile, realDir] = await Promise.all([
+    fsPromises.realpath(filePath),
+    fsPromises.realpath(CLIPBOARD_TEMP_DIR),
+  ]);
+  const relative = path.relative(realDir, realFile);
+  return (
+    relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative)
+  );
+}
 
 // User-level agent instruction files as path segments under the home
 // directory, most-preferred first: AGENTS.md (the cross-agent convention) from
@@ -493,6 +505,13 @@ export class OsService {
     maxSizeBytes: number,
   ): Promise<string | null> {
     try {
+      // Message text can name a clipboard-shaped path, so it must resolve inside the real folder.
+      if (
+        isClipboardAttachmentPath(filePath) &&
+        !(await isInsideClipboardTempDir(filePath))
+      ) {
+        return null;
+      }
       const stat = await fsPromises.stat(filePath);
       if (stat.size > maxSizeBytes) return null;
 

--- a/products/desktop/packages/workspace-server/src/services/os/os.ts
+++ b/products/desktop/packages/workspace-server/src/services/os/os.ts
@@ -26,6 +26,8 @@ import {
 } from "@posthog/platform/workspace-settings";
 import {
   ALLOWED_IMAGE_MIME_TYPES,
+  CLIPBOARD_ATTACHMENT_DIR_NAME,
+  CLIPBOARD_ATTACHMENT_PREFIX,
   IMAGE_MIME_TYPES,
   isRasterImageFile,
 } from "@posthog/shared";
@@ -47,7 +49,10 @@ const fsPromises = fs.promises;
 const MAX_IMAGE_DIMENSION = 1568;
 const JPEG_QUALITY = 85;
 const MAX_FILE_SIZE = 50 * 1024 * 1024;
-const CLIPBOARD_TEMP_DIR = path.join(os.tmpdir(), "posthog-code-clipboard");
+const CLIPBOARD_TEMP_DIR = path.join(
+  os.tmpdir(),
+  CLIPBOARD_ATTACHMENT_DIR_NAME,
+);
 const claudeSettingsPath = path.join(os.homedir(), ".claude", "settings.json");
 
 // User-level agent instruction files as path segments under the home
@@ -565,7 +570,7 @@ export class OsService {
     const safeName = path.basename(displayName) || "attachment";
     await fsPromises.mkdir(CLIPBOARD_TEMP_DIR, { recursive: true });
     const tempDir = await fsPromises.mkdtemp(
-      path.join(CLIPBOARD_TEMP_DIR, "attachment-"),
+      path.join(CLIPBOARD_TEMP_DIR, CLIPBOARD_ATTACHMENT_PREFIX),
     );
     return path.join(tempDir, safeName);
   }


### PR DESCRIPTION
## Problem

- A person who pastes an image into a desktop follow-up sees a file chip (`attachment-…/clipboard.png`), not the image.
- The chip shows on submit and stays after reload.
- The composer sends the image only as a `<file path>` tag in the message text, and the thread draws that tag as a chip.

<img width="1904" height="634" alt="2026-09-11 17 22 40" src="https://github.com/user-attachments/assets/26aee3b0-7e90-46a2-a1b0-995208ca0cd7" />


## Changes

- Images sent with a message now show above the message bubble, at their own aspect ratio, up to 256×192.
- This applies in the chat thread and in the conversation view.
- Core `resolveMessageAttachments` lifts an image `<file>` tag out of the text only when the path is a file the composer saved (`<tmp>/posthog-code-clipboard/attachment-*/<name>`).
- Any other path, including network share paths and non-image files, stays inline as a chip and reads nothing from disk.
- The workspace server reads a clipboard-shaped path only when it resolves inside the real clipboard temp folder, so look-alike folders and symlinks read nothing.
- Lifted images get `file://` ids, so they dedupe against the `resource_link` blocks that task creation builds.
- `splitUserMessage` calls `resolveMessageAttachments`, so the optimistic row, the stored row, and cloud rows share one path.
- An image-only message drops its "Attached files: …" line, but only when every file the line names is shown.
- The user bubble header drops its inline padding (`px-0`).

| Before | After |
| --- | --- |
| ![pr-before](https://raw.githubusercontent.com/PostHog/pr-assets/eb507d50a55e86c36e7fddf3d9a12c049ae80ad0/2026/09/d29cc47f-5d3f-43d4-93b8-4c8a0758070b.png) | ![pr-after](https://raw.githubusercontent.com/PostHog/pr-assets/67e5c782554ace4c137391825442ab2fedcb8cd3/2026/09/290da803-ab42-461d-b6e3-deed425f03c3.png) |

## How did you test this code?

- `promptContent.test.ts` cases: composer image tags are lifted, and other, network share, and non-image paths stay inline.
- They also check that the summary line drops only when it names shown files.
- `os.test.ts` cases: `readFileAsDataUrl` rejects a look-alike folder and a symlink that resolves outside the clipboard folder.
- The running desktop app over CDP showed images above existing follow-ups, with no file chips and no summary text.
- Not checked: a fresh image send watched live, and the web and mobile hosts.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Claude Opus 5) authored the change under direction from the assignee.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/reviewing-with-coderabbit`, `/thermo-nuclear-code-quality-review`, `/ship-it-pr`.
- The CodeRabbit pass is paused, so the PR opened without a local pass.
- The quality review replaced a path-normalizing dedupe helper with `pathToFileUri` ids.
- No duplicate: an open PR search for desktop image attachments found nothing.
- The screenshots show only test strings from a local session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G62zuZBdg8iZLQoGmQ7Vkn

