### PR TITLE
feat(personhog): identity saga metrics and leader fan-out knobs

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -8727,7 +8727,6 @@ dependencies = [
  "envconfig",
  "futures",
  "lifecycle",
- "metrics",
  "metrics-exporter-prometheus",
  "personhog-common",
  "personhog-proto",

--- a/rust/personhog-identity/Cargo.toml
+++ b/rust/personhog-identity/Cargo.toml
@@ -10,7 +10,6 @@ personhog-proto = { path = "../personhog-proto" }
 common-database = { path = "../common/database" }
 common-alloc = { path = "../common/alloc" }
 common-metrics = { path = "../common/metrics" }
-metrics = { workspace = true }
 lifecycle = { path = "../common/lifecycle" }
 
 async-trait = { workspace = true }

--- a/rust/personhog-identity/src/config.rs
+++ b/rust/personhog-identity/src/config.rs
@@ -114,6 +114,14 @@ pub struct Config {
     #[envconfig(default = "0")]
     pub max_concurrent_requests: usize,
 
+    /// Leader property writes in flight per get-or-create batch (0 acts as 1).
+    #[envconfig(default = "8")]
+    pub property_write_concurrency: usize,
+
+    /// Leader calls in flight per lifecycle saga step (0 acts as 1).
+    #[envconfig(default = "8")]
+    pub lifecycle_leader_call_concurrency: usize,
+
     /// How long one claim of a lifecycle op lasts before another instance
     /// may steal it (seconds).
     #[envconfig(default = "15")]

--- a/rust/personhog-identity/src/lifecycle/delete.rs
+++ b/rust/personhog-identity/src/lifecycle/delete.rs
@@ -42,9 +42,6 @@ use crate::lifecycle::engine::{
 };
 use crate::storage::postgres::begin_timed;
 
-/// Bound on concurrent leader calls per step, matching the merge driver.
-const LEADER_CALL_CONCURRENCY: usize = 8;
-
 // Derived from the shared enum so the op-type string cannot drift from
 // the leader's fence records or the lifecycle_op CHECK constraint.
 pub const OP_TYPE_DELETE: &str = LifecycleOpType::Delete.as_op_type_str();
@@ -147,12 +144,22 @@ fn record_outcomes(outcome: &Value) {
 pub struct DeleteDriver {
     leader: Arc<dyn LifecycleLeader>,
     tables: IdentityTables,
+    leader_call_concurrency: usize,
 }
 
 impl DeleteDriver {
-    pub fn new(leader: Arc<dyn LifecycleLeader>, tables: IdentityTables) -> Self {
+    pub fn new(
+        leader: Arc<dyn LifecycleLeader>,
+        tables: IdentityTables,
+        leader_call_concurrency: usize,
+    ) -> Self {
         tables.validate().expect("invalid identity table set");
-        Self { leader, tables }
+        Self {
+            leader,
+            tables,
+            // Clamped to 1: a zero-width buffered stream never polls.
+            leader_call_concurrency: leader_call_concurrency.max(1),
+        }
     }
 }
 
@@ -175,9 +182,13 @@ impl OpDriver for DeleteDriver {
         })?;
         match step {
             DeleteStep::Started => mark(pool, &self.tables.person, op).await,
-            DeleteStep::Marked => seal(pool, self.leader.as_ref(), op).await,
+            DeleteStep::Marked => {
+                seal(pool, self.leader.as_ref(), self.leader_call_concurrency, op).await
+            }
             DeleteStep::Sealed => unmap(pool, &self.tables, op).await,
-            DeleteStep::Unmapped => complete(pool, self.leader.as_ref(), op).await,
+            DeleteStep::Unmapped => {
+                complete(pool, self.leader.as_ref(), self.leader_call_concurrency, op).await
+            }
         }
     }
 }
@@ -372,7 +383,12 @@ async fn mark(pool: &PgPool, person_table: &str, op: &OpRow) -> Result<(), SagaE
 /// op; unlike the merge driver's pre-flip abort, delete has no abort path
 /// past `started`, and a parked delete is an operator signal, not a stuck
 /// customer flow.
-async fn seal(pool: &PgPool, leader: &dyn LifecycleLeader, op: &OpRow) -> Result<(), SagaError> {
+async fn seal(
+    pool: &PgPool,
+    leader: &dyn LifecycleLeader,
+    leader_call_concurrency: usize,
+    op: &OpRow,
+) -> Result<(), SagaError> {
     let victims = sqlx::query!(
         r#"
         SELECT person_id FROM lifecycle_op_person
@@ -398,7 +414,7 @@ async fn seal(pool: &PgPool, leader: &dyn LifecycleLeader, op: &OpRow) -> Result
         })
         .collect();
     let fence_results: Vec<_> = stream::iter(fence_calls)
-        .buffer_unordered(LEADER_CALL_CONCURRENCY)
+        .buffer_unordered(leader_call_concurrency)
         .collect()
         .await;
 
@@ -649,6 +665,7 @@ async fn unmap(pool: &PgPool, tables: &IdentityTables, op: &OpRow) -> Result<(),
 async fn complete(
     pool: &PgPool,
     leader: &dyn LifecycleLeader,
+    leader_call_concurrency: usize,
     op: &OpRow,
 ) -> Result<(), SagaError> {
     let request = parse_request(op)?;
@@ -682,7 +699,7 @@ async fn complete(
         })
         .collect();
     let release_results: Vec<_> = stream::iter(release_calls)
-        .buffer_unordered(LEADER_CALL_CONCURRENCY)
+        .buffer_unordered(leader_call_concurrency)
         .collect()
         .await;
     for result in release_results {

--- a/rust/personhog-identity/src/lifecycle/engine.rs
+++ b/rust/personhog-identity/src/lifecycle/engine.rs
@@ -16,7 +16,7 @@
 //! renew/release match only while `attempt` is unchanged, so a displaced
 //! driver cannot extend or clear a stealer's lease.
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -37,6 +37,7 @@ const SWEEPER_RESUMED_TOTAL: &str = "personhog_lifecycle_sweeper_resumed_total";
 const STEP_FAILURES_TOTAL: &str = "personhog_lifecycle_step_failures_total";
 const OPS_PARKED_TOTAL: &str = "personhog_lifecycle_ops_parked_total";
 const OPS_PARKED: &str = "personhog_lifecycle_ops_parked";
+const STEP_DURATION_MS: &str = "personhog_lifecycle_step_duration_ms";
 
 /// How many abandoned ops one sweep pass will pick up.
 const SWEEP_BATCH_SIZE: i64 = 100;
@@ -141,6 +142,17 @@ impl From<SagaError> for Status {
             SagaError::CorruptState(msg) => Status::internal(msg),
         }
     }
+}
+
+fn record_step_duration(row: &OpRow, start: Instant) {
+    common_metrics::histogram(
+        STEP_DURATION_MS,
+        &[
+            ("op_type".to_string(), row.op_type.clone()),
+            ("step".to_string(), row.step.clone()),
+        ],
+        start.elapsed().as_secs_f64() * 1000.0,
+    );
 }
 
 /// One row of `lifecycle_op`: the complete checkpoint of an operation.
@@ -302,7 +314,10 @@ impl Engine {
         if row.completed_at.is_some() {
             return Ok(row);
         }
-        driver.run_step(&self.pool, &row).await?;
+        let step_start = Instant::now();
+        let stepped = driver.run_step(&self.pool, &row).await;
+        record_step_duration(&row, step_start);
+        stepped?;
         self.load(op_id).await?.ok_or_else(|| {
             SagaError::CorruptState(format!("op {op_id} vanished while being driven"))
         })
@@ -418,7 +433,10 @@ impl Engine {
                 }
             }
 
-            if let Err(err) = driver.run_step(&self.pool, &row).await {
+            let step_start = Instant::now();
+            let stepped = driver.run_step(&self.pool, &row).await;
+            record_step_duration(&row, step_start);
+            if let Err(err) = stepped {
                 // Attributable escalation: a persistently failing op (a
                 // corrupt row, a wedged leader call) shows up as this
                 // counter climbing for one op_type/kind, not as generic

--- a/rust/personhog-identity/src/lifecycle/merge.rs
+++ b/rust/personhog-identity/src/lifecycle/merge.rs
@@ -209,10 +209,6 @@ const STATUS_SKIPPED_CONFLICT: &str = "skipped_conflict";
 const ROLE_TARGET: &str = "target";
 const ROLE_SOURCE: &str = "source";
 
-/// Cap on concurrent leader RPCs per fan-out (fence, release): a bulk
-/// merge must not burst the router with one in-flight call per source.
-const LEADER_CALL_CONCURRENCY: usize = 8;
-
 const STEPS_TOTAL: &str = "personhog_lifecycle_merge_steps_total";
 const OUTCOMES_TOTAL: &str = "personhog_lifecycle_merge_outcomes_total";
 /// Pre-flip aborts by refusal slug.
@@ -320,12 +316,22 @@ struct SealedSnapshot {
 pub struct MergeDriver {
     leader: Arc<dyn LifecycleLeader>,
     tables: IdentityTables,
+    leader_call_concurrency: usize,
 }
 
 impl MergeDriver {
-    pub fn new(leader: Arc<dyn LifecycleLeader>, tables: IdentityTables) -> Self {
+    pub fn new(
+        leader: Arc<dyn LifecycleLeader>,
+        tables: IdentityTables,
+        leader_call_concurrency: usize,
+    ) -> Self {
         tables.validate().expect("invalid identity table set");
-        Self { leader, tables }
+        Self {
+            leader,
+            tables,
+            // Clamped to 1: a zero-width buffered stream never polls.
+            leader_call_concurrency: leader_call_concurrency.max(1),
+        }
     }
 }
 
@@ -991,7 +997,7 @@ impl MergeDriver {
             })
             .collect();
         let fence_results: Vec<_> = stream::iter(fence_calls)
-            .buffer_unordered(LEADER_CALL_CONCURRENCY)
+            .buffer_unordered(self.leader_call_concurrency)
             .collect()
             .await;
         for (person_id, result) in fence_results {
@@ -1247,7 +1253,7 @@ impl MergeDriver {
             })
             .collect();
         let results: Vec<_> = stream::iter(calls)
-            .buffer_unordered(LEADER_CALL_CONCURRENCY)
+            .buffer_unordered(self.leader_call_concurrency)
             .collect()
             .await;
         for result in results {
@@ -1850,7 +1856,7 @@ impl MergeDriver {
             })
             .collect();
         let release_results: Vec<_> = stream::iter(release_calls)
-            .buffer_unordered(LEADER_CALL_CONCURRENCY)
+            .buffer_unordered(self.leader_call_concurrency)
             .collect()
             .await;
         for (_, result) in release_results {

--- a/rust/personhog-identity/src/lifecycle/mod.rs
+++ b/rust/personhog-identity/src/lifecycle/mod.rs
@@ -38,13 +38,16 @@ impl PersonHogLifecycleService {
         engine: Arc<Engine>,
         leader: Arc<dyn LifecycleLeader>,
         tables: crate::config::IdentityTables,
+        leader_call_concurrency: usize,
     ) -> Self {
         Self {
             engine,
-            delete_driver: DeleteDriver::new(leader, tables),
+            delete_driver: DeleteDriver::new(leader, tables, leader_call_concurrency),
         }
     }
 }
+
+const DELETE_PERSONS_PER_CALL: &str = "personhog_lifecycle_delete_persons_per_call";
 
 /// Translate a terminal op row's recorded outcome into the proto response.
 /// The recorded outcome is the single source of truth — a retried call gets
@@ -93,6 +96,11 @@ impl PersonHogLifecycle for PersonHogLifecycleService {
     ) -> Result<Response<DeletePersonsResponse>, Status> {
         let request = request.into_inner();
         let op_id = validate_delete_persons(&request)?;
+        common_metrics::histogram(
+            DELETE_PERSONS_PER_CALL,
+            &[],
+            request.person_ids.len() as f64,
+        );
 
         let frozen = serde_json::to_value(delete::DeleteRequest {
             person_ids: request.person_ids,

--- a/rust/personhog-identity/src/lifecycle/validation.rs
+++ b/rust/personhog-identity/src/lifecycle/validation.rs
@@ -7,6 +7,8 @@ use uuid::Uuid;
 use personhog_proto::personhog::identity::v1::MergePersonsRequest;
 use personhog_proto::personhog::lifecycle::v1::DeletePersonsRequest;
 
+use crate::service::validation::rejected;
+
 /// Maximum person ids per DeletePersons request. Matches the identity
 /// get-or-create batch cap; GDPR jobs chunk above this.
 pub const MAX_DELETE_BATCH_SIZE: usize = 250;
@@ -98,26 +100,30 @@ pub fn validate_delete_persons(request: &DeletePersonsRequest) -> Result<Uuid, S
     // with `as i32` — an unchecked value above i32::MAX would wrap and read
     // or write another tenant's rows.
     if request.team_id <= 0 || request.team_id > i32::MAX as i64 {
-        return Err(Status::invalid_argument(
+        return Err(rejected(
+            "team_id",
             "team_id must be a positive 32-bit integer",
         ));
     }
     if request.person_ids.is_empty() {
-        return Err(Status::invalid_argument("person_ids must not be empty"));
+        return Err(rejected("person_ids_empty", "person_ids must not be empty"));
     }
     if request.person_ids.len() > MAX_DELETE_BATCH_SIZE {
-        return Err(Status::invalid_argument(format!(
-            "batch size {} exceeds maximum {MAX_DELETE_BATCH_SIZE}",
-            request.person_ids.len()
-        )));
+        return Err(rejected(
+            "batch_size",
+            format!(
+                "batch size {} exceeds maximum {MAX_DELETE_BATCH_SIZE}",
+                request.person_ids.len()
+            ),
+        ));
     }
     if request.person_ids.iter().any(|&id| id <= 0) {
-        return Err(Status::invalid_argument(
+        return Err(rejected(
+            "person_id",
             "person_ids must be positive integers",
         ));
     }
-    Uuid::parse_str(&request.op_id)
-        .map_err(|_| Status::invalid_argument("op_id must be a valid UUID"))
+    Uuid::parse_str(&request.op_id).map_err(|_| rejected("op_id", "op_id must be a valid UUID"))
 }
 
 // See validate_delete_persons for why result_large_err is allowed.
@@ -128,17 +134,20 @@ pub fn validate_delete_persons(request: &DeletePersonsRequest) -> Result<Uuid, S
 /// merge into a bug).
 pub fn validate_merge_persons(request: &MergePersonsRequest) -> Result<(Uuid, i64), Status> {
     if request.team_id <= 0 || request.team_id > i32::MAX as i64 {
-        return Err(Status::invalid_argument(
+        return Err(rejected(
+            "team_id",
             "team_id must be a positive 32-bit integer",
         ));
     }
     if is_distinct_id_oversized(&request.target_distinct_id) {
-        return Err(Status::invalid_argument(format!(
-            "target_distinct_id exceeds {MAX_DISTINCT_ID_LENGTH} characters"
-        )));
+        return Err(rejected(
+            "target_distinct_id_length",
+            format!("target_distinct_id exceeds {MAX_DISTINCT_ID_LENGTH} characters"),
+        ));
     }
     if is_distinct_id_illegal(&request.target_distinct_id) {
-        return Err(Status::invalid_argument(
+        return Err(rejected(
+            "target_distinct_id_illegal",
             "target_distinct_id is an illegal distinct id",
         ));
     }
@@ -146,18 +155,22 @@ pub fn validate_merge_persons(request: &MergePersonsRequest) -> Result<(Uuid, i6
     // reach the establish path and fail person creation with an internal
     // error on every attempt.
     if request.target_distinct_id.contains('\u{0000}') {
-        return Err(Status::invalid_argument(
+        return Err(rejected(
+            "target_distinct_id_nul",
             "target_distinct_id must not contain NUL",
         ));
     }
     if request.sources.is_empty() {
-        return Err(Status::invalid_argument("sources must not be empty"));
+        return Err(rejected("sources_empty", "sources must not be empty"));
     }
     if request.sources.len() > MAX_MERGE_BATCH_SIZE {
-        return Err(Status::invalid_argument(format!(
-            "batch size {} exceeds maximum {MAX_MERGE_BATCH_SIZE}",
-            request.sources.len()
-        )));
+        return Err(rejected(
+            "batch_size",
+            format!(
+                "batch size {} exceeds maximum {MAX_MERGE_BATCH_SIZE}",
+                request.sources.len()
+            ),
+        ));
     }
     let mut seen = HashSet::with_capacity(request.sources.len());
     for source in &request.sources {
@@ -166,28 +179,32 @@ pub fn validate_merge_persons(request: &MergePersonsRequest) -> Result<(Uuid, i6
         // so the frozen op row — which must record every requested
         // source for retries — would be unwritable jsonb.
         if source.source_distinct_id.contains('\u{0000}') {
-            return Err(Status::invalid_argument(
+            return Err(rejected(
+                "source_distinct_id_nul",
                 "source distinct ids must not contain NUL",
             ));
         }
         if !seen.insert(source.source_distinct_id.as_str()) {
-            return Err(Status::invalid_argument(format!(
-                "duplicate source distinct id: the caller must dedupe (\"{}\")",
-                source.source_distinct_id
-            )));
+            return Err(rejected(
+                "duplicate_source",
+                format!(
+                    "duplicate source distinct id: the caller must dedupe (\"{}\")",
+                    source.source_distinct_id
+                ),
+            ));
         }
     }
     // Unlimited is not a supported mode: the flip's repoint would be an
     // unbounded statement under statement_timeout.
     let move_limit = match request.move_limit {
         Some(limit) if limit >= 1 => limit,
-        Some(_) => return Err(Status::invalid_argument("move_limit must be positive")),
-        None => return Err(Status::invalid_argument("move_limit is required")),
+        Some(_) => return Err(rejected("move_limit", "move_limit must be positive")),
+        None => return Err(rejected("move_limit", "move_limit is required")),
     };
     if request.created_at < 0 {
-        return Err(Status::invalid_argument("created_at must not be negative"));
+        return Err(rejected("created_at", "created_at must not be negative"));
     }
     let op_id = Uuid::parse_str(&request.op_id)
-        .map_err(|_| Status::invalid_argument("op_id must be a valid UUID"))?;
+        .map_err(|_| rejected("op_id", "op_id must be a valid UUID"))?;
     Ok((op_id, move_limit))
 }

--- a/rust/personhog-identity/src/main.rs
+++ b/rust/personhog-identity/src/main.rs
@@ -76,6 +76,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing::info!("gRPC address: {}", config.grpc_address);
     tracing::info!("Metrics port: {}", config.metrics_port);
     tracing::info!("Router URL: {}", config.router_url);
+    tracing::info!(
+        property_write_concurrency = config.property_write_concurrency,
+        leader_call_concurrency = config.lifecycle_leader_call_concurrency,
+        "Leader fan-out concurrency"
+    );
     tracing::info!("Tables: {:?}", config.tables());
 
     // Build lifecycle manager and register components
@@ -127,8 +132,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             10.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0, 10000.0, 30000.0, 60000.0,
             300000.0, 1800000.0, 3600000.0,
         ];
-        // Source counts, not latency; the request cap is 250.
-        const MERGE_SOURCES_BUCKETS: &[f64] = &[1.0, 2.0, 3.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0];
+        // Batch sizes, not latency; the request caps are 250.
+        const PER_CALL_BUCKETS: &[f64] = &[1.0, 2.0, 3.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0];
         let recorder_handle = PrometheusBuilder::new()
             .add_global_label("service", "personhog-identity")
             .set_buckets(BUCKETS)
@@ -138,10 +143,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 OP_DURATION_BUCKETS,
             )
             .unwrap()
-            .set_buckets_for_metric(
-                Matcher::Full("personhog_identity_merge_sources_per_call".into()),
-                MERGE_SOURCES_BUCKETS,
-            )
+            .set_buckets_for_metric(Matcher::Suffix("_per_call".into()), PER_CALL_BUCKETS)
             .unwrap()
             .install_recorder()
             .expect("Failed to install metrics recorder");
@@ -228,8 +230,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config.lifecycle_engine_config(),
     ));
     if let Some(sweeper_handle) = sweeper_handle {
-        let sweeper_merge_driver = MergeDriver::new(property_writer.clone(), config.tables());
-        let sweeper_delete_driver = DeleteDriver::new(lifecycle_leader.clone(), config.tables());
+        let sweeper_merge_driver = MergeDriver::new(
+            property_writer.clone(),
+            config.tables(),
+            config.lifecycle_leader_call_concurrency,
+        );
+        let sweeper_delete_driver = DeleteDriver::new(
+            lifecycle_leader.clone(),
+            config.tables(),
+            config.lifecycle_leader_call_concurrency,
+        );
         let sweeper_engine = engine.clone();
         let sweep_interval = config.lifecycle_sweep_interval();
         let retention = config.lifecycle_op_retention();
@@ -274,16 +284,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         property_writer.clone(),
         MergeOpExecutor::new(
             engine.clone(),
-            MergeDriver::new(property_writer.clone(), config.tables()),
+            MergeDriver::new(
+                property_writer.clone(),
+                config.tables(),
+                config.lifecycle_leader_call_concurrency,
+            ),
         ),
     );
-    let lifecycle_service =
-        PersonHogLifecycleService::new(engine, lifecycle_leader, config.tables());
+    let lifecycle_service = PersonHogLifecycleService::new(
+        engine,
+        lifecycle_leader,
+        config.tables(),
+        config.lifecycle_leader_call_concurrency,
+    );
     let service = PersonHogIdentityService::new(
         storage,
         property_writer,
         config.request_limits(),
         merge_entrance,
+        config.property_write_concurrency,
     );
 
     let grpc_addr = config.grpc_address;

--- a/rust/personhog-identity/src/service/get_or_create.rs
+++ b/rust/personhog-identity/src/service/get_or_create.rs
@@ -13,6 +13,7 @@ use chrono::{DateTime, Utc};
 use futures::stream::{self, StreamExt};
 use tonic::{Code, Status};
 
+use personhog_common::grpc::current_client_name;
 use personhog_proto::personhog::identity::v1::GetOrCreatePersonEntry;
 use personhog_proto::personhog::types::v1::{Person as ProtoPerson, UpdatePersonPropertiesRequest};
 
@@ -21,11 +22,11 @@ use crate::service::validation::validate_entry;
 use crate::service::PersonHogIdentityService;
 use crate::storage::{Person, PersonStub, StubOutcome};
 
-/// Bound on concurrent leader-routed property writes within one batch.
-const MAX_CONCURRENT_PROPERTY_WRITES: usize = 8;
-
 const GET_OR_CREATE_TOTAL: &str = "personhog_identity_get_or_create_total";
 const GET_OR_CREATE_PHASE_DURATION: &str = "personhog_identity_get_or_create_phase_duration_ms";
+const GET_OR_CREATE_ENTRIES_PER_CALL: &str = "personhog_identity_get_or_create_entries_per_call";
+const CREATE_STUB_LOST_TOTAL: &str = "personhog_identity_create_stub_lost_total";
+const CREATED_AT_FALLBACK_TOTAL: &str = "personhog_identity_created_at_fallback_total";
 
 fn count_outcome(outcome: &str) {
     common_metrics::inc(
@@ -36,8 +37,30 @@ fn count_outcome(outcome: &str) {
 }
 
 fn record_phase(phase: &'static str, start: Instant) {
-    metrics::histogram!(GET_OR_CREATE_PHASE_DURATION, "phase" => phase)
-        .record(start.elapsed().as_secs_f64() * 1000.0);
+    common_metrics::histogram(
+        GET_OR_CREATE_PHASE_DURATION,
+        &[
+            ("phase".to_string(), phase.to_string()),
+            ("client".to_string(), current_client_name().to_string()),
+        ],
+        start.elapsed().as_secs_f64() * 1000.0,
+    );
+}
+
+fn count_stub_lost(resolution: &'static str) {
+    common_metrics::inc(
+        CREATE_STUB_LOST_TOTAL,
+        &[("resolution".to_string(), resolution.to_string())],
+        1,
+    );
+}
+
+fn count_created_at_fallback(reason: &'static str) {
+    common_metrics::inc(
+        CREATED_AT_FALLBACK_TOTAL,
+        &[("reason".to_string(), reason.to_string())],
+        1,
+    );
 }
 
 /// Empty bytes and an empty JSON object both mean "no properties to apply".
@@ -46,11 +69,14 @@ fn has_properties(raw: &[u8]) -> bool {
 }
 
 fn entry_created_at(entry: &GetOrCreatePersonEntry) -> DateTime<Utc> {
-    if entry.created_at > 0 {
-        DateTime::from_timestamp_millis(entry.created_at).unwrap_or_else(Utc::now)
-    } else {
-        Utc::now()
+    if entry.created_at <= 0 {
+        count_created_at_fallback("missing");
+        return Utc::now();
     }
+    DateTime::from_timestamp_millis(entry.created_at).unwrap_or_else(|| {
+        count_created_at_fallback("invalid");
+        Utc::now()
+    })
 }
 
 /// How each entry proceeds after the resolve phase.
@@ -74,10 +100,17 @@ impl PersonHogIdentityService {
         &self,
         entries: Vec<GetOrCreatePersonEntry>,
     ) -> Result<Vec<Result<(ProtoPerson, bool), Status>>, Status> {
+        common_metrics::histogram(GET_OR_CREATE_ENTRIES_PER_CALL, &[], entries.len() as f64);
+        // One pass: rejected() counts each failure, so the key filter and the plan share it.
+        let validations: Vec<Result<(), Status>> = entries
+            .iter()
+            .map(|entry| validate_entry(&self.limits, entry))
+            .collect();
         let keys: Vec<(i64, String)> = entries
             .iter()
-            .filter(|entry| validate_entry(&self.limits, entry).is_ok())
-            .map(|entry| (entry.team_id, entry.distinct_id.clone()))
+            .zip(&validations)
+            .filter(|(_, validation)| validation.is_ok())
+            .map(|(entry, _)| (entry.team_id, entry.distinct_id.clone()))
             .collect();
         let phase = Instant::now();
         let resolved = self.storage.resolve_distinct_ids(&keys).await;
@@ -89,8 +122,9 @@ impl PersonHogIdentityService {
         let mut stub_index: HashMap<(i64, String), usize> = HashMap::new();
         let plans: Vec<Plan> = entries
             .iter()
-            .map(|entry| {
-                if let Err(status) = validate_entry(&self.limits, entry) {
+            .zip(validations)
+            .map(|(entry, validation)| {
+                if let Err(status) = validation {
                     return Plan::Done(Err(status));
                 }
                 let key = (entry.team_id, entry.distinct_id.clone());
@@ -188,7 +222,7 @@ impl PersonHogIdentityService {
                 let entry = &entries[i];
                 async move { (i, self.apply_initial_properties(entry, person).await) }
             }))
-            .buffered(MAX_CONCURRENT_PROPERTY_WRITES)
+            .buffered(self.property_write_concurrency)
             .collect()
             .await;
         record_phase("apply_properties", phase);
@@ -250,11 +284,14 @@ impl PersonHogIdentityService {
                     .await
                     .map_err(|e| log_and_convert_error(e, "resolve_after_leader_not_found"))?;
                 let Some(current) = resolved.remove(&key) else {
+                    count_stub_lost("unresolved");
                     return Err(status);
                 };
                 if current.id == person.id {
+                    count_stub_lost("unchanged");
                     return Err(status);
                 }
+                count_stub_lost("moved");
                 let retry = UpdatePersonPropertiesRequest {
                     // Creation properties persist regardless of the filtered list.
                     force_update: true,

--- a/rust/personhog-identity/src/service/mod.rs
+++ b/rust/personhog-identity/src/service/mod.rs
@@ -31,10 +31,13 @@ use crate::service::validation::{
 };
 use crate::storage::IdentityStorage;
 
+const RESOLVE_KEYS_PER_CALL: &str = "personhog_identity_resolve_keys_per_call";
+
 pub struct PersonHogIdentityService {
     pub(crate) storage: Arc<dyn IdentityStorage>,
     pub(crate) property_writer: Arc<dyn PropertyWriter>,
     pub(crate) limits: RequestLimits,
+    pub(crate) property_write_concurrency: usize,
     merge: MergeEntrance,
 }
 
@@ -44,11 +47,14 @@ impl PersonHogIdentityService {
         property_writer: Arc<dyn PropertyWriter>,
         limits: RequestLimits,
         merge: MergeEntrance,
+        property_write_concurrency: usize,
     ) -> Self {
         Self {
             storage,
             property_writer,
             limits,
+            // Clamped to 1: a zero-width buffered stream never polls.
+            property_write_concurrency: property_write_concurrency.max(1),
             merge,
         }
     }
@@ -118,6 +124,7 @@ impl PersonHogIdentity for PersonHogIdentityService {
         request: Request<GetPersonsByDistinctIdsRequest>,
     ) -> Result<Response<GetPersonsByDistinctIdsResponse>, Status> {
         let keys = request.into_inner().keys;
+        common_metrics::histogram(RESOLVE_KEYS_PER_CALL, &[], keys.len() as f64);
         validate_batch_size(&self.limits, keys.len())?;
         for key in &keys {
             validate_team_id(key.team_id)?;

--- a/rust/personhog-identity/src/service/validation.rs
+++ b/rust/personhog-identity/src/service/validation.rs
@@ -17,6 +17,17 @@ pub struct RequestLimits {
     pub max_extra_distinct_ids: usize,
 }
 
+const VALIDATION_REJECTIONS_TOTAL: &str = "personhog_identity_validation_rejections_total";
+
+pub(crate) fn rejected(reason: &'static str, message: impl Into<String>) -> Status {
+    common_metrics::inc(
+        VALIDATION_REJECTIONS_TOTAL,
+        &[("reason".to_string(), reason.to_string())],
+        1,
+    );
+    Status::invalid_argument(message)
+}
+
 // tonic Status is a large Err variant; boxing here would diverge from the
 // tonic handler signatures these feed into.
 
@@ -26,7 +37,8 @@ pub struct RequestLimits {
 #[allow(clippy::result_large_err)]
 pub fn validate_team_id(team_id: i64) -> Result<(), Status> {
     if team_id <= 0 || team_id > i32::MAX as i64 {
-        return Err(Status::invalid_argument(
+        return Err(rejected(
+            "team_id",
             "team_id must be a positive 32-bit integer",
         ));
     }
@@ -36,10 +48,10 @@ pub fn validate_team_id(team_id: i64) -> Result<(), Status> {
 #[allow(clippy::result_large_err)]
 pub fn validate_batch_size(limits: &RequestLimits, len: usize) -> Result<(), Status> {
     if len > limits.max_batch_size {
-        return Err(Status::invalid_argument(format!(
-            "batch size {len} exceeds maximum {}",
-            limits.max_batch_size
-        )));
+        return Err(rejected(
+            "batch_size",
+            format!("batch size {len} exceeds maximum {}", limits.max_batch_size),
+        ));
     }
     Ok(())
 }
@@ -53,17 +65,21 @@ pub fn validate_entry(
     // with `as i32` — an unchecked value above i32::MAX would wrap and read
     // or write another tenant's rows.
     if entry.team_id <= 0 || entry.team_id > i32::MAX as i64 {
-        return Err(Status::invalid_argument(
+        return Err(rejected(
+            "team_id",
             "team_id must be a positive 32-bit integer",
         ));
     }
     validate_distinct_id(limits, &entry.distinct_id)?;
     if entry.extra_distinct_ids.len() > limits.max_extra_distinct_ids {
-        return Err(Status::invalid_argument(format!(
-            "entry has {} extra distinct ids, exceeding maximum {}",
-            entry.extra_distinct_ids.len(),
-            limits.max_extra_distinct_ids
-        )));
+        return Err(rejected(
+            "extra_distinct_ids",
+            format!(
+                "entry has {} extra distinct ids, exceeding maximum {}",
+                entry.extra_distinct_ids.len(),
+                limits.max_extra_distinct_ids
+            ),
+        ));
     }
     for extra in &entry.extra_distinct_ids {
         validate_distinct_id(limits, extra)?;
@@ -74,19 +90,28 @@ pub fn validate_entry(
 #[allow(clippy::result_large_err)]
 fn validate_distinct_id(limits: &RequestLimits, distinct_id: &str) -> Result<(), Status> {
     if distinct_id.is_empty() {
-        return Err(Status::invalid_argument("distinct_id must not be empty"));
+        return Err(rejected(
+            "distinct_id_empty",
+            "distinct_id must not be empty",
+        ));
     }
     if distinct_id.chars().count() > limits.max_distinct_id_length {
-        return Err(Status::invalid_argument(format!(
-            "distinct_id exceeds {} characters",
-            limits.max_distinct_id_length
-        )));
+        return Err(rejected(
+            "distinct_id_length",
+            format!(
+                "distinct_id exceeds {} characters",
+                limits.max_distinct_id_length
+            ),
+        ));
     }
     // Postgres cannot store NUL in text, so this id could never be
     // created — reject it instead of surfacing the insert failure as an
     // internal error.
     if distinct_id.contains('\u{0000}') {
-        return Err(Status::invalid_argument("distinct_id must not contain NUL"));
+        return Err(rejected(
+            "distinct_id_nul",
+            "distinct_id must not contain NUL",
+        ));
     }
     Ok(())
 }

--- a/rust/personhog-identity/tests/common/mod.rs
+++ b/rust/personhog-identity/tests/common/mod.rs
@@ -14,6 +14,9 @@ use personhog_identity::storage::postgres::PostgresIdentityStorage;
 
 /// The production table set. Most tests run here; the raw-SQL assertion
 /// helpers in the test binaries assume it.
+/// Leader fan-out width the suites run with; production reads it from config.
+pub const FAN_OUT_CONCURRENCY: usize = 8;
+
 pub fn default_tables() -> IdentityTables {
     IdentityTables::real()
 }

--- a/rust/personhog-identity/tests/lifecycle_delete_tests.rs
+++ b/rust/personhog-identity/tests/lifecycle_delete_tests.rs
@@ -26,7 +26,12 @@ impl TestContext {
             self.pool.clone(),
             self.tables.person.clone(),
         ));
-        PersonHogLifecycleService::new(engine, leader.clone(), self.tables.clone())
+        PersonHogLifecycleService::new(
+            engine,
+            leader.clone(),
+            self.tables.clone(),
+            common::FAN_OUT_CONCURRENCY,
+        )
     }
 
     /// (is_deleted, version, properties) of a person row.
@@ -553,7 +558,11 @@ impl FencedHarness {
         let ctx = TestContext::new().await;
         let engine = ctx.engine();
         let leader = Arc::new(SimLeader::new(ctx.pool.clone(), ctx.tables.person.clone()));
-        let driver = DeleteDriver::new(leader.clone(), ctx.tables.clone());
+        let driver = DeleteDriver::new(
+            leader.clone(),
+            ctx.tables.clone(),
+            common::FAN_OUT_CONCURRENCY,
+        );
         Self {
             ctx,
             engine,

--- a/rust/personhog-identity/tests/lifecycle_merge_tests.rs
+++ b/rust/personhog-identity/tests/lifecycle_merge_tests.rs
@@ -50,7 +50,11 @@ impl MergeHarness {
         let ctx = TestContext::new_with_tables(tables).await;
         let engine = ctx.engine();
         let leader = Arc::new(SimLeader::new(ctx.pool.clone(), ctx.tables.person.clone()));
-        let driver = MergeDriver::new(leader.clone(), ctx.tables.clone());
+        let driver = MergeDriver::new(
+            leader.clone(),
+            ctx.tables.clone(),
+            common::FAN_OUT_CONCURRENCY,
+        );
         Self {
             ctx,
             engine,
@@ -1673,9 +1677,14 @@ impl MergeHarness {
                 self.leader.clone(),
                 MergeOpExecutor::new(
                     engine,
-                    MergeDriver::new(self.leader.clone(), self.ctx.tables.clone()),
+                    MergeDriver::new(
+                        self.leader.clone(),
+                        self.ctx.tables.clone(),
+                        common::FAN_OUT_CONCURRENCY,
+                    ),
                 ),
             ),
+            common::FAN_OUT_CONCURRENCY,
         )
     }
 
@@ -1694,9 +1703,14 @@ impl MergeHarness {
                 self.leader.clone(),
                 MergeOpExecutor::new(
                     engine,
-                    MergeDriver::new(self.leader.clone(), self.ctx.tables.clone()),
+                    MergeDriver::new(
+                        self.leader.clone(),
+                        self.ctx.tables.clone(),
+                        common::FAN_OUT_CONCURRENCY,
+                    ),
                 ),
             ),
+            common::FAN_OUT_CONCURRENCY,
         )
     }
 }
@@ -2132,7 +2146,11 @@ async fn a_create_race_loser_answers_retryable_unavailable() {
     let h = MergeHarness::new().await;
     let executor = MergeOpExecutor::new(
         Arc::new(h.ctx.engine()),
-        MergeDriver::new(h.leader.clone(), h.ctx.tables.clone()),
+        MergeDriver::new(
+            h.leader.clone(),
+            h.ctx.tables.clone(),
+            common::FAN_OUT_CONCURRENCY,
+        ),
     );
     let op_id = Uuid::now_v7();
 

--- a/rust/personhog-identity/tests/lifecycle_service_tests.rs
+++ b/rust/personhog-identity/tests/lifecycle_service_tests.rs
@@ -43,6 +43,7 @@ async fn delete_status(request: DeletePersonsRequest) -> Code {
         engine,
         Arc::new(SimLeader::new(pool, tables.person.clone())),
         tables,
+        common::FAN_OUT_CONCURRENCY,
     );
     service
         .delete_persons(Request::new(request))

--- a/rust/personhog-identity/tests/service_tests.rs
+++ b/rust/personhog-identity/tests/service_tests.rs
@@ -84,11 +84,20 @@ impl ServiceTestContext {
             writer.clone(),
             MergeOpExecutor::new(
                 engine,
-                MergeDriver::new(Arc::new(common::UnusedLeader), ctx.tables.clone()),
+                MergeDriver::new(
+                    Arc::new(common::UnusedLeader),
+                    ctx.tables.clone(),
+                    common::FAN_OUT_CONCURRENCY,
+                ),
             ),
         );
-        let service =
-            PersonHogIdentityService::new(ctx.storage.clone(), writer.clone(), limits, merge);
+        let service = PersonHogIdentityService::new(
+            ctx.storage.clone(),
+            writer.clone(),
+            limits,
+            merge,
+            common::FAN_OUT_CONCURRENCY,
+        );
         Self {
             ctx,
             writer,

--- a/rust/personhog-test-harness/src/client.rs
+++ b/rust/personhog-test-harness/src/client.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use personhog_common::client::RouterClient;
+use personhog_common::grpc::CLIENT_NAME_HEADER;
 use personhog_proto::personhog::{
     identity::v1::{
         person_hog_identity_client::PersonHogIdentityClient, GetOrCreatePersonEntry,
@@ -18,10 +19,21 @@ use personhog_proto::personhog::{
         UpdatePersonPropertiesResponse,
     },
 };
+use tonic::metadata::MetadataValue;
 use tonic::transport::Channel;
 use tonic::Request;
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const HARNESS_CLIENT_NAME: &str = "personhog-test-harness";
+
+fn with_client_name<T>(message: T) -> Request<T> {
+    let mut request = Request::new(message);
+    request.metadata_mut().insert(
+        CLIENT_NAME_HEADER,
+        MetadataValue::from_static(HARNESS_CLIENT_NAME),
+    );
+    request
+}
 
 /// Harness wrapper over the shared router client: same wire behavior,
 /// anyhow-flavored results for scenario code.
@@ -41,7 +53,8 @@ impl HarnessClient {
     /// connection landed on.
     pub async fn connect_with_channels(url: &str, channels: usize) -> Result<Self> {
         let inner = RouterClient::with_channels(url, REQUEST_TIMEOUT, channels)
-            .context("invalid router URL")?;
+            .context("invalid router URL")?
+            .with_client_name(HARNESS_CLIENT_NAME);
         Ok(Self { inner })
     }
 
@@ -150,7 +163,7 @@ impl IdentityClient {
         let resp = self
             .inner
             .clone()
-            .get_or_create_persons_by_distinct_ids(Request::new(
+            .get_or_create_persons_by_distinct_ids(with_client_name(
                 GetOrCreatePersonsByDistinctIdsRequest { entries },
             ))
             .await
@@ -179,7 +192,7 @@ impl IdentityClient {
         let resp = self
             .inner
             .clone()
-            .merge_persons(Request::new(MergePersonsRequest {
+            .merge_persons(with_client_name(MergePersonsRequest {
                 team_id,
                 target_distinct_id: target_distinct_id.to_string(),
                 sources: source_distinct_ids
@@ -236,7 +249,7 @@ impl LifecycleClient {
         let resp = self
             .inner
             .clone()
-            .delete_persons(Request::new(DeletePersonsRequest {
+            .delete_persons(with_client_name(DeletePersonsRequest {
                 team_id,
                 person_ids,
                 op_id: op_id.to_string(),


### PR DESCRIPTION
## Problem

An operator tuning the identity service cannot see where a delete or merge op spends its time, and cannot change how hard the create and saga paths fan out to the leader without a code change.

- The op-duration histogram spans creation to terminal commit; the saga's four steps are not timed, so the non-leader part of an op cannot be attributed to a step.
- The get-or-create phase histogram has no client label, so the harness's 250-entry batches and ingestion's few-entry calls average into one per-RPC number.
- Validation rejects requests with INVALID_ARGUMENT and no counter, so a misbehaving caller looks like silence.
- The leader fan-out width is a compile-time constant in three places.

## Changes

- Two env knobs replace the constants and are passed through the constructors: `PROPERTY_WRITE_CONCURRENCY` for property writes in flight per get-or-create batch, and `LIFECYCLE_LEADER_CALL_CONCURRENCY` for leader calls in flight per saga step, delete and merge alike. Both default to 8; 0 is clamped to 1 so a fan-out cannot stall.
- New metrics on the identity service:

| metric | labels | answers |
| --- | --- | --- |
| `personhog_lifecycle_step_duration_ms` | `op_type`, `step` | which step a slow op spent its time in |
| `personhog_identity_get_or_create_phase_duration_ms` | adds `client` | the phase breakdown per caller |
| `personhog_identity_get_or_create_entries_per_call`, `personhog_identity_resolve_keys_per_call`, `personhog_lifecycle_delete_persons_per_call` | none | the batch sizes behind every per-RPC number; one bucket rule covers all `_per_call` histograms |
| `personhog_identity_create_stub_lost_total` | `resolution` = `moved`, `unresolved`, `unchanged` | how often a stub is destroyed between its commit and its property write |
| `personhog_identity_created_at_fallback_total` | `reason` = `missing`, `invalid` | callers that send no usable timestamp |
| `personhog_identity_validation_rejections_total` | `reason` | rejections by check |

- The test harness stamps `x-client-name: personhog-test-harness` on all three of its clients, so identity, and the leader through the router, attribute its traffic instead of filing it under `unknown`.
- Mechanical: every `Status::invalid_argument` in the two validation modules now goes through one `rejected()` helper with unchanged messages, and the constructor signatures gained the concurrency parameter.
- Nothing user-visible changes. The riskiest part is the constructor plumbing, which the existing saga and service suites exercise.

## How did you test this code?

- No new tests. The only new behavior is the clamp of 0 to 1, which follows the existing `channels.max(1)` precedent in the router client and would be a trivial-function test.
- Ran locally against the persons database: the identity crate's in-source tests and its integration suites (delete, engine, merge, lifecycle service, service, storage), and clippy with warnings denied on both crates.
- Not run: `cargo shear`, which is not installed locally; no dependencies were added or removed.
- Not verified: the new series on a live cluster. Dashboard panels for them are a follow-up in the grafana-dashboards repo.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: no user-facing behavior changes; the env knobs are documented on the config struct.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5.1); session: https://claude.ai/code/session_01SCPZV5SzK8vJNY5b9RuPkt
- Skills invoked: `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`.
- CodeRabbit local pass: paused; the PR opened without one.
- Duplicate check not run: the `gh` CLI was unavailable in the session.
- Decisions along the way: the knobs began as builder methods with in-code defaults and moved to constructor parameters so the config is the only default; the branch was squashed to one commit after the comment-density hook flagged the first version, and every added comment was cut to one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)