### PR TITLE
fix(notebooks): avoid backtracking in component recognition

### DIFF
--- a/posthog/test/regex_timeout.py
+++ b/posthog/test/regex_timeout.py
@@ -1,0 +1,21 @@
+from collections.abc import Callable
+from multiprocessing import get_context
+
+
+def assert_regex_completes(callback: Callable[[], None], timeout: float = 5.0) -> None:
+    """Run pure matching assertions in a killable process, outside the test runner.
+
+    Fork inherits already imported application code, keeping Django startup outside
+    the deadline. The callback must not use database connections or other services.
+    """
+    process = get_context("fork").Process(target=callback)
+    process.start()
+    try:
+        process.join(timeout)
+        assert not process.is_alive(), f"Matching did not finish within {timeout} seconds"
+        assert process.exitcode == 0, f"Matching assertions failed (exit code {process.exitcode})"
+    finally:
+        if process.is_alive():
+            process.kill()
+            process.join()
+        process.close()

--- a/products/notebooks/backend/test/test_sharing.py
+++ b/products/notebooks/backend/test/test_sharing.py
@@ -8,6 +8,7 @@ from parameterized import parameterized
 from rest_framework import status
 
 from posthog.models import SharingConfiguration
+from posthog.test.regex_timeout import assert_regex_completes
 
 from products.notebooks.backend.models import Notebook
 from products.notebooks.backend.util import (
@@ -275,6 +276,25 @@ class TestExtractInlineQueryNodes(TestCase):
 
 
 class TestFilterNotebookContentForSharing(TestCase):
+    def test_large_unterminated_component_remains_plain_text(self) -> None:
+        def check() -> None:
+            content = _markdown_doc("<Query " + ">" * 100_000 + "!")
+            self.assertEqual(filter_notebook_content_for_sharing(content), content)
+
+        assert_regex_completes(check)
+
+    @parameterized.expand(
+        [
+            ('<Embed src="https://example.com">caption</Embed>', '<Embed src="https://example.com" />'),
+            ("<Query>text</Query></Query>", "<Query />"),
+            ("<QueryExtra title=x></Query>", "<QueryExtra />"),
+            ("<Query></Q>", "<Query />"),
+            ('<Query title="unfinished />', "<Query />"),
+        ]
+    )
+    def test_component_closing_tag_compatibility(self, markdown: str, expected: str) -> None:
+        self.assertEqual(filter_notebook_content_for_sharing(_markdown_doc(markdown)), _markdown_doc(expected))
+
     @parameterized.expand(
         [
             ("none", None, None),

--- a/products/notebooks/backend/util.py
+++ b/products/notebooks/backend/util.py
@@ -65,7 +65,7 @@ _SHARED_NOTEBOOK_MARKDOWN_COMPONENT_PROP_TYPES: dict[str, dict[str, type | tuple
 }
 
 _MARKDOWN_COMPONENT_START_REGEX = re.compile(r"^<[A-Z][A-Za-z0-9]*(\s|>|/)")
-_MARKDOWN_COMPONENT_TAG_REGEX = re.compile(r"^<([A-Z][A-Za-z0-9]*)([\s\S]*?)(?:/>|>[\s\S]*</\1>)$")
+_MARKDOWN_COMPONENT_TAG_NAME_REGEX = re.compile(r"<([A-Z][A-Za-z0-9]*)")
 _MARKDOWN_COMPONENT_PROP_NAME_REGEX = re.compile(r"^([A-Za-z_][A-Za-z0-9_-]*)")
 _MARKDOWN_COMPONENT_RAW_PROP_VALUE_REGEX = re.compile(r"^([^\s/>]+)")
 _MARKDOWN_COMPONENT_NUMBER_REGEX = re.compile(r"^-?\d+(\.\d+)?$")
@@ -405,7 +405,7 @@ def _read_markdown_component_block(lines: list[str], line_index: int) -> tuple[s
     if recover_escaped_source and scan.next_line_index <= line_index + 1:
         return None
     if not scan.found_terminator:
-        if _MARKDOWN_COMPONENT_TAG_REGEX.match(first_line):
+        if _extract_markdown_component_prop_source(first_line) is not None:
             return tag_name, first_line, line_index + 1
         return None
 
@@ -546,13 +546,36 @@ def _advance_markdown_component_expression(state: _MarkdownComponentScanState, c
         state.expression_depth -= 1
 
 
+def _extract_markdown_component_prop_source(raw: str) -> str | None:
+    # A final newline is allowed by the component grammar's end anchor.
+    raw = raw.removesuffix("\n")
+    match = _MARKDOWN_COMPONENT_TAG_NAME_REGEX.match(raw)
+    if match is None:
+        return None
+    if raw.endswith("/>"):
+        return raw[match.end() : -2]
+    if not raw.endswith(">"):
+        return None
+    closing_start = raw.rfind("</")
+    if closing_start == -1:
+        return None
+    closing_name = raw[closing_start + 2 : -1]
+    # Malformed tags can end the opening name early when the closing name is a prefix.
+    if not closing_name or not match.group(1).startswith(closing_name):
+        return None
+    props_start = 1 + len(closing_name)
+    opening_end = raw.find(">", props_start, closing_start)
+    if opening_end == -1:
+        return None
+    return raw[props_start:opening_end]
+
+
 def _parse_markdown_component_props(raw: str) -> dict[str, Any]:
-    match = _MARKDOWN_COMPONENT_TAG_REGEX.match(raw)
-    if not match:
+    source = _extract_markdown_component_prop_source(raw)
+    if source is None:
         return {}
 
     props: dict[str, Any] = {}
-    source = match.group(2) or ""
     index = 0
     while index < len(source):
         index = _skip_markdown_component_whitespace(source, index)


### PR DESCRIPTION
## Problem

A shared notebook can take disproportionate CPU time to render when its stored Markdown contains an unterminated component. The shared-notebook response calls `filter_notebook_content_for_sharing`, whose fallback component recognizer backtracks even on input below its nominal 256 KiB scanner budget.

Creating or modifying that content requires notebook write access; shared reads can repeat its parsing. This is not an unauthenticated notebook-write claim.

## Changes

Recognize component endings with deterministic string operations while preserving the accepted grammar, including malformed closing-name prefixes. Component properties, filtering policy and unrelated parser behavior stay unchanged.

## How did you test this code?

Confirmed against master `d78546a2eba08c6c17a7604e2276200e9f91e52f` before applying the fix:

```sh
pytest -q products/notebooks/backend/test/test_sharing.py::TestFilterNotebookContentForSharing
```

With only this PR's tests and helper applied to that baseline, the unterminated-component test fails its five-second child-process deadline. The test calls the actual sharing filter and checks that malformed content remains plain text. With the production fix, it passes alongside closing-tag compatibility cases.

Local measurements for 2,000 / 4,000 / 8,000-character inputs dropped from 38 / 149 / 582 ms to 0.27 / 0.41 / 0.77 ms. The 100,000-character regression completes in 9.36 ms after the fix. These are local algorithm measurements, not deployed latency.

Focused sharing, query-extraction, cell-extraction, cell-limit and widget-generation tests passed. A separate bounded 1,005-case comparison matched the previous grammar. Python lint, formatting, type-checking hook and committed-diff preflight passed. Database-backed sharing, deployed endpoints and full monorepo acceptance were not run.

The killable test helper is identical to #99403 and #99406; all three PRs are independently based on master.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None; component syntax and sharing behavior are unchanged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). Codex with Git, GitHub CLI, pytest and hogli; private session. This narrow replacement for closed #99392 leaves the separate property-parser optimization out. Committed inputs are synthetic; no incident details are included. Open-PR searches for the recognizer and notebook component backtracking found no duplicate. Patch coverage and external review remain CI gates.

Skills used: posthog-pr-finish, engineering:code-review, writing-pr-descriptions, running-ci-preflight, writing-tests, writing-code-comments, and Superpowers worktree, TDD, debugging, review-feedback and verification guidance. CodeRabbit CLI review is paused; this PR opens without a local CodeRabbit pass. The requested simplification kept only the proven recognition fix, with concise compatibility tests rather than a committed exploratory corpus.
