### PR TITLE
fix(replay): build the canvas replay image in the recorded document

### DIFF
--- a/common/replay-shared/src/canvas/canvas-plugin.test.ts
+++ b/common/replay-shared/src/canvas/canvas-plugin.test.ts
@@ -394,6 +394,28 @@ describe('CanvasReplayerPlugin', () => {
         )
     })
 
+    describe('reconstructed image document', () => {
+        it('builds the image in the document that holds the recorded canvas', () => {
+            const replayDocument = document.implementation.createHTMLDocument()
+            const canvas = replayDocument.createElement('canvas')
+            replayDocument.body.appendChild(canvas)
+
+            const created: Element[] = []
+            const createInReplayDocument = replayDocument.createElement.bind(replayDocument)
+            jest.spyOn(replayDocument, 'createElement').mockImplementation((tagName: string) => {
+                const element = createInReplayDocument(tagName)
+                created.push(element)
+                return element
+            })
+
+            const plugin = CanvasReplayerPlugin([])
+            plugin.onBuild?.(canvas, { id: 1, replayer: mockReplayer } as any)
+
+            const image = created.find((element) => element.tagName === 'IMG')
+            expect(image?.ownerDocument).toBe(replayDocument)
+        })
+    })
+
     describe('target canvas sizing from snapshot mutations', () => {
         const makeCanvasEvent = (
             id: number,

--- a/common/replay-shared/src/canvas/canvas-plugin.ts
+++ b/common/replay-shared/src/canvas/canvas-plugin.ts
@@ -363,17 +363,22 @@ export const CanvasReplayerPlugin = (
             }
 
             if (node.nodeName === 'CANVAS' && node.nodeType === 1) {
-                const el = containers.get(id) || document.createElement('img')
                 const canvasElement = node as HTMLCanvasElement
+                // The <img> takes the recorded canvas's place, so it is built in that canvas's own
+                // document. A blob: URL is fetched under the Content-Security-Policy of the document
+                // that owns the element, and the element owns that policy from the moment `src` is
+                // assigned, which happens below while the <img> is still detached. Building it in the
+                // app's document therefore puts every replayed canvas frame under the app's policy.
+                const el = containers.get(id) || canvasElement.ownerDocument.createElement('img')
 
                 for (let i = 0; i < canvasElement.attributes.length; i++) {
                     const attr = canvasElement.attributes[i]
                     const name = attr.name.toLowerCase()
-                    // The reconstructed <img> lives in the top-level document, so it inherits only
-                    // presentational attributes from the recorded canvas. Skip inline event handlers
-                    // (every handler is named `on<event>`, so this covers the whole class) and the
-                    // URL-loading attributes — the plugin points `src` at the rendered canvas blob
-                    // itself, so a copied `src`/`srcset` would only fetch an attacker-controlled URL.
+                    // The reconstructed <img> inherits only presentational attributes from the
+                    // recorded canvas. Skip inline event handlers (every handler is named
+                    // `on<event>`, so this covers the whole class) and the URL-loading attributes,
+                    // because the plugin points `src` at the rendered canvas blob itself, so a
+                    // copied `src`/`srcset` would only fetch an attacker-controlled URL.
                     if (name.startsWith('on') || name === 'src' || name === 'srcset') {
                         continue
                     }


### PR DESCRIPTION
## Problem

Replaying a recording that contains a `<canvas>` reports a CSP violation on every viewing, roughly **246 distinct documents a day**. Canvas frames replay as an `<img>` on a `blob:` URL, and the app policy has no `img-src blob:`.

[#94400](https://github.com/PostHog/posthog/pull/94400) gave the player its own frame document with a permissive `img-src * data: blob:`, which should have ended this. It did not, and the violation count has not moved through the whole rollout.

## Changes

- A recording with a canvas stops reporting a blocked image, wherever the player frame is active.
- The reconstructed `<img>` is now created from the recorded canvas's own document rather than the app's. An element's fetch is judged against the policy of the document that owns it, and `src` is assigned while the `<img>` is still detached — so the app policy applied no matter where the element was inserted afterwards.
- `ownerDocument`, not `replayer.iframe.contentDocument`: a canvas can sit inside a nested iframe within the recording, and only `ownerDocument` follows it there.
- The attribute-copying comment above it opened by asserting the image "lives in the top-level document". This change makes that false, so it is rewritten. The `src`/`srcset`/`on*` reasoning under it is unchanged.

## How did you test this code?

I am an agent. No manual testing.

- The new test catches the regression this PR fixes: it builds the canvas in a second real document via `document.implementation.createHTMLDocument()` and asserts the produced image's `ownerDocument`. The second document matters — the existing global `document.createElement` spy would otherwise mask the difference.
- **Verified it fails without the fix**, rather than assuming: checked out the pre-fix file, confirmed line 366 read `document.createElement('img')`, reran, got `Received: undefined` because no image was created in the replay document. Restored: 20/20 in that file, 74/74 across all seven replay-shared suites.
- Audited the rest of the file for the same create-in-the-wrong-realm bug. Nothing else: the `adoptNode` clone is an offscreen render target that issues no fetch, `getComputedStyle` reads style, and `deserialize-canvas-args.ts` builds no DOM elements.
- `oxfmt --check` and `oxlint` pass on both files; `tsgo` reports zero errors in either. Not run: the repo-wide fix script.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5), with the PostHog MCP server for the violation data. Skills invoked: `/writing-code-comments`.

No duplicate: searched open PRs for canvas/replay/img-src work, nothing related.

Two things a reviewer should know rather than infer:

- **This is gated on the `replay-player-own-document` rollout.** Where the flag is off, or the frame failed to load, the player deliberately re-mounts in the app document, so `canvasElement.ownerDocument` *is* the app document and the fetch is genuinely under the app policy. Residual `img-src blob` volume will track the inverse of that rollout.
- **`blob:` is deliberately not being added to the app `img-src`.** Holding it out keeps the 246-document signal available as a falsification test: if this fix works, that number should collapse after deploy on its own.

One stated limitation: `containers.get(id) || …createElement('img')` reuses a cached image whose `ownerDocument` would be stale if the frame document were replaced within one plugin instance. No path does this today — rrweb keeps the same Document across full-snapshot rebuilds — so no defensive check was added.

Public artifact: nothing here draws on anything outside this repository.
