### PR TITLE
fix(warehouse-sources): fix the Metronome usage request window

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/metronome/metronome.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/metronome/metronome.py
@@ -1,7 +1,7 @@
 import dataclasses
 from collections.abc import Callable, Iterable, Iterator
-from datetime import UTC, datetime
-from typing import Any, Literal, Optional, cast
+from datetime import UTC, datetime, timedelta
+from typing import Any, Optional, cast
 
 from requests import Request, Response
 
@@ -52,6 +52,9 @@ RFC_3339_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 # Lower bound for a first incremental run — earlier than any Metronome account.
 EPOCH_RFC_3339 = "1970-01-01T00:00:00Z"
+
+# `POST /v1/usage` documents `ending_before` as at least one day after `starting_on`.
+MIN_USAGE_WINDOW = timedelta(days=1)
 
 
 @frozen
@@ -133,17 +136,48 @@ def _incremental_window(config: MetronomeEndpointConfig, cursor_path: str) -> In
     }
 
 
-def _align_to_window(value: datetime, window_size: Literal["hour", "day"]) -> datetime:
-    """Floor a window bound to the boundary Metronome aggregates on.
+def _align_to_utc_midnight(value: datetime) -> datetime:
+    """Floor a usage window bound to the boundary Metronome requires.
 
-    A period's `start_timestamp` is part of the table's primary key, and the bound this run asks
-    from is the watermark shifted back by a lookback the user sets in seconds, so it usually lands
-    mid-period. Asking from mid-period risks a partial aggregate for a period the table already
-    holds in full, which then upserts as a second row instead of replacing the first.
+    `POST /v1/usage` documents both bounds as aligned to UTC midnight and answers a 400 when either
+    is not, whatever the `window_size`, so an hourly table also asks for whole days.
+
+    Flooring also keeps a bucketed table's rows stable. A period's `start_timestamp` is part of the
+    table's primary key, and the bound this run asks from is the watermark shifted back by a
+    lookback the user sets in seconds, so it usually lands mid-period. Asking from mid-period
+    returns a partial aggregate for a period the table already holds in full, which then upserts as
+    a second row instead of replacing the first.
     """
-    if window_size == "day":
-        return value.replace(hour=0, minute=0, second=0, microsecond=0)
-    return value.replace(minute=0, second=0, microsecond=0)
+    return value.replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def _usage_window_end(value: datetime) -> datetime:
+    """The end bound a usage request asks for.
+
+    Metronome takes a UTC-midnight bound only, so the nearest aligned end that still covers the
+    period in progress is the next midnight rather than the last one. Ending at the last one would
+    hold every table a full period behind, which is the period a usage table is most asked about.
+
+    Rows for a period still in progress come back partial. The merge key carries the period start,
+    so each later run upserts a fresher value over them, and the row settles once the period
+    closes. This is the same path a period already takes when Metronome accepts a backdated event
+    for it.
+    """
+    return _align_to_utc_midnight(value) + timedelta(days=1)
+
+
+def _clamp_window_start(starting_on: str, ending_before: str) -> str:
+    """Hold the requested window to the one-day minimum Metronome documents.
+
+    Both bounds floor to UTC midnight, so a table whose watermark already reached the newest
+    complete period resolves a start equal to the end. Metronome rejects that window, so ask for
+    the last whole day instead. Those rows upsert over ones the table already holds.
+    """
+    start = parse_datetime_value(starting_on)
+    end = parse_datetime_value(ending_before)
+    if start is None or end is None or end - start >= MIN_USAGE_WINDOW:
+        return starting_on
+    return _format_rfc3339(end - MIN_USAGE_WINDOW)
 
 
 def _resolve_window_start(
@@ -167,7 +201,7 @@ def _resolve_window_start(
         or coerce_datetime_to_utc(history_start)
         or datetime.now(UTC) - USAGE_HISTORY[config.name]
     )
-    return _format_rfc3339(_align_to_window(start, window_size))
+    return _format_rfc3339(_align_to_utc_midnight(start))
 
 
 @frozen
@@ -215,9 +249,13 @@ def _walk_start(
 
     if config.window_size is not None:
         if ending_before is None:
-            ending_before = _format_rfc3339(datetime.now(UTC))
+            ending_before = _format_rfc3339(_usage_window_end(datetime.now(UTC)))
         if starting_on is None:
-            starting_on = _resolve_window_start(config, db_incremental_field_last_value, history_start)
+            # Only a freshly resolved start is clamped. A resumed walk replays the exact window its
+            # checkpoint stored, and both bounds come back together or neither does.
+            starting_on = _clamp_window_start(
+                _resolve_window_start(config, db_incremental_field_last_value, history_start), ending_before
+            )
 
     return MetronomeWalkStart(starting_on=starting_on, ending_before=ending_before, paginator_state=paginator_state)
 
@@ -292,13 +330,16 @@ def get_resource(
     if config.method == "post":
         json_body = dict(config.json_body)
         if config.window_size is not None:
-            # `starting_on` at the epoch means "all usage the account has". `ending_before` is the
-            # sync time; the caller pins both for the whole walk so a resumed attempt replays the
-            # same window, and these fall back only for a one-shot build with no pinned window.
-            json_body["window_size"] = config.window_size
+            # `starting_on` at the epoch means "all usage the account has". The caller pins both
+            # bounds for the whole walk so a resumed attempt replays the same window, and these
+            # fall back only for a one-shot build with no pinned window.
+            # The spec's enum accepts three casings, but both vendor SDKs emit upper case only.
+            json_body["window_size"] = config.window_size.upper()
             json_body["starting_on"] = window_starting_on if window_starting_on is not None else EPOCH_RFC_3339
             json_body["ending_before"] = (
-                window_ending_before if window_ending_before is not None else _format_rfc3339(datetime.now(UTC))
+                window_ending_before
+                if window_ending_before is not None
+                else _format_rfc3339(_usage_window_end(datetime.now(UTC)))
             )
         endpoint_config["json"] = json_body
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/metronome/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/metronome/settings.py
@@ -84,7 +84,7 @@ class MetronomeEndpointConfig:
     fanout: DependentEndpointConfig | None = None
     body_fanout: BodyFanoutConfig | None = None
     # `POST /v1/usage` needs a `window_size`/`starting_on`/`ending_before` window in its body. The
-    # window is computed per run, because `ending_before` is the sync time, so it can't live in the
+    # window is computed per run, because `ending_before` tracks the clock, so it can't live in the
     # static `json_body`. When set, the resource builder fills the window in. None means the
     # endpoint sends no window.
     window_size: WindowSize | None = None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/metronome/tests/test_metronome.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/metronome/tests/test_metronome.py
@@ -15,6 +15,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.metronome.
     EPOCH_RFC_3339,
     MetronomeCursorPaginator,
     MetronomeResumeConfig,
+    _clamp_window_start,
     _format_rfc3339,
     _paginator_for,
     get_resource,
@@ -168,7 +169,7 @@ class TestMetronomeResources:
         with pytest.raises(ValueError, match="Fan-out endpoint"):
             get_resource(endpoint, should_use_incremental_field=False)
 
-    @parameterized.expand([("usage_daily", "day"), ("usage_hourly", "hour")])
+    @parameterized.expand([("usage_daily", "DAY"), ("usage_hourly", "HOUR")])
     def test_bucketed_usage_merges_on_a_body_window_with_no_injected_param(self, endpoint, window_size) -> None:
         resource = cast(
             dict[str, Any],
@@ -182,6 +183,24 @@ class TestMetronomeResources:
         assert body["window_size"] == window_size
         assert body["starting_on"] == "2026-01-01T00:00:00Z"
         assert body["ending_before"] > "2026-01-01T00:00:00Z"
+        # An hourly table asks for whole days too; Metronome 400s on a bound off UTC midnight.
+        assert body["ending_before"].endswith("T00:00:00Z")
+
+    @parameterized.expand(
+        [
+            ("a_full_day_is_left_alone", "2026-09-03T00:00:00Z", "2026-09-04T00:00:00Z", "2026-09-03T00:00:00Z"),
+            (
+                "a_shorter_window_backs_the_start_off",
+                "2026-09-04T00:00:00Z",
+                "2026-09-04T00:00:00Z",
+                "2026-09-03T00:00:00Z",
+            ),
+        ]
+    )
+    def test_clamp_window_start_holds_the_one_day_minimum(self, _name, starting_on, ending_before, expected) -> None:
+        # Metronome rejects a window shorter than a day, so the end bound reaching the start has to
+        # widen the request rather than send one the vendor answers with a 400.
+        assert _clamp_window_start(starting_on, ending_before) == expected
 
     @parameterized.expand([("usage_daily",), ("usage_hourly",)])
     def test_get_resource_rejects_a_bucketed_endpoint_with_no_lower_bound(self, endpoint) -> None:
@@ -195,9 +214,10 @@ class TestMetronomeResources:
 
         assert resource["endpoint"]["method"] == "post"
         body = resource["endpoint"]["json"]
-        assert body["window_size"] == "none"
+        assert body["window_size"] == "NONE"
         assert body["starting_on"] == EPOCH_RFC_3339
         assert body["ending_before"] > EPOCH_RFC_3339
+        assert body["ending_before"].endswith("T00:00:00Z")
 
 
 class TestMetronomeSourceResponse:
@@ -235,11 +255,11 @@ class TestMetronomeSourceResponse:
                 "2026-03-14T00:00:00Z",
             ),
             (
-                "a_watermark_is_floored_to_the_hour",
+                "an_hourly_watermark_floors_to_utc_midnight_too",
                 "usage_hourly",
                 datetime(2026, 3, 14, 15, 9, 26, tzinfo=UTC),
                 None,
-                "2026-03-14T15:00:00Z",
+                "2026-03-14T00:00:00Z",
             ),
             (
                 "a_first_sync_starts_where_the_schema_recorded_its_range",
@@ -260,7 +280,15 @@ class TestMetronomeSourceResponse:
                 "usage_hourly",
                 None,
                 None,
-                "2026-08-04T12:00:00Z",
+                "2026-08-04T00:00:00Z",
+            ),
+            # The window runs to the next midnight, so the day in progress is inside it.
+            (
+                "a_watermark_inside_today_still_asks_for_today",
+                "usage_daily",
+                NOW,
+                None,
+                "2026-09-03T00:00:00Z",
             ),
         ]
     )


### PR DESCRIPTION
## Problem

Metronome usage tables still fail after #99337. The `limit` parameter is gone from the request, and Metronome now rejects the body instead, so `usage`, `usage_daily` and `usage_hourly` stay broken for every source that enables them.

`POST /v1/usage` documents two rules this source breaks:

- Both `starting_on` and `ending_before` must be aligned to UTC midnight.
- `ending_before` must be at least one day after `starting_on`.

The observed request, reconstructed from an outbound-request log line of exactly 103 bytes:

```json
{"window_size": "none", "starting_on": "1970-01-01T00:00:00Z", "ending_before": "2026-09-11T17:44:32Z"}
```

- `ending_before` was the raw sync time, so every usage request sent an unaligned bound.
- `usage_hourly` floored its start to the hour rather than to midnight, breaking the same rule.
- The one-day minimum had no guard.

## Changes

- The three usage tables sync. Every request carries two UTC-midnight bounds and a window of at least one day.
- **The day in progress is inside the window.** `ending_before` is the next UTC midnight rather than the last one, so `usage_daily` and `usage_hourly` carry today, and the lifetime `usage` aggregate includes today instead of stopping at yesterday.
- `_align_to_utc_midnight` replaces `_align_to_window`. The alignment rule holds for every `window_size`, so the hourly table asks for whole days and receives them split by hour.
- `_clamp_window_start` holds the window to the one-day minimum.
- Only a freshly resolved start is clamped. A resumed walk still replays the exact window its checkpoint stored.
- `window_size` goes out in upper case.

### Why a partial period is safe

Rows for an open period come back partial. The bucketed tables merge on `(customer_id, billable_metric_id, start_timestamp)`, so each later run upserts a fresher value over today's row, and it settles once the day closes. That is the path a period already takes: Metronome accepts backdated events for 34 days, which is why the per-run lookback re-reads recent periods at all. A partial current day is the same class of value, not a new one.

The lookback is user-configurable, so the obvious worry is a setting low enough to strand a partial row. It cannot happen here. The watermark is at most the current period's start, and flooring pulls `starting_on` back to today's midnight at the latest, so the open period falls inside the next window at any lookback, including zero.

The `usage` table has no partial-row question at all. It is one aggregate per customer and metric under a `replace` disposition, so ending at the last midnight simply understated the lifetime total by a day.

> [!NOTE]
> A daily or hourly trend now shows today's bucket filling as the day runs, rather than appearing only once the day closes. Consumers that need settled numbers should exclude the newest period, which is true of these tables regardless, given the 34-day backdating window.

`window_size` in upper case is belt and braces, not a diagnosed cause. The spec enum lists lower, upper and title case, so the previous lower case should have been accepted; both vendor SDKs emit upper case only. Sending it removes the variable rather than leaving it to be retested.

No user-visible surface changes, so there is nothing to screenshot.

## How did you test this code?

Diagnosis came from the failing request logged in production, not a guess: `status_code: 400`, `request_bytes: 103`, and a URL with no query string, which pins the body above byte for byte.

Tests:

- `test_bucketed_usage_merges_on_a_body_window_with_no_injected_param` and `test_usage_resource_sends_the_full_window_in_the_body` assert `ending_before` ends in `T00:00:00Z`. That fails against master, which sends the unaligned bound this PR fixes.
- `an_hourly_watermark_floors_to_utc_midnight_too` replaces the case that pinned hour alignment, which was itself the defect for `usage_hourly`.
- `a_watermark_inside_today_still_asks_for_today` covers the forward bound: a watermark inside the current day still resolves a window that contains it.
- `test_clamp_window_start_holds_the_one_day_minimum` covers the guard directly. It catches a return to a sub-day window if the end bound is ever moved back to the last midnight.

Running the three built request bodies with the clock pinned to the failing instant gives two aligned bounds, no query parameters, and a window whose end is the next midnight on all three endpoints.

Not run: nothing was exercised against the live Metronome API, which needs an account token. Two points rest on documentation rather than observation, and the first scheduled sync after deploy is what settles both:

- That Metronome accepts an `ending_before` in the future. The docs neither permit nor forbid it. The sibling endpoint's `current_period` flag returns in-progress usage, and Metronome's customer-dashboard guide points at `/v1/usage` for live dashboards, which needs a window ending past now. Neither is proof.
- That the previous fix would be sufficient. It passed every local test and still failed in production, because the defect behind it lived in a rule no test encoded.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code (Opus 5). Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- CodeRabbit CLI pass: paused, so this PR opened without a local pass.
- No duplicate: no open PR touches the Metronome usage window.
- Public artifact: the failure surfaced through a support ticket. Nothing from that conversation appears in the code, tests, comments, commit message or this description. The request body quoted above is reconstructed from a byte count and this repository's own code, and carries no account data.
- The alignment rule was confirmed against the endpoint reference and the sibling `POST /v1/usage/groups`, with a third endpoint that reuses the same parameter names and states no alignment rule acting as a control.
- The forward bound was added after the alignment fix was already written. The agent recommended landing it separately, so an unverified assumption could not re-break an account that is currently broken; the reviewer chose to bundle it.
