### PR TITLE
fix(posthog-ai): pluralize the answered question card title

### DIFF
--- a/products/desktop/packages/agent/src/adapters/claude/conversion/tool-use-to-acp.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/conversion/tool-use-to-acp.test.ts
@@ -33,4 +33,31 @@ describe("toolUpdateFromToolResult", () => {
     ]);
     expect(JSON.stringify(result)).not.toContain(pdfData);
   });
+
+  it.each([
+    { questionCount: 1, withText: false, title: "Question answered" },
+    { questionCount: 2, withText: false, title: "Questions answered" },
+    { questionCount: 1, withText: true, title: "Answer received" },
+    { questionCount: 2, withText: true, title: "Answers received" },
+  ])(
+    "titles an AskUserQuestion result for $questionCount question(s) with text=$withText as $title",
+    ({ questionCount, withText, title }) => {
+      const questions = Array.from({ length: questionCount }, (_, index) => ({
+        question: `Question ${index + 1}?`,
+        header: `Q${index + 1}`,
+        options: [{ label: "Yes" }, { label: "No" }],
+      }));
+
+      const result = toolUpdateFromToolResult(
+        {
+          type: "tool_result",
+          tool_use_id: "toolu_1",
+          content: withText ? [{ type: "text", text: "Yes" }] : [],
+        },
+        { name: "AskUserQuestion", input: { questions } },
+      );
+
+      expect(result.title).toBe(title);
+    },
+  );
 });

--- a/products/desktop/packages/agent/src/adapters/claude/conversion/tool-use-to-acp.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/conversion/tool-use-to-acp.ts
@@ -21,6 +21,10 @@ import type {
   BetaWebFetchToolResultBlockParam,
   BetaWebSearchToolResultBlockParam,
 } from "@anthropic-ai/sdk/resources/beta.mjs";
+import {
+  type AskUserQuestionInput,
+  normalizeAskUserQuestionInput,
+} from "../questions/utils";
 
 const SYSTEM_REMINDER_REGEX =
   /\s*<system-reminder>[\s\S]*?<\/system-reminder>/g;
@@ -723,6 +727,10 @@ export function toolUpdateFromToolResult(
       return { title: "Exited Plan Mode" };
     }
     case "AskUserQuestion": {
+      const questions = normalizeAskUserQuestionInput(
+        (toolUse?.input ?? {}) as AskUserQuestionInput,
+      );
+      const plural = (questions?.length ?? 0) > 1;
       const content = toolResult.content;
       if (Array.isArray(content) && content.length > 0) {
         const firstItem = content[0];
@@ -732,12 +740,12 @@ export function toolUpdateFromToolResult(
           "text" in firstItem
         ) {
           return {
-            title: "Answer received",
+            title: plural ? "Answers received" : "Answer received",
             content: toolContent().text(String(firstItem.text)).build(),
           };
         }
       }
-      return { title: "Question answered" };
+      return { title: plural ? "Questions answered" : "Question answered" };
     }
     case "WebFetch": {
       const input = toolUse?.input as Record<string, unknown> | undefined;

--- a/products/posthog_ai/frontend/components/QuestionRenderer.test.tsx
+++ b/products/posthog_ai/frontend/components/QuestionRenderer.test.tsx
@@ -83,6 +83,30 @@ describe('QuestionRenderer', () => {
         expect(screen.queryByText('Weekly')).not.toBeInTheDocument()
     })
 
+    it.each([
+        { count: 1, title: 'Question answered' },
+        { count: 2, title: 'Questions answered' },
+    ])(
+        'titles a completed call with $count question(s) "$title" despite the singular agent title',
+        ({ count, title }) => {
+            const questions = Array.from({ length: count }, (_, index) => ({
+                question: `Question ${index + 1}?`,
+                header: `Q${index + 1}`,
+                multiSelect: false,
+                options: [{ label: 'Yes' }],
+            }))
+            renderCard(
+                makeMessage({
+                    title: 'Question answered',
+                    rawInput: { questions },
+                    rawOutput: { answers: { 'Question 1?': 'Yes' } },
+                })
+            )
+
+            expect(screen.getByText(title)).toBeInTheDocument()
+        }
+    )
+
     it('falls back to a joined answer string when there is no per-question map', () => {
         renderCard(makeMessage({ rawOutput: { text: 'User picked Revenue' } }))
 

--- a/products/posthog_ai/frontend/components/QuestionRenderer.tsx
+++ b/products/posthog_ai/frontend/components/QuestionRenderer.tsx
@@ -33,6 +33,15 @@ export function QuestionRenderer(props: ToolRendererProps): JSX.Element {
         answer: answersByKey[question.question] ?? (index === 0 ? fallbackAnswer : null),
     }))
 
+    // The agent titles every finished call "Question answered" whatever the question count, so the
+    // recap derives its own title from the parsed input once the call completes.
+    const title =
+        message.status === 'completed'
+            ? questions.length > 1
+                ? 'Questions answered'
+                : 'Question answered'
+            : message.title || displayName || 'Question'
+
     const body = (
         <div className="flex flex-col gap-3 break-words">
             {entries.map((entry, index) => (
@@ -48,7 +57,7 @@ export function QuestionRenderer(props: ToolRendererProps): JSX.Element {
         <ToolActivity
             message={message}
             icon={icon ?? <IconAI />}
-            title={message.title || displayName || 'Question'}
+            title={title}
             body={body}
             turnComplete={turnComplete}
             turnCancelled={turnCancelled}


### PR DESCRIPTION
## Problem

- A PostHog AI thread titles a finished ask card "Question answered" even when the agent asked several questions in one call.
- The agent hardcodes that title on the tool result it sends over ACP, and the card echoed it as is.

## Changes

- The card now reads "Questions answered" when the call carried more than one question, and "Question answered" for one.
- `QuestionRenderer` derives that title from the parsed questions once the call completes, so the thread no longer waits on a new sandbox agent build.
- The agent's tool result conversion pluralizes its own titles the same way ("Questions answered", "Answers received"), so the desktop app gets the same fix.
- The visible change is the one title word. No screenshot was captured, and no Storybook story renders this card.

## How did you test this code?

- `QuestionRenderer.test.tsx`: two `it.each` cases render a completed call whose message still carries the agent's singular title, for one and two questions. They catch the card echoing the agent title again.
- `tool-use-to-acp.test.ts`: four cases cover one and two questions, with and without text in the result. They catch the agent title dropping the count.
- Not checked: a rendered thread. The agent package's `tsc --noEmit` also went unchecked locally because `@posthog/shared` is not built in this sandbox.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code with Claude Fable 5.1, session linked below.
- Skills invoked: /writing-tests, /writing-user-facing-copy, /writing-code-comments, /writing-pr-descriptions, /reviewing-with-coderabbit.
- The CodeRabbit pass is paused, so the PR opened without a local pass.
- Duplicate check: `gh pr list --state open` searches for "question answered" and "AskUserQuestion title" found no PR on this title.
- The fix first landed only in the agent conversion. The frontend derivation was added afterwards so the thread does not depend on a sandbox agent rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNgoPd9FBtN2eNPndFMBUn
