### PR TITLE
fix(replay): normalize referer slashes without backtracking

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -822,8 +822,8 @@ def clean_referer_url(current_url: str | None) -> str:
         path = re.sub(r"^/?replay/playlists/.+$", "replay-playlists-direct", path)
 
         # remove leading and trailing slashes
-        path = re.sub(r"^/+|/+$", "", path)
-        path = re.sub("/", "-", path)
+        path = path.strip("/")
+        path = path.replace("/", "-")
         return path or "unknown"
     except Exception as e:
         capture_exception(e, additional_properties={"current_url": current_url, "function_name": "clean_referer_url"})

--- a/posthog/session_recordings/test/test_clean_referer_url.py
+++ b/posthog/session_recordings/test/test_clean_referer_url.py
@@ -3,9 +3,17 @@ from django.test.testcases import SimpleTestCase
 from parameterized import parameterized
 
 from posthog.session_recordings.session_recording_api import clean_referer_url
+from posthog.test.regex_timeout import assert_regex_completes
 
 
 class TestCleanRefererUrl(SimpleTestCase):
+    def test_long_interior_slash_run(self) -> None:
+        def check() -> None:
+            path = "/other/" + "/" * 100_000 + "end/"
+            assert clean_referer_url(path) == "other" + "-" * 100_001 + "end"
+
+        assert_regex_completes(check)
+
     @parameterized.expand(
         [
             ("https://example.com/project/1234/", "unknown"),

--- a/posthog/test/regex_timeout.py
+++ b/posthog/test/regex_timeout.py
@@ -1,0 +1,21 @@
+from collections.abc import Callable
+from multiprocessing import get_context
+
+
+def assert_regex_completes(callback: Callable[[], None], timeout: float = 5.0) -> None:
+    """Run pure matching assertions in a killable process, outside the test runner.
+
+    Fork inherits already imported application code, keeping Django startup outside
+    the deadline. The callback must not use database connections or other services.
+    """
+    process = get_context("fork").Process(target=callback)
+    process.start()
+    try:
+        process.join(timeout)
+        assert not process.is_alive(), f"Matching did not finish within {timeout} seconds"
+        assert process.exitcode == 0, f"Matching assertions failed (exit code {process.exitcode})"
+    finally:
+        if process.is_alive():
+            process.kill()
+            process.join()
+        process.close()


### PR DESCRIPTION
## Problem

Replay updates can spend disproportionate CPU time normalizing a caller-supplied `Referer` header. `SessionRecordingViewSet.update` passes it to `clean_referer_url` after recording lookup and serializer validation; slash trimming retries over interior slash runs.

## Changes

Replace slash trimming and substitution with `str.strip` and `str.replace`. Existing normalized labels stay unchanged; only two production lines change.

## How did you test this code?

Confirmed against master `f492df0d3d98572f81e25f777d914c5dda67ff9b` before applying the fix. The new regression exercises the real normalizer in a killable child process:

```sh
pytest -q posthog/session_recordings/test/test_clean_referer_url.py
```

With only this PR's test and helper applied to that baseline, `test_long_interior_slash_run` fails its five-second deadline. With the production fix, it passes alongside the existing normalization cases.

Local measurements for 2,000 / 4,000 / 8,000 interior slashes were 10 / 37 / 146 ms before, and below 1 ms after. The larger regression also completes below 1 ms after. This catches the missing resource-bound regression without leaving a runaway test process.

Python lint, formatting, type-checking hook, and committed-diff preflight passed. Deployed endpoint behavior and proxy/header-size limits were not tested; these measurements establish the code-path issue, not production exploitability or latency.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None; normalization behavior is unchanged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). Codex with Git, GitHub CLI, pytest and hogli; private session. This independent replay-only replacement for closed #99392 retains no incident details; all new inputs are synthetic. Open-PR searches for `clean_referer_url` and replay regex fixes found no overlapping normalizer fix. Patch coverage and external review remain CI gates.

Skills used: posthog-pr-finish, engineering:code-review, writing-pr-descriptions, running-ci-preflight, writing-tests, writing-code-comments, and Superpowers brainstorming, worktree, TDD, debugging and verification guidance. CodeRabbit CLI review is paused; this PR opens without a local CodeRabbit pass. The requested scoped self-review found no actionable correctness issue.
