### PR TITLE
fix(posthog-ai): hide the Slack context wrapper and align the card's copy icon

### DIFF
--- a/products/posthog_ai/frontend/components/RunAlertActivity.tsx
+++ b/products/posthog_ai/frontend/components/RunAlertActivity.tsx
@@ -1,4 +1,4 @@
-import { IconWarning } from '@posthog/icons'
+import { IconCopy, IconWarning } from '@posthog/icons'
 import { LemonButton, Spinner } from '@posthog/lemon-ui'
 
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
@@ -67,7 +67,18 @@ export function RunAlertActivity({
         >
             <div className="flex items-center gap-2 font-semibold">
                 <IconWarning className="size-4 shrink-0 text-danger" />
-                <span>{TITLES[kind]}</span>
+                <span className="grow">{TITLES[kind]}</span>
+                {copyDetails && (
+                    <LemonButton
+                        type="tertiary"
+                        size="xsmall"
+                        className="-my-1 -mr-1"
+                        icon={<IconCopy />}
+                        tooltip="Copy run details for support"
+                        onClick={() => void copyToClipboard(copyDetails, 'run details')}
+                        data-attr="run-error-copy-details"
+                    />
+                )}
             </div>
             <div className="pl-6 flex flex-col gap-1 text-secondary">
                 {message ? <MarkdownMessage content={message} id={`${activityId}-message`} /> : null}
@@ -75,18 +86,6 @@ export function RunAlertActivity({
                     <div>Your last message was not delivered.</div>
                 ) : null}
             </div>
-            {copyDetails && (
-                <div className="pl-6 flex items-center">
-                    <LemonButton
-                        type="tertiary"
-                        size="xsmall"
-                        onClick={() => void copyToClipboard(copyDetails, 'run details')}
-                        data-attr="run-error-copy-details"
-                    >
-                        Copy details
-                    </LemonButton>
-                </div>
-            )}
         </div>
     )
 }

--- a/products/posthog_ai/frontend/logics/runStreamLogic.test.ts
+++ b/products/posthog_ai/frontend/logics/runStreamLogic.test.ts
@@ -1221,9 +1221,20 @@ describe('runStreamLogic', () => {
             expect(logic.values.threadItems[0]).toMatchObject({ type: 'human_message', text: 'first second' })
         })
 
-        it('strips the posthog_context wrapper so a replayed prompt matches the live one', async () => {
-            const wrapped =
-                '<posthog_context>\nThe user attached the following PostHog entities.\n- Insight #1\n</posthog_context>\n\nWhy did signups drop?'
+        it.each([
+            [
+                'legacy posthog_context',
+                '<posthog_context>\nThe user attached the following PostHog entities.\n- Insight #1\n</posthog_context>\n\nWhy did signups drop?',
+            ],
+            [
+                'slack thread context on a task started from Slack',
+                '<slack_thread_context>\nSlack thread leading up to the request.\n<@U1|Someone>:\n  it is broken\n</slack_thread_context>\n\nWhy did signups drop?',
+            ],
+            [
+                'slack thread update on a follow-up from Slack',
+                '<slack_thread_context_update>\nMessages posted since you last spoke.\n</slack_thread_context_update>\n\nWhy did signups drop?',
+            ],
+        ])('strips a leading %s wrapper from a replayed human message', async (_name, wrapped) => {
             const frames: StoredLogEntry[] = [notification('_posthog/user_message', { content: wrapped })]
             jest.spyOn(api.tasks.runs, 'getLogEntries').mockResolvedValue(frames as any)
             jest.spyOn(api.tasks.runs, 'get').mockResolvedValue({ status: 'completed' } as any)

--- a/products/posthog_ai/frontend/logics/runStreamLogic.ts
+++ b/products/posthog_ai/frontend/logics/runStreamLogic.ts
@@ -292,10 +292,18 @@ export function mapHttpStatusToStreamError(status: number | undefined): StreamEr
  * prepend context blocks when attachments are present — `<posthog_trusted_context>` and/or
  * `<posthog_untrusted_context>` from the frontend builder (`utils/posthogContextBlock.ts`), or the
  * legacy `<posthog_context>` wrapper from the deprecated backend `context_wrapper.py` path and old
- * persisted history. Stripping every leading block keeps a replayed prompt identical to the one the
- * live send path echoed via `pushHumanMessage`.
+ * persisted history. A task started from Slack carries the thread as `<slack_thread_context>`, and
+ * each Slack follow-up as `<slack_thread_context_update>` (products/slack_app). Stripping every
+ * leading block keeps a replayed prompt identical to the one the live send path echoed via
+ * `pushHumanMessage`.
  */
-const CONTEXT_BLOCK_TAGS = ['posthog_trusted_context', 'posthog_untrusted_context', 'posthog_context']
+const CONTEXT_BLOCK_TAGS = [
+    'posthog_trusted_context',
+    'posthog_untrusted_context',
+    'posthog_context',
+    'slack_thread_context',
+    'slack_thread_context_update',
+]
 
 export interface SplitUserMessageContent {
     /** The user's own text, with every leading context block removed. */


### PR DESCRIPTION
## Problem

Two small follow-ups to #98942.

- A task started from Slack showed the thread-context boilerplate the Slack integration prepends for the agent as the user's first message. Slack follow-ups repeated it.
- The "Run stopped" card had a text button under the message. Review asked for an icon aligned with the card, like the insight widget's actions.

## Changes

- The first bubble of a Slack-started task is the request only. The wrapper tags join the list of context blocks the thread already strips from user messages.
- The card's copy action is a copy icon on the title row, right-aligned, with the tooltip "Copy run details for support". It copies the task id, run id, trace id, and the reason.

![slack task, request only](https://raw.githubusercontent.com/PostHog/pr-assets/2a950fe7a83015293dd00d1dc89e46aefdfaecdd/2026/09/78a007f5-f98b-469f-89fd-e7c027dd734e.png)

![run stopped card with copy icon](https://raw.githubusercontent.com/PostHog/pr-assets/6ea6d3c251299d2be73bed91cd4191d98a68ce9d/2026/09/5e480fe9-6553-4208-b9d9-02e2d6ab1d81.png)

## How did you test this code?

- Checked on a production Codex run imported into local dev, started from Slack with a Slack follow-up. Both wrappers are gone; the requests read as typed.
- `runStreamLogic.test.ts`: the existing wrapper-stripping test is now parameterized over the legacy PostHog wrapper and both Slack wrappers.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Claude Fable 5.1) with the assignee. Skills: /writing-ui-components, /writing-tests, /writing-user-facing-copy, /writing-code-comments, /writing-pr-descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
