### PR TITLE
chore: move hobby-installer to posthog-go/v2

### DIFF
--- a/bin/hobby-installer/core/telemetry.go
+++ b/bin/hobby-installer/core/telemetry.go
@@ -1,7 +1,7 @@
 package core
 
 import (
-	"github.com/posthog/posthog-go"
+	"github.com/posthog/posthog-go/v2"
 )
 
 const posthogAPIKey = "sTMFPsFhdP1Ssg"

--- a/bin/hobby-installer/go.mod
+++ b/bin/hobby-installer/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/charmbracelet/bubbles v0.20.0
 	github.com/charmbracelet/bubbletea v1.2.4
 	github.com/charmbracelet/lipgloss v1.0.0
-	github.com/posthog/posthog-go v1.25.1
+	github.com/posthog/posthog-go/v2 v2.0.0
 )
 
 require (


### PR DESCRIPTION
Moves `bin/hobby-installer` — the only consumer of posthog-go in this repo — to the `/v2` import path, ready for the posthog-go 2.0.0 release.

**Do not merge until posthog-go v2.0.0 is published.** Go cannot resolve `/v2` before the tag exists, so `go.sum` cannot be generated and CI will fail until then.

- Import and `go.mod` require move to `github.com/posthog/posthog-go/v2`.
- No code change — the installer uses only `Config{Endpoint}`, `Enqueue`, `Capture`, `NewProperties` and `Close`, none of which changed in 2.0.0.
- Install telemetry moves from `POST /batch/` to `POST /i/v1/analytics/events`; it posts to `us.i.posthog.com`, which serves that route.

Nothing is broken while this waits: the installer keeps building against v1.25.1, whose tags remain available. posthog-go's upgrade automation skips the bump across a major and explains why, rather than failing, so this PR is the tracked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
