### PR TITLE
fix(tasks): pin pnpm in the sandbox base image

### DIFF
--- a/products/tasks/backend/sandbox/images/Dockerfile.sandbox-base
+++ b/products/tasks/backend/sandbox/images/Dockerfile.sandbox-base
@@ -84,7 +84,8 @@ RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
     rm -rf /var/lib/apt/lists/*
 
 # Install additional language package managers
-RUN npm install -g yarn pnpm typescript ts-node nodemon
+ARG PNPM_VERSION=10.34.5
+RUN npm install -g yarn "pnpm@${PNPM_VERSION}" typescript ts-node nodemon
 
 # Install ruff and ty
 # uv comes from its pinned, registry-verified official image (same pattern as the

--- a/products/tasks/backend/sandbox/images/bake-posthog-dev-stack.sh
+++ b/products/tasks/backend/sandbox/images/bake-posthog-dev-stack.sh
@@ -201,7 +201,7 @@ log "warming pnpm store"
 # store (under ~/.local/share/pnpm), which lives outside the checkout and survives the
 # cleanup below — the task-time `pnpm install` becomes mostly a linking pass. Bake and
 # task time run the same image's pnpm, so the store layout always matches.
-pnpm fetch --frozen-lockfile
+pnpm fetch
 # Link a full node_modules once: it backfills anything fetch skipped (git/tarball
 # resolutions) and provides the workspace-pinned playwright CLI for the browser
 # install below. --ignore-scripts keeps third-party postinstall hooks from failing


### PR DESCRIPTION
## Problem

- PostHog-internal dev-stack cloud tasks boot from a dev-stack image last published on 2026-09-09 
- The sandbox base image installs pnpm unpinned, and npm's `latest` tag now resolves to pnpm 12
- pnpm 12 ships a Rust CLI that rejects `pnpm fetch --frozen-lockfile` with `error: unexpected argument '--frozen-lockfile' found`

## Changes

- The base image pins pnpm to the repo's `packageManager` version, 10.29.3
- The bake calls `pnpm fetch` without `--frozen-lockfile`. `fetch` always reads the lockfile, so the flag did nothing.

