### PR TITLE
fix(hogql): answer 400 when a query filters on a missing cohort

### DIFF
--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -1570,7 +1570,12 @@ def property_to_expr(
             raise Exception("Can not convert cohort property to expression without team")
         if not isinstance(property.value, (str, int)):
             raise ValidationError("Cohort property value must be a cohort ID")
-        cohort = Cohort.objects.get(team__project_id=team.project_id, id=property.value)
+        try:
+            cohort = Cohort.objects.get(team__project_id=team.project_id, id=property.value)
+        except Cohort.DoesNotExist:
+            # The id comes from the request, so a deleted or foreign cohort must read as
+            # bad input rather than escaping as an unhandled DoesNotExist.
+            raise QueryError(f"Cohort {property.value} does not exist")
         return ast.CompareOperation(
             left=ast.Field(chain=["id" if scope == "person" else "person_id"]),
             op=(

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -982,6 +982,10 @@ class TestProperty(BaseTest):
             self._parse_expr(f"person_id IN COHORT {cohort.pk}"),
         )
 
+    def test_cohort_filter_missing_cohort(self):
+        with self.assertRaisesMessage(QueryError, "Cohort 2137 does not exist"):
+            self._property_to_expr({"type": "cohort", "key": "id", "value": 2137}, self.team)
+
     def test_person_scope(self):
         self.assertEqual(
             self._property_to_expr(


### PR DESCRIPTION
## Problem

A query filtered on a cohort that no longer exists fails with a 500, rather than a 400 saying the cohort is gone.

- `property_to_expr` looks the cohort up with a bare `get()`.
- `Cohort.DoesNotExist` is not one of the exceptions the API maps, so it escapes unhandled.
- The legacy `trend` endpoint answered 400 here through its own `ObjectDoesNotExist` handler. [#97647](https://github.com/PostHog/posthog/pull/97647) removes that endpoint, which leaves `/query/` as the only path and the gap visible.

## Changes

- A query filtering on a missing cohort now answers 400 with `Cohort <id> does not exist`. `property_to_expr` raises `QueryError`, which `/query/` already turns into a 400.

## How did you test this code?

- Verified against a real database, by calling `property_to_expr` directly on a migrated test database: before the change `Cohort.DoesNotExist` escapes unhandled, after it raises `QueryError: Cohort 2137 does not exist`.
- Not run: the new test as a pytest case. This sandbox has no ClickHouse and cannot get one, and the session fixtures need it even for Postgres-only tests.
- New test `test_cohort_filter_missing_cohort` catches the 500. It sits in `posthog/hogql/test/test_property.py` beside the other cohort cases, which is where the behavior is decided and the cheapest level that catches it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. `docs/` carries nothing about cohort filter errors.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code. Skills invoked: `/writing-pr-descriptions`, `/merging-prs`. Opened without a local CodeRabbit pass, which is paused.

Split out of [#97647](https://github.com/PostHog/posthog/pull/97647), which carried this fix alongside the legacy endpoint removal. `posthog/hogql/**` belongs to @PostHog/hogql in CODEOWNERS, so these two files put a team review requirement on a PR that otherwise only deletes endpoints. Separating them lets each land on its own reviewers.

No duplicate: the only PR that held this fix is #97647, and the matching commit is removed from it in the same change.

Public artifact: no material from the session reaches the diff. Nothing carries a customer, team, or account identifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Filtering by a nonexistent or inaccessible cohort now returns a clear query error indicating that the cohort does not exist, instead of exposing an internal error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->