### PR TITLE
fix(warehouse-sources): stop retrying postgres foreign-table timestamp mismatches

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -1001,6 +1001,23 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                 "column's declared length to match the remote server, or remove the foreign table "
                 "from the sync, then re-enable the sync."
             ),
+            # A selected relation is a foreign table (postgres_fdw, or a wrapper such as Supabase's
+            # "Wrappers" extension) whose locally-declared column is a timestamp/date type, but the
+            # remote server returns a value that doesn't parse as one (SQLSTATE 22007). Postgres
+            # enforces type validity at write time on ordinary tables, so this can only surface via a
+            # foreign table's separately-declared type reading data the remote side never validated
+            # against it — for example a text "\N" NULL marker left over from a text-format export
+            # that the remote side or wrapper didn't translate to a real NULL. The mismatch lives on
+            # the customer's side and is deterministic, so retrying re-reads into the same row every
+            # time. Match the stable message and exclude the volatile offending value.
+            "invalid input syntax for type timestamp": (
+                "One of the tables you selected to sync is a foreign table whose locally-declared "
+                "column is a timestamp type, but the remote server returned a value that isn't a "
+                'valid timestamp (PostgreSQL reported "invalid input syntax for type timestamp"). '
+                'This can happen when a NULL marker from a text-format export (for example "\\N") '
+                "wasn't translated to a real NULL. Fix the remote data or the foreign table's column "
+                "type, or remove the foreign table from the sync, then re-enable the sync."
+            ),
         }
 
     def get_retryable_errors(self) -> set[str]:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1448,6 +1448,27 @@ class TestPostgresSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # Raw psycopg message (what the activity-level check sees via str(e)).
+            'invalid input syntax for type timestamp: "\\N"\nCONTEXT:  column "created_at" of foreign table "events"',
+            # Temporal-wrapped message (what the workflow-level check sees) — carries the class name.
+            'InvalidDatetimeFormat: invalid input syntax for type timestamp: "\\N"',
+        ],
+    )
+    def test_fdw_timestamp_mismatch_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"FDW timestamp mismatch error should be non-retryable: {error_msg}"
+
+    def test_fdw_timestamp_mismatch_returns_friendly_message(self, source):
+        non_retryable = source.get_non_retryable_errors()
+        error_msg = 'invalid input syntax for type timestamp: "\\N"'
+        friendly = [reason for pattern, reason in non_retryable.items() if pattern in error_msg and reason]
+        assert friendly, "FDW timestamp mismatch error should surface an actionable message"
+        assert "timestamp" in friendly[0]
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # A single recovery conflict is retried in-process; on its own it must stay retryable.
             "canceling statement due to conflict with recovery",
             "could not serialize access due to conflict with recovery",


### PR DESCRIPTION
## Problem

A Postgres sync through a foreign table (for example one built with Supabase's Wrappers extension) fails every retry when the remote data behind a locally-declared timestamp column isn't a valid timestamp — PostgreSQL rejects it with `InvalidDatetimeFormat: invalid input syntax for type timestamp`. A stray `"\N"` text NULL marker left over from a text-format export is one way this happens.

This error was unclassified, so Temporal burned its full retry budget re-reading the same row before giving up, and error tracking saw the identical failure on every attempt (see the linked issue below).

Reference: [error tracking issue](https://us.posthog.com/project/2/error_tracking/01a0918b-f86c-7701-a3a7-606a9ad4cefd)

## Changes

- `PostgresSource.get_non_retryable_errors` now recognizes `invalid input syntax for type timestamp`, matching the existing FDW type-mismatch entries for enum values and string truncation already in that dict — the mismatch lives on the remote/foreign-table side, not something a retry can fix.
- No other pipeline behavior changed.

## How did you test this code?

- Added `test_fdw_timestamp_mismatch_is_non_retryable` and `test_fdw_timestamp_mismatch_returns_friendly_message` to `TestPostgresSourceNonRetryableErrors`, following the same shape as the existing FDW enum-mismatch/string-truncation cases — guards against this error going unclassified again.
- Ran the full `TestPostgresSourceNonRetryableErrors` class (163 passed) and `mypy` against the changed file.
- Not run: an end-to-end sync against a real foreign table, since this sandbox has no such source configured.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None needed — this only changes internal error classification.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code, triaging a live error-tracking issue in the data-warehouse import pipeline.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- No duplicate found: searched open PRs for "invalid input syntax for type timestamp" and related terms, and listed all open PRs from this automation/maintainer — none address this error.
- Public artifact: nothing in this PR references the originating team, table, or customer; the test fixtures use invented table/column names.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*