### PR TITLE
fix(phai): animate the custom answer reveal in the option selector

### DIFF
--- a/products/posthog_ai/frontend/components/OptionSelector.stories.tsx
+++ b/products/posthog_ai/frontend/components/OptionSelector.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { OptionSelector } from './OptionSelector'
+
+const meta: Meta<typeof OptionSelector> = {
+    title: 'Products/PostHog AI/OptionSelector',
+    component: OptionSelector,
+    // The global `^on[A-Z].*` action inference would inject an `onSkip` handler, which keeps the footer open.
+    parameters: { actions: { argTypesRegex: null } },
+    args: {
+        options: [
+            { label: 'Product analytics', value: 'Product analytics', description: 'Track product metrics and KPIs' },
+            { label: 'Session replay', value: 'Session replay', description: 'Watch how people use the product' },
+            { label: 'Feature flags', value: 'Feature flags' },
+        ],
+        onSelect: () => {},
+        allowCustom: true,
+        customPlaceholder: 'Type your answer...',
+    },
+    decorators: [
+        (Story) => (
+            <div className="w-128 border rounded p-3">
+                <Story />
+            </div>
+        ),
+    ],
+}
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const CustomAnswerOpen: Story = {
+    args: { selectedValue: 'Something else', initialCustomValue: 'Something else' },
+}
+
+export const WithSkip: Story = {
+    args: { onSkip: () => {} },
+}
+
+export const NoDescriptions: Story = {
+    args: {
+        options: [
+            { label: 'Weekly', value: 'Weekly' },
+            { label: 'Monthly', value: 'Monthly' },
+            { label: 'Quarterly', value: 'Quarterly' },
+        ],
+    },
+}

--- a/products/posthog_ai/frontend/components/OptionSelector.tsx
+++ b/products/posthog_ai/frontend/components/OptionSelector.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 
 import { LemonButton, LemonInput, Spinner } from '@posthog/lemon-ui'
 
+import { CollapsiblePrimitive, CollapsiblePrimitiveContent } from 'lib/ui/Collapsible/lib/CollapsiblePrimitive'
 import { cn } from 'lib/utils/css-classes'
 
 export interface Option {
@@ -95,6 +96,11 @@ export function OptionSelector({
     }, [options, onSelect, allowCustom, disabled, loading, showCustomInput])
 
     const noDescriptions = options.every((o) => !o.description)
+    const footerOpen = !!onSkip || showCustomInput
+    // Without a skip button the submit button is the panel's only content. Base UI measures the closing
+    // height after React commits, so if the button unmounted in the same render the row would snap to
+    // its padding before it slides shut. Keep it mounted for as long as the panel is.
+    const showSubmit = showCustomInput || !onSkip
 
     const handleCustomSubmit = (): void => {
         if (!customInput.trim()) {
@@ -117,89 +123,99 @@ export function OptionSelector({
     }
 
     return (
-        <div
-            className={cn('flex flex-col gap-1.5', {
-                // When there are no descriptions, reduce the gap between options to 0.5
-                'gap-0.5': noDescriptions,
-            })}
-        >
-            <div className="flex flex-col gap-2 font-medium">
-                {options.map((o) => (
-                    <label
-                        key={o.value}
-                        className="grid items-center gap-x-2 grid-cols-[min-content_auto] text-sm cursor-pointer"
-                        onClick={(e) => {
-                            e.preventDefault()
-                            if (selectedValue === o.value) {
-                                onSelect(null)
-                            } else {
-                                setUserWantsCustomMode(false)
-                                onSelect(o.value)
-                            }
-                        }}
-                    >
+        <CollapsiblePrimitive open={footerOpen} className="flex flex-col">
+            <div
+                className={cn('flex flex-col gap-1.5', {
+                    // When there are no descriptions, reduce the gap between options to 0.5
+                    'gap-0.5': noDescriptions,
+                })}
+            >
+                <div className="flex flex-col gap-2 font-medium">
+                    {options.map((o) => (
+                        <label
+                            key={o.value}
+                            className="grid items-center gap-x-2 grid-cols-[min-content_auto] text-sm cursor-pointer"
+                            onClick={(e) => {
+                                e.preventDefault()
+                                if (selectedValue === o.value) {
+                                    onSelect(null)
+                                } else {
+                                    setUserWantsCustomMode(false)
+                                    onSelect(o.value)
+                                }
+                            }}
+                        >
+                            <input
+                                type="radio"
+                                className="cursor-pointer"
+                                checked={selectedValue === o.value && !showCustomInput}
+                                onChange={() => {}}
+                            />
+                            <span>{o.label}</span>
+                            {o.description && (
+                                <div className="text-secondary font-normal row-start-2 col-start-2 text-pretty text-xs">
+                                    {o.description}
+                                </div>
+                            )}
+                        </label>
+                    ))}
+                </div>
+
+                {allowCustom && (
+                    <label className="grid items-center gap-x-2 grid-cols-[min-content_auto] text-sm font-medium cursor-pointer">
                         <input
                             type="radio"
                             className="cursor-pointer"
-                            checked={selectedValue === o.value && !showCustomInput}
-                            onChange={() => {}}
+                            checked={showCustomInput}
+                            onChange={() => {
+                                setUserWantsCustomMode(true)
+                            }}
+                            value="custom"
                         />
-                        <span>{o.label}</span>
-                        {o.description && (
-                            <div className="text-secondary font-normal row-start-2 col-start-2 text-pretty text-xs">
-                                {o.description}
-                            </div>
+                        {showCustomInput ? (
+                            <LemonInput
+                                className="starting:opacity-0 opacity-100 transition-[opacity] duration-150 motion-reduce:transition-none"
+                                placeholder={customPlaceholder}
+                                fullWidth
+                                size="small"
+                                value={customInput}
+                                onChange={setCustomInput}
+                                onPressEnter={handleCustomSubmit}
+                                autoFocus={true}
+                            />
+                        ) : (
+                            <span className="my-1.5">Explain what you'd like instead.</span>
                         )}
                     </label>
-                ))}
+                )}
             </div>
-
-            {allowCustom && (
-                <label className="grid items-center gap-x-2 grid-cols-[min-content_auto] text-sm font-medium cursor-pointer">
-                    <input
-                        type="radio"
-                        className="cursor-pointer"
-                        checked={showCustomInput}
-                        onChange={() => {
-                            setUserWantsCustomMode(true)
-                        }}
-                        value="custom"
-                    />
-                    {showCustomInput ? (
-                        <LemonInput
-                            placeholder={customPlaceholder}
-                            fullWidth
-                            size="small"
-                            value={customInput}
-                            onChange={setCustomInput}
-                            onPressEnter={handleCustomSubmit}
-                            autoFocus={true}
-                        />
-                    ) : (
-                        <span className="my-1.5">Explain what you'd like instead.</span>
-                    )}
-                </label>
+            {(allowCustom || footerOpen) && (
+                <CollapsiblePrimitiveContent className="transition-[height,opacity] duration-150 ease-out opacity-100 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 motion-reduce:transition-none">
+                    <div
+                        className={cn('flex items-center justify-between gap-2 pt-3.5', {
+                            'pt-2.5': noDescriptions,
+                        })}
+                    >
+                        {onSkip && (
+                            <LemonButton type="secondary" size="small" onClick={onSkip}>
+                                Skip question
+                            </LemonButton>
+                        )}
+                        {showSubmit && (
+                            <div className="ml-auto starting:opacity-0 opacity-100 transition-[opacity] duration-150 motion-reduce:transition-none">
+                                <LemonButton
+                                    type="primary"
+                                    size="small"
+                                    disabledReason={!customInput.trim() ? 'Please type a response' : undefined}
+                                    onClick={handleCustomSubmit}
+                                >
+                                    {submitLabel}
+                                </LemonButton>
+                            </div>
+                        )}
+                    </div>
+                </CollapsiblePrimitiveContent>
             )}
-            {(onSkip || showCustomInput) && (
-                <div className="flex items-center justify-between gap-2 pt-2">
-                    {onSkip && (
-                        <LemonButton type="secondary" size="small" onClick={onSkip}>
-                            Skip question
-                        </LemonButton>
-                    )}
-                    {showCustomInput && (
-                        <LemonButton
-                            type="primary"
-                            size="small"
-                            disabledReason={!customInput.trim() ? 'Please type a response' : undefined}
-                            onClick={handleCustomSubmit}
-                            className="ml-auto"
-                        >
-                            {submitLabel}
-                        </LemonButton>
-                    )}
-                </div>
-            )}
-        </div>
+        </CollapsiblePrimitive>
     )
 }


### PR DESCRIPTION
## Problem

- Picking "Explain what you'd like instead." in a PostHog AI question pops the Next button row into place with no transition, so the thread above it jumps by about 45px.
- Every consumer of the shared `OptionSelector` that passes no skip handler hits this: the sandbox question prompt and the Max approval card.
- The footer row was rendered conditionally, so nothing existed for a transition to animate.

## Changes

- The footer now slides open and closed over 150ms, and the input and the Next button fade in.
- The panel is the same Base UI collapsible that `ActivityDisclosure` uses, so the surface keeps one motion style.
- Reduced-motion users get an instant change.
- Consumers that pass `onSkip` keep a permanently open footer and only see the Next button fade in, so the multi-question form does not move.
- The panel sits outside the gapped options column, so a collapsed footer adds no height. The open layout keeps the previous spacing below the input.
- The submit button stays mounted while the panel closes, because Base UI measures the closing height after React commits. Unmounting it in the same render would snap the row before it slides.
- A measured-height wrapper, the pattern the Max multi-question form uses, was rejected because the repo deprecates ResizeObserver-driven layout for snapshot flapping.
- Mechanical: a new `OptionSelector` story covers the collapsed, open, skip, and no-description variants.

Before, mid-transition, and after clicking the custom option:

![default-before](https://raw.githubusercontent.com/PostHog/pr-assets/efa81ff17aed50ea1cf6945b7cb642d917bb7056/2026/09/a92830f5-a9ad-4aee-af9e-36bc50665b3c.png)

![default-mid](https://raw.githubusercontent.com/PostHog/pr-assets/efd5a4177e0ba6efaea0c71dded9b644b1c1c115/2026/09/6bbab723-f1d9-43f8-a238-a02f833357fc.png)

![default-after](https://raw.githubusercontent.com/PostHog/pr-assets/996aac373a665325d2ed19ce4f08f5f190edadc1/2026/09/3818fe16-6bc5-4597-be68-d4d9c799a12f.png)

With a skip handler, the row keeps its height and only the Next button fades in:

![with-skip-after](https://raw.githubusercontent.com/PostHog/pr-assets/950987e9ad25e335eff4a6c4ff3662557a598a0a/2026/09/61751d59-309f-4a99-880e-1d1e5bbf47b5.png)

## How did you test this code?

- The existing Jest suites for `QuestionInput`, `QuestionField`, and `InputFormArea` pass unchanged. No Jest test was added because jsdom does not run CSS transitions.
- A Playwright script sampled the story's height on every frame in a local Storybook. Opening and closing each spread about 47px over 9 frames with no single-frame step above 15px. The `onSkip` variant kept a constant height. The row fit at 320px without clipping. Reduced motion changed in one frame.
- Not checked: the Max approval card in a running app. It renders the same component with no `onSkip`, so it takes the same path as the default story.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code with Claude Fable 5.1; session linked below.
- Skills invoked: /writing-ui-components, /writing-code-comments, /writing-pr-descriptions, /reviewing-with-coderabbit.
- The CodeRabbit pass is paused, so the PR opened without a local pass.
- A search of open PRs for this layout shift found nothing.
- Storybook's global `on*` action inference injected an `onSkip` handler into the new story and hid the collapse until the story meta disabled it.
- The screenshots come from the new synthetic story and contain no customer data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VikY7DdKNbLezJEBKTUr5Q
