### PR TITLE
feat(mcp-analytics): collect inline session usefulness feedback

### DIFF
--- a/docs/internal/mcp-analytics-feedback.md
+++ b/docs/internal/mcp-analytics-feedback.md
@@ -1,0 +1,28 @@
+# MCP analytics feedback invitations
+
+The session detail panel offers feedback after 30 seconds with loaded, nonempty tool calls.
+Changing sessions, leaving the panel, or hiding the browser tab cancels the delay.
+A visible tab starts a fresh delay.
+Loading, empty, and impersonated sessions do not receive an invitation.
+The survey must be loaded and running before the delay starts.
+
+The invitation opens the same survey as the header's Feedback button.
+It does not automatically open a popover or change the survey's questions or targeting.
+An invitation starts a 30-day cooldown for that signed-in user in the browser, including when dismissed or left unanswered.
+The header button remains available during the cooldown.
+The cooldown uses local storage; it does not follow the user across browsers or coordinate simultaneous tabs.
+
+## Measurement
+
+Invitation events are `mcp analytics feedback prompt shown`, `mcp analytics feedback prompt clicked`, and `mcp analytics feedback prompt dismissed`.
+These measure the invitation, not the survey popover.
+The SDK owns the survey lifecycle events, including `survey sent`.
+
+Contextual survey responses carry `feedback_entry_point: session_review_prompt`, `feedback_surface: mcp_analytics`, and `mcp_analytics_tab: sessions`.
+Header responses carry `feedback_entry_point: header` and the active tab.
+No session IDs, tool inputs, outputs, or customer end-user details are attached by this invitation.
+
+Use unique viewers as the denominator for invitation click rate.
+Compare survey submissions by entry point over the same period, distinguishing partial from completed responses.
+Do not interpret a missing survey-impression event as a zero response rate.
+Reported findings or changes are qualitative evidence; invitation clicks and continued usage do not establish customer outcomes.

--- a/docs/internal/mcp-analytics-feedback.md
+++ b/docs/internal/mcp-analytics-feedback.md
@@ -24,7 +24,7 @@ The cooldown uses local storage; it does not follow the user across browsers or 
 Create the API survey in draft with partial responses enabled and an Always schedule.
 The questions are:
 
-1. Did this session help you find what you needed? Choices: Yes, Partly, No.
+1. Did this session help you find what you needed? Choices: Yes and No, displayed as thumbs up and thumbs down.
 2. What did you learn, or what was missing? Optional open text.
 
 The ID in `MCP_ANALYTICS_USEFULNESS_SURVEY_ID` selects this survey.
@@ -56,7 +56,7 @@ The SDK's existing viewer identity and group context remain available for cohort
 
 Filter reporting to this survey ID and use distinct submission IDs for response rate: submissions with a first answer divided by shown submissions.
 Do not count both the partial and completed events as separate responses.
-Report Yes, Partly, and No separately, including partial submissions with a first answer.
+Report thumbs up (Yes) and thumbs down (No) separately, including partial submissions with a first answer.
 For adoption analysis, also report unique responding viewers and organizations rather than treating repeat responses as independent customers.
 Do not interpret a missing impression event as a zero response rate.
 

--- a/docs/internal/mcp-analytics-feedback.md
+++ b/docs/internal/mcp-analytics-feedback.md
@@ -1,28 +1,65 @@
-# MCP analytics feedback invitations
+# MCP analytics session feedback
 
-The session detail panel offers feedback after 30 seconds with loaded, nonempty tool calls.
+The session detail panel offers an inline API survey after 30 seconds with loaded, nonempty tool calls.
 Changing sessions, leaving the panel, or hiding the browser tab cancels the delay.
 A visible tab starts a fresh delay.
-Loading, empty, and impersonated sessions do not receive an invitation.
-The survey must be loaded and running before the delay starts.
+Loading, empty, impersonated, and capture-disabled sessions do not receive a prompt.
+The SDK must load the survey and its feature flags and return it as an active matching survey before the delay starts.
 
-The invitation opens the same survey as the header's Feedback button.
-It does not automatically open a popover or change the survey's questions or targeting.
-An invitation starts a 30-day cooldown for that signed-in user in the browser, including when dismissed or left unanswered.
-The header button remains available during the cooldown.
+The question and choices come from a separate API survey, rather than the generic header feedback survey.
+The supported shape is one single-choice question followed by one optional open-text question.
+The UI renders both as plain text using LemonUI components.
+The first choice queues a partial response immediately and reveals the optional follow-up.
+Selecting Done or Send feedback completes the same submission.
+Closing or navigating away after the first answer leaves that answer available as a partial response.
+A failed capture keeps the current answer and text available for retry.
+The confirmation means the SDK accepted the event for delivery, not that the server acknowledged receipt.
+
+A prompt starts a 30-day cooldown for that signed-in user in the browser, including when dismissed or left unanswered.
+The header button remains available during the cooldown and opens the existing general feedback popover.
 The cooldown uses local storage; it does not follow the user across browsers or coordinate simultaneous tabs.
+
+## Configuration and release
+
+Create the API survey in draft with partial responses enabled and an Always schedule.
+The questions are:
+
+1. Did this session help you find what you needed? Choices: Yes, Partly, No.
+2. What did you learn, or what was missing? Optional open text.
+
+The ID in `MCP_ANALYTICS_USEFULNESS_SURVEY_ID` selects this survey.
+Deploy the frontend before launching the survey.
+Draft and stopped surveys do not start a new prompt; a viewer with an already visible prompt can finish it.
+Feature flag targeting is checked through `getActiveMatchingSurveys`, while the frontend owns the reading delay and cooldown.
+Keep the question types, order, and meaning stable; use a new survey for a different measurement.
+An incompatible question count or type suppresses the prompt.
 
 ## Measurement
 
-Invitation events are `mcp analytics feedback prompt shown`, `mcp analytics feedback prompt clicked`, and `mcp analytics feedback prompt dismissed`.
-These measure the invitation, not the survey popover.
-The SDK owns the survey lifecycle events, including `survey sent`.
+| Event              | Trigger                                      | Response fields                                                              |
+| ------------------ | -------------------------------------------- | ---------------------------------------------------------------------------- |
+| `survey shown`     | The inline question becomes visible          | Survey ID, name, and submission ID                                           |
+| `survey sent`      | The first choice is selected                 | Question-ID response, question text snapshot, submission ID, completed false |
+| `survey sent`      | Done or Send feedback is selected            | Same submission ID and first answer, optional text, completed true           |
+| `survey dismissed` | The question or optional follow-up is closed | Same submission ID and whether the first answer was recorded                 |
 
-Contextual survey responses carry `feedback_entry_point: session_review_prompt`, `feedback_surface: mcp_analytics`, and `mcp_analytics_tab: sessions`.
+The properties use the standard survey schema: `$survey_id`, `$survey_name`, `$survey_submission_id`, `$survey_questions`, `$survey_response_<question-id>`, `$survey_completed`, and `$survey_partially_completed`.
+Closing the thank-you state does not emit a dismissal.
+Repeated answer or completion clicks do not queue another response.
+These existing event names need no new event-definition registration.
+Do not send synthetic events to initialize production reporting.
+
+All inline events carry `feedback_entry_point: session_review_prompt`, `feedback_surface: mcp_analytics`, and `mcp_analytics_tab: sessions`.
 Header responses carry `feedback_entry_point: header` and the active tab.
-No session IDs, tool inputs, outputs, or customer end-user details are attached by this invitation.
+No MCP session IDs, tool inputs, outputs, or customer end-user details are attached by this prompt.
+The SDK's existing viewer identity and group context remain available for cohort analysis.
 
-Use unique viewers as the denominator for invitation click rate.
-Compare survey submissions by entry point over the same period, distinguishing partial from completed responses.
-Do not interpret a missing survey-impression event as a zero response rate.
-Reported findings or changes are qualitative evidence; invitation clicks and continued usage do not establish customer outcomes.
+Filter reporting to this survey ID and use distinct submission IDs for response rate: submissions with a first answer divided by shown submissions.
+Do not count both the partial and completed events as separate responses.
+Report Yes, Partly, and No separately, including partial submissions with a first answer.
+For adoption analysis, also report unique responding viewers and organizations rather than treating repeat responses as independent customers.
+Do not interpret a missing impression event as a zero response rate.
+
+This question measures reported usefulness of a session review.
+It does not establish that the viewer changed their product or achieved a business outcome.
+Assess those separately through follow-up conversations about the change made and the result observed.

--- a/docs/internal/mcp-analytics-feedback.md
+++ b/docs/internal/mcp-analytics-feedback.md
@@ -7,8 +7,8 @@ Loading, empty, impersonated, and capture-disabled sessions do not receive a pro
 The SDK must load the survey and its feature flags and return it as an active matching survey before the delay starts.
 
 The question and choices come from a separate API survey, rather than the generic header feedback survey.
-The supported shape is one single-choice question followed by one optional open-text question.
-The UI renders both as plain text using LemonUI components.
+The supported shape is one two-point emoji rating question followed by one optional open-text question.
+The UI renders the question text and thumbs buttons using LemonUI components.
 The first choice queues a partial response immediately and reveals the optional follow-up.
 Selecting Done or Send feedback completes the same submission.
 Closing or navigating away after the first answer leaves that answer available as a partial response.
@@ -24,7 +24,7 @@ The cooldown uses local storage; it does not follow the user across browsers or 
 Create the API survey in draft with partial responses enabled and an Always schedule.
 The questions are:
 
-1. Did this session help you find what you needed? Choices: Yes and No, displayed as thumbs up and thumbs down.
+1. Did this session help you find what you needed? Native rating question with emoji display and a two-point scale.
 2. What did you learn, or what was missing? Optional open text.
 
 The ID in `MCP_ANALYTICS_USEFULNESS_SURVEY_ID` selects this survey.
@@ -43,6 +43,7 @@ An incompatible question count or type suppresses the prompt.
 | `survey sent`      | Done or Send feedback is selected            | Same submission ID and first answer, optional text, completed true           |
 | `survey dismissed` | The question or optional follow-up is closed | Same submission ID and whether the first answer was recorded                 |
 
+The rating uses the native survey values as strings: `"1"` for thumbs up and `"2"` for thumbs down.
 The properties use the standard survey schema: `$survey_id`, `$survey_name`, `$survey_submission_id`, `$survey_questions`, `$survey_response_<question-id>`, `$survey_completed`, and `$survey_partially_completed`.
 Closing the thank-you state does not emit a dismissal.
 Repeated answer or completion clicks do not queue another response.
@@ -56,7 +57,7 @@ The SDK's existing viewer identity and group context remain available for cohort
 
 Filter reporting to this survey ID and use distinct submission IDs for response rate: submissions with a first answer divided by shown submissions.
 Do not count both the partial and completed events as separate responses.
-Report thumbs up (Yes) and thumbs down (No) separately, including partial submissions with a first answer.
+Report thumbs up (`1`) and thumbs down (`2`) separately, including partial submissions with a first answer.
 For adoption analysis, also report unique responding viewers and organizations rather than treating repeat responses as independent customers.
 Do not interpret a missing impression event as a zero response rate.
 

--- a/frontend/src/lib/components/FeedbackSurveyButton/FeedbackSurveyButton.test.tsx
+++ b/frontend/src/lib/components/FeedbackSurveyButton/FeedbackSurveyButton.test.tsx
@@ -16,10 +16,8 @@ function mockSurveysLoaded(context: { isLoaded: boolean } | null): void {
     }) as typeof posthog.onSurveysLoaded)
 }
 
-function renderButton(properties?: Properties, onClick?: () => void): HTMLElement {
-    const { getByRole } = render(
-        <FeedbackSurveyButton surveyId={SURVEY_ID} properties={properties} onClick={onClick} />
-    )
+function renderButton(properties?: Properties): HTMLElement {
+    const { getByRole } = render(<FeedbackSurveyButton surveyId={SURVEY_ID} properties={properties} />)
     return getByRole('button')
 }
 
@@ -32,20 +30,17 @@ describe('FeedbackSurveyButton', () => {
 
     it('is disabled and does not display the survey before the surveys extension reports in', () => {
         mockSurveysLoaded(null)
-        const onClick = jest.fn()
-        const button = renderButton(undefined, onClick)
+        const button = renderButton()
 
         expect(button.getAttribute('aria-disabled')).toBe('true')
         fireEvent.click(button)
         expect(posthog.displaySurvey).not.toHaveBeenCalled()
-        expect(onClick).not.toHaveBeenCalled()
     })
 
     it('displays the survey with condition bypass once surveys load', () => {
         mockSurveysLoaded({ isLoaded: true })
         const properties = { feedback_surface: 'mcp_analytics', mcp_analytics_tab: 'activity' }
-        const onClick = jest.fn()
-        const button = renderButton(properties, onClick)
+        const button = renderButton(properties)
 
         expect(button.getAttribute('aria-disabled')).not.toBe('true')
         fireEvent.click(button)
@@ -55,7 +50,6 @@ describe('FeedbackSurveyButton', () => {
             ignoreDelay: true,
             properties,
         })
-        expect(onClick).toHaveBeenCalledTimes(1)
     })
 
     it('stays disabled when the surveys extension reports a failed load', () => {

--- a/frontend/src/lib/components/FeedbackSurveyButton/FeedbackSurveyButton.test.tsx
+++ b/frontend/src/lib/components/FeedbackSurveyButton/FeedbackSurveyButton.test.tsx
@@ -16,8 +16,10 @@ function mockSurveysLoaded(context: { isLoaded: boolean } | null): void {
     }) as typeof posthog.onSurveysLoaded)
 }
 
-function renderButton(properties?: Properties): HTMLElement {
-    const { getByRole } = render(<FeedbackSurveyButton surveyId={SURVEY_ID} properties={properties} />)
+function renderButton(properties?: Properties, onClick?: () => void): HTMLElement {
+    const { getByRole } = render(
+        <FeedbackSurveyButton surveyId={SURVEY_ID} properties={properties} onClick={onClick} />
+    )
     return getByRole('button')
 }
 
@@ -30,17 +32,20 @@ describe('FeedbackSurveyButton', () => {
 
     it('is disabled and does not display the survey before the surveys extension reports in', () => {
         mockSurveysLoaded(null)
-        const button = renderButton()
+        const onClick = jest.fn()
+        const button = renderButton(undefined, onClick)
 
         expect(button.getAttribute('aria-disabled')).toBe('true')
         fireEvent.click(button)
         expect(posthog.displaySurvey).not.toHaveBeenCalled()
+        expect(onClick).not.toHaveBeenCalled()
     })
 
     it('displays the survey with condition bypass once surveys load', () => {
         mockSurveysLoaded({ isLoaded: true })
         const properties = { feedback_surface: 'mcp_analytics', mcp_analytics_tab: 'activity' }
-        const button = renderButton(properties)
+        const onClick = jest.fn()
+        const button = renderButton(properties, onClick)
 
         expect(button.getAttribute('aria-disabled')).not.toBe('true')
         fireEvent.click(button)
@@ -50,6 +55,7 @@ describe('FeedbackSurveyButton', () => {
             ignoreDelay: true,
             properties,
         })
+        expect(onClick).toHaveBeenCalledTimes(1)
     })
 
     it('stays disabled when the surveys extension reports a failed load', () => {

--- a/frontend/src/lib/components/FeedbackSurveyButton/FeedbackSurveyButton.tsx
+++ b/frontend/src/lib/components/FeedbackSurveyButton/FeedbackSurveyButton.tsx
@@ -6,7 +6,6 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 export interface FeedbackSurveyButtonProps {
     surveyId: string
     properties?: Properties
-    onClick?: () => void
     'data-attr'?: string
 }
 
@@ -18,7 +17,6 @@ export interface FeedbackSurveyButtonProps {
 export function FeedbackSurveyButton({
     surveyId,
     properties,
-    onClick,
     'data-attr': dataAttr,
 }: FeedbackSurveyButtonProps): JSX.Element {
     const [surveysLoaded, setSurveysLoaded] = useState(false)
@@ -39,7 +37,7 @@ export function FeedbackSurveyButton({
             data-attr={dataAttr}
             tooltip="Have any questions or feedback?"
             disabledReason={surveysLoaded ? undefined : 'Feedback is unavailable right now'}
-            onClick={() => {
+            onClick={() =>
                 // A deliberate click should always bring up the survey, so bypass the
                 // popover's URL/cohort/already-dismissed targeting.
                 posthog.displaySurvey(surveyId, {
@@ -48,8 +46,7 @@ export function FeedbackSurveyButton({
                     ignoreDelay: true,
                     properties,
                 })
-                onClick?.()
-            }}
+            }
         >
             Feedback
         </LemonButton>

--- a/frontend/src/lib/components/FeedbackSurveyButton/FeedbackSurveyButton.tsx
+++ b/frontend/src/lib/components/FeedbackSurveyButton/FeedbackSurveyButton.tsx
@@ -6,6 +6,7 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 export interface FeedbackSurveyButtonProps {
     surveyId: string
     properties?: Properties
+    onClick?: () => void
     'data-attr'?: string
 }
 
@@ -17,6 +18,7 @@ export interface FeedbackSurveyButtonProps {
 export function FeedbackSurveyButton({
     surveyId,
     properties,
+    onClick,
     'data-attr': dataAttr,
 }: FeedbackSurveyButtonProps): JSX.Element {
     const [surveysLoaded, setSurveysLoaded] = useState(false)
@@ -37,7 +39,7 @@ export function FeedbackSurveyButton({
             data-attr={dataAttr}
             tooltip="Have any questions or feedback?"
             disabledReason={surveysLoaded ? undefined : 'Feedback is unavailable right now'}
-            onClick={() =>
+            onClick={() => {
                 // A deliberate click should always bring up the survey, so bypass the
                 // popover's URL/cohort/already-dismissed targeting.
                 posthog.displaySurvey(surveyId, {
@@ -46,7 +48,8 @@ export function FeedbackSurveyButton({
                     ignoreDelay: true,
                     properties,
                 })
-            }
+                onClick?.()
+            }}
         >
             Feedback
         </LemonButton>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3901,6 +3901,9 @@ importers:
       kea-router:
         specifier: 'catalog:'
         version: 3.4.1(kea@4.0.0-pre.6(patch_hash=139b8d1f1304f9d9da452a9a1244c94ea679dbcb85687d8999563146879fb6f5)(react@18.3.1))
+      posthog-js:
+        specifier: 'catalog:'
+        version: 1.429.2(@types/react@18.3.27)(react@18.3.1)
       react:
         specifier: 18.3.1
         version: 18.3.1

--- a/products/mcp_analytics/frontend/MCPAnalyticsScene.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsScene.tsx
@@ -19,6 +19,7 @@ import { MCPAnalyticsClustering } from './clustering/MCPAnalyticsClustering'
 import { MCPAnalyticsActivityDashboard } from './earlyData/MCPAnalyticsEarlyData'
 import { mcpAnalyticsEmptyState } from './emptyState/mcpAnalyticsEmptyState'
 import { mcpAnalyticsFeaturePreviewGate } from './featurePreviewGate'
+import { MCP_ANALYTICS_FEEDBACK_SURVEY_ID } from './feedback/constants'
 import { MCPAnalyticsDashboard } from './MCPAnalyticsDashboard'
 import { mcpAnalyticsOnboardingLogic } from './mcpAnalyticsOnboardingLogic'
 import { MCPAnalyticsTab, TAB_DESCRIPTIONS, mcpAnalyticsSceneLogic } from './mcpAnalyticsSceneLogic'
@@ -37,7 +38,6 @@ export const scene: SceneExport = {
 }
 
 const MCP_DOCS_URL = 'https://posthog.com/docs/mcp-analytics/installation'
-const MCP_ANALYTICS_FEEDBACK_SURVEY_ID = '01a04991-bc80-0000-70c5-beeea0553cd0'
 
 export function MCPAnalyticsScene(): JSX.Element {
     return (
@@ -145,6 +145,7 @@ function MCPAnalyticsSceneContent(): JSX.Element {
                             surveyId={MCP_ANALYTICS_FEEDBACK_SURVEY_ID}
                             properties={{
                                 feedback_surface: 'mcp_analytics',
+                                feedback_entry_point: 'header',
                                 mcp_analytics_tab: activeTab,
                             }}
                             data-attr="mcp-analytics-feedback-button"

--- a/products/mcp_analytics/frontend/feedback/MCPAnalyticsFeedbackPrompt.stories.tsx
+++ b/products/mcp_analytics/frontend/feedback/MCPAnalyticsFeedbackPrompt.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react'
 import { useValues } from 'kea'
-import posthog from 'posthog-js'
+import posthog, { Survey, SurveyType, SurveyQuestionType } from 'posthog-js'
 import { useEffect } from 'react'
 
 import { userLogic } from 'scenes/userLogic'
@@ -8,14 +8,45 @@ import { userLogic } from 'scenes/userLogic'
 import { mswDecorator } from '~/mocks/browser'
 
 import { MCPSessionDetail } from '../sessions/MCPSessionDetail'
+import { MCP_ANALYTICS_USEFULNESS_SURVEY_ID } from './constants'
 import { mcpAnalyticsFeedbackLogic } from './mcpAnalyticsFeedbackLogic'
 import { MCPAnalyticsFeedbackPrompt } from './MCPAnalyticsFeedbackPrompt'
+
+const survey: Survey = {
+    id: MCP_ANALYTICS_USEFULNESS_SURVEY_ID,
+    name: 'Session usefulness',
+    type: SurveyType.API,
+    start_date: '2026-01-01T00:00:00Z',
+    feature_flag_keys: null,
+    linked_flag_key: null,
+    targeting_flag_key: null,
+    internal_targeting_flag_key: null,
+    appearance: null,
+    conditions: null,
+    end_date: null,
+    current_iteration: null,
+    current_iteration_start_date: null,
+    questions: [
+        {
+            id: 'example-choice',
+            type: SurveyQuestionType.SingleChoice,
+            question: 'Did this session help you find what you needed?',
+            choices: ['Yes', 'Partly', 'No'],
+        },
+        {
+            id: 'example-detail',
+            type: SurveyQuestionType.Open,
+            question: 'What did you learn, or what was missing?',
+            optional: true,
+        },
+    ],
+}
 
 const meta: Meta<typeof MCPAnalyticsFeedbackPrompt> = {
     title: 'Products/MCP Analytics/Feedback prompt',
     component: MCPAnalyticsFeedbackPrompt,
     decorators: [
-        (Story) => {
+        (Story, context) => {
             const { user } = useValues(userLogic)
             const logic = mcpAnalyticsFeedbackLogic({
                 userId: user?.uuid ?? '',
@@ -25,15 +56,29 @@ const meta: Meta<typeof MCPAnalyticsFeedbackPrompt> = {
             useValues(logic)
             useEffect(() => {
                 const onSurveysLoaded = posthog.onSurveysLoaded
+                const capture = posthog.capture
+                posthog.capture = () => ({ uuid: 'example-event' }) as ReturnType<typeof posthog.capture>
                 posthog.onSurveysLoaded = (callback) => {
                     callback([], { isLoaded: true })
                     return () => {}
                 }
-                logic.actions.showPrompt(Date.now())
+                logic.actions.showPrompt(survey, Date.now(), 'example-submission')
+                if (context.parameters.feedbackStage === 'followup') {
+                    logic.actions.responseQueued('Partly', false)
+                }
+                if (context.parameters.feedbackStage === 'error') {
+                    logic.actions.responseQueued('Partly', false)
+                    logic.actions.setDetail('Found a tool call that needs a clearer error message.')
+                    logic.actions.responseFailed()
+                }
+                if (context.parameters.feedbackStage === 'thanks') {
+                    logic.actions.responseQueued('Yes', true)
+                }
                 return () => {
                     posthog.onSurveysLoaded = onSurveysLoaded
+                    posthog.capture = capture
                 }
-            }, [logic])
+            }, [logic, context.parameters.feedbackStage])
             return <Story />
         },
     ],
@@ -98,3 +143,7 @@ export const SessionReview: Story = {
         </div>
     ),
 }
+
+export const FollowUp: Story = { ...Narrow, parameters: { feedbackStage: 'followup' } }
+export const Error: Story = { ...Narrow, parameters: { feedbackStage: 'error' } }
+export const Thanks: Story = { ...Narrow, parameters: { feedbackStage: 'thanks' } }

--- a/products/mcp_analytics/frontend/feedback/MCPAnalyticsFeedbackPrompt.stories.tsx
+++ b/products/mcp_analytics/frontend/feedback/MCPAnalyticsFeedbackPrompt.stories.tsx
@@ -31,7 +31,7 @@ const survey: Survey = {
             id: 'example-choice',
             type: SurveyQuestionType.SingleChoice,
             question: 'Did this session help you find what you needed?',
-            choices: ['Yes', 'Partly', 'No'],
+            choices: ['Yes', 'No'],
         },
         {
             id: 'example-detail',
@@ -64,10 +64,10 @@ const meta: Meta<typeof MCPAnalyticsFeedbackPrompt> = {
                 }
                 logic.actions.showPrompt(survey, Date.now(), 'example-submission')
                 if (context.parameters.feedbackStage === 'followup') {
-                    logic.actions.responseQueued('Partly', false)
+                    logic.actions.responseQueued('No', false)
                 }
                 if (context.parameters.feedbackStage === 'error') {
-                    logic.actions.responseQueued('Partly', false)
+                    logic.actions.responseQueued('No', false)
                     logic.actions.setDetail('Found a tool call that needs a clearer error message.')
                     logic.actions.responseFailed()
                 }

--- a/products/mcp_analytics/frontend/feedback/MCPAnalyticsFeedbackPrompt.stories.tsx
+++ b/products/mcp_analytics/frontend/feedback/MCPAnalyticsFeedbackPrompt.stories.tsx
@@ -29,9 +29,12 @@ const survey: Survey = {
     questions: [
         {
             id: 'example-choice',
-            type: SurveyQuestionType.SingleChoice,
+            type: SurveyQuestionType.Rating,
             question: 'Did this session help you find what you needed?',
-            choices: ['Yes', 'No'],
+            display: 'emoji',
+            scale: 2,
+            lowerBoundLabel: '',
+            upperBoundLabel: '',
         },
         {
             id: 'example-detail',
@@ -64,15 +67,15 @@ const meta: Meta<typeof MCPAnalyticsFeedbackPrompt> = {
                 }
                 logic.actions.showPrompt(survey, Date.now(), 'example-submission')
                 if (context.parameters.feedbackStage === 'followup') {
-                    logic.actions.responseQueued('No', false)
+                    logic.actions.responseQueued('2', false)
                 }
                 if (context.parameters.feedbackStage === 'error') {
-                    logic.actions.responseQueued('No', false)
+                    logic.actions.responseQueued('2', false)
                     logic.actions.setDetail('Found a tool call that needs a clearer error message.')
                     logic.actions.responseFailed()
                 }
                 if (context.parameters.feedbackStage === 'thanks') {
-                    logic.actions.responseQueued('Yes', true)
+                    logic.actions.responseQueued('1', true)
                 }
                 return () => {
                     posthog.onSurveysLoaded = onSurveysLoaded

--- a/products/mcp_analytics/frontend/feedback/MCPAnalyticsFeedbackPrompt.stories.tsx
+++ b/products/mcp_analytics/frontend/feedback/MCPAnalyticsFeedbackPrompt.stories.tsx
@@ -1,0 +1,100 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { useValues } from 'kea'
+import posthog from 'posthog-js'
+import { useEffect } from 'react'
+
+import { userLogic } from 'scenes/userLogic'
+
+import { mswDecorator } from '~/mocks/browser'
+
+import { MCPSessionDetail } from '../sessions/MCPSessionDetail'
+import { mcpAnalyticsFeedbackLogic } from './mcpAnalyticsFeedbackLogic'
+import { MCPAnalyticsFeedbackPrompt } from './MCPAnalyticsFeedbackPrompt'
+
+const meta: Meta<typeof MCPAnalyticsFeedbackPrompt> = {
+    title: 'Products/MCP Analytics/Feedback prompt',
+    component: MCPAnalyticsFeedbackPrompt,
+    decorators: [
+        (Story) => {
+            const { user } = useValues(userLogic)
+            const logic = mcpAnalyticsFeedbackLogic({
+                userId: user?.uuid ?? '',
+                sessionId: 'example-session',
+                isImpersonated: false,
+            })
+            useValues(logic)
+            useEffect(() => {
+                const onSurveysLoaded = posthog.onSurveysLoaded
+                posthog.onSurveysLoaded = (callback) => {
+                    callback([], { isLoaded: true })
+                    return () => {}
+                }
+                logic.actions.showPrompt(Date.now())
+                return () => {
+                    posthog.onSurveysLoaded = onSurveysLoaded
+                }
+            }, [logic])
+            return <Story />
+        },
+    ],
+}
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+    render: () => (
+        <div className="w-[800px] max-w-full">
+            <MCPAnalyticsFeedbackPrompt sessionId="example-session" />
+        </div>
+    ),
+}
+
+export const Narrow: Story = {
+    render: () => (
+        <div className="w-[520px] max-w-full">
+            <MCPAnalyticsFeedbackPrompt sessionId="example-session" />
+        </div>
+    ),
+}
+
+export const SessionReview: Story = {
+    decorators: [
+        mswDecorator({
+            get: {
+                '/api/projects/:team_id/mcp_analytics/sessions/': {
+                    results: [
+                        {
+                            session_id: 'example-session',
+                            distinct_id: 'example-user',
+                            session_start: '2026-09-01T12:00:00Z',
+                            session_end: '2026-09-01T12:00:02Z',
+                            tool_calls: 1,
+                            intent: 'Check the status of a deployment.',
+                            mcp_client_name: 'Example client',
+                        },
+                    ],
+                    has_next: false,
+                },
+                '/api/projects/:team_id/mcp_analytics/sessions/:session_id/tool_calls/': {
+                    results: [
+                        {
+                            event_id: 'example-call',
+                            timestamp: '2026-09-01T12:00:01Z',
+                            tool_name: 'deployment-status',
+                            intent: 'Check whether the deployment completed.',
+                            is_error: false,
+                            duration_ms: 240,
+                        },
+                    ],
+                    has_next: false,
+                },
+            },
+        }),
+    ],
+    render: () => (
+        <div className="w-[520px] max-w-full h-[400px] rounded border border-primary">
+            <MCPSessionDetail />
+        </div>
+    ),
+}

--- a/products/mcp_analytics/frontend/feedback/MCPAnalyticsFeedbackPrompt.tsx
+++ b/products/mcp_analytics/frontend/feedback/MCPAnalyticsFeedbackPrompt.tsx
@@ -8,7 +8,10 @@ import { userLogic } from 'scenes/userLogic'
 
 import { mcpAnalyticsFeedbackLogic } from './mcpAnalyticsFeedbackLogic'
 
-const answerIcons: Record<string, JSX.Element> = { Yes: <IconThumbsUp />, No: <IconThumbsDown /> }
+const thumbRatings = [
+    { value: '1', label: 'Thumbs up', icon: <IconThumbsUp /> },
+    { value: '2', label: 'Thumbs down', icon: <IconThumbsDown /> },
+]
 
 export function MCPAnalyticsFeedbackPrompt({ sessionId }: { sessionId: string }): JSX.Element | null {
     const { user } = useValues(userLogic)
@@ -20,7 +23,12 @@ export function MCPAnalyticsFeedbackPrompt({ sessionId }: { sessionId: string })
     const { visible, survey, answer, detail, completed, submitting, error } = useValues(logic)
     const { dismissPrompt, setDetail, submitResponse } = useActions(logic)
 
-    if (!visible || !survey || survey.questions[0].type !== SurveyQuestionType.SingleChoice) {
+    if (
+        !visible ||
+        !survey ||
+        survey.questions[0].type !== SurveyQuestionType.Rating ||
+        survey.questions[0].scale !== 2
+    ) {
         return null
     }
 
@@ -70,20 +78,18 @@ export function MCPAnalyticsFeedbackPrompt({ sessionId }: { sessionId: string })
                             role="group"
                             aria-labelledby="mcp-session-feedback-question"
                         >
-                            {survey.questions[0].choices.map((choice) => (
+                            {thumbRatings.map((rating) => (
                                 <LemonButton
-                                    key={choice}
+                                    key={rating.value}
                                     type="secondary"
                                     size="small"
                                     loading={submitting}
-                                    icon={answerIcons[choice]}
-                                    aria-label={choice}
-                                    tooltip={choice}
-                                    onClick={() => submitResponse(choice, false)}
+                                    icon={rating.icon}
+                                    aria-label={rating.label}
+                                    tooltip={rating.label}
+                                    onClick={() => submitResponse(rating.value, false)}
                                     data-attr="mcp-analytics-feedback-answer"
-                                >
-                                    {answerIcons[choice] ? null : choice}
-                                </LemonButton>
+                                />
                             ))}
                         </div>
                     </div>

--- a/products/mcp_analytics/frontend/feedback/MCPAnalyticsFeedbackPrompt.tsx
+++ b/products/mcp_analytics/frontend/feedback/MCPAnalyticsFeedbackPrompt.tsx
@@ -1,11 +1,10 @@
 import { useActions, useValues } from 'kea'
+import { SurveyQuestionType } from 'posthog-js'
 
-import { LemonBanner } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonLabel, LemonTextArea } from '@posthog/lemon-ui'
 
-import { FeedbackSurveyButton } from 'lib/components/FeedbackSurveyButton/FeedbackSurveyButton'
 import { userLogic } from 'scenes/userLogic'
 
-import { MCP_ANALYTICS_FEEDBACK_PROPERTIES, MCP_ANALYTICS_FEEDBACK_SURVEY_ID } from './constants'
 import { mcpAnalyticsFeedbackLogic } from './mcpAnalyticsFeedbackLogic'
 
 export function MCPAnalyticsFeedbackPrompt({ sessionId }: { sessionId: string }): JSX.Element | null {
@@ -15,28 +14,79 @@ export function MCPAnalyticsFeedbackPrompt({ sessionId }: { sessionId: string })
         sessionId,
         isImpersonated: user?.is_impersonated ?? false,
     })
-    const { visible } = useValues(logic)
-    const { dismissPrompt, openSurvey } = useActions(logic)
+    const { visible, survey, answer, detail, completed, submitting, error } = useValues(logic)
+    const { dismissPrompt, setDetail, submitResponse } = useActions(logic)
 
-    if (!visible) {
+    if (!visible || !survey || survey.questions[0].type !== SurveyQuestionType.SingleChoice) {
         return null
     }
 
     return (
         <div className="shrink-0 p-2" data-attr="mcp-analytics-feedback-prompt">
             <LemonBanner type="info" hideIcon onClose={dismissPrompt}>
-                <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-                    <div className="flex-1 min-w-48">
-                        <div className="font-semibold">What did you learn from these sessions?</div>
-                        <div>Tell us what you changed or what was missing.</div>
+                {completed ? (
+                    <div role="status">Thanks for your feedback.</div>
+                ) : answer ? (
+                    <div className="space-y-2">
+                        <div className="text-secondary text-xs" role="status">
+                            Thanks for answering.
+                        </div>
+                        <LemonLabel htmlFor="mcp-session-feedback-detail" showOptional>
+                            {survey.questions[1].question}
+                        </LemonLabel>
+                        <LemonTextArea
+                            id="mcp-session-feedback-detail"
+                            value={detail}
+                            onChange={setDetail}
+                            autoFocus
+                            minRows={2}
+                            maxRows={4}
+                            maxLength={2000}
+                            disabled={submitting}
+                            data-attr="mcp-analytics-feedback-detail"
+                        />
+                        <div className="flex flex-wrap gap-2">
+                            <LemonButton
+                                type="primary"
+                                size="small"
+                                loading={submitting}
+                                onClick={() => submitResponse(answer, true)}
+                                data-attr="mcp-analytics-feedback-submit"
+                            >
+                                {detail.trim() ? 'Send feedback' : 'Done'}
+                            </LemonButton>
+                        </div>
                     </div>
-                    <FeedbackSurveyButton
-                        surveyId={MCP_ANALYTICS_FEEDBACK_SURVEY_ID}
-                        properties={MCP_ANALYTICS_FEEDBACK_PROPERTIES}
-                        onClick={openSurvey}
-                        data-attr="mcp-analytics-contextual-feedback-button"
-                    />
-                </div>
+                ) : (
+                    <div className="space-y-2">
+                        <div className="font-semibold" id="mcp-session-feedback-question">
+                            {survey.questions[0].question}
+                        </div>
+                        <div
+                            className="flex flex-wrap gap-2"
+                            role="group"
+                            aria-labelledby="mcp-session-feedback-question"
+                        >
+                            {survey.questions[0].choices.map((choice) => (
+                                <LemonButton
+                                    key={choice}
+                                    type="secondary"
+                                    size="small"
+                                    loading={submitting}
+                                    onClick={() => submitResponse(choice, false)}
+                                    data-attr="mcp-analytics-feedback-answer"
+                                >
+                                    {choice}
+                                </LemonButton>
+                            ))}
+                        </div>
+                    </div>
+                )}
+                {error && (
+                    <div className="text-danger mt-2" role="alert">
+                        Couldn't send your feedback. Please try again.
+                    </div>
+                )}
             </LemonBanner>
         </div>
     )

--- a/products/mcp_analytics/frontend/feedback/MCPAnalyticsFeedbackPrompt.tsx
+++ b/products/mcp_analytics/frontend/feedback/MCPAnalyticsFeedbackPrompt.tsx
@@ -1,11 +1,14 @@
 import { useActions, useValues } from 'kea'
 import { SurveyQuestionType } from 'posthog-js'
 
+import { IconThumbsDown, IconThumbsUp } from '@posthog/icons'
 import { LemonBanner, LemonButton, LemonLabel, LemonTextArea } from '@posthog/lemon-ui'
 
 import { userLogic } from 'scenes/userLogic'
 
 import { mcpAnalyticsFeedbackLogic } from './mcpAnalyticsFeedbackLogic'
+
+const answerIcons: Record<string, JSX.Element> = { Yes: <IconThumbsUp />, No: <IconThumbsDown /> }
 
 export function MCPAnalyticsFeedbackPrompt({ sessionId }: { sessionId: string }): JSX.Element | null {
     const { user } = useValues(userLogic)
@@ -73,10 +76,13 @@ export function MCPAnalyticsFeedbackPrompt({ sessionId }: { sessionId: string })
                                     type="secondary"
                                     size="small"
                                     loading={submitting}
+                                    icon={answerIcons[choice]}
+                                    aria-label={choice}
+                                    tooltip={choice}
                                     onClick={() => submitResponse(choice, false)}
                                     data-attr="mcp-analytics-feedback-answer"
                                 >
-                                    {choice}
+                                    {answerIcons[choice] ? null : choice}
                                 </LemonButton>
                             ))}
                         </div>

--- a/products/mcp_analytics/frontend/feedback/MCPAnalyticsFeedbackPrompt.tsx
+++ b/products/mcp_analytics/frontend/feedback/MCPAnalyticsFeedbackPrompt.tsx
@@ -1,0 +1,43 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonBanner } from '@posthog/lemon-ui'
+
+import { FeedbackSurveyButton } from 'lib/components/FeedbackSurveyButton/FeedbackSurveyButton'
+import { userLogic } from 'scenes/userLogic'
+
+import { MCP_ANALYTICS_FEEDBACK_PROPERTIES, MCP_ANALYTICS_FEEDBACK_SURVEY_ID } from './constants'
+import { mcpAnalyticsFeedbackLogic } from './mcpAnalyticsFeedbackLogic'
+
+export function MCPAnalyticsFeedbackPrompt({ sessionId }: { sessionId: string }): JSX.Element | null {
+    const { user } = useValues(userLogic)
+    const logic = mcpAnalyticsFeedbackLogic({
+        userId: user?.uuid ?? '',
+        sessionId,
+        isImpersonated: user?.is_impersonated ?? false,
+    })
+    const { visible } = useValues(logic)
+    const { dismissPrompt, openSurvey } = useActions(logic)
+
+    if (!visible) {
+        return null
+    }
+
+    return (
+        <div className="shrink-0 p-2" data-attr="mcp-analytics-feedback-prompt">
+            <LemonBanner type="info" hideIcon onClose={dismissPrompt}>
+                <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                    <div className="flex-1 min-w-48">
+                        <div className="font-semibold">What did you learn from these sessions?</div>
+                        <div>Tell us what you changed or what was missing.</div>
+                    </div>
+                    <FeedbackSurveyButton
+                        surveyId={MCP_ANALYTICS_FEEDBACK_SURVEY_ID}
+                        properties={MCP_ANALYTICS_FEEDBACK_PROPERTIES}
+                        onClick={openSurvey}
+                        data-attr="mcp-analytics-contextual-feedback-button"
+                    />
+                </div>
+            </LemonBanner>
+        </div>
+    )
+}

--- a/products/mcp_analytics/frontend/feedback/constants.ts
+++ b/products/mcp_analytics/frontend/feedback/constants.ts
@@ -1,0 +1,7 @@
+export const MCP_ANALYTICS_FEEDBACK_SURVEY_ID = '01a04991-bc80-0000-70c5-beeea0553cd0'
+
+export const MCP_ANALYTICS_FEEDBACK_PROPERTIES = {
+    feedback_surface: 'mcp_analytics',
+    feedback_entry_point: 'session_review_prompt',
+    mcp_analytics_tab: 'sessions',
+}

--- a/products/mcp_analytics/frontend/feedback/constants.ts
+++ b/products/mcp_analytics/frontend/feedback/constants.ts
@@ -1,5 +1,7 @@
 export const MCP_ANALYTICS_FEEDBACK_SURVEY_ID = '01a04991-bc80-0000-70c5-beeea0553cd0'
 
+export const MCP_ANALYTICS_USEFULNESS_SURVEY_ID = '01a091d3-2706-0000-124f-3aab2a5e9e11'
+
 export const MCP_ANALYTICS_FEEDBACK_PROPERTIES = {
     feedback_surface: 'mcp_analytics',
     feedback_entry_point: 'session_review_prompt',

--- a/products/mcp_analytics/frontend/feedback/mcpAnalyticsFeedbackLogic.test.ts
+++ b/products/mcp_analytics/frontend/feedback/mcpAnalyticsFeedbackLogic.test.ts
@@ -33,7 +33,7 @@ describe('mcpAnalyticsFeedbackLogic', () => {
                 id: 'example-choice',
                 type: SurveyQuestionType.SingleChoice,
                 question: 'Was this useful?',
-                choices: ['Yes', 'Partly', 'No'],
+                choices: ['Yes', 'No'],
             },
             { id: 'example-detail', type: SurveyQuestionType.Open, question: 'What did you learn?', optional: true },
         ],
@@ -157,21 +157,21 @@ describe('mcpAnalyticsFeedbackLogic', () => {
         (detail) => {
             loadSurvey()
             jest.advanceTimersByTime(FEEDBACK_PROMPT_DELAY_MS)
-            logic.actions.submitResponse('Partly', false)
+            logic.actions.submitResponse('No', false)
             logic.actions.submitResponse('Yes', false)
-            expect(logic.values.answer).toBe('Partly')
+            expect(logic.values.answer).toBe('No')
             expect(posthog.capture).toHaveBeenCalledWith(
                 'survey sent',
                 expect.objectContaining({
                     $survey_id: survey.id,
                     $survey_completed: false,
-                    '$survey_response_example-choice': 'Partly',
+                    '$survey_response_example-choice': 'No',
                 })
             )
             const submissionId = logic.values.submissionId
             logic.actions.setDetail(detail)
-            logic.actions.submitResponse('Partly', true)
-            logic.actions.submitResponse('Partly', true)
+            logic.actions.submitResponse('No', true)
+            logic.actions.submitResponse('No', true)
             expect(logic.values.completed).toBe(true)
             expect(logic.values.submitting).toBe(false)
             const sent = jest.mocked(posthog.capture).mock.calls.filter(([name]) => name === 'survey sent')
@@ -180,7 +180,7 @@ describe('mcpAnalyticsFeedbackLogic', () => {
                 expect.objectContaining({
                     $survey_submission_id: submissionId,
                     $survey_completed: true,
-                    '$survey_response_example-choice': 'Partly',
+                    '$survey_response_example-choice': 'No',
                     ...(detail ? { '$survey_response_example-detail': detail } : {}),
                 })
             )

--- a/products/mcp_analytics/frontend/feedback/mcpAnalyticsFeedbackLogic.test.ts
+++ b/products/mcp_analytics/frontend/feedback/mcpAnalyticsFeedbackLogic.test.ts
@@ -1,0 +1,119 @@
+import posthog, { Survey } from 'posthog-js'
+
+import { initKeaTests } from '~/test/init'
+
+import { MCP_ANALYTICS_FEEDBACK_PROPERTIES, MCP_ANALYTICS_FEEDBACK_SURVEY_ID } from './constants'
+import {
+    FEEDBACK_PROMPT_COOLDOWN_MS,
+    FEEDBACK_PROMPT_DELAY_MS,
+    mcpAnalyticsFeedbackLogic,
+} from './mcpAnalyticsFeedbackLogic'
+
+describe('mcpAnalyticsFeedbackLogic', () => {
+    let logic: ReturnType<typeof mcpAnalyticsFeedbackLogic.build>
+    let surveysLoaded: Parameters<typeof posthog.onSurveysLoaded>[0]
+    let unmount: () => void
+
+    const loadSurvey = (available = true): void => {
+        surveysLoaded(
+            available ? [{ id: MCP_ANALYTICS_FEEDBACK_SURVEY_ID, start_date: '2026-01-01T00:00:00Z' } as Survey] : [],
+            { isLoaded: true }
+        )
+    }
+
+    beforeEach(() => {
+        jest.useFakeTimers()
+        jest.setSystemTime(new Date('2026-09-01T12:00:00Z'))
+        localStorage.clear()
+        initKeaTests(false)
+        jest.mocked(posthog.capture).mockClear()
+        jest.mocked(posthog.onSurveysLoaded).mockImplementation((callback) => {
+            surveysLoaded = callback
+            return () => {}
+        })
+        logic = mcpAnalyticsFeedbackLogic({
+            userId: 'example-user',
+            sessionId: 'example-session',
+            isImpersonated: false,
+        })
+        unmount = logic.mount()
+    })
+
+    afterEach(() => {
+        unmount()
+        jest.useRealTimers()
+        jest.clearAllMocks()
+    })
+
+    it('waits for the running survey and reading delay, then records one invitation without opening the survey', () => {
+        jest.mocked(posthog.displaySurvey).mockClear()
+        jest.advanceTimersByTime(FEEDBACK_PROMPT_DELAY_MS)
+        expect(logic.values.visible).toBe(false)
+        loadSurvey(false)
+        jest.advanceTimersByTime(FEEDBACK_PROMPT_DELAY_MS)
+        expect(logic.values.visible).toBe(false)
+        loadSurvey()
+        jest.advanceTimersByTime(FEEDBACK_PROMPT_DELAY_MS - 1)
+        expect(logic.values.visible).toBe(false)
+        jest.advanceTimersByTime(1)
+        expect(logic.values.visible).toBe(true)
+        expect(posthog.capture).toHaveBeenCalledWith(
+            'mcp analytics feedback prompt shown',
+            MCP_ANALYTICS_FEEDBACK_PROPERTIES
+        )
+        expect(posthog.displaySurvey).not.toHaveBeenCalled()
+        loadSurvey()
+        jest.advanceTimersByTime(FEEDBACK_PROMPT_DELAY_MS)
+        expect(jest.mocked(posthog.capture).mock.calls.filter(([name]) => name.endsWith('prompt shown'))).toHaveLength(
+            1
+        )
+    })
+
+    it.each(['dismissPrompt', 'openSurvey'] as const)('keeps the cooldown across sessions after %s', (action) => {
+        loadSurvey()
+        jest.advanceTimersByTime(FEEDBACK_PROMPT_DELAY_MS)
+        logic.actions[action]()
+        expect(logic.values.visible).toBe(false)
+        unmount()
+        logic = mcpAnalyticsFeedbackLogic({
+            userId: 'example-user',
+            sessionId: 'another-session',
+            isImpersonated: false,
+        })
+        unmount = logic.mount()
+        loadSurvey()
+        jest.advanceTimersByTime(FEEDBACK_PROMPT_DELAY_MS)
+        expect(logic.values.visible).toBe(false)
+        unmount()
+        jest.advanceTimersByTime(FEEDBACK_PROMPT_COOLDOWN_MS)
+        logic = mcpAnalyticsFeedbackLogic({
+            userId: 'example-user',
+            sessionId: 'example-session',
+            isImpersonated: false,
+        })
+        unmount = logic.mount()
+        loadSurvey()
+        jest.advanceTimersByTime(FEEDBACK_PROMPT_DELAY_MS)
+        expect(logic.values.visible).toBe(true)
+    })
+
+    it('cancels a pending invitation when leaving the session detail', () => {
+        loadSurvey()
+        unmount()
+        jest.advanceTimersByTime(FEEDBACK_PROMPT_DELAY_MS)
+        expect(posthog.capture).not.toHaveBeenCalledWith('mcp analytics feedback prompt shown', expect.anything())
+        unmount = () => {}
+    })
+
+    it.each([
+        { userId: '', sessionId: 'example-session', isImpersonated: false },
+        { userId: 'example-user', sessionId: 'example-session', isImpersonated: true },
+    ])('does not prompt an ineligible user: %j', (props) => {
+        unmount()
+        logic = mcpAnalyticsFeedbackLogic(props)
+        unmount = logic.mount()
+        loadSurvey()
+        jest.advanceTimersByTime(FEEDBACK_PROMPT_DELAY_MS)
+        expect(logic.values.visible).toBe(false)
+    })
+})

--- a/products/mcp_analytics/frontend/feedback/mcpAnalyticsFeedbackLogic.test.ts
+++ b/products/mcp_analytics/frontend/feedback/mcpAnalyticsFeedbackLogic.test.ts
@@ -1,8 +1,8 @@
-import posthog, { Survey } from 'posthog-js'
+import posthog, { Survey, SurveyType, SurveyQuestionType } from 'posthog-js'
 
 import { initKeaTests } from '~/test/init'
 
-import { MCP_ANALYTICS_FEEDBACK_PROPERTIES, MCP_ANALYTICS_FEEDBACK_SURVEY_ID } from './constants'
+import { MCP_ANALYTICS_FEEDBACK_PROPERTIES, MCP_ANALYTICS_USEFULNESS_SURVEY_ID } from './constants'
 import {
     FEEDBACK_PROMPT_COOLDOWN_MS,
     FEEDBACK_PROMPT_DELAY_MS,
@@ -14,19 +14,52 @@ describe('mcpAnalyticsFeedbackLogic', () => {
     let surveysLoaded: Parameters<typeof posthog.onSurveysLoaded>[0]
     let unmount: () => void
 
+    const survey: Survey = {
+        id: MCP_ANALYTICS_USEFULNESS_SURVEY_ID,
+        name: 'Session usefulness',
+        type: SurveyType.API,
+        start_date: '2026-01-01T00:00:00Z',
+        feature_flag_keys: null,
+        linked_flag_key: null,
+        targeting_flag_key: null,
+        internal_targeting_flag_key: null,
+        appearance: null,
+        conditions: null,
+        end_date: null,
+        current_iteration: null,
+        current_iteration_start_date: null,
+        questions: [
+            {
+                id: 'example-choice',
+                type: SurveyQuestionType.SingleChoice,
+                question: 'Was this useful?',
+                choices: ['Yes', 'Partly', 'No'],
+            },
+            { id: 'example-detail', type: SurveyQuestionType.Open, question: 'What did you learn?', optional: true },
+        ],
+    }
+
     const loadSurvey = (available = true): void => {
-        surveysLoaded(
-            available ? [{ id: MCP_ANALYTICS_FEEDBACK_SURVEY_ID, start_date: '2026-01-01T00:00:00Z' } as Survey] : [],
-            { isLoaded: true }
+        jest.mocked(posthog.getActiveMatchingSurveys).mockImplementation((callback) =>
+            callback(available ? [survey] : [])
         )
+        surveysLoaded(available ? [survey] : [], { isLoaded: true })
     }
 
     beforeEach(() => {
         jest.useFakeTimers()
         jest.setSystemTime(new Date('2026-09-01T12:00:00Z'))
         localStorage.clear()
+        crypto.randomUUID = () => '00000000-0000-4000-8000-000000000001'
         initKeaTests(false)
+        posthog.is_capturing = jest.fn(() => true)
+        posthog.getActiveMatchingSurveys = jest.fn((callback) => callback([]))
+        jest.mocked(posthog.onFeatureFlags).mockImplementation((callback) => {
+            callback([], {})
+            return () => {}
+        })
         jest.mocked(posthog.capture).mockClear()
+        jest.mocked(posthog.capture).mockReturnValue({ uuid: 'example-event' } as ReturnType<typeof posthog.capture>)
         jest.mocked(posthog.onSurveysLoaded).mockImplementation((callback) => {
             surveysLoaded = callback
             return () => {}
@@ -42,10 +75,11 @@ describe('mcpAnalyticsFeedbackLogic', () => {
     afterEach(() => {
         unmount()
         jest.useRealTimers()
+        jest.restoreAllMocks()
         jest.clearAllMocks()
     })
 
-    it('waits for the running survey and reading delay, then records one invitation without opening the survey', () => {
+    it('waits for matching surveys and the reading delay, then records one impression', () => {
         jest.mocked(posthog.displaySurvey).mockClear()
         jest.advanceTimersByTime(FEEDBACK_PROMPT_DELAY_MS)
         expect(logic.values.visible).toBe(false)
@@ -58,21 +92,23 @@ describe('mcpAnalyticsFeedbackLogic', () => {
         jest.advanceTimersByTime(1)
         expect(logic.values.visible).toBe(true)
         expect(posthog.capture).toHaveBeenCalledWith(
-            'mcp analytics feedback prompt shown',
-            MCP_ANALYTICS_FEEDBACK_PROPERTIES
+            'survey shown',
+            expect.objectContaining({
+                ...MCP_ANALYTICS_FEEDBACK_PROPERTIES,
+                $survey_id: survey.id,
+                $survey_submission_id: expect.any(String),
+            })
         )
         expect(posthog.displaySurvey).not.toHaveBeenCalled()
         loadSurvey()
         jest.advanceTimersByTime(FEEDBACK_PROMPT_DELAY_MS)
-        expect(jest.mocked(posthog.capture).mock.calls.filter(([name]) => name.endsWith('prompt shown'))).toHaveLength(
-            1
-        )
+        expect(jest.mocked(posthog.capture).mock.calls.filter(([name]) => name === 'survey shown')).toHaveLength(1)
     })
 
-    it.each(['dismissPrompt', 'openSurvey'] as const)('keeps the cooldown across sessions after %s', (action) => {
+    it('keeps the cooldown across sessions after dismissal', () => {
         loadSurvey()
         jest.advanceTimersByTime(FEEDBACK_PROMPT_DELAY_MS)
-        logic.actions[action]()
+        logic.actions.dismissPrompt()
         expect(logic.values.visible).toBe(false)
         unmount()
         logic = mcpAnalyticsFeedbackLogic({
@@ -101,7 +137,7 @@ describe('mcpAnalyticsFeedbackLogic', () => {
         loadSurvey()
         unmount()
         jest.advanceTimersByTime(FEEDBACK_PROMPT_DELAY_MS)
-        expect(posthog.capture).not.toHaveBeenCalledWith('mcp analytics feedback prompt shown', expect.anything())
+        expect(posthog.capture).not.toHaveBeenCalledWith('survey shown', expect.anything())
         unmount = () => {}
     })
 
@@ -115,5 +151,105 @@ describe('mcpAnalyticsFeedbackLogic', () => {
         loadSurvey()
         jest.advanceTimersByTime(FEEDBACK_PROMPT_DELAY_MS)
         expect(logic.values.visible).toBe(false)
+    })
+    it.each(['', 'Found a failed tool call.'])(
+        'keeps the first answer and optional detail in one submission: %j',
+        (detail) => {
+            loadSurvey()
+            jest.advanceTimersByTime(FEEDBACK_PROMPT_DELAY_MS)
+            logic.actions.submitResponse('Partly', false)
+            logic.actions.submitResponse('Yes', false)
+            expect(logic.values.answer).toBe('Partly')
+            expect(posthog.capture).toHaveBeenCalledWith(
+                'survey sent',
+                expect.objectContaining({
+                    $survey_id: survey.id,
+                    $survey_completed: false,
+                    '$survey_response_example-choice': 'Partly',
+                })
+            )
+            const submissionId = logic.values.submissionId
+            logic.actions.setDetail(detail)
+            logic.actions.submitResponse('Partly', true)
+            logic.actions.submitResponse('Partly', true)
+            expect(logic.values.completed).toBe(true)
+            expect(logic.values.submitting).toBe(false)
+            const sent = jest.mocked(posthog.capture).mock.calls.filter(([name]) => name === 'survey sent')
+            expect(sent).toHaveLength(2)
+            expect(sent[1][1]).toEqual(
+                expect.objectContaining({
+                    $survey_submission_id: submissionId,
+                    $survey_completed: true,
+                    '$survey_response_example-choice': 'Partly',
+                    ...(detail ? { '$survey_response_example-detail': detail } : {}),
+                })
+            )
+            logic.actions.dismissPrompt()
+            expect(posthog.capture).not.toHaveBeenCalledWith('survey dismissed', expect.anything())
+        }
+    )
+
+    it('preserves an answered question when dismissed before the optional follow-up', () => {
+        loadSurvey()
+        jest.advanceTimersByTime(FEEDBACK_PROMPT_DELAY_MS)
+        logic.actions.submitResponse('No', false)
+        logic.actions.dismissPrompt()
+        expect(posthog.capture).toHaveBeenCalledWith(
+            'survey dismissed',
+            expect.objectContaining({
+                $survey_submission_id: logic.values.submissionId,
+                $survey_partially_completed: true,
+            })
+        )
+        expect(jest.mocked(posthog.capture).mock.calls.filter(([name]) => name === 'survey sent')).toHaveLength(1)
+    })
+
+    it.each(['dropped', 'thrown'] as const)(
+        'allows retry when capture is %s without losing optional text',
+        (failure) => {
+            loadSurvey()
+            jest.advanceTimersByTime(FEEDBACK_PROMPT_DELAY_MS)
+            logic.actions.submitResponse('Yes', false)
+            logic.actions.setDetail('Found the slow call.')
+            const submissionId = logic.values.submissionId
+            jest.mocked(posthog.capture).mockImplementationOnce(() => {
+                if (failure === 'thrown') {
+                    throw new Error('capture failed')
+                }
+                return undefined
+            })
+            logic.actions.submitResponse('Yes', true)
+            expect(logic.values).toMatchObject({
+                error: true,
+                completed: false,
+                submitting: false,
+                detail: 'Found the slow call.',
+            })
+            logic.actions.submitResponse('Yes', true)
+            expect(logic.values).toMatchObject({ error: false, completed: true, submissionId })
+        }
+    )
+
+    it('cancels the pending prompt when targeting changes and skips users without capture', () => {
+        loadSurvey()
+        loadSurvey(false)
+        jest.advanceTimersByTime(FEEDBACK_PROMPT_DELAY_MS)
+        expect(logic.values.visible).toBe(false)
+        jest.mocked(posthog.is_capturing).mockReturnValue(false)
+        loadSurvey()
+        jest.advanceTimersByTime(FEEDBACK_PROMPT_DELAY_MS)
+        expect(logic.values.visible).toBe(false)
+    })
+    it.each([
+        { start_date: null },
+        { end_date: '2026-08-01T00:00:00Z' },
+        { type: SurveyType.Popover },
+        { questions: [] },
+        { questions: [survey.questions[0], { ...survey.questions[1], optional: false }] },
+    ])('does not show a stopped or incompatible survey: %j', (overrides) => {
+        logic.actions.schedulePrompt({ ...survey, ...overrides })
+        jest.advanceTimersByTime(FEEDBACK_PROMPT_DELAY_MS)
+        expect(logic.values.visible).toBe(false)
+        expect(posthog.capture).not.toHaveBeenCalled()
     })
 })

--- a/products/mcp_analytics/frontend/feedback/mcpAnalyticsFeedbackLogic.test.ts
+++ b/products/mcp_analytics/frontend/feedback/mcpAnalyticsFeedbackLogic.test.ts
@@ -31,9 +31,12 @@ describe('mcpAnalyticsFeedbackLogic', () => {
         questions: [
             {
                 id: 'example-choice',
-                type: SurveyQuestionType.SingleChoice,
+                type: SurveyQuestionType.Rating,
                 question: 'Was this useful?',
-                choices: ['Yes', 'No'],
+                display: 'emoji',
+                scale: 2,
+                lowerBoundLabel: '',
+                upperBoundLabel: '',
             },
             { id: 'example-detail', type: SurveyQuestionType.Open, question: 'What did you learn?', optional: true },
         ],
@@ -157,21 +160,21 @@ describe('mcpAnalyticsFeedbackLogic', () => {
         (detail) => {
             loadSurvey()
             jest.advanceTimersByTime(FEEDBACK_PROMPT_DELAY_MS)
-            logic.actions.submitResponse('No', false)
-            logic.actions.submitResponse('Yes', false)
-            expect(logic.values.answer).toBe('No')
+            logic.actions.submitResponse('2', false)
+            logic.actions.submitResponse('1', false)
+            expect(logic.values.answer).toBe('2')
             expect(posthog.capture).toHaveBeenCalledWith(
                 'survey sent',
                 expect.objectContaining({
                     $survey_id: survey.id,
                     $survey_completed: false,
-                    '$survey_response_example-choice': 'No',
+                    '$survey_response_example-choice': '2',
                 })
             )
             const submissionId = logic.values.submissionId
             logic.actions.setDetail(detail)
-            logic.actions.submitResponse('No', true)
-            logic.actions.submitResponse('No', true)
+            logic.actions.submitResponse('2', true)
+            logic.actions.submitResponse('2', true)
             expect(logic.values.completed).toBe(true)
             expect(logic.values.submitting).toBe(false)
             const sent = jest.mocked(posthog.capture).mock.calls.filter(([name]) => name === 'survey sent')
@@ -180,7 +183,7 @@ describe('mcpAnalyticsFeedbackLogic', () => {
                 expect.objectContaining({
                     $survey_submission_id: submissionId,
                     $survey_completed: true,
-                    '$survey_response_example-choice': 'No',
+                    '$survey_response_example-choice': '2',
                     ...(detail ? { '$survey_response_example-detail': detail } : {}),
                 })
             )
@@ -192,7 +195,7 @@ describe('mcpAnalyticsFeedbackLogic', () => {
     it('preserves an answered question when dismissed before the optional follow-up', () => {
         loadSurvey()
         jest.advanceTimersByTime(FEEDBACK_PROMPT_DELAY_MS)
-        logic.actions.submitResponse('No', false)
+        logic.actions.submitResponse('2', false)
         logic.actions.dismissPrompt()
         expect(posthog.capture).toHaveBeenCalledWith(
             'survey dismissed',
@@ -209,7 +212,7 @@ describe('mcpAnalyticsFeedbackLogic', () => {
         (failure) => {
             loadSurvey()
             jest.advanceTimersByTime(FEEDBACK_PROMPT_DELAY_MS)
-            logic.actions.submitResponse('Yes', false)
+            logic.actions.submitResponse('1', false)
             logic.actions.setDetail('Found the slow call.')
             const submissionId = logic.values.submissionId
             jest.mocked(posthog.capture).mockImplementationOnce(() => {
@@ -218,14 +221,14 @@ describe('mcpAnalyticsFeedbackLogic', () => {
                 }
                 return undefined
             })
-            logic.actions.submitResponse('Yes', true)
+            logic.actions.submitResponse('1', true)
             expect(logic.values).toMatchObject({
                 error: true,
                 completed: false,
                 submitting: false,
                 detail: 'Found the slow call.',
             })
-            logic.actions.submitResponse('Yes', true)
+            logic.actions.submitResponse('1', true)
             expect(logic.values).toMatchObject({ error: false, completed: true, submissionId })
         }
     )
@@ -245,6 +248,13 @@ describe('mcpAnalyticsFeedbackLogic', () => {
         { end_date: '2026-08-01T00:00:00Z' },
         { type: SurveyType.Popover },
         { questions: [] },
+        {
+            questions: [
+                { ...survey.questions[0], type: SurveyQuestionType.SingleChoice, choices: ['Yes', 'No'] },
+                survey.questions[1],
+            ],
+        },
+        { questions: [{ ...survey.questions[0], scale: 5 as const }, survey.questions[1]] },
         { questions: [survey.questions[0], { ...survey.questions[1], optional: false }] },
     ])('does not show a stopped or incompatible survey: %j', (overrides) => {
         logic.actions.schedulePrompt({ ...survey, ...overrides })

--- a/products/mcp_analytics/frontend/feedback/mcpAnalyticsFeedbackLogic.ts
+++ b/products/mcp_analytics/frontend/feedback/mcpAnalyticsFeedbackLogic.ts
@@ -11,9 +11,9 @@ import {
     props,
     reducers,
 } from 'kea'
-import posthog from 'posthog-js'
+import posthog, { Survey, SurveyQuestionType, SurveyType } from 'posthog-js'
 
-import { MCP_ANALYTICS_FEEDBACK_PROPERTIES, MCP_ANALYTICS_FEEDBACK_SURVEY_ID } from './constants'
+import { MCP_ANALYTICS_FEEDBACK_PROPERTIES, MCP_ANALYTICS_USEFULNESS_SURVEY_ID } from './constants'
 
 export const FEEDBACK_PROMPT_DELAY_MS = 30_000
 export const FEEDBACK_PROMPT_COOLDOWN_MS = 30 * 24 * 60 * 60 * 1000
@@ -27,13 +27,27 @@ export interface MCPAnalyticsFeedbackLogicProps {
 export interface mcpAnalyticsFeedbackLogicValues {
     visible: boolean
     lastPromptAt: number
+    survey: Survey | null
+    submissionId: string
+    answer: string
+    detail: string
+    completed: boolean
+    submitting: boolean
+    error: boolean
 }
 
 export interface mcpAnalyticsFeedbackLogicActions {
-    schedulePrompt: () => { value: true }
-    showPrompt: (timestamp: number) => { timestamp: number }
+    schedulePrompt: (survey: Survey | null) => { survey: Survey | null }
+    showPrompt: (
+        survey: Survey,
+        timestamp: number,
+        submissionId: string
+    ) => { survey: Survey; timestamp: number; submissionId: string }
     dismissPrompt: () => { value: true }
-    openSurvey: () => { value: true }
+    setDetail: (detail: string) => { detail: string }
+    submitResponse: (answer: string, completed: boolean) => { answer: string; completed: boolean }
+    responseQueued: (answer: string, completed: boolean) => { answer: string; completed: boolean }
+    responseFailed: () => { value: true }
 }
 
 export type mcpAnalyticsFeedbackLogicType = MakeLogicType<
@@ -42,19 +56,49 @@ export type mcpAnalyticsFeedbackLogicType = MakeLogicType<
     MCPAnalyticsFeedbackLogicProps
 >
 
+function hasFeedbackQuestions(survey: Survey): boolean {
+    const [choice, detail] = survey.questions
+    return (
+        survey.questions.length === 2 &&
+        choice.type === SurveyQuestionType.SingleChoice &&
+        !!choice.id &&
+        choice.choices.length > 0 &&
+        detail.type === SurveyQuestionType.Open &&
+        !!detail.id &&
+        !!detail.optional
+    )
+}
+
 export const mcpAnalyticsFeedbackLogic: LogicWrapper<mcpAnalyticsFeedbackLogicType> =
     kea<mcpAnalyticsFeedbackLogicType>([
         props({} as MCPAnalyticsFeedbackLogicProps),
         key(({ userId, sessionId }) => `${userId}:${sessionId}`),
         path((key) => ['products', 'mcp_analytics', 'frontend', 'feedback', 'mcpAnalyticsFeedbackLogic', key]),
         actions({
-            schedulePrompt: true,
-            showPrompt: (timestamp: number) => ({ timestamp }),
+            schedulePrompt: (survey: Survey | null) => ({ survey }),
+            showPrompt: (survey: Survey, timestamp: number, submissionId: string) => ({
+                survey,
+                timestamp,
+                submissionId,
+            }),
             dismissPrompt: true,
-            openSurvey: true,
+            setDetail: (detail: string) => ({ detail }),
+            submitResponse: (answer: string, completed: boolean) => ({ answer, completed }),
+            responseQueued: (answer: string, completed: boolean) => ({ answer, completed }),
+            responseFailed: true,
         }),
         reducers(({ props }) => ({
-            visible: [false, { showPrompt: () => true, dismissPrompt: () => false, openSurvey: () => false }],
+            visible: [false, { showPrompt: () => true, dismissPrompt: () => false }],
+            survey: [null as Survey | null, { showPrompt: (_, { survey }) => survey }],
+            submissionId: ['', { showPrompt: (_, { submissionId }) => submissionId }],
+            answer: ['', { responseQueued: (_, { answer }) => answer }],
+            detail: ['', { setDetail: (_, { detail }) => detail }],
+            completed: [false, { responseQueued: (_, { completed }) => completed }],
+            submitting: [
+                false,
+                { submitResponse: () => true, responseQueued: () => false, responseFailed: () => false },
+            ],
+            error: [false, { submitResponse: () => false, responseFailed: () => true }],
             lastPromptAt: [
                 0,
                 { persist: true, storageKey: `mcp-analytics-feedback-last-prompt:${props.userId}` },
@@ -62,10 +106,18 @@ export const mcpAnalyticsFeedbackLogic: LogicWrapper<mcpAnalyticsFeedbackLogicTy
             ],
         })),
         listeners(({ actions, values, props, cache }) => ({
-            schedulePrompt: () => {
+            schedulePrompt: ({ survey }) => {
+                cache.disposables.dispose('prompt-delay')
                 if (
                     !props.userId ||
                     props.isImpersonated ||
+                    values.visible ||
+                    !survey ||
+                    survey.type !== SurveyType.API ||
+                    !survey.start_date ||
+                    survey.end_date ||
+                    !hasFeedbackQuestions(survey) ||
+                    !posthog.is_capturing() ||
                     Date.now() - values.lastPromptAt < FEEDBACK_PROMPT_COOLDOWN_MS
                 ) {
                     return
@@ -76,33 +128,88 @@ export const mcpAnalyticsFeedbackLogic: LogicWrapper<mcpAnalyticsFeedbackLogicTy
                         if (getContext() !== context) {
                             return
                         }
-                        actions.showPrompt(Date.now())
+                        if (posthog.is_capturing()) {
+                            actions.showPrompt(survey, Date.now(), crypto.randomUUID())
+                        }
                         cache.disposables.dispose('prompt-delay')
                     }, FEEDBACK_PROMPT_DELAY_MS)
                     return () => window.clearTimeout(timer)
                 }, 'prompt-delay')
             },
-            showPrompt: () => {
-                posthog.capture('mcp analytics feedback prompt shown', MCP_ANALYTICS_FEEDBACK_PROPERTIES)
+            showPrompt: ({ survey, submissionId }) => {
+                posthog.capture('survey shown', {
+                    ...MCP_ANALYTICS_FEEDBACK_PROPERTIES,
+                    $survey_id: survey.id,
+                    $survey_name: survey.name,
+                    $survey_submission_id: submissionId,
+                })
             },
             dismissPrompt: () => {
-                posthog.capture('mcp analytics feedback prompt dismissed', MCP_ANALYTICS_FEEDBACK_PROPERTIES)
+                if (values.survey && !values.completed) {
+                    posthog.capture('survey dismissed', {
+                        ...MCP_ANALYTICS_FEEDBACK_PROPERTIES,
+                        $survey_id: values.survey.id,
+                        $survey_name: values.survey.name,
+                        $survey_submission_id: values.submissionId,
+                        $survey_partially_completed: !!values.answer,
+                    })
+                }
             },
-            openSurvey: () => {
-                posthog.capture('mcp analytics feedback prompt clicked', MCP_ANALYTICS_FEEDBACK_PROPERTIES)
+            submitResponse: ({ answer, completed }) => {
+                const { survey } = values
+                if (
+                    !values.visible ||
+                    !survey ||
+                    values.completed ||
+                    (completed ? !values.answer || answer !== values.answer : !!values.answer) ||
+                    survey.questions[0].type !== SurveyQuestionType.SingleChoice ||
+                    !survey.questions[0].choices.includes(answer)
+                ) {
+                    actions.responseQueued(values.answer, values.completed)
+                    return
+                }
+                try {
+                    const queued = posthog.capture('survey sent', {
+                        ...MCP_ANALYTICS_FEEDBACK_PROPERTIES,
+                        $survey_id: survey.id,
+                        $survey_name: survey.name,
+                        $survey_submission_id: values.submissionId,
+                        $survey_completed: completed,
+                        $survey_questions: survey.questions.map(({ id, question }) => ({ id, question })),
+                        [`$survey_response_${survey.questions[0].id}`]: answer,
+                        ...(completed && values.detail.trim()
+                            ? { [`$survey_response_${survey.questions[1].id}`]: values.detail.trim() }
+                            : {}),
+                    })
+                    if (queued) {
+                        actions.responseQueued(answer, completed)
+                    } else {
+                        actions.responseFailed()
+                    }
+                } catch {
+                    actions.responseFailed()
+                }
             },
         })),
         afterMount(({ actions, cache }) => {
+            const context = getContext()
             cache.disposables.add(() =>
-                posthog.onSurveysLoaded((surveys, context) => {
-                    if (
-                        context?.isLoaded &&
-                        surveys.some(
-                            (survey) =>
-                                survey.id === MCP_ANALYTICS_FEEDBACK_SURVEY_ID && survey.start_date && !survey.end_date
+                posthog.onSurveysLoaded((_, surveyContext) => {
+                    if (surveyContext?.isLoaded) {
+                        cache.disposables.add(
+                            () =>
+                                posthog.onFeatureFlags(() => {
+                                    posthog.getActiveMatchingSurveys((surveys) => {
+                                        if (!cache.disposables.isDisposed && getContext() === context) {
+                                            actions.schedulePrompt(
+                                                surveys.find(({ id }) => id === MCP_ANALYTICS_USEFULNESS_SURVEY_ID) ??
+                                                    null
+                                            )
+                                        }
+                                    })
+                                }),
+                            'survey-flags'
                         )
-                    ) {
-                        actions.schedulePrompt()
                     }
                 })
             )

--- a/products/mcp_analytics/frontend/feedback/mcpAnalyticsFeedbackLogic.ts
+++ b/products/mcp_analytics/frontend/feedback/mcpAnalyticsFeedbackLogic.ts
@@ -1,0 +1,110 @@
+import {
+    LogicWrapper,
+    MakeLogicType,
+    actions,
+    afterMount,
+    getContext,
+    kea,
+    key,
+    listeners,
+    path,
+    props,
+    reducers,
+} from 'kea'
+import posthog from 'posthog-js'
+
+import { MCP_ANALYTICS_FEEDBACK_PROPERTIES, MCP_ANALYTICS_FEEDBACK_SURVEY_ID } from './constants'
+
+export const FEEDBACK_PROMPT_DELAY_MS = 30_000
+export const FEEDBACK_PROMPT_COOLDOWN_MS = 30 * 24 * 60 * 60 * 1000
+
+export interface MCPAnalyticsFeedbackLogicProps {
+    userId: string
+    sessionId: string
+    isImpersonated: boolean
+}
+
+export interface mcpAnalyticsFeedbackLogicValues {
+    visible: boolean
+    lastPromptAt: number
+}
+
+export interface mcpAnalyticsFeedbackLogicActions {
+    schedulePrompt: () => { value: true }
+    showPrompt: (timestamp: number) => { timestamp: number }
+    dismissPrompt: () => { value: true }
+    openSurvey: () => { value: true }
+}
+
+export type mcpAnalyticsFeedbackLogicType = MakeLogicType<
+    mcpAnalyticsFeedbackLogicValues,
+    mcpAnalyticsFeedbackLogicActions,
+    MCPAnalyticsFeedbackLogicProps
+>
+
+export const mcpAnalyticsFeedbackLogic: LogicWrapper<mcpAnalyticsFeedbackLogicType> =
+    kea<mcpAnalyticsFeedbackLogicType>([
+        props({} as MCPAnalyticsFeedbackLogicProps),
+        key(({ userId, sessionId }) => `${userId}:${sessionId}`),
+        path((key) => ['products', 'mcp_analytics', 'frontend', 'feedback', 'mcpAnalyticsFeedbackLogic', key]),
+        actions({
+            schedulePrompt: true,
+            showPrompt: (timestamp: number) => ({ timestamp }),
+            dismissPrompt: true,
+            openSurvey: true,
+        }),
+        reducers(({ props }) => ({
+            visible: [false, { showPrompt: () => true, dismissPrompt: () => false, openSurvey: () => false }],
+            lastPromptAt: [
+                0,
+                { persist: true, storageKey: `mcp-analytics-feedback-last-prompt:${props.userId}` },
+                { showPrompt: (_, { timestamp }) => timestamp },
+            ],
+        })),
+        listeners(({ actions, values, props, cache }) => ({
+            schedulePrompt: () => {
+                if (
+                    !props.userId ||
+                    props.isImpersonated ||
+                    Date.now() - values.lastPromptAt < FEEDBACK_PROMPT_COOLDOWN_MS
+                ) {
+                    return
+                }
+                const context = getContext()
+                cache.disposables.add(() => {
+                    const timer = window.setTimeout(() => {
+                        if (getContext() !== context) {
+                            return
+                        }
+                        actions.showPrompt(Date.now())
+                        cache.disposables.dispose('prompt-delay')
+                    }, FEEDBACK_PROMPT_DELAY_MS)
+                    return () => window.clearTimeout(timer)
+                }, 'prompt-delay')
+            },
+            showPrompt: () => {
+                posthog.capture('mcp analytics feedback prompt shown', MCP_ANALYTICS_FEEDBACK_PROPERTIES)
+            },
+            dismissPrompt: () => {
+                posthog.capture('mcp analytics feedback prompt dismissed', MCP_ANALYTICS_FEEDBACK_PROPERTIES)
+            },
+            openSurvey: () => {
+                posthog.capture('mcp analytics feedback prompt clicked', MCP_ANALYTICS_FEEDBACK_PROPERTIES)
+            },
+        })),
+        afterMount(({ actions, cache }) => {
+            cache.disposables.add(() =>
+                posthog.onSurveysLoaded((surveys, context) => {
+                    if (
+                        context?.isLoaded &&
+                        surveys.some(
+                            (survey) =>
+                                survey.id === MCP_ANALYTICS_FEEDBACK_SURVEY_ID && survey.start_date && !survey.end_date
+                        )
+                    ) {
+                        actions.schedulePrompt()
+                    }
+                })
+            )
+        }),
+    ])

--- a/products/mcp_analytics/frontend/feedback/mcpAnalyticsFeedbackLogic.ts
+++ b/products/mcp_analytics/frontend/feedback/mcpAnalyticsFeedbackLogic.ts
@@ -60,9 +60,10 @@ function hasFeedbackQuestions(survey: Survey): boolean {
     const [choice, detail] = survey.questions
     return (
         survey.questions.length === 2 &&
-        choice.type === SurveyQuestionType.SingleChoice &&
+        choice.type === SurveyQuestionType.Rating &&
         !!choice.id &&
-        choice.choices.length > 0 &&
+        choice.scale === 2 &&
+        choice.display === 'emoji' &&
         detail.type === SurveyQuestionType.Open &&
         !!detail.id &&
         !!detail.optional
@@ -162,8 +163,8 @@ export const mcpAnalyticsFeedbackLogic: LogicWrapper<mcpAnalyticsFeedbackLogicTy
                     !survey ||
                     values.completed ||
                     (completed ? !values.answer || answer !== values.answer : !!values.answer) ||
-                    survey.questions[0].type !== SurveyQuestionType.SingleChoice ||
-                    !survey.questions[0].choices.includes(answer)
+                    !hasFeedbackQuestions(survey) ||
+                    !['1', '2'].includes(answer)
                 ) {
                     actions.responseQueued(values.answer, values.completed)
                     return

--- a/products/mcp_analytics/frontend/sessions/MCPSessionDetail.tsx
+++ b/products/mcp_analytics/frontend/sessions/MCPSessionDetail.tsx
@@ -10,6 +10,7 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 
 import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
+import { MCPAnalyticsFeedbackPrompt } from '../feedback/MCPAnalyticsFeedbackPrompt'
 import { mcpSessionsLogic } from './mcpSessionsLogic'
 import { formatDuration, formatRelativeOffset, sessionDurationMs, shortenSessionId } from './utils'
 
@@ -238,6 +239,7 @@ export function MCPSessionDetail(): JSX.Element {
                     </AccessControlAction>
                 )}
             </footer>
+            {!loading && toolCalls.length > 0 && <MCPAnalyticsFeedbackPrompt sessionId={selectedSession.session_id} />}
         </div>
     )
 }

--- a/products/mcp_analytics/package.json
+++ b/products/mcp_analytics/package.json
@@ -10,7 +10,8 @@
         "@posthog/quill-primitives": "workspace:*",
         "kea": "catalog:",
         "kea-loaders": "catalog:",
-        "kea-router": "catalog:"
+        "kea-router": "catalog:",
+        "posthog-js": "catalog:"
     },
     "devDependencies": {
         "kea-test-utils": "catalog:"


### PR DESCRIPTION
## Problem

MCP analytics viewers can now answer whether a session review helped them, directly in the session panel.
Feedback is requested during session review, and the general header Feedback button is removed.

## Changes

- The session panel asks “Did this session help you find what you needed?” after 30 seconds of viewing loaded tool calls.
- Thumbs record an answer immediately; optional text completes the same submission.
- One API survey supplies stable question IDs. Placement configuration supplies wording and event metadata.
- SDK targeting and a shared 30-day browser cooldown limit contextual prompts.
- Remove the general header Feedback button; Documentation stays available.

The contextual API survey can launch before deployment because it only appears through the custom UI.
The existing header survey needs no configuration change.

Updated header:

![Header with Documentation and no general Feedback button](https://raw.githubusercontent.com/PostHog/pr-assets/b3fb0a713d17f46191c66a381a5ae04f97dde1a3/2026/09/53a98d2a-0b7a-4c19-819d-18cdce38b0c4.png)

| Before | Inline question |
| --- | --- |
| ![Session without feedback prompt](https://raw.githubusercontent.com/PostHog/pr-assets/8d5da4620b3a7448f7a5ad90b4217149f94788f7/2026/09/18379750-7872-41d1-b545-ef5529575074.png) | ![Inline session question](https://raw.githubusercontent.com/PostHog/pr-assets/6f3f6aaff7363c58bea863a686ce7a10533e35b4/2026/09/884d7faa-5382-4ab1-aa44-5450aaa9d4a9.png) |

![Optional follow-up](https://raw.githubusercontent.com/PostHog/pr-assets/2f94739e035463f9bc99c8eecfdcf2069960914a/2026/09/ce35ec40-30a9-46c4-b877-cc16cccab350.png)

<details>
<summary>Feedback flow before and after</summary>

Before:

```mermaid
flowchart LR
    H[Header Feedback button] -->|displaySurvey| S[General feedback survey]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class H phYellow;
    class S phGray;
```

After:

```mermaid
flowchart LR
    R[Read loaded session for 30 seconds] --> Q[Inline usefulness question]
    Q -->|One answer| P[Partial response]
    P --> F[Optional follow-up]
    F -->|Done or Send feedback| C[Complete same submission]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class R phYellow;
    class Q,F phBlue;
    class P,C phGray;
```

</details>

## How did you test this code?

- All 20 feedback logic tests pass, including a regression that preserves the prompt deadline and refreshes survey metadata across repeated feature-flag reloads. Existing tests cover targeting, timer cleanup, cooldowns, duplicate submissions, partial-answer loss, retries, and contextual metadata.
- Feedback logic and session tests, TypeScript, typegen, formatting, and strict preflight ran locally.
- Storybook browser checks covered 520px and 800px layouts, contextual copy, session detail, answer submission, and retry UI. Screenshots use invented data.
- Devbox checks at 1280px and 800px confirmed the header has no Feedback button and retains Documentation.
- Production deployment remains pending. [Earlier inline layout approval](https://github.com/PostHog/posthog/pull/99442#issuecomment-5687900394).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

A short `docs/internal/mcp-analytics-feedback.md` note covers contextual prompts, survey configuration, and response counting.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used repository tools, the PostHog connector, and the browser. No customer data or private metrics appear in this PR.
Survey and voice foundations are separate drafts: #101337 and #101340. This PR contains only MCP analytics feedback.
Overlapping submission tests share one parameterized lifecycle test; targeting, cooldown, background-tab, and capture-failure checks remain.
Skills: writing-ui-components, writing-kea-logics, using-kea-disposables, placing-product-frontend-code, writing-tests, writing-code-comments, writing-user-facing-copy, running-ci-preflight, setting-up-devbox, run-posthog, writing-pr-descriptions, reviewing-with-coderabbit, impeccable, survey-sdk-audit, and debugging-ci-failures.
The PR opened without a local CodeRabbit pass while that review was paused. The open-PR title search found no duplicate MCP feedback change.

CodeRabbit's [tab-visibility finding](https://github.com/PostHog/posthog/pull/99442#pullrequestreview-5215802546) is a false positive.
The timer uses `cache.disposables`, which cancels it on hide and restarts the full delay on show.
A local regression case confirms no hidden-tab impression or cooldown and a fresh delay on return; it is included in this PR.
Greptile posted no findings in the earlier review.

QA Swarm follow-up:

- Fixed repeated flag refreshes restarting the reading delay, moved submission state changes after validation, reused survey event/rating constants, regenerated inline Kea types, and installed Storybook SDK mocks before mount.
- Kept the header removal as the intended product change. Survey eligibility comes from PostHog's own analytics SDK project, not the customer project being viewed; rollout notes require checking impressions before interpreting response counts.
- Documented the current limits: one mounted placement at a time, no recurring survey iterations, and no dismissal/abandonment event on navigation. Already-captured partial responses remain.
- Kept the contextual copy snapshot and parameterized lifecycle tests because they protect the displayed wording and partial-response contract. Broader multi-placement coordination and new abandonment tracking are outside this change.
- Verified the default answer/completion flow and error retry in Storybook, full frontend TypeScript, typegen, and strict preflight. Merged master and preserved both sets of snapshot entries.

<details>
<summary>Deferred voice foundation reference</summary>

The voice prototype is removed from this diff. Its screenshot is retained for reference.

![Voice prototype](https://raw.githubusercontent.com/PostHog/pr-assets/dab267af4520751386fb862b34b6ecdfcdd264b0/2026/09/dfc7f218-6e37-43f0-9c14-43e2d83876a7.png)

A later backend PR will address model selection, observability, and the [transcription gateway limitation](https://github.com/PostHog/posthog/blob/master/services/llm-gateway/PARITY.md).

</details>

