### PR TITLE
chore(clickhouse): test adhoc deletes across events clusters

### DIFF
--- a/docker-compose.deletes-test.yml
+++ b/docker-compose.deletes-test.yml
@@ -1,0 +1,41 @@
+name: posthog-deletes-test
+
+services:
+    data: &node
+        image: clickhouse/clickhouse-server:26.6.2.158
+        network_mode: host
+        environment:
+            CLICKHOUSE_SKIP_USER_SETUP: 1
+            DELETE_TEST_TCP_PORT: 19101
+            DELETE_TEST_HTTP_PORT: 18101
+            DELETE_TEST_INTERSERVER_PORT: 19201
+            DELETE_TEST_ROLE: data
+            DELETE_TEST_SHARD: 1
+        volumes:
+            - ./docker/clickhouse/config.d/deletes-test.xml:/etc/clickhouse-server/config.d/zz-deletes-test.xml:ro
+            - ./docker/clickhouse/users-dev.xml:/etc/clickhouse-server/users.xml:ro
+        healthcheck:
+            test: ['CMD-SHELL', 'clickhouse-client --port $$DELETE_TEST_TCP_PORT --query "SELECT 1"']
+            interval: 2s
+            timeout: 5s
+            retries: 30
+
+    events-1:
+        <<: *node
+        environment:
+            CLICKHOUSE_SKIP_USER_SETUP: 1
+            DELETE_TEST_TCP_PORT: 19102
+            DELETE_TEST_HTTP_PORT: 18102
+            DELETE_TEST_INTERSERVER_PORT: 19202
+            DELETE_TEST_ROLE: events
+            DELETE_TEST_SHARD: 1
+
+    events-2:
+        <<: *node
+        environment:
+            CLICKHOUSE_SKIP_USER_SETUP: 1
+            DELETE_TEST_TCP_PORT: 19103
+            DELETE_TEST_HTTP_PORT: 18103
+            DELETE_TEST_INTERSERVER_PORT: 19203
+            DELETE_TEST_ROLE: events
+            DELETE_TEST_SHARD: 2

--- a/docker/clickhouse/config.d/deletes-test.xml
+++ b/docker/clickhouse/config.d/deletes-test.xml
@@ -1,0 +1,27 @@
+<clickhouse>
+    <listen_host replace="replace">127.0.0.1</listen_host>
+    <tcp_port from_env="DELETE_TEST_TCP_PORT" />
+    <http_port from_env="DELETE_TEST_HTTP_PORT" />
+    <interserver_http_port from_env="DELETE_TEST_INTERSERVER_PORT" />
+    <max_thread_pool_size>256</max_thread_pool_size>
+    <background_pool_size>16</background_pool_size>
+    <background_schedule_pool_size>4</background_schedule_pool_size>
+    <background_message_broker_schedule_pool_size>2</background_message_broker_schedule_pool_size>
+    <background_distributed_schedule_pool_size>2</background_distributed_schedule_pool_size>
+    <remote_servers replace="replace">
+        <delete_test_data>
+            <shard><replica><host>127.0.0.1</host><port>19101</port></replica></shard>
+        </delete_test_data>
+        <delete_test_events>
+            <shard><replica><host>127.0.0.1</host><port>19102</port></replica></shard>
+            <shard><replica><host>127.0.0.1</host><port>19103</port></replica></shard>
+        </delete_test_events>
+    </remote_servers>
+    <macros>
+        <hostClusterType>online</hostClusterType>
+        <hostClusterRole from_env="DELETE_TEST_ROLE" />
+        <shard from_env="DELETE_TEST_SHARD" />
+        <replica>1</replica>
+    </macros>
+    <zookeeper><node><host>127.0.0.1</host><port>2181</port></node></zookeeper>
+</clickhouse>

--- a/docs/internal/clickhouse-deletes-multinode-test.md
+++ b/docs/internal/clickhouse-deletes-multinode-test.md
@@ -2,12 +2,19 @@
 
 The opt-in test in `posthog/dags/tests/test_deletes_multinode.py` executes the complete `deletes_job` across two distinct ClickHouse clusters: a data cluster with one node and an events cluster with two shards.
 It uses real ClickHouse discovery, S3 dictionary staging, asynchronous delete mutations, mutation waits, request completion, and cleanup.
+Dagster initializes the cluster resource from one bootstrap host, port, and cluster name.
+The resource uses the production `ClickhouseCluster` discovery queries against `system.clusters` and node-role macros; the test supplies no node list or prebuilt cluster handle to the job.
+The resource adapter supports the isolated stack's nonstandard bootstrap port.
+The fixture's direct clients only create schemas, seed data, and check results.
 It does not mock cluster routing or the deletion ops.
 
 Both `events` and `events_json` start with the same four events.
 Two `(team_id, uuid)` pairs are queued in `adhoc_events_deletion`, with one matching row on each events shard.
 The two controls are an unqueued event and the same UUID as a queued event in another team.
 The test compares the ordered event rows before and after the job, checks the exact remaining identities on each storage shard, checks the deletion markers, and checks the job's survivor counts.
+The run must report a successful step for every op in the job graph and remove the temporary deletion tables.
+Only adhoc requests are seeded: the team-deletion ops execute their normal no-pending-team path.
+The event deletion assertions therefore cannot pass because of a team or person deletion request.
 
 ## Run locally
 

--- a/docs/internal/clickhouse-deletes-multinode-test.md
+++ b/docs/internal/clickhouse-deletes-multinode-test.md
@@ -1,0 +1,54 @@
+# Test adhoc event deletion across clusters
+
+The opt-in test in `posthog/dags/tests/test_deletes_multinode.py` executes the complete `deletes_job` with a data node and two separate events shards.
+It uses real ClickHouse discovery, S3 dictionary staging, asynchronous delete mutations, mutation waits, request completion, and cleanup.
+It does not mock cluster routing or the deletion ops.
+
+Both `events` and `events_json` start with the same four events.
+Two `(team_id, uuid)` pairs are queued in `adhoc_events_deletion`, with one matching row on each events shard.
+The two controls are an unqueued event and the same UUID as a queued event in another team.
+The test compares the ordered event rows before and after the job, checks the exact remaining identities on each storage shard, checks the deletion markers, and checks the job's survivor counts.
+
+## Run locally
+
+Start the usual backend test dependencies first, including PostgreSQL, ZooKeeper on port 2181, and SeaweedFS on port 19000 with the configured object-storage bucket.
+Use the repository's activated Python environment.
+The existing Dagster pytest fixtures also require the `test_dagster` PostgreSQL database.
+
+```bash
+docker compose -f docker-compose.deletes-test.yml up -d --wait
+TEST_MULTINODE_DELETES=1 hogli test posthog/dags/tests/test_deletes_multinode.py
+```
+
+The compose file uses host networking, so run it on Linux or Docker Desktop with host networking enabled.
+It adds three ClickHouse servers on native ports 19101 through 19103, HTTP ports 18101 through 18103, and interserver ports 19201 through 19203.
+The existing development ClickHouse service stays on its usual ports.
+Do not run this test concurrently with another invocation of itself.
+Each case creates the configured ClickHouse test database on the dedicated nodes and drops it afterward; setup refuses an already-existing database.
+The test is skipped unless `TEST_MULTINODE_DELETES=1` is set.
+
+```bash
+docker compose -f docker-compose.deletes-test.yml down -v
+```
+
+## Cases
+
+- `remote_only`: `sharded_events_json` exists only on the two events nodes. The job must delete the same requested events from both event representations.
+- `empty_local_table`: the data node also has an empty `sharded_events_json`, while `events_json` still reads the separate events cluster. The same equality assertion must hold.
+
+The second case is a regression reproducer for the current local-first placement resolution.
+`placement_for` returns the data cluster as soon as it finds the local table, without checking the events cluster.
+Consequently the job can delete legacy events and mark the adhoc requests deleted while JSON events remain readable.
+The test deliberately fails on the resulting row mismatch; it is not marked as an expected failure.
+
+The separate-cluster case also exercises overlapping shard numbers: both the data cluster and the first events shard have shard number 1.
+Both event storage tables and their Distributed proxies use the application's schema factories.
+The row comparison covers team ID, event UUID, timestamp, event name, distinct ID, and person ID.
+Each case uses a unique S3 staging prefix and removes its staged objects afterward.
+This is a deletion-routing test, not a migration or ingestion test.
+It uses one replica per shard and a shared local ZooKeeper; replica lag and independent Keeper deployments are outside its coverage.
+The events nodes do not have the source deletion table, so their dictionaries must load through S3.
+
+A local reproduction identifies a possible failure mode, not the cause of a particular deployed run.
+For that diagnosis, compare the deployed job version, the cluster configuration, the placement of `sharded_events_json`, and the run's `mark_deletions_verified` metadata.
+The current job marks requests verified even when survivor counts are nonzero or unavailable.

--- a/docs/internal/clickhouse-deletes-multinode-test.md
+++ b/docs/internal/clickhouse-deletes-multinode-test.md
@@ -1,6 +1,6 @@
 # Test adhoc event deletion across clusters
 
-The opt-in test in `posthog/dags/tests/test_deletes_multinode.py` executes the complete `deletes_job` with a data node and two separate events shards.
+The opt-in test in `posthog/dags/tests/test_deletes_multinode.py` executes the complete `deletes_job` across two distinct ClickHouse clusters: a data cluster with one node and an events cluster with two shards.
 It uses real ClickHouse discovery, S3 dictionary staging, asynchronous delete mutations, mutation waits, request completion, and cleanup.
 It does not mock cluster routing or the deletion ops.
 
@@ -24,27 +24,34 @@ The compose file uses host networking, so run it on Linux or Docker Desktop with
 It adds three ClickHouse servers on native ports 19101 through 19103, HTTP ports 18101 through 18103, and interserver ports 19201 through 19203.
 The existing development ClickHouse service stays on its usual ports.
 Do not run this test concurrently with another invocation of itself.
-Each case creates the configured ClickHouse test database on the dedicated nodes and drops it afterward; setup refuses an already-existing database.
+The test creates the configured ClickHouse test database on the dedicated nodes and drops it afterward; setup refuses an already-existing database.
 The test is skipped unless `TEST_MULTINODE_DELETES=1` is set.
 
 ```bash
 docker compose -f docker-compose.deletes-test.yml down -v
 ```
 
-## Cases
+## Topology and assertions
 
-- `remote_only`: `sharded_events_json` exists only on the two events nodes. The job must delete the same requested events from both event representations.
-- `empty_local_table`: the data node also has an empty `sharded_events_json`, while `events_json` still reads the separate events cluster. The same equality assertion must hold.
+| Cluster              | Nodes             | Event tables on each node            |
+| -------------------- | ----------------- | ------------------------------------ |
+| `delete_test_data`   | One data node     | `events`, `sharded_events`           |
+| `delete_test_events` | Two events shards | `events_json`, `sharded_events_json` |
 
-The second case is a regression reproducer for the current local-first placement resolution.
-`placement_for` returns the data cluster as soon as it finds the local table, without checking the events cluster.
-Consequently the job can delete legacy events and mark the adhoc requests deleted while JSON events remain readable.
-The test deliberately fails on the resulting row mismatch; it is not marked as an expected failure.
+The test asserts the table placement on every node before inserting rows.
+Neither JSON event table exists on the data node, and neither legacy event table exists on the events nodes.
+Each events node's `events_json` Distributed table reads both events shards.
+The test reads `events` from the data cluster and `events_json` from each events node, comparing identical input rows and exact survivors after the job.
+
+The job's current verification tries to query `events_json` on the data cluster, where it does not exist in this topology.
+That metadata count is `None`, meaning unknown.
+The test asserts this limitation explicitly and independently verifies JSON event deletion through both events proxies and each physical shard.
+The job's separate `sharded_events_json` storage count must also report zero surviving matches.
 
 The separate-cluster case also exercises overlapping shard numbers: both the data cluster and the first events shard have shard number 1.
 Both event storage tables and their Distributed proxies use the application's schema factories.
 The row comparison covers team ID, event UUID, timestamp, event name, distinct ID, and person ID.
-Each case uses a unique S3 staging prefix and removes its staged objects afterward.
+The test uses a unique S3 staging prefix and removes its staged objects afterward.
 This is a deletion-routing test, not a migration or ingestion test.
 It uses one replica per shard and a shared local ZooKeeper; replica lag and independent Keeper deployments are outside its coverage.
 The events nodes do not have the source deletion table, so their dictionaries must load through S3.

--- a/posthog/dags/tests/test_deletes_multinode.py
+++ b/posthog/dags/tests/test_deletes_multinode.py
@@ -1,0 +1,156 @@
+import os
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import pytest
+
+from django.test import override_settings
+
+from clickhouse_driver import Client
+
+from posthog.clickhouse.adhoc_events_deletion import ADHOC_EVENTS_DELETION_TABLE_SQL
+from posthog.clickhouse.cluster import ClickhouseCluster, NodeRole
+from posthog.dags.deletes import deletes_job
+from posthog.models.event.sql import (
+    DISTRIBUTED_EVENTS_JSON_TABLE_SQL,
+    DISTRIBUTED_EVENTS_TABLE_SQL,
+    EVENTS_DATA_TABLE,
+    EVENTS_JSON_DATA_TABLE,
+    EVENTS_JSON_TABLE_SQL,
+    EVENTS_TABLE_SQL,
+)
+from posthog.models.person.sql import PERSON_DISTINCT_ID_OVERRIDES_TABLE
+from posthog.storage import object_storage
+
+pytestmark = [
+    pytest.mark.django_db,
+    pytest.mark.timeout(180),
+    pytest.mark.skipif(os.getenv("TEST_MULTINODE_DELETES") != "1", reason="Requires docker-compose.deletes-test.yml"),
+]
+
+
+@pytest.fixture
+def deletion_nodes(settings, request) -> Iterator[tuple[ClickhouseCluster, list[Client]]]:
+    settings.CLICKHOUSE_ENABLE_STORAGE_POLICY = False
+    settings.DICTIONARY_STAGING_S3_PREFIX = f"deletes_multinode/{uuid4()}"
+    settings.CLICKHOUSE_EVENTS_CLUSTER = "delete_test_events"
+    settings.DICTIONARY_STAGING_S3_ENDPOINT = "http://127.0.0.1:19000"
+    clients = [
+        Client("127.0.0.1", port=port, settings={"mutations_sync": 1, "lightweight_deletes_sync": 1})
+        for port in (19101, 19102, 19103)
+    ]
+    database = settings.CLICKHOUSE_DATABASE
+    created = []
+    try:
+        for client in clients:
+            client.execute(f"CREATE DATABASE {database}")
+            created.append(client)
+            client.execute(f"USE {database}")
+        data, *events = clients
+        data.execute(EVENTS_TABLE_SQL())
+        with override_settings(CLICKHOUSE_CLUSTER="delete_test_data"):
+            data.execute(DISTRIBUTED_EVENTS_TABLE_SQL(on_cluster=False))
+        data.execute(
+            f"CREATE TABLE {PERSON_DISTINCT_ID_OVERRIDES_TABLE} (_timestamp DateTime) ENGINE = MergeTree ORDER BY tuple()"
+        )
+        data.execute(ADHOC_EVENTS_DELETION_TABLE_SQL(on_cluster=False))
+        for client in events:
+            client.execute(EVENTS_JSON_TABLE_SQL())
+        if request.param:
+            data.execute(EVENTS_JSON_TABLE_SQL())
+        with override_settings(CLICKHOUSE_CLUSTER="delete_test_events"):
+            data.execute(DISTRIBUTED_EVENTS_JSON_TABLE_SQL(on_cluster=False))
+        cluster = ClickhouseCluster(
+            data,
+            cluster="delete_test_data",
+            client_settings={"mutations_sync": "0", "lightweight_deletes_sync": "0"},
+            connection_overrides={"user": "default", "password": "", "secure": False},
+        )
+        yield cluster, clients
+    finally:
+        for client in created:
+            client.execute(f"DROP DATABASE {database} SYNC")
+        for client in clients:
+            client.disconnect()
+        staged = object_storage.list_objects(
+            settings.DICTIONARY_STAGING_S3_PREFIX + "/", bucket=settings.DICTIONARY_STAGING_S3_BUCKET
+        )
+        if staged:
+            object_storage.delete_objects(staged, bucket=settings.DICTIONARY_STAGING_S3_BUCKET)
+
+
+@pytest.mark.parametrize("deletion_nodes", [False, True], indirect=True, ids=["remote_only", "empty_local_table"])
+def test_adhoc_deletes_reach_every_events_shard(deletion_nodes):
+    cluster, clients = deletion_nodes
+    data, *event_nodes = clients
+    timestamp = datetime.now(UTC)
+    queued = [(101, UUID(int=1)), (101, UUID(int=2))]
+    controls = {(101, UUID(int=3)), (202, UUID(int=1))}
+    rows = [
+        (team, event_uuid, timestamp, "deletion_test_event", f"distinct_{team}_{event_uuid.int}", UUID(int=team))
+        for team, event_uuid in [*queued, *sorted(controls)]
+    ]
+
+    assert len(cluster.shards) == 1
+    assert len(cluster.sibling("delete_test_events", NodeRole.EVENTS).shards) == 2
+    for shard_index, client in enumerate(event_nodes):
+        assert client.execute("SELECT getMacro('hostClusterRole')") == [("events",)]
+        assert client.execute("EXISTS TABLE adhoc_events_deletion") == [(0,)]
+        client.execute(
+            f"INSERT INTO {EVENTS_JSON_DATA_TABLE} (team_id, uuid, timestamp, event, distinct_id, person_id) VALUES",
+            rows[shard_index::2],
+        )
+    data.execute(
+        f"INSERT INTO {EVENTS_DATA_TABLE()} (team_id, uuid, timestamp, event, distinct_id, person_id) VALUES",
+        rows,
+    )
+    data.execute("INSERT INTO adhoc_events_deletion (team_id, uuid) VALUES", queued)
+
+    def survivors(client, table):
+        return set(client.execute(f"SELECT team_id, uuid FROM {table} WHERE _row_exists = 1"))
+
+    for shard_index, client in enumerate(event_nodes):
+        assert survivors(client, EVENTS_JSON_DATA_TABLE) == {(row[0], row[1]) for row in rows[shard_index::2]}
+
+    def read_events(table):
+        return data.execute(
+            f"SELECT team_id, uuid, timestamp, event, distinct_id, person_id FROM {table} ORDER BY team_id, uuid"
+        )
+
+    before = read_events("events")
+    assert before == read_events("events_json")
+    assert before == sorted(rows, key=lambda row: (row[0], row[1]))
+
+    result = deletes_job.execute_in_process(
+        resources={"cluster": cluster},
+        run_config={
+            "ops": {
+                name: {"config": {"shards": 1, "dictionary_load_timeout": 30}}
+                for name in ("create_deletes_dict", "create_adhoc_event_deletes_dict")
+            }
+        },
+    )
+
+    assert result.success
+    assert set(data.execute("SELECT team_id, uuid FROM adhoc_events_deletion WHERE is_deleted = 1")) == set(queued)
+    after_events = read_events("events")
+    after_events_json = read_events("events_json")
+    assert after_events == after_events_json, (
+        "deletes_job succeeded and marked requests deleted, but the event tables differ"
+    )
+    assert {(row[0], row[1]) for row in after_events} == controls
+    assert after_events == [row for row in before if (row[0], row[1]) in controls]
+    for shard_index, client in enumerate(event_nodes):
+        expected = {(row[0], row[1]) for row in rows[shard_index::2]} & controls
+        assert survivors(client, EVENTS_JSON_DATA_TABLE) == expected
+        assert client.execute("SELECT count() FROM system.dictionaries WHERE database = currentDatabase()") == [(0,)]
+    verification = next(
+        event
+        for event in result.all_events
+        if event.event_type_value == "STEP_OUTPUT" and event.step_key == "mark_deletions_verified"
+    )
+    counts = verification.step_output_data.metadata["unswept_rows"].value
+    assert counts["events"] == 0
+    assert counts["events_json"] == 0
+    assert counts[EVENTS_JSON_DATA_TABLE] == 0

--- a/posthog/dags/tests/test_deletes_multinode.py
+++ b/posthog/dags/tests/test_deletes_multinode.py
@@ -31,7 +31,7 @@ pytestmark = [
 
 
 @pytest.fixture
-def deletion_nodes(settings, request) -> Iterator[tuple[ClickhouseCluster, list[Client]]]:
+def deletion_nodes(settings) -> Iterator[tuple[ClickhouseCluster, list[Client]]]:
     settings.CLICKHOUSE_ENABLE_STORAGE_POLICY = False
     settings.DICTIONARY_STAGING_S3_PREFIX = f"deletes_multinode/{uuid4()}"
     settings.CLICKHOUSE_EVENTS_CLUSTER = "delete_test_events"
@@ -57,10 +57,8 @@ def deletion_nodes(settings, request) -> Iterator[tuple[ClickhouseCluster, list[
         data.execute(ADHOC_EVENTS_DELETION_TABLE_SQL(on_cluster=False))
         for client in events:
             client.execute(EVENTS_JSON_TABLE_SQL())
-        if request.param:
-            data.execute(EVENTS_JSON_TABLE_SQL())
-        with override_settings(CLICKHOUSE_CLUSTER="delete_test_events"):
-            data.execute(DISTRIBUTED_EVENTS_JSON_TABLE_SQL(on_cluster=False))
+            with override_settings(CLICKHOUSE_CLUSTER="delete_test_events"):
+                client.execute(DISTRIBUTED_EVENTS_JSON_TABLE_SQL(on_cluster=False))
         cluster = ClickhouseCluster(
             data,
             cluster="delete_test_data",
@@ -80,7 +78,6 @@ def deletion_nodes(settings, request) -> Iterator[tuple[ClickhouseCluster, list[
             object_storage.delete_objects(staged, bucket=settings.DICTIONARY_STAGING_S3_BUCKET)
 
 
-@pytest.mark.parametrize("deletion_nodes", [False, True], indirect=True, ids=["remote_only", "empty_local_table"])
 def test_adhoc_deletes_reach_every_events_shard(deletion_nodes):
     cluster, clients = deletion_nodes
     data, *event_nodes = clients
@@ -92,10 +89,22 @@ def test_adhoc_deletes_reach_every_events_shard(deletion_nodes):
         for team, event_uuid in [*queued, *sorted(controls)]
     ]
 
+    def event_tables(client):
+        return {
+            row[0]
+            for row in client.execute(
+                "SELECT name FROM system.tables WHERE database = currentDatabase() AND name IN %(tables)s",
+                {"tables": ("events", EVENTS_DATA_TABLE(), "events_json", EVENTS_JSON_DATA_TABLE)},
+            )
+        }
+
+    assert data.execute("SELECT getMacro('hostClusterRole')") == [("data",)]
+    assert event_tables(data) == {"events", EVENTS_DATA_TABLE()}
     assert len(cluster.shards) == 1
     assert len(cluster.sibling("delete_test_events", NodeRole.EVENTS).shards) == 2
     for shard_index, client in enumerate(event_nodes):
         assert client.execute("SELECT getMacro('hostClusterRole')") == [("events",)]
+        assert event_tables(client) == {"events_json", EVENTS_JSON_DATA_TABLE}
         assert client.execute("EXISTS TABLE adhoc_events_deletion") == [(0,)]
         client.execute(
             f"INSERT INTO {EVENTS_JSON_DATA_TABLE} (team_id, uuid, timestamp, event, distinct_id, person_id) VALUES",
@@ -113,13 +122,14 @@ def test_adhoc_deletes_reach_every_events_shard(deletion_nodes):
     for shard_index, client in enumerate(event_nodes):
         assert survivors(client, EVENTS_JSON_DATA_TABLE) == {(row[0], row[1]) for row in rows[shard_index::2]}
 
-    def read_events(table):
-        return data.execute(
+    def read_events(client, table):
+        return client.execute(
             f"SELECT team_id, uuid, timestamp, event, distinct_id, person_id FROM {table} ORDER BY team_id, uuid"
         )
 
-    before = read_events("events")
-    assert before == read_events("events_json")
+    before = read_events(data, "events")
+    for client in event_nodes:
+        assert before == read_events(client, "events_json")
     assert before == sorted(rows, key=lambda row: (row[0], row[1]))
 
     result = deletes_job.execute_in_process(
@@ -134,11 +144,11 @@ def test_adhoc_deletes_reach_every_events_shard(deletion_nodes):
 
     assert result.success
     assert set(data.execute("SELECT team_id, uuid FROM adhoc_events_deletion WHERE is_deleted = 1")) == set(queued)
-    after_events = read_events("events")
-    after_events_json = read_events("events_json")
-    assert after_events == after_events_json, (
-        "deletes_job succeeded and marked requests deleted, but the event tables differ"
-    )
+    after_events = read_events(data, "events")
+    for client in event_nodes:
+        assert after_events == read_events(client, "events_json"), (
+            "deletes_job succeeded and marked requests deleted, but the event tables differ"
+        )
     assert {(row[0], row[1]) for row in after_events} == controls
     assert after_events == [row for row in before if (row[0], row[1]) in controls]
     for shard_index, client in enumerate(event_nodes):
@@ -152,5 +162,5 @@ def test_adhoc_deletes_reach_every_events_shard(deletion_nodes):
     )
     counts = verification.step_output_data.metadata["unswept_rows"].value
     assert counts["events"] == 0
-    assert counts["events_json"] == 0
+    assert counts["events_json"] is None
     assert counts[EVENTS_JSON_DATA_TABLE] == 0

--- a/posthog/dags/tests/test_deletes_multinode.py
+++ b/posthog/dags/tests/test_deletes_multinode.py
@@ -25,7 +25,7 @@ from posthog.storage import object_storage
 
 pytestmark = [
     pytest.mark.django_db,
-    pytest.mark.timeout(180),
+    pytest.mark.timeout(180, func_only=True),
     pytest.mark.skipif(os.getenv("TEST_MULTINODE_DELETES") != "1", reason="Requires docker-compose.deletes-test.yml"),
 ]
 

--- a/posthog/dags/tests/test_deletes_multinode.py
+++ b/posthog/dags/tests/test_deletes_multinode.py
@@ -8,9 +8,10 @@ import pytest
 from django.test import override_settings
 
 from clickhouse_driver import Client
+from dagster import resource
 
 from posthog.clickhouse.adhoc_events_deletion import ADHOC_EVENTS_DELETION_TABLE_SQL
-from posthog.clickhouse.cluster import ClickhouseCluster, NodeRole
+from posthog.clickhouse.cluster import ClickhouseCluster
 from posthog.dags.deletes import deletes_job
 from posthog.models.event.sql import (
     DISTRIBUTED_EVENTS_JSON_TABLE_SQL,
@@ -30,8 +31,23 @@ pytestmark = [
 ]
 
 
+@resource(config_schema={"host": str, "port": int, "cluster": str})
+def discovered_cluster(context) -> Iterator[ClickhouseCluster]:
+    config = context.resource_config
+    bootstrap = Client(config["host"], port=config["port"], database="system")
+    try:
+        yield ClickhouseCluster(
+            bootstrap,
+            cluster=config["cluster"],
+            client_settings={"mutations_sync": "0", "lightweight_deletes_sync": "0"},
+            connection_overrides={"user": "default", "password": "", "secure": False},
+        )
+    finally:
+        bootstrap.disconnect()
+
+
 @pytest.fixture
-def deletion_nodes(settings) -> Iterator[tuple[ClickhouseCluster, list[Client]]]:
+def deletion_nodes(settings) -> Iterator[list[Client]]:
     settings.CLICKHOUSE_ENABLE_STORAGE_POLICY = False
     settings.DICTIONARY_STAGING_S3_PREFIX = f"deletes_multinode/{uuid4()}"
     settings.CLICKHOUSE_EVENTS_CLUSTER = "delete_test_events"
@@ -59,13 +75,7 @@ def deletion_nodes(settings) -> Iterator[tuple[ClickhouseCluster, list[Client]]]
             client.execute(EVENTS_JSON_TABLE_SQL())
             with override_settings(CLICKHOUSE_CLUSTER="delete_test_events"):
                 client.execute(DISTRIBUTED_EVENTS_JSON_TABLE_SQL(on_cluster=False))
-        cluster = ClickhouseCluster(
-            data,
-            cluster="delete_test_data",
-            client_settings={"mutations_sync": "0", "lightweight_deletes_sync": "0"},
-            connection_overrides={"user": "default", "password": "", "secure": False},
-        )
-        yield cluster, clients
+        yield clients
     finally:
         for client in created:
             client.execute(f"DROP DATABASE {database} SYNC")
@@ -78,8 +88,8 @@ def deletion_nodes(settings) -> Iterator[tuple[ClickhouseCluster, list[Client]]]
             object_storage.delete_objects(staged, bucket=settings.DICTIONARY_STAGING_S3_BUCKET)
 
 
-def test_adhoc_deletes_reach_every_events_shard(deletion_nodes):
-    cluster, clients = deletion_nodes
+def test_adhoc_deletes_discover_clusters_and_run_all_ops(deletion_nodes):
+    clients = deletion_nodes
     data, *event_nodes = clients
     timestamp = datetime.now(UTC)
     queued = [(101, UUID(int=1)), (101, UUID(int=2))]
@@ -100,8 +110,6 @@ def test_adhoc_deletes_reach_every_events_shard(deletion_nodes):
 
     assert data.execute("SELECT getMacro('hostClusterRole')") == [("data",)]
     assert event_tables(data) == {"events", EVENTS_DATA_TABLE()}
-    assert len(cluster.shards) == 1
-    assert len(cluster.sibling("delete_test_events", NodeRole.EVENTS).shards) == 2
     for shard_index, client in enumerate(event_nodes):
         assert client.execute("SELECT getMacro('hostClusterRole')") == [("events",)]
         assert event_tables(client) == {"events_json", EVENTS_JSON_DATA_TABLE}
@@ -133,16 +141,22 @@ def test_adhoc_deletes_reach_every_events_shard(deletion_nodes):
     assert before == sorted(rows, key=lambda row: (row[0], row[1]))
 
     result = deletes_job.execute_in_process(
-        resources={"cluster": cluster},
+        resources={"cluster": discovered_cluster},
         run_config={
+            "resources": {"cluster": {"config": {"host": "127.0.0.1", "port": 19101, "cluster": "delete_test_data"}}},
             "ops": {
                 name: {"config": {"shards": 1, "dictionary_load_timeout": 30}}
                 for name in ("create_deletes_dict", "create_adhoc_event_deletes_dict")
-            }
+            },
         },
     )
 
     assert result.success
+    assert {event.step_key for event in result.get_step_success_events()} == set(deletes_job.graph.node_dict)
+    for client in clients:
+        assert client.execute(
+            "SELECT count() FROM system.tables WHERE database = currentDatabase() AND startsWith(name, 'pending_deletes_')"
+        ) == [(0,)]
     assert set(data.execute("SELECT team_id, uuid FROM adhoc_events_deletion WHERE is_deleted = 1")) == set(queued)
     after_events = read_events(data, "events")
     for client in event_nodes:


### PR DESCRIPTION
## Problem

Deletion tests need to detect events that remain readable after their adhoc requests are marked deleted.
The existing single-node test does not exercise separate data and events clusters.

## Changes

- Initialize the job resource from one bootstrap endpoint and discover nodes through real ClickHouse topology queries.
- Execute the complete job across two distinct clusters and require every graph op to succeed.
- Keep `events` and `sharded_events` only on the data node.
- Keep `events_json` and `sharded_events_json` only on the two events nodes.
- Compare identical event rows across clusters before deletion and exact survivors afterward.
- Cover both events shards, an unqueued event, and a queued UUID belonging to another team.
- Exercise application schema factories, S3 dictionary staging, asynchronous mutations, completion markers, and cleanup.

Mechanical setup: a dedicated Compose stack and local run instructions. Production deletion code is unchanged.

> [!NOTE]
> The job currently queries `events_json` verification on the data cluster, where this topology has no such table.
> The test checks that metadata reports unknown, and independently verifies both events proxies and every JSON storage shard.

<details>
<summary>Test topology</summary>

Existing coverage:

```mermaid
flowchart LR
    Job[deletes_job] --> Data[One data node]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Job phBlue;
    class Data phGray;
```

Added coverage:

```mermaid
flowchart LR
    Job[deletes_job]
    subgraph DataCluster[Data cluster]
        Data[events and sharded_events]
    end
    subgraph EventsCluster[Events cluster]
        E1[Shard 1: events_json and sharded_events_json]
        E2[Shard 2: events_json and sharded_events_json]
    end
    Job --> Data
    Job --> E1
    Job --> E2
    Data --> S3[S3 dictionary staging]
    S3 --> E1
    S3 --> E2
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Job phBlue;
    class Data,E1,E2,S3 phGray;
```

</details>

## How did you test this code?

The test catches skipped events shards and checks actual row equality across clusters, which existing single-node coverage cannot establish.

```bash
docker compose -f docker-compose.deletes-test.yml up -d --wait
TEST_MULTINODE_DELETES=1 hogli test posthog/dags/tests/test_deletes_multinode.py
```

The local full-job test passes, as do preflight and the targeted type check.
The test seeds only adhoc requests, so team or person deletions cannot hide a broken adhoc predicate.
All graph ops must succeed; team-deletion ops take their normal empty-request path.

The test is opt-in and uses a 180-second timeout for its body, excluding shared Django database setup.
Replica lag and independent Keeper deployments are outside its coverage.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

[Local setup, assertions, and coverage limits](https://github.com/PostHog/posthog/blob/chore/clickhouse-deletes-multinode-tests/docs/internal/clickhouse-deletes-multinode-test.md).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex authored the tests using shell, Docker, pytest, and GitHub CLI.
Skills used: `writing-tests`, `writing-user-facing-copy`, `writing-pr-descriptions`, and `reviewing-with-coderabbit`.
The CodeRabbit pass is paused; this PR opens without a local review pass.
Fixtures and topology values are synthetic; no private schema dump or production data is included.
Open-PR searches found no duplicate multinode deletion test; #98865 covers squash invariants and mutation-wait retries.
Human review is required.
