### PR TITLE
fix(csp): allow data: URL fonts and drop an unused CDN origin

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -1326,7 +1326,12 @@ class CSPMiddleware:
                 # can. Session replay decompresses snapshots with snappy-wasm and the HogQL editor
                 # parses with a WebAssembly build, so both break without it.
                 f"script-src 'self' 'nonce-{nonce}' 'wasm-unsafe-eval' {resource_url} https://*.i.posthog.com",
-                f"font-src 'self' {resource_url} https://app-static.eu.posthog.com https://app-static-prod.posthog.com https://fonts.gstatic.com https://cdn.jsdelivr.net",
+                # A data: font cannot execute script, and this directive governs font loading only,
+                # so the token widens nothing else. It also carries nothing out: a data: URL makes
+                # no request, which is what the CSS-injection attacks on this directive need. The
+                # `data:` refusal in the worker-src note below is a different case, because a
+                # worker body is code.
+                f"font-src 'self' data: {resource_url} https://app-static.eu.posthog.com https://app-static-prod.posthog.com https://fonts.gstatic.com",
                 # `blob:` grants nothing to an attacker who cannot already run script, because only
                 # script can mint a blob URL, and a worker started from one inherits this policy
                 # rather than escaping it. The ServiceWorker spec rejects `blob:` on its own, so


### PR DESCRIPTION
## Problem

Under enforcement, text on app pages would drop to a fallback font. Pages we serve load fonts from `data:` URLs, and the app's `font-src` lists origins only, so each of those loads violates our own policy. The policy is report-only today, so the font still loads — about 360 sampled reports a day. The reports name our own bundles, inline styles on app pages, and posthog-js recording our app, with no single dominant source.

`https://cdn.jsdelivr.net` sits in the same directive and nothing loads a font from it.

## Changes

- `font-src` accepts `data:`. Nothing looks different today, because the policy is report-only.
- `font-src` drops `https://cdn.jsdelivr.net`.
- `data:` is the safe token in this directive. A font cannot execute, and a `data:` URL makes no request, so it carries nothing out. The CSS-injection attacks on `font-src`, including the unicode-range text oracle, all need a remote origin to receive the load.
- The CDN is the opposite trade, and removing it is the larger win here. An open CDN serves content anyone can publish at paths an attacker picks, which is both a wider font-parser surface and exactly the remote origin those attacks need.
- Mechanical: the comment above the directive is rewritten. It named a single cause for the `data:` fonts that the violation reports do not support.

## How did you test this code?

- No new tests. No test asserts the app's `font-src`, and `cdn.jsdelivr.net` appears in no other Python file.
- Not run: `TestCSPMiddleware` needs Postgres, which this sandbox does not have. CI covers it.
- The evidence that jsdelivr is unused is negative. No font under `frontend/src` loads from it, and the only references are a comment in `frontend/src/lib/monaco/monacoEnvironment.ts` and `posthog/templates/demo.html`, which pulls rrweb's CSS and JS and so needs `style-src` and `script-src` instead.
- Nothing is enforced, so a wrong removal surfaces as a report naming a PostHog source file rather than a broken page. That argument carried the earlier removal of three font origins in `chore(csp): remove unused font-src origins`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The policy is internal and report-only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 5). Skills invoked: `/writing-pr-descriptions`, `/writing-tests`, `/reviewing-with-coderabbit`.
- CodeRabbit CLI pass: paused, so this PR opened without a local pass.
- No duplicate: searched open PRs for `font-src` and CSP. #92074 proposes allowing the replay asset proxy in `font-src`, which is a different origin and a separate decision.
- Patch coverage: the changed line is a policy string that no test asserts, so the patch is uncovered by design. Adding an assertion would pin the exact directive text and fail on every future edit.
- The change began as the `data:` token alone. The CDN removal came after checking what actually loads fonts from it, and the code comment lost a causal claim about posthog-js that the violation reports do not support.
- Public artifact: nothing here draws on non-public material.
