### PR TITLE
fix(aio): restore offline evaluation event reporting

### DIFF
--- a/.agents/skills/writing-evals/SKILL.md
+++ b/.agents/skills/writing-evals/SKILL.md
@@ -48,7 +48,7 @@ async def eval_my_thing(ctx: EvalContext) -> None:
 
 - One suite = one Braintrust experiment. Bundle related cases into one suite; split only when the scorecard would be heterogeneous (self-skipping scorers stretch a shared scorer list across mildly different cases, but a scorecard where half the scorers skip half the cases is a sign to split).
 - `experiment_name` is the Braintrust history key — renaming it resets cross-run comparison. Existing sandboxed suites end in `-cli` because the MCP server serves the `cli` surface.
-- `SandboxedPublicEval` sends logs to Braintrust (summary gets an experiment URL); `SandboxedPrivateEval` sets `no_send_logs` for Braintrust. Both report `$ai_evaluation` results to PostHog, including available input, output, and expected values. Use `OPT_OUT_CAPTURE=1` with a private eval to keep prompts and results out of both reporting services. Local logs are still written. See [evaluation result reporting](../../../docs/internal/ai-offline-evaluation-reporting.md).
+- `SandboxedPublicEval` sets `no_send_logs=False` and reports results to Braintrust and PostHog, including available input, output, and expected values. `SandboxedPrivateEval` sets `no_send_logs=True` and uploads results to neither service; local logs are still written. PostHog result uploads follow `no_send_logs` independently of `OPT_OUT_CAPTURE`, which still applies to ordinary SDK and trace clients. See [evaluation result reporting](../../../docs/internal/ai-offline-evaluation-reporting.md).
 
 ## One-shot suites
 

--- a/.agents/skills/writing-evals/SKILL.md
+++ b/.agents/skills/writing-evals/SKILL.md
@@ -48,7 +48,7 @@ async def eval_my_thing(ctx: EvalContext) -> None:
 
 - One suite = one Braintrust experiment. Bundle related cases into one suite; split only when the scorecard would be heterogeneous (self-skipping scorers stretch a shared scorer list across mildly different cases, but a scorecard where half the scorers skip half the cases is a sign to split).
 - `experiment_name` is the Braintrust history key — renaming it resets cross-run comparison. Existing sandboxed suites end in `-cli` because the MCP server serves the `cli` surface.
-- `SandboxedPublicEval` sends logs to Braintrust (summary gets an experiment URL); `SandboxedPrivateEval` runs with `no_send_logs`, so the local log dir is the only record. Use private for cases whose prompts or seeds shouldn't leave the machine.
+- `SandboxedPublicEval` sends logs to Braintrust (summary gets an experiment URL); `SandboxedPrivateEval` sets `no_send_logs` for Braintrust. Both report `$ai_evaluation` results to PostHog, including available input, output, and expected values. Use `OPT_OUT_CAPTURE=1` with a private eval to keep prompts and results out of both reporting services. Local logs are still written. See [evaluation result reporting](../../../docs/internal/ai-offline-evaluation-reporting.md).
 
 ## One-shot suites
 

--- a/docs/internal/ai-offline-evaluation-reporting.md
+++ b/docs/internal/ai-offline-evaluation-reporting.md
@@ -1,0 +1,23 @@
+# Offline evaluation result reporting
+
+The sandboxed evaluation harness in `products/posthog_ai/eval_harness/` reports scorer results as PostHog `$ai_evaluation` events.
+With the Braintrust engine, each suite runs once and the harness sends the resulting scores to PostHog after the run.
+Reporting does not run the agent or scorers again.
+
+## Capture settings
+
+The harness uses a dedicated client for evaluation result events.
+This client permits `$ai_evaluation` reporting when `TEST=1`, which the harness uses for its test database setup.
+Ordinary PostHog SDK clients and trace clients retain their existing capture guards.
+
+Set `OPT_OUT_CAPTURE` to any nonempty value to disable PostHog result reporting.
+Values such as `0` and `false` also opt out, matching the existing capture helper.
+Leave the variable unset or empty to allow result reporting.
+
+## Result contents and scope
+
+Each event contains the existing experiment, case, and metric properties, including input, output, and expected values when available.
+Result reporting uses the existing event schema.
+`SandboxedPublicEval` uploads results to Braintrust, and `SandboxedPrivateEval` sets `no_send_logs=True` for Braintrust.
+Both report results to PostHog unless `OPT_OUT_CAPTURE` is set; the Braintrust upload setting does not control PostHog reporting.
+The legacy SQL evaluation path in `ee/hogai/eval/offline/` has a separate reporter and is outside this behavior.

--- a/docs/internal/ai-offline-evaluation-reporting.md
+++ b/docs/internal/ai-offline-evaluation-reporting.md
@@ -1,23 +1,21 @@
 # Offline evaluation result reporting
 
 The sandboxed evaluation harness in `products/posthog_ai/eval_harness/` reports scorer results as PostHog `$ai_evaluation` events.
-With the Braintrust engine, each suite runs once and the harness sends the resulting scores to PostHog after the run.
+With the Braintrust engine, each suite runs once and the harness sends the resulting scores to PostHog when uploads are enabled.
 Reporting does not run the agent or scorers again.
 
 ## Capture settings
 
-The harness uses a dedicated client for evaluation result events.
-This client permits `$ai_evaluation` reporting when `TEST=1`, which the harness uses for its test database setup.
-Ordinary PostHog SDK clients and trace clients retain their existing capture guards.
+Evaluation result uploads to Braintrust and PostHog share the `no_send_logs` setting.
+`SandboxedPublicEval` sets `no_send_logs=False` and uploads to both services.
+`SandboxedPrivateEval` sets `no_send_logs=True` and uploads to neither service; local logs are still written.
 
-Set `OPT_OUT_CAPTURE` to any nonempty value to disable PostHog result reporting.
-Values such as `0` and `false` also opt out, matching the existing capture helper.
-Leave the variable unset or empty to allow result reporting.
+The harness creates one dedicated result client at startup, shares it across all suites, and shuts it down after the invocation.
+This client permits `$ai_evaluation` reporting independently of `TEST` and `OPT_OUT_CAPTURE`, so those settings do not separate the two result destinations.
+Ordinary PostHog SDK clients and trace clients retain their existing `TEST` and `OPT_OUT_CAPTURE` guards.
 
 ## Result contents and scope
 
 Each event contains the existing experiment, case, and metric properties, including input, output, and expected values when available.
 Result reporting uses the existing event schema.
-`SandboxedPublicEval` uploads results to Braintrust, and `SandboxedPrivateEval` sets `no_send_logs=True` for Braintrust.
-Both report results to PostHog unless `OPT_OUT_CAPTURE` is set; the Braintrust upload setting does not control PostHog reporting.
 The legacy SQL evaluation path in `ee/hogai/eval/offline/` has a separate reporter and is outside this behavior.

--- a/docs/internal/ai-offline-evaluation-reporting.md
+++ b/docs/internal/ai-offline-evaluation-reporting.md
@@ -11,6 +11,7 @@ Evaluation result uploads to Braintrust and PostHog share the `no_send_logs` set
 `SandboxedPrivateEval` sets `no_send_logs=True` and uploads to neither service; local logs are still written.
 
 The harness creates one dedicated result client at startup, shares it across all suites, and shuts it down after the invocation.
+Each suite waits for queued PostHog uploads in worker threads so other suites can keep running.
 This client permits `$ai_evaluation` reporting independently of `TEST` and `OPT_OUT_CAPTURE`, so those settings do not separate the two result destinations.
 Ordinary PostHog SDK clients and trace clients retain their existing `TEST` and `OPT_OUT_CAPTURE` guards.
 

--- a/products/posthog_ai/eval_harness/README.md
+++ b/products/posthog_ai/eval_harness/README.md
@@ -274,4 +274,7 @@ Suite listing (`--list`) and argument errors do not create transcripts.
 
 Raw per-case agent logs land on local disk (`<case>.jsonl`, `<case>.artifacts.json`, `<case>.summary.txt`), which is usually the fastest way to see what the agent actually did.
 
-`SandboxedPrivateEval` runs with `no_send_logs`, so its summary has no Braintrust URL; the local logs are the record.
+`SandboxedPrivateEval` disables Braintrust uploads with `no_send_logs`, so its summary has no Braintrust URL.
+It still reports `$ai_evaluation` results to PostHog, including available input, output, and expected values.
+Use `OPT_OUT_CAPTURE=1` with a private eval to keep prompts and results out of both reporting services; local logs are still written.
+See [evaluation result reporting](../../../docs/internal/ai-offline-evaluation-reporting.md) for capture settings and scope.

--- a/products/posthog_ai/eval_harness/README.md
+++ b/products/posthog_ai/eval_harness/README.md
@@ -274,7 +274,7 @@ Suite listing (`--list`) and argument errors do not create transcripts.
 
 Raw per-case agent logs land on local disk (`<case>.jsonl`, `<case>.artifacts.json`, `<case>.summary.txt`), which is usually the fastest way to see what the agent actually did.
 
-`SandboxedPrivateEval` disables Braintrust uploads with `no_send_logs`, so its summary has no Braintrust URL.
-It still reports `$ai_evaluation` results to PostHog, including available input, output, and expected values.
-Use `OPT_OUT_CAPTURE=1` with a private eval to keep prompts and results out of both reporting services; local logs are still written.
+`SandboxedPublicEval` sets `no_send_logs=False` and reports results to both Braintrust and PostHog.
+`SandboxedPrivateEval` sets `no_send_logs=True` and uploads results to neither service; local logs are still written.
+PostHog result uploads follow `no_send_logs` independently of `OPT_OUT_CAPTURE`, which still applies to ordinary SDK and trace clients.
 See [evaluation result reporting](../../../docs/internal/ai-offline-evaluation-reporting.md) for capture settings and scope.

--- a/products/posthog_ai/eval_harness/base.py
+++ b/products/posthog_ai/eval_harness/base.py
@@ -13,8 +13,6 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import orjson
 
-from posthog.ph_client import get_client
-
 from products.tasks.backend.facade.agents import EVAL_INTERACTION_ORIGIN
 
 from .acp_log import ParsedLog, parse_log
@@ -268,23 +266,25 @@ class _BaseEvalRun:
                 except Exception:
                     logger.exception("Failed to append scores to local log summary for '%s'", case_name)
 
-        # Emit evaluation events and trace roots to PostHog (after scoring)
+        evaluation_client = self.ctx.posthog_evaluation_client
+        if not self.no_send_logs and evaluation_client is not None and result.results:
+            try:
+                emit_evaluation_events(
+                    evaluation_client,
+                    self.experiment_id,
+                    self.experiment_name,
+                    result.results,
+                    namespace=self.trace_namespace,
+                    scorer_traces=self.scorer_traces,
+                )
+                evaluation_client.flush()
+                await self.ctx.reporter.record_posthog_evaluations_url(self.experiment_name, self.experiment_id)
+            except Exception:
+                logger.exception("Failed to emit evaluation events for '%s'", self.experiment_name)
+
+        # Emit trace roots to PostHog (after scoring)
         if self.posthog_client and result.results:
             try:
-                # Eval results need capture under TEST without enabling the shared trace client.
-                evaluation_client = get_client("US", disabled=bool(os.environ.get("OPT_OUT_CAPTURE", False)))
-                if evaluation_client is not None:
-                    try:
-                        emit_evaluation_events(
-                            evaluation_client,
-                            self.experiment_id,
-                            self.experiment_name,
-                            result.results,
-                            namespace=self.trace_namespace,
-                            scorer_traces=self.scorer_traces,
-                        )
-                    finally:
-                        evaluation_client.shutdown()
                 # Emit $ai_trace root events now that scores are available
                 for eval_result in result.results:
                     case_name = eval_result.input.get("name", "") if isinstance(eval_result.input, dict) else ""
@@ -307,9 +307,8 @@ class _BaseEvalRun:
                             token_usage=meta.get("token_usage"),
                         )
                 self.posthog_client.flush()
-                await self.ctx.reporter.record_posthog_evaluations_url(self.experiment_name, self.experiment_id)
             except Exception:
-                logger.exception("Failed to emit evaluation events for '%s'", self.experiment_name)
+                logger.exception("Failed to emit trace roots for '%s'", self.experiment_name)
 
         # Hand the summary to the reporter: suites don't return their Braintrust
         # result up to the orchestrator, so this is the only place the final table

--- a/products/posthog_ai/eval_harness/base.py
+++ b/products/posthog_ai/eval_harness/base.py
@@ -277,7 +277,7 @@ class _BaseEvalRun:
                     namespace=self.trace_namespace,
                     scorer_traces=self.scorer_traces,
                 )
-                evaluation_client.flush()
+                await asyncio.to_thread(evaluation_client.flush)
                 await self.ctx.reporter.record_posthog_evaluations_url(self.experiment_name, self.experiment_id)
             except Exception:
                 logger.exception("Failed to emit evaluation events for '%s'", self.experiment_name)
@@ -306,7 +306,7 @@ class _BaseEvalRun:
                             scores=eval_result.scores,
                             token_usage=meta.get("token_usage"),
                         )
-                self.posthog_client.flush()
+                await asyncio.to_thread(self.posthog_client.flush)
             except Exception:
                 logger.exception("Failed to emit trace roots for '%s'", self.experiment_name)
 

--- a/products/posthog_ai/eval_harness/base.py
+++ b/products/posthog_ai/eval_harness/base.py
@@ -13,6 +13,8 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import orjson
 
+from posthog.ph_client import get_client
+
 from products.tasks.backend.facade.agents import EVAL_INTERACTION_ORIGIN
 
 from .acp_log import ParsedLog, parse_log
@@ -269,14 +271,20 @@ class _BaseEvalRun:
         # Emit evaluation events and trace roots to PostHog (after scoring)
         if self.posthog_client and result.results:
             try:
-                emit_evaluation_events(
-                    self.posthog_client,
-                    self.experiment_id,
-                    self.experiment_name,
-                    result.results,
-                    namespace=self.trace_namespace,
-                    scorer_traces=self.scorer_traces,
-                )
+                # Eval results need capture under TEST without enabling the shared trace client.
+                evaluation_client = get_client("US", disabled=bool(os.environ.get("OPT_OUT_CAPTURE", False)))
+                if evaluation_client is not None:
+                    try:
+                        emit_evaluation_events(
+                            evaluation_client,
+                            self.experiment_id,
+                            self.experiment_name,
+                            result.results,
+                            namespace=self.trace_namespace,
+                            scorer_traces=self.scorer_traces,
+                        )
+                    finally:
+                        evaluation_client.shutdown()
                 # Emit $ai_trace root events now that scores are available
                 for eval_result in result.results:
                     case_name = eval_result.input.get("name", "") if isinstance(eval_result.input, dict) else ""

--- a/products/posthog_ai/eval_harness/harness/context.py
+++ b/products/posthog_ai/eval_harness/harness/context.py
@@ -53,7 +53,10 @@ class EvalContext:
     when no selected suite requires demo data."""
 
     posthog_client: Posthog | None
-    """Analytics client for eval trace + evaluation event capture."""
+    """Analytics client for eval traces, with the default capture guards."""
+
+    posthog_evaluation_client: Posthog | None
+    """Shared result client for suites that enable experiment uploads."""
 
     sandbox_slots: asyncio.Semaphore | None
     """The one global limiter on concurrently live sandboxes, shared by every

--- a/products/posthog_ai/eval_harness/harness/lifecycle.py
+++ b/products/posthog_ai/eval_harness/harness/lifecycle.py
@@ -106,6 +106,7 @@ class SandboxedEvalHarness:
         self._database: EvalDatabase | None = None
         self._live_server: EvalLiveServer | None = None
         self._posthog_client: Posthog | None = None
+        self._posthog_evaluation_client: Posthog | None = None
         self._demo_data: SandboxedDemoData | None = None
 
     def run(self) -> int:
@@ -279,6 +280,11 @@ class SandboxedEvalHarness:
         if self._posthog_client is not None:
             self._stack.callback(self._posthog_client.shutdown)
 
+        # Each suite's no_send_logs setting controls result uploads to both services.
+        self._posthog_evaluation_client = get_client("US", disabled=False)
+        if self._posthog_evaluation_client is not None:
+            self._stack.callback(self._posthog_evaluation_client.shutdown)
+
         if Infra.DEMO_DATA in required:
             assert self._database is not None
             self._demo_data = ensure_demo_ready(
@@ -389,6 +395,7 @@ class SandboxedEvalHarness:
             case_filter=self.options.case_filter,
             demo_data=self._demo_data,
             posthog_client=self._posthog_client,
+            posthog_evaluation_client=self._posthog_evaluation_client,
             sandbox_slots=asyncio.Semaphore(self.options.max_sandboxes) if Infra.SANDBOX in required else None,
             team_setup_slots=asyncio.Semaphore(self.options.team_setup_concurrency),
             one_shot_slots=asyncio.Semaphore(DEFAULT_ONE_SHOT_CONCURRENCY),

--- a/products/posthog_ai/eval_harness/test/test_one_shot_runner.py
+++ b/products/posthog_ai/eval_harness/test/test_one_shot_runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from functools import partial
 from pathlib import Path
+from threading import Event
 from typing import Any, ClassVar
 
 import pytest
@@ -178,6 +179,19 @@ def test_run_routes_through_the_engine(
     async def task(case: BaseEvalCase, ctx: EvalContext) -> dict[str, Any]:
         raise AssertionError("the engine is stubbed, so the task must not run")
 
+    async def run_suite(run: _OneShotEvalRun) -> None:
+        loop = asyncio.get_running_loop()
+        loop_progress_during_flush: list[bool] = []
+
+        def blocking_flush() -> None:
+            loop_progress = Event()
+            loop.call_soon_threadsafe(loop_progress.set)
+            loop_progress_during_flush.append(loop_progress.wait(timeout=5))
+
+        with patch.object(Posthog, "flush", side_effect=blocking_flush):
+            assert await run.run() is canned
+        assert all(loop_progress_during_flush)
+
     canned = ExperimentResult(
         summary=EvalSummary(engine_name="stub", experiment_name="one-shot-test", scores={}),
         results=[
@@ -212,7 +226,7 @@ def test_run_routes_through_the_engine(
                 run.is_public = not no_send_logs
                 run.agent_trace_id_lookup["c1"] = "trace-1"
                 run.case_trace_meta["c1"] = {"prompt": "the prompt", "duration": 1.0, "first_timestamp": ""}
-                assert asyncio.run(run.run()) is canned
+                asyncio.run(run_suite(run))
             assert settings.TEST
             assert ctx.posthog_client is not None
             assert ctx.posthog_client.disabled

--- a/products/posthog_ai/eval_harness/test/test_one_shot_runner.py
+++ b/products/posthog_ai/eval_harness/test/test_one_shot_runner.py
@@ -12,8 +12,6 @@ from django.conf import settings
 
 from posthoganalytics import Posthog
 
-from posthog.ph_client import get_client
-
 from products.posthog_ai.eval_harness.config import BaseEvalCase
 from products.posthog_ai.eval_harness.engines.registry import resolve_engine
 from products.posthog_ai.eval_harness.engines.types import (
@@ -24,7 +22,9 @@ from products.posthog_ai.eval_harness.engines.types import (
     ExperimentSpec,
     NullCaseHooks,
 )
+from products.posthog_ai.eval_harness.harness.cli import parse_args
 from products.posthog_ai.eval_harness.harness.context import EvalContext
+from products.posthog_ai.eval_harness.harness.lifecycle import SandboxedEvalHarness
 from products.posthog_ai.eval_harness.one_shot import _OneShotEvalRun
 
 
@@ -76,6 +76,7 @@ def _build_ctx(timeout_seconds: int = 30, one_shot_slots: int = 2, case_filter: 
         case_filter=case_filter,
         demo_data=None,
         posthog_client=None,
+        posthog_evaluation_client=None,
         sandbox_slots=None,
         team_setup_slots=asyncio.Semaphore(1),
         one_shot_slots=asyncio.Semaphore(one_shot_slots),
@@ -169,8 +170,11 @@ def test_case_filter_narrows_eval_cases(tmp_path: Path, monkeypatch: pytest.Monk
     assert [case.input["name"] for case in run._build_eval_cases()] == ["c2"]
 
 
-@pytest.mark.parametrize("opt_out_capture", ["", "1", "0"])
-def test_run_routes_through_the_engine(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, opt_out_capture: str) -> None:
+@pytest.mark.parametrize("opt_out_capture", ["", "1"])
+@pytest.mark.parametrize("no_send_logs", [False, True])
+def test_run_routes_through_the_engine(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, opt_out_capture: str, no_send_logs: bool
+) -> None:
     async def task(case: BaseEvalCase, ctx: EvalContext) -> dict[str, Any]:
         raise AssertionError("the engine is stubbed, so the task must not run")
 
@@ -188,43 +192,54 @@ def test_run_routes_through_the_engine(tmp_path: Path, monkeypatch: pytest.Monke
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
     engine = _StubEngine(canned)
-    ctx = _build_ctx()
-    ctx.posthog_client = get_client("US", sync_mode=True, enable_local_evaluation=False)
-    run = _build_run(tmp_path, monkeypatch, ctx, task)
-    run.engine = engine
-    run.no_send_logs = False
-    run.is_public = True
-    run.agent_trace_id_lookup["c1"] = "trace-1"
-    run.case_trace_meta["c1"] = {"prompt": "the prompt", "duration": 1.0, "first_timestamp": ""}
+    harness = SandboxedEvalHarness(parse_args(["--agent-model", "claude-test"]))
+    reporter = _StubReporter()
 
     with (
-        patch("posthoganalytics.Posthog", partial(Posthog, sync_mode=True, enable_local_evaluation=False)),
+        patch(
+            "posthoganalytics.Posthog", side_effect=partial(Posthog, sync_mode=True, enable_local_evaluation=False)
+        ) as create_client,
         patch("posthoganalytics.client.batch_post") as batch_post,
+        patch("products.posthog_ai.eval_harness.harness.lifecycle.atexit.register"),
     ):
-        returned = asyncio.run(run.run())
-        assert settings.TEST
-        assert ctx.posthog_client is not None
-        assert ctx.posthog_client.disabled
-        ctx.posthog_client.capture(event="ordinary_test_event", distinct_id="test")
-        ctx.posthog_client.shutdown()
+        with harness._stack:
+            harness._bootstrap(frozenset())
+            ctx = harness._build_context(frozenset(), reporter)  # type: ignore[arg-type]
+            runs = [_build_run(tmp_path, monkeypatch, ctx, task) for _ in range(2)]
+            for run in runs:
+                run.engine = engine
+                run.no_send_logs = no_send_logs
+                run.is_public = not no_send_logs
+                run.agent_trace_id_lookup["c1"] = "trace-1"
+                run.case_trace_meta["c1"] = {"prompt": "the prompt", "duration": 1.0, "first_timestamp": ""}
+                assert asyncio.run(run.run()) is canned
+            assert settings.TEST
+            assert ctx.posthog_client is not None
+            assert ctx.posthog_client.disabled
+            ctx.posthog_client.capture(event="ordinary_test_event", distinct_id="test")
 
-    if opt_out_capture:
+        assert create_client.call_count == 2
+        assert ctx.posthog_evaluation_client is not None
+        assert ctx.posthog_evaluation_client.capture(event="$ai_evaluation", distinct_id="after-shutdown") is None
+
+    if no_send_logs:
         batch_post.assert_not_called()
+        assert reporter.posthog_urls == []
     else:
-        batch_post.assert_called_once()
-        event = batch_post.call_args.kwargs["batch"][0]
-        assert event["event"] == "$ai_evaluation"
-        assert event["properties"]["$ai_metric_name"] == "correctness"
-        assert event["properties"]["$ai_score"] == 1.0
-        assert event["properties"]["$ai_experiment_id"] == run.experiment_id
+        assert batch_post.call_count == 2
+        for run, call in zip(runs, batch_post.call_args_list):
+            event = call.kwargs["batch"][0]
+            assert event["event"] == "$ai_evaluation"
+            assert event["properties"]["$ai_metric_name"] == "correctness"
+            assert event["properties"]["$ai_score"] == 1.0
+            assert event["properties"]["$ai_experiment_id"] == run.experiment_id
+        assert reporter.posthog_urls == [("one-shot-test", run.experiment_id) for run in runs]
 
-    assert returned is canned
-    assert len(engine.calls) == 1
-    call = engine.calls[0]
-    assert call.project_name == "one-shot-test"
-    assert [case.input["name"] for case in call.cases] == ["c1", "c2"]
-    assert call.metadata == {"agent_model": "claude-test"}
-    assert not call.no_send_logs
-    reporter = ctx.reporter
-    assert reporter.started == [("one-shot-test", 2)]  # type: ignore[attr-defined]
-    assert reporter.summaries == [("one-shot-test", canned.summary, 0)]  # type: ignore[attr-defined]
+    assert len(engine.calls) == 2
+    for call in engine.calls:
+        assert call.project_name == "one-shot-test"
+        assert [case.input["name"] for case in call.cases] == ["c1", "c2"]
+        assert call.metadata == {"agent_model": "claude-test"}
+        assert call.no_send_logs == no_send_logs
+    assert reporter.started == [("one-shot-test", 2)] * 2
+    assert reporter.summaries == [("one-shot-test", canned.summary, 0)] * 2

--- a/products/posthog_ai/eval_harness/test/test_one_shot_runner.py
+++ b/products/posthog_ai/eval_harness/test/test_one_shot_runner.py
@@ -1,14 +1,23 @@
 from __future__ import annotations
 
 import asyncio
+from functools import partial
 from pathlib import Path
 from typing import Any, ClassVar
 
 import pytest
+from unittest.mock import patch
+
+from django.conf import settings
+
+from posthoganalytics import Posthog
+
+from posthog.ph_client import get_client
 
 from products.posthog_ai.eval_harness.config import BaseEvalCase
 from products.posthog_ai.eval_harness.engines.registry import resolve_engine
 from products.posthog_ai.eval_harness.engines.types import (
+    CaseResult,
     EnvVarSpec,
     EvalSummary,
     ExperimentResult,
@@ -24,6 +33,7 @@ class _StubReporter:
         self.done: list[tuple[str, str]] = []
         self.started: list[tuple[str, int]] = []
         self.summaries: list[tuple[str, Any, int]] = []
+        self.posthog_urls: list[tuple[str, str]] = []
 
     async def case_done(self, experiment_name: str, case_name: str, duration_seconds: float, status: str) -> None:
         self.done.append((case_name, status))
@@ -33,6 +43,9 @@ class _StubReporter:
 
     async def record_summary(self, experiment_name: str, summary: Any, error_count: int) -> None:
         self.summaries.append((experiment_name, summary, error_count))
+
+    async def record_posthog_evaluations_url(self, experiment_name: str, experiment_id: str) -> None:
+        self.posthog_urls.append((experiment_name, experiment_id))
 
 
 class _StubEngine:
@@ -156,20 +169,54 @@ def test_case_filter_narrows_eval_cases(tmp_path: Path, monkeypatch: pytest.Monk
     assert [case.input["name"] for case in run._build_eval_cases()] == ["c2"]
 
 
-def test_run_routes_through_the_engine(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("opt_out_capture", ["", "1", "0"])
+def test_run_routes_through_the_engine(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, opt_out_capture: str) -> None:
     async def task(case: BaseEvalCase, ctx: EvalContext) -> dict[str, Any]:
         raise AssertionError("the engine is stubbed, so the task must not run")
 
     canned = ExperimentResult(
         summary=EvalSummary(engine_name="stub", experiment_name="one-shot-test", scores={}),
-        results=[],
+        results=[
+            CaseResult(
+                input={"name": "c1", "prompt": "the prompt"},
+                output={"last_message": "done"},
+                scores={"correctness": 1.0},
+            )
+        ],
     )
+    monkeypatch.setenv("OPT_OUT_CAPTURE", opt_out_capture)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
     engine = _StubEngine(canned)
     ctx = _build_ctx()
+    ctx.posthog_client = get_client("US", sync_mode=True, enable_local_evaluation=False)
     run = _build_run(tmp_path, monkeypatch, ctx, task)
     run.engine = engine
+    run.no_send_logs = False
+    run.is_public = True
+    run.agent_trace_id_lookup["c1"] = "trace-1"
+    run.case_trace_meta["c1"] = {"prompt": "the prompt", "duration": 1.0, "first_timestamp": ""}
 
-    returned = asyncio.run(run.run())
+    with (
+        patch("posthoganalytics.Posthog", partial(Posthog, sync_mode=True, enable_local_evaluation=False)),
+        patch("posthoganalytics.client.batch_post") as batch_post,
+    ):
+        returned = asyncio.run(run.run())
+        assert settings.TEST
+        assert ctx.posthog_client is not None
+        assert ctx.posthog_client.disabled
+        ctx.posthog_client.capture(event="ordinary_test_event", distinct_id="test")
+        ctx.posthog_client.shutdown()
+
+    if opt_out_capture:
+        batch_post.assert_not_called()
+    else:
+        batch_post.assert_called_once()
+        event = batch_post.call_args.kwargs["batch"][0]
+        assert event["event"] == "$ai_evaluation"
+        assert event["properties"]["$ai_metric_name"] == "correctness"
+        assert event["properties"]["$ai_score"] == 1.0
+        assert event["properties"]["$ai_experiment_id"] == run.experiment_id
 
     assert returned is canned
     assert len(engine.calls) == 1
@@ -177,6 +224,7 @@ def test_run_routes_through_the_engine(tmp_path: Path, monkeypatch: pytest.Monke
     assert call.project_name == "one-shot-test"
     assert [case.input["name"] for case in call.cases] == ["c1", "c2"]
     assert call.metadata == {"agent_model": "claude-test"}
+    assert not call.no_send_logs
     reporter = ctx.reporter
     assert reporter.started == [("one-shot-test", 2)]  # type: ignore[attr-defined]
     assert reporter.summaries == [("one-shot-test", canned.summary, 0)]  # type: ignore[attr-defined]

--- a/products/posthog_ai/eval_harness/test/test_one_shot_runner.py
+++ b/products/posthog_ai/eval_harness/test/test_one_shot_runner.py
@@ -227,8 +227,8 @@ def test_run_routes_through_the_engine(
         assert reporter.posthog_urls == []
     else:
         assert batch_post.call_count == 2
-        for run, call in zip(runs, batch_post.call_args_list):
-            event = call.kwargs["batch"][0]
+        for run, upload_call in zip(runs, batch_post.call_args_list):
+            event = upload_call.kwargs["batch"][0]
             assert event["event"] == "$ai_evaluation"
             assert event["properties"]["$ai_metric_name"] == "correctness"
             assert event["properties"]["$ai_score"] == 1.0
@@ -236,10 +236,10 @@ def test_run_routes_through_the_engine(
         assert reporter.posthog_urls == [("one-shot-test", run.experiment_id) for run in runs]
 
     assert len(engine.calls) == 2
-    for call in engine.calls:
-        assert call.project_name == "one-shot-test"
-        assert [case.input["name"] for case in call.cases] == ["c1", "c2"]
-        assert call.metadata == {"agent_model": "claude-test"}
-        assert call.no_send_logs == no_send_logs
+    for experiment in engine.calls:
+        assert experiment.project_name == "one-shot-test"
+        assert [case.input["name"] for case in experiment.cases] == ["c1", "c2"]
+        assert experiment.metadata == {"agent_model": "claude-test"}
+        assert experiment.no_send_logs == no_send_logs
     assert reporter.started == [("one-shot-test", 2)] * 2
     assert reporter.summaries == [("one-shot-test", canned.summary, 0)] * 2


### PR DESCRIPTION
## Problem

Offline eval users cannot see their results in PostHog because the harness runs with `TEST=1`, which disables its reporting client.
The shared capture guard protects ordinary tests and traces ([#83133](https://github.com/PostHog/posthog/pull/83133)).

## Changes

- Restore `$ai_evaluation` uploads through one dedicated PostHog client, shared across all suites and shut down when the harness finishes.
- Use the same `no_send_logs` setting for Braintrust and PostHog: public suites upload to both; private suites upload to neither.
- Wait for PostHog flushes in worker threads so a slow upload does not pause concurrent suites.
- Preserve the existing event schema and run each evaluation only once.

Before:

```mermaid
flowchart LR
    A[Public eval results]:::phGray --> B[Braintrust]:::phBlue
    A --> C[Shared PostHog client]:::phBlue --> D[Dropped under TEST]:::phYellow
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
```

After:

```mermaid
flowchart LR
    A[Suite results]:::phGray --> B{Uploads enabled?}:::phYellow
    B -->|Yes| C[Braintrust]:::phBlue
    B -->|Yes| D[Shared PostHog result client]:::phBlue --> E[PostHog]:::phRed
    B -->|No| F[No result uploads]:::phGray
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
```

> [!NOTE]
> `TEST` and `OPT_OUT_CAPTURE` still guard ordinary SDK and trace clients. Evaluation result uploads follow `no_send_logs` independently of those guards.

## How did you test this code?

- The [runner regression](https://github.com/PostHog/posthog/blob/c4fda2185a9c66eeea2ef2f9df0a081e64c5f5ac/products/posthog_ai/eval_harness/test/test_one_shot_runner.py#L176) uses the real SDK with intercepted uploads.
  It checks matching upload settings, client reuse across suites, shutdown, and continued suppression of ordinary test events.
  The same test checks that the event loop progresses during a blocking flush.
- Existing harness, event schema, and SDK guard tests passed locally, along with suite discovery, lint, repository-wide mypy, and preflight.
- Live uploads were not tested. Backend patch coverage is not available yet.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Document the shared upload setting and client lifetime in the internal reporting guide, harness README, and eval-writing skill.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented this change using local Git, Python tooling, and the GitHub connector.
The duplicate search found no matching fix.
The patch uses repository code and synthetic test values.

Skills invoked: debugging-ci-failures, maintaining-python-tests, writing-evals, writing-tests, writing-code-comments, writing-dataclasses, writing-user-facing-copy, writing-skills, posthog-efficient-validation, llma-git-workflow, create-pr, writing-pr-descriptions, running-ci-preflight, reviewing-with-coderabbit, and github-efficient-operations.

The local CodeRabbit pass is paused; this PR opened without one.


