### PR TITLE
chore(devbox): raise mutagen ssh connect timeout for devboxes

### DIFF
--- a/tools/hogli-commands/hogli_commands/devbox/mutagen.py
+++ b/tools/hogli-commands/hogli_commands/devbox/mutagen.py
@@ -37,6 +37,7 @@ _MUTAGEN_VERSION = "0.18.1"
 # resulting silence tolerance (~30s, comfortably past the ~26s reset cadence).
 _SSH_SHIM_DIR = Path.home() / ".hogli" / "mutagen-ssh-shim"
 _KEEPALIVE_COUNT = 3
+_CONNECT_TIMEOUT_SECONDS = 60
 
 # Baked at generation time (see ensure_ssh_shim): only when the ssh/scp target is
 # a devbox (a `coder.*` host -- the sole thing hogli syncs to) do we bump
@@ -55,6 +56,7 @@ done
 args=()
 for a in "$@"; do
   case "$a" in
+  -oConnectTimeout=*) [ -n "$devbox" ] && a="-oConnectTimeout={connect_timeout}" ;;
   -oServerAliveCountMax=*) [ -n "$devbox" ] && a="-oServerAliveCountMax={count}" ;;
   esac
   args+=("$a")
@@ -271,7 +273,11 @@ def ensure_ssh_shim() -> Path:
     _SSH_SHIM_DIR.chmod(0o700)
     for name in ("ssh", "scp"):
         target = _SSH_SHIM_DIR / name
-        content = _SHIM_TEMPLATE.format(count=_KEEPALIVE_COUNT, real=_resolve_real_ssh(name))
+        content = _SHIM_TEMPLATE.format(
+            count=_KEEPALIVE_COUNT,
+            connect_timeout=_CONNECT_TIMEOUT_SECONDS,
+            real=_resolve_real_ssh(name),
+        )
         if not target.exists() or target.read_text() != content:
             _write_owner_only(target, content)
         else:

--- a/tools/hogli-commands/hogli_commands/tests/test_devbox.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_devbox.py
@@ -3890,7 +3890,7 @@ class TestKeepaliveShim:
         [("coder.devbox-test-user", True), ("nobody@127.0.0.1", False)],
         ids=["devbox-host-bumped", "non-devbox-host-untouched"],
     )
-    def test_shim_rewrites_keepalive_only_for_devbox_hosts(
+    def test_shim_rewrites_ssh_options_only_for_devbox_hosts(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, target: str, bumped: bool
     ) -> None:
         # End-to-end of the generated shim script: run it like mutagen would and
@@ -3920,9 +3920,14 @@ class TestKeepaliveShim:
 
         forwarded = log.read_text().splitlines()
         if bumped:
-            bump = f"-oServerAliveCountMax={devbox_mutagen._KEEPALIVE_COUNT}"
-            assert forwarded == [bump if a.startswith("-oServerAliveCountMax=") else a for a in incoming]
+            rewrites = {
+                "-oServerAliveCountMax=": f"-oServerAliveCountMax={devbox_mutagen._KEEPALIVE_COUNT}",
+                "-oConnectTimeout=": f"-oConnectTimeout={devbox_mutagen._CONNECT_TIMEOUT_SECONDS}",
+            }
+            expected = [next((v for k, v in rewrites.items() if a.startswith(k)), a) for a in incoming]
+            assert forwarded == expected
             assert "-oServerAliveCountMax=1" not in forwarded
+            assert "-oConnectTimeout=5" not in forwarded
         else:
             # Non-devbox ssh must pass through byte-for-byte, keepalive included.
             assert forwarded == incoming


### PR DESCRIPTION
## Problem

`hogli devbox:sync` fails for an engineer whose devbox is healthy, and the error points at the wrong thing.

```
unable to receive server magic number: EOF
(error output: Connection timed out during banner exchange)
```

- mutagen hardcodes `-oConnectTimeout=5` onto every ssh command line it builds.
- Reaching a devbox goes through the `coder.*` ProxyCommand, which stands up a fresh tailnet client per invocation.
- That dial takes 4.6 to 5.8 seconds, measured six times on one machine, so it straddles the bound.
- `devbox:doctor`, `coder list` and `devbox:ssh` all pass, because the coder-managed block in `~/.ssh/config` sets `ConnectTimeout=0`. A command-line `-o` overrides `~/.ssh/config`, so only sync breaks.

The failure is intermittent and reads as a tailnet problem, so the engineer checks the tailnet, the ACL and the box first.

## Changes

- `hogli devbox:sync` now connects on a slow dial instead of failing. Nothing else about sync changes.
- The ssh shim on `MUTAGEN_SSH_PATH` rewrites `-oConnectTimeout` to 60 for `coder.*` targets.
- The shim already existed for the same reason: mutagen also hardcodes `-oServerAliveCountMax=1`, which config cannot override. This adds a second flag to the same mechanism.

Two decisions a reviewer should check:

- The shim replaces the flag in place rather than appending one. ssh takes the first value it obtains for a keyword, so an appended `-oConnectTimeout=60` would lose to mutagen's leading `-oConnectTimeout=5`.
- 60 seconds keeps the timeout bounded. Adopting the config's `ConnectTimeout=0` would let a stopped box hang the daemon forever. 60 clears the observed dial and leaves room for a cold or DERP-relayed path.

Non-devbox targets still pass through untouched, so a shared daemon's other syncs keep mutagen's own timeout. `ensure_ssh_shim` rewrites the on-disk shim whenever the generated content differs, and `devbox:sync` calls it on every run, so no migration is needed.

No UI changes.

## How did you test this code?

`TestKeepaliveShim::test_shim_rewrites_ssh_options_only_for_devbox_hosts` gains two assertions. The test executes the generated shim against a fake ssh, and its fixture already passed `-oConnectTimeout=5` through untouched. That pass was the bug, so no existing test caught it.

Removing the new `case` arm turns the `devbox-host-bumped` case red. Restoring it turns it green.

Verified end to end against a real devbox with the fix applied locally:

<details>
<summary>devbox:sync run and dial timings</summary>

```
$ for i in 1 2 3; do /usr/bin/time -p ssh coder.devbox-thiagos true 2>&1 | grep real; done
real 4.99
real 4.62
real 4.63

$ hogli devbox:sync
Creating sync: <local checkout> -> coder.devbox-thiagos:/home/coder/posthog
Created session sync_dDTbOH3bTb2bdUKcKeeP9UIgZ51BydXmV0pFURH4gHT

$ grep ConnectTimeout ~/.hogli/mutagen-ssh-shim/ssh
  -oConnectTimeout=*) [ -n "$devbox" ] && a="-oConnectTimeout=60" ;;

$ mutagen sync list
Status: Watching for changes
```

Before the fix the same command failed at the banner exchange.

</details>

Not checked: behavior when the dial exceeds 60 seconds, and the `scp` shim path, which mutagen only uses during agent install.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. `.agents/skills/setting-up-devbox/SKILL.md` describes `devbox:sync` behavior, not its ssh options.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) diagnosed the reported `devbox:sync` failure and wrote the change. Skills invoked: `/writing-pr-descriptions`, `/reviewing-with-coderabbit`. The CodeRabbit local pass is paused, so this PR opened without one.

The session started from a live failure, not from the code. Timing the `coder.*` dial repeatedly is what separated this from the tailnet and ACL causes that `setting-up-devbox` lists first, since `devbox:doctor` reported every check green. The repo's own test fixture at `tools/hogli-commands/hogli_commands/tests/test_devbox.py` already recorded mutagen's argv with `-oConnectTimeout=5`, which confirmed the bound without inspecting the mutagen binary.

Two comments in `mutagen.py` now describe only half the reason the shim exists: the rationale block above `_KEEPALIVE_COUNT`, and the header inside `_SHIM_TEMPLATE`. The `ensure_ssh_shim` docstring also still says the rewrite is a no-op for any arg that is not `-oServerAliveCountMax=`, which this change makes wrong. They were left as written on the author's instruction, which is why the reasoning above is unusually detailed. Say the word and a follow-up will correct them.

No duplicate: `gh pr list --state open --search "mutagen"` and `--search "devbox sync"` returned no PR touching this.

Public artifact: nothing here came from a customer conversation, ticket or log.
