### PR TITLE
chore(urls): keep root routing declarative

### DIFF
--- a/docs/internal/url-routing.md
+++ b/docs/internal/url-routing.md
@@ -1,0 +1,25 @@
+# Root URL routing
+
+`posthog/urls.py` declares the ordered root `urlpatterns` and imports Django's `handler500` binding.
+View implementations live outside the URL configuration.
+
+- `posthog/frontend_views.py` renders the frontend and redirects visitors to their logged-in cloud region before the login check.
+- `posthog/api/integration_connect.py` starts integration connection flows.
+- `posthog/api/oauth/toolbar_views.py` handles toolbar and forum authorization redirects.
+- `posthog/views.py` owns the server-error and debug metrics views alongside the existing operational views.
+- `posthog/api/playwright_setup.py` owns test setup and the test-only event deletion view.
+- `posthog/ee_urls.py` loads optional Enterprise routes and extends the API router before its URLs are evaluated.
+
+Keep routing declarative and preserve precedence when adding an entry.
+The EU personal-spend override comes before the API router.
+The API fallback comes after API endpoints.
+GitHub and Slack identity callbacks come before the generic social-auth routes.
+Public frontend routes come before the authenticated catch-all, which stays last.
+
+The metrics endpoint is available only with `DEBUG`.
+Event deletion is available only with `TEST`.
+The Temporal codec endpoint is registered once when either setting is enabled.
+These conditions control registration, not only view behavior.
+
+Product DRF routes continue to register through `products/<product>/backend/routes.py`.
+Root-level product routes remain explicit in `posthog/urls.py`.

--- a/posthog/api/integration_connect.py
+++ b/posthog/api/integration_connect.py
@@ -1,0 +1,32 @@
+from urllib.parse import urlencode
+
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
+
+_CONNECT_REDIRECT_ALLOWED_KINDS = {"github", "slack", "linear"}
+# Surfaces allowed to start a connect flow and be returned to afterwards (see
+# posthog/api/github_callback/types.py APP_CONNECT_FROM_VALUES, plus Slack).
+_CONNECT_REDIRECT_ALLOWED_SURFACES = {"posthog_code", "posthog_mobile", "slack"}
+
+
+def integration_connect_redirect(request: HttpRequest, kind: str) -> HttpResponse:
+    """Login-gated entry point for starting an integration OAuth connect from an external surface
+    (a Slack message, the desktop app, etc.). Wrapped in ``login_required`` so unauthenticated users
+    are bounced to login and resume here, then redirected into the existing ``integrations/authorize``
+    flow with a ``connect_from``-tagged return page. ``next`` is constructed internally (never taken
+    from the query) so this can't be used as an open redirect."""
+    if kind not in _CONNECT_REDIRECT_ALLOWED_KINDS:
+        return HttpResponse("Unsupported integration kind", status=400)
+    connect_from = request.GET.get("connect_from", "")
+    if connect_from not in _CONNECT_REDIRECT_ALLOWED_SURFACES:
+        return HttpResponse("Unsupported connect_from", status=400)
+    project_id = request.GET.get("project_id") or getattr(request.user, "current_team_id", None)
+    if not project_id or not str(project_id).isdigit():
+        return HttpResponse("Missing or invalid project_id", status=400)
+
+    next_path = "/account-connected/{}-integration?{}".format(
+        kind, urlencode({"provider": kind, "project_id": project_id, "connect_from": connect_from})
+    )
+    authorize_url = "/api/projects/{}/integrations/authorize/?{}".format(
+        project_id, urlencode({"kind": kind, "next": next_path})
+    )
+    return HttpResponseRedirect(authorize_url)

--- a/posthog/api/oauth/toolbar_views.py
+++ b/posthog/api/oauth/toolbar_views.py
@@ -1,0 +1,73 @@
+from typing import cast
+from urllib.parse import urlencode, urlparse
+
+from django.conf import settings
+from django.http import HttpRequest, HttpResponse
+
+from posthog.api.utils import hostname_in_allowed_url_list
+from posthog.constants import PERMITTED_FORUM_DOMAINS
+from posthog.models import User
+from posthog.utils import render_template
+
+
+def authorize_and_redirect(request: HttpRequest) -> HttpResponse:
+    if not request.GET.get("redirect"):
+        return HttpResponse("You need to pass a url to ?redirect=", status=400)
+    if not request.headers.get("referer"):
+        return HttpResponse('You need to make a request that includes the "Referer" header.', status=400)
+
+    current_team = cast(User, request.user).team
+    referer_url = urlparse(request.headers["referer"])
+    redirect_url = urlparse(request.GET["redirect"])
+    is_forum_login = request.GET.get("forum_login", "").lower() == "true"
+
+    if (
+        not current_team
+        or (redirect_url.hostname not in PERMITTED_FORUM_DOMAINS and is_forum_login)
+        or (not is_forum_login and not hostname_in_allowed_url_list(current_team.app_urls, redirect_url.hostname))
+    ):
+        hostname = redirect_url.hostname or request.GET["redirect"]
+        return render_template(
+            "toolbar_oauth_error.html",
+            request,
+            context={
+                "error_title": "Domain not authorized",
+                "error_message": "The toolbar cannot authenticate on this domain because it is not in your project's authorized URLs.",
+                "error_detail": (
+                    f"The hostname {hostname} needs to be added to your project's "
+                    "authorized URLs before the toolbar can be used on this site."
+                ),
+                "error_code": "403",
+                "settings_url": f"{settings.SITE_URL}/settings/project-toolbar#authorized-urls",
+            },
+            status_code=403,
+        )
+
+    if referer_url.hostname != redirect_url.hostname:
+        return HttpResponse(
+            f"Can only redirect to the same domain as the referer: {referer_url.hostname}",
+            status=403,
+        )
+
+    if referer_url.scheme != redirect_url.scheme:
+        return HttpResponse(
+            f"Can only redirect to the same scheme as the referer: {referer_url.scheme}",
+            status=403,
+        )
+
+    if referer_url.port != redirect_url.port:
+        return HttpResponse(
+            f"Can only redirect to the same port as the referer: {referer_url.port or 'no port in URL'}",
+            status=403,
+        )
+
+    return render_template(
+        "authorize_and_link.html" if is_forum_login else "authorize_and_redirect.html",
+        request=request,
+        context={
+            "email": request.user,
+            "domain": redirect_url.hostname,
+            "redirect_url": request.GET["redirect"],
+            "authorization_url": f"/api/user/redirect_to_site/?{urlencode({'appUrl': request.GET['redirect']})}",
+        },
+    )

--- a/posthog/api/playwright_setup.py
+++ b/posthog/api/playwright_setup.py
@@ -1,7 +1,8 @@
 """Test setup API endpoint for Playwright tests."""
 
 from django.conf import settings
-from django.http import Http404
+from django.http import Http404, HttpRequest, HttpResponse
+from django.views.decorators.csrf import csrf_exempt
 
 from pydantic import BaseModel
 from rest_framework import status
@@ -47,3 +48,14 @@ def setup_test(request: Request, test_name: str) -> Response:
             {"error": f"Failed to run playwright setup '{test_name}': {str(e)}", "test_name": test_name},
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
+
+
+@csrf_exempt
+def delete_events(request: HttpRequest) -> HttpResponse:
+    from posthog.clickhouse.client import sync_execute  # noqa: PLC0415 - keep test-only ClickHouse imports deferred
+    from posthog.models.event.sql import (
+        TRUNCATE_EVENTS_TABLE_SQL,  # noqa: PLC0415 - keep test-only ClickHouse imports deferred
+    )
+
+    sync_execute(TRUNCATE_EVENTS_TABLE_SQL())
+    return HttpResponse()

--- a/posthog/ee_urls.py
+++ b/posthog/ee_urls.py
@@ -1,0 +1,16 @@
+from django.conf import settings
+from django.urls import URLPattern, URLResolver
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+ee_urlpatterns: list[URLPattern | URLResolver] = []
+try:
+    from ee import urls
+except ImportError:
+    if settings.DEBUG:
+        logger.warning("Could not import ee.urls", exc_info=True)
+else:
+    ee_urlpatterns = urls.urlpatterns
+    urls.extend_api_router()

--- a/posthog/frontend_views.py
+++ b/posthog/frontend_views.py
@@ -1,0 +1,83 @@
+from typing import Any
+from urllib.parse import urlparse
+
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
+from django.utils.http import url_has_allowed_host_and_scheme
+from django.views.decorators.csrf import ensure_csrf_cookie
+
+from posthog.models.instance_setting import get_instance_setting
+from posthog.utils import render_template
+from posthog.views import login_required
+
+APP_POSTHOG_HOST = "app.posthog.com"
+# Canonical per-region hosts a `ph_current_instance` cookie is allowed to resolve to.
+# Restricting to this set keeps the cookie from being turned into an open redirect.
+_REGION_HOSTS = {"us.posthog.com", "eu.posthog.com"}
+
+
+def region_host_from_current_instance(cookie_value: str | None) -> str | None:
+    """Map a `ph_current_instance` cookie (an instance SITE_URL) to its canonical region
+    host, or None when it isn't a recognized cloud region. Mirrors the frontend
+    `cleanedCookieSubdomain` in RedirectToLoggedInInstance.tsx — the value is sometimes
+    wrapped in quotes by the cookie serializer, so strip those before parsing."""
+    if not cookie_value:
+        return None
+    hostname = urlparse(cookie_value.replace('"', "")).hostname
+    return hostname if hostname in _REGION_HOSTS else None
+
+
+def app_region_redirect(request: HttpRequest) -> HttpResponseRedirect | None:
+    """For `app.posthog.com` page loads, send the browser to the region the user is
+    actually logged into (per the `ph_current_instance` cookie), preserving the path and
+    query. Falls back to the `REDIRECT_APP_TO_US` instance setting when there's no region
+    cookie. Returns None when no redirect applies so callers render normally.
+
+    This has to run before the `login_required` auth gate: `app.posthog.com` is the US
+    backend, so an EU user hitting a deep link like /organization/billing is otherwise
+    bounced to /login on US first, and only the login page honors the cookie."""
+    if request.method not in ("GET", "HEAD"):
+        return None
+    if request.get_host().split(":")[0] != APP_POSTHOG_HOST:
+        return None
+
+    target_host = region_host_from_current_instance(request.COOKIES.get("ph_current_instance"))
+    if target_host is None and get_instance_setting("REDIRECT_APP_TO_US"):
+        target_host = "us.posthog.com"
+    if target_host is None:
+        return None
+
+    url = "https://{}{}".format(target_host, request.get_full_path())
+    if url_has_allowed_host_and_scheme(url, target_host, True):
+        return HttpResponseRedirect(url)
+    return None
+
+
+@ensure_csrf_cookie
+def _render_home(request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
+    return render_template("index.html", request)
+
+
+# Wrapped once at import time (as `login_required(home)` used to be) so the catch-all
+# authenticated route doesn't rebuild the wrapper on every request.
+_login_required_render_home = login_required(_render_home)
+
+
+def home(request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
+    """Entrypoint for the unauthenticated frontend routes (login, signup, …). Runs the
+    cross-region redirect before rendering so `app.posthog.com` visitors land on their
+    logged-in region (see `app_region_redirect`)."""
+    region_redirect = app_region_redirect(request)
+    if region_redirect is not None:
+        return region_redirect
+    return _render_home(request, *args, **kwargs)
+
+
+def home_with_region_redirect(request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
+    """Catch-all entrypoint for authenticated frontend routes. The cross-region redirect
+    runs before `login_required` so `app.posthog.com` deep links reach the right region
+    without a detour through the login page (see `app_region_redirect`). It wraps
+    `_render_home` rather than `home` so the redirect check runs exactly once per request."""
+    region_redirect = app_region_redirect(request)
+    if region_redirect is not None:
+        return region_redirect
+    return _login_required_render_home(request, *args, **kwargs)

--- a/posthog/test/test_urls.py
+++ b/posthog/test/test_urls.py
@@ -1,15 +1,25 @@
 import uuid
+import importlib.util
+from itertools import product
+from pathlib import Path
 
 from posthog.test.base import APIBaseTest
 
 from django.test import RequestFactory, SimpleTestCase, override_settings
-from django.urls import resolve
+from django.urls import URLResolver, resolve
+from django.urls.resolvers import RegexPattern
 
 from parameterized import parameterized
 from rest_framework import status
 
+from posthog import urls
+from posthog.api.playwright_setup import delete_events
+from posthog.frontend_views import home, home_with_region_redirect, region_host_from_current_instance
 from posthog.models.instance_setting import override_instance_config
-from posthog.urls import region_host_from_current_instance
+from posthog.temporal.codec_server import decode_payloads
+from posthog.views import handler500, metrics_view
+
+from products.ai_observability.backend.api.personal_spend import PersonalSpendEUProxyViewSet
 
 
 class TestUrls(APIBaseTest):
@@ -250,3 +260,27 @@ class TestLegacyDuckgresAdminUrls(SimpleTestCase):
 
         assert response.status_code == 302
         assert response["Location"] == expected_location
+
+
+class TestConditionalRoutes(SimpleTestCase):
+    @parameterized.expand(list(product([False, True], [False, True], ["US", "EU"])))
+    def test_route_gates_and_precedence(self, debug: bool, test: bool, region: str) -> None:
+        with override_settings(DEBUG=debug, TEST=test, CLOUD_DEPLOYMENT=region):
+            spec = importlib.util.spec_from_file_location("posthog._test_urls", Path(urls.__file__))
+            assert spec is not None and spec.loader is not None
+            urlconf = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(urlconf)
+        patterns = urlconf.urlpatterns
+        resolver = URLResolver(RegexPattern(r"^/"), patterns)
+        self.assertIs(resolver.resolve("/_metrics").func, metrics_view if debug else home_with_region_redirect)
+        self.assertIs(resolver.resolve("/delete_events/").func, delete_events if test else home_with_region_redirect)
+        self.assertIs(resolver.resolve("/decode").func, decode_payloads if debug or test else home_with_region_redirect)
+        self.assertEqual(
+            sum(pattern.name == "temporal_decode" for pattern in patterns if hasattr(pattern, "name")),
+            int(debug or test),
+        )
+        spend = resolver.resolve("/api/llm_analytics/@me/spend/")
+        self.assertEqual(getattr(spend.func, "cls", None) is PersonalSpendEUProxyViewSet, region == "EU")
+        self.assertIs(resolver.resolve("/login").func, home)
+        self.assertIs(resolver.resolve("/events").func, home_with_region_redirect)
+        self.assertIs(urlconf.handler500, handler500)

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -1,17 +1,9 @@
-from typing import Any, cast
-from urllib.parse import urlencode, urlparse
-
 from django.conf import settings
-from django.http import HttpRequest, HttpResponse, HttpResponseRedirect, HttpResponseServerError
-from django.template import loader
 from django.urls import include, path, re_path
-from django.utils.http import url_has_allowed_host_and_scheme
-from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie, requires_csrf_token
+from django.views.decorators.csrf import csrf_exempt
 from django.views.generic.base import RedirectView
 
-import structlog
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
-from prometheus_client import CollectorRegistry, generate_latest, multiprocess
 from two_factor.urls import urlpatterns as tf_urls
 
 from posthog.api import (
@@ -32,17 +24,17 @@ from posthog.api import (
 )
 from posthog.api.github_callback.views import github_oauth_callback, github_setup_callback
 from posthog.api.github_webhooks.views import github_webhook
+from posthog.api.integration_connect import integration_connect_redirect
 from posthog.api.oauth.connected_apps import ConnectedAppsViewSet
 from posthog.api.oauth.hogli_metadata import HOGLI_METADATA_PATH, HogliClientMetadataView
 from posthog.api.oauth.raycast_metadata import RAYCAST_METADATA_PATH, RaycastClientMetadataView
+from posthog.api.oauth.toolbar_views import authorize_and_redirect
 from posthog.api.oauth.wizard_metadata import WIZARD_METADATA_PATH, WizardClientMetadataView
 from posthog.api.sdk_health import sdk_health
 from posthog.api.two_factor_qrcode import CacheAwareQRGeneratorView
-from posthog.api.utils import hostname_in_allowed_url_list
 from posthog.api.web_experiment import web_experiments
-from posthog.constants import PERMITTED_FORUM_DOMAINS
-from posthog.models import User
-from posthog.models.instance_setting import get_instance_setting
+from posthog.ee_urls import ee_urlpatterns
+from posthog.frontend_views import home, home_with_region_redirect
 from posthog.oauth2_urls import urlpatterns as oauth2_urls
 from posthog.temporal.codec_server import decode_payloads
 from posthog.web_bot_auth import http_message_signatures_directory
@@ -90,10 +82,12 @@ from products.warehouse_sources.backend.presentation.views.public_source_configs
 from products.workflows.backend.api import hog_flow, hog_flow_template
 from products.workflows.backend.api.ses_events_webhook import ses_tenant_events_webhook
 
-from .utils import opt_slash_path, render_template
+from .utils import opt_slash_path
 from .views import (
+    handler500 as handler500,
     health,
     login_required,
+    metrics_view,
     preferences_page,
     preflight_check,
     render_query,
@@ -104,202 +98,19 @@ from .views import (
     update_preferences,
 )
 
-logger = structlog.get_logger(__name__)
-
-ee_urlpatterns: list[Any] = []
-try:
-    from ee.urls import (
-        extend_api_router,
-        urlpatterns as ee_urlpatterns,
-    )
-except ImportError:
-    if settings.DEBUG:
-        logger.warn(f"Could not import ee.urls", exc_info=True)
-    pass
-else:
-    extend_api_router()
-
-
-@requires_csrf_token
-def handler500(request):
-    """
-    500 error handler.
-
-    Templates: :template:`500.html`
-    Context: request
-    """
-    template = loader.get_template("500.html")
-    return HttpResponseServerError(template.render({"request": request}, request))
-
-
-APP_POSTHOG_HOST = "app.posthog.com"
-# Canonical per-region hosts a `ph_current_instance` cookie is allowed to resolve to.
-# Restricting to this set keeps the cookie from being turned into an open redirect.
-_REGION_HOSTS = {"us.posthog.com", "eu.posthog.com"}
-
-
-def region_host_from_current_instance(cookie_value: str | None) -> str | None:
-    """Map a `ph_current_instance` cookie (an instance SITE_URL) to its canonical region
-    host, or None when it isn't a recognized cloud region. Mirrors the frontend
-    `cleanedCookieSubdomain` in RedirectToLoggedInInstance.tsx — the value is sometimes
-    wrapped in quotes by the cookie serializer, so strip those before parsing."""
-    if not cookie_value:
-        return None
-    hostname = urlparse(cookie_value.replace('"', "")).hostname
-    return hostname if hostname in _REGION_HOSTS else None
-
-
-def app_region_redirect(request: HttpRequest) -> HttpResponseRedirect | None:
-    """For `app.posthog.com` page loads, send the browser to the region the user is
-    actually logged into (per the `ph_current_instance` cookie), preserving the path and
-    query. Falls back to the `REDIRECT_APP_TO_US` instance setting when there's no region
-    cookie. Returns None when no redirect applies so callers render normally.
-
-    This has to run before the `login_required` auth gate: `app.posthog.com` is the US
-    backend, so an EU user hitting a deep link like /organization/billing is otherwise
-    bounced to /login on US first, and only the login page honors the cookie."""
-    if request.method not in ("GET", "HEAD"):
-        return None
-    if request.get_host().split(":")[0] != APP_POSTHOG_HOST:
-        return None
-
-    target_host = region_host_from_current_instance(request.COOKIES.get("ph_current_instance"))
-    if target_host is None and get_instance_setting("REDIRECT_APP_TO_US"):
-        target_host = "us.posthog.com"
-    if target_host is None:
-        return None
-
-    url = "https://{}{}".format(target_host, request.get_full_path())
-    if url_has_allowed_host_and_scheme(url, target_host, True):
-        return HttpResponseRedirect(url)
-    return None
-
-
-@ensure_csrf_cookie
-def _render_home(request, *args, **kwargs):
-    return render_template("index.html", request)
-
-
-# Wrapped once at import time (as `login_required(home)` used to be) so the catch-all
-# authenticated route doesn't rebuild the wrapper on every request.
-_login_required_render_home = login_required(_render_home)
-
-
-def home(request, *args, **kwargs):
-    """Entrypoint for the unauthenticated frontend routes (login, signup, …). Runs the
-    cross-region redirect before rendering so `app.posthog.com` visitors land on their
-    logged-in region (see `app_region_redirect`)."""
-    region_redirect = app_region_redirect(request)
-    if region_redirect is not None:
-        return region_redirect
-    return _render_home(request, *args, **kwargs)
-
-
-def home_with_region_redirect(request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
-    """Catch-all entrypoint for authenticated frontend routes. The cross-region redirect
-    runs before `login_required` so `app.posthog.com` deep links reach the right region
-    without a detour through the login page (see `app_region_redirect`). It wraps
-    `_render_home` rather than `home` so the redirect check runs exactly once per request."""
-    region_redirect = app_region_redirect(request)
-    if region_redirect is not None:
-        return region_redirect
-    return _login_required_render_home(request, *args, **kwargs)
-
-
-_CONNECT_REDIRECT_ALLOWED_KINDS = {"github", "slack", "linear"}
-# Surfaces allowed to start a connect flow and be returned to afterwards (see
-# posthog/api/github_callback/types.py APP_CONNECT_FROM_VALUES, plus Slack).
-_CONNECT_REDIRECT_ALLOWED_SURFACES = {"posthog_code", "posthog_mobile", "slack"}
-
-
-def integration_connect_redirect(request: HttpRequest, kind: str) -> HttpResponse:
-    """Login-gated entry point for starting an integration OAuth connect from an external surface
-    (a Slack message, the desktop app, etc.). Wrapped in ``login_required`` so unauthenticated users
-    are bounced to login and resume here, then redirected into the existing ``integrations/authorize``
-    flow with a ``connect_from``-tagged return page. ``next`` is constructed internally (never taken
-    from the query) so this can't be used as an open redirect."""
-    if kind not in _CONNECT_REDIRECT_ALLOWED_KINDS:
-        return HttpResponse("Unsupported integration kind", status=400)
-    connect_from = request.GET.get("connect_from", "")
-    if connect_from not in _CONNECT_REDIRECT_ALLOWED_SURFACES:
-        return HttpResponse("Unsupported connect_from", status=400)
-    project_id = request.GET.get("project_id") or getattr(request.user, "current_team_id", None)
-    if not project_id or not str(project_id).isdigit():
-        return HttpResponse("Missing or invalid project_id", status=400)
-
-    next_path = "/account-connected/{}-integration?{}".format(
-        kind, urlencode({"provider": kind, "project_id": project_id, "connect_from": connect_from})
-    )
-    authorize_url = "/api/projects/{}/integrations/authorize/?{}".format(
-        project_id, urlencode({"kind": kind, "next": next_path})
-    )
-    return HttpResponseRedirect(authorize_url)
-
-
-def authorize_and_redirect(request: HttpRequest) -> HttpResponse:
-    if not request.GET.get("redirect"):
-        return HttpResponse("You need to pass a url to ?redirect=", status=400)
-    if not request.headers.get("referer"):
-        return HttpResponse('You need to make a request that includes the "Referer" header.', status=400)
-
-    current_team = cast(User, request.user).team
-    referer_url = urlparse(request.headers["referer"])
-    redirect_url = urlparse(request.GET["redirect"])
-    is_forum_login = request.GET.get("forum_login", "").lower() == "true"
-
-    if (
-        not current_team
-        or (redirect_url.hostname not in PERMITTED_FORUM_DOMAINS and is_forum_login)
-        or (not is_forum_login and not hostname_in_allowed_url_list(current_team.app_urls, redirect_url.hostname))
-    ):
-        hostname = redirect_url.hostname or request.GET["redirect"]
-        return render_template(
-            "toolbar_oauth_error.html",
-            request,
-            context={
-                "error_title": "Domain not authorized",
-                "error_message": "The toolbar cannot authenticate on this domain because it is not in your project's authorized URLs.",
-                "error_detail": (
-                    f"The hostname {hostname} needs to be added to your project's "
-                    "authorized URLs before the toolbar can be used on this site."
-                ),
-                "error_code": "403",
-                "settings_url": f"{settings.SITE_URL}/settings/project-toolbar#authorized-urls",
-            },
-            status_code=403,
-        )
-
-    if referer_url.hostname != redirect_url.hostname:
-        return HttpResponse(
-            f"Can only redirect to the same domain as the referer: {referer_url.hostname}",
-            status=403,
-        )
-
-    if referer_url.scheme != redirect_url.scheme:
-        return HttpResponse(
-            f"Can only redirect to the same scheme as the referer: {referer_url.scheme}",
-            status=403,
-        )
-
-    if referer_url.port != redirect_url.port:
-        return HttpResponse(
-            f"Can only redirect to the same port as the referer: {referer_url.port or 'no port in URL'}",
-            status=403,
-        )
-
-    return render_template(
-        "authorize_and_link.html" if is_forum_login else "authorize_and_redirect.html",
-        request=request,
-        context={
-            "email": request.user,
-            "domain": redirect_url.hostname,
-            "redirect_url": request.GET["redirect"],
-            "authorization_url": f"/api/user/redirect_to_site/?{urlencode({'appUrl': request.GET['redirect']})}",
-        },
-    )
-
-
 urlpatterns = [
+    # EU spend must precede both the API router and the API fallback.
+    *(
+        [
+            path(
+                "api/llm_analytics/@me/spend/",
+                PersonalSpendEUProxyViewSet.as_view({"get": "list"}),
+                name="personal_spend_eu",
+            )
+        ]
+        if settings.CLOUD_DEPLOYMENT == "EU"
+        else []
+    ),
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
     # Optional UI:
     path(
@@ -557,97 +368,36 @@ urlpatterns = [
     # Message preferences
     path("messaging-preferences/<str:token>/", preferences_page, name="message_preferences"),
     opt_slash_path("messaging-preferences/update", update_preferences, name="message_preferences_update"),
-]
-
-# Personal LLM spend data only lives in PostHog Cloud US — EU forwards its product
-# LLM telemetry over — so the EU view proxies the query to US server-side. Must be
-# inserted *before* the `^api.+` catch-all above; otherwise the catch-all matches
-# first and the view is unreachable.
-if settings.CLOUD_DEPLOYMENT == "EU":
-    urlpatterns.insert(
-        0,
-        path(
-            "api/llm_analytics/@me/spend/",
-            PersonalSpendEUProxyViewSet.as_view({"get": "list"}),
-            name="personal_spend_eu",
-        ),
-    )
-
-if settings.DEBUG:
-    # If we have DEBUG=1 set, then let's expose the metrics for debugging. Note
-    # that in production we expose these metrics on a separate port (8001), to ensure
-    # external clients cannot see them. See bin/granian_metrics.py for details on the
-    # production metrics setup.
-
-    # Use multiprocess mode to collect metrics from all processes (Django + Celery workers)
-    import os
-
-    def metrics_view(request):
-        """Metrics endpoint that aggregates from all processes using multiprocess mode."""
-        registry = CollectorRegistry()
-        # If prometheus_multiproc_dir is set, collect from all processes
-        if "prometheus_multiproc_dir" in os.environ or "PROMETHEUS_MULTIPROC_DIR" in os.environ:
-            multiprocess.MultiProcessCollector(registry)
-        else:
-            # Fallback to default registry if multiprocess not configured
-            from prometheus_client import REGISTRY
-
-            registry = REGISTRY
-
-        metrics_output = generate_latest(registry)
-        return HttpResponse(metrics_output, content_type="text/plain; charset=utf-8; version=0.0.4")
-
-    urlpatterns.append(path("_metrics", metrics_view))
-    # Temporal codec server endpoint for UI decryption - locally only for now
-    urlpatterns.append(path("decode", decode_payloads, name="temporal_decode"))
-
-
-if settings.TEST:
-    # Used in posthog-js e2e tests
-    @csrf_exempt
-    def delete_events(request):
-        from posthog.clickhouse.client import sync_execute
-        from posthog.models.event.sql import TRUNCATE_EVENTS_TABLE_SQL
-
-        sync_execute(TRUNCATE_EVENTS_TABLE_SQL())
-        return HttpResponse()
-
-    urlpatterns.append(path("delete_events/", delete_events))
-    # Temporal codec server endpoint for UI decryption - needed for tests (if not added already in DEBUG)
-    if not settings.DEBUG:
-        urlpatterns.append(path("decode", decode_payloads, name="temporal_decode"))
-
-
-# Redirect the legacy `/sign-up` path to the canonical `/signup` route. Works across
-# app./us./eu. subdomains because only the path changes; the host is preserved by the
-# relative redirect.
-urlpatterns.append(
-    re_path(r"^canvas-artifacts/(?P<token>[^/]+)/(?P<artifact_path>.+)$", canvas_artifact, name="canvas-artifact")
-)
-urlpatterns.append(
+    # In production metrics use a separate port (8001), so external clients cannot
+    # see them. See bin/granian_metrics.py for the production metrics setup.
+    *(
+        [path("_metrics", metrics_view), path("decode", decode_payloads, name="temporal_decode")]
+        if settings.DEBUG
+        else []
+    ),
+    # Used in posthog-js e2e tests.
+    *([path("delete_events/", playwright_setup.delete_events)] if settings.TEST else []),
+    # Temporal UI decryption is needed in tests even when DEBUG is off.
+    *([path("decode", decode_payloads, name="temporal_decode")] if settings.TEST and not settings.DEBUG else []),
+    re_path(r"^canvas-artifacts/(?P<token>[^/]+)/(?P<artifact_path>.+)$", canvas_artifact, name="canvas-artifact"),
+    # Preserve the host and query when redirecting the legacy signup URL.
     opt_slash_path("sign-up", RedirectView.as_view(url="/signup", permanent=True, query_string=True)),
-)
-
-# Routes added individually to remove login requirement
-frontend_unauthenticated_routes = [
-    "preflight",
-    "signup",
-    r"signup\/[A-Za-z0-9\-]*",
-    "reset",
-    "organization/billing/subscribed",
-    "organization/confirm-creation",
-    "login",
-    "unsubscribe",
+    # Public frontend routes must precede the authenticated catch-all.
+    re_path("preflight", home),
+    re_path("signup", home),
+    re_path(r"signup\/[A-Za-z0-9\-]*", home),
+    re_path("reset", home),
+    re_path("organization/billing/subscribed", home),
+    re_path("organization/confirm-creation", home),
+    re_path("login", home),
+    re_path("unsubscribe", home),
     # Public bridges for desktop-app share links — deep-link into PostHog Desktop.
-    r"code/canvas/[^/]+/[^/]+",
-    r"code/task/[^/]+",
-    "verify_email",
-    r"agentic/account-mismatch",
+    re_path(r"code/canvas/[^/]+/[^/]+", home),
+    re_path(r"code/task/[^/]+", home),
+    re_path("verify_email", home),
+    re_path(r"agentic/account-mismatch", home),
     # OAuth redirect target when logging the local frontend into a remote cloud region;
     # the SPA handles the code→token exchange client-side, so it must load without auth.
-    r"^oauth/callback",
+    re_path(r"^oauth/callback", home),
+    re_path(r"^.*", home_with_region_redirect),
 ]
-for route in frontend_unauthenticated_routes:
-    urlpatterns.append(re_path(route, home))
-
-urlpatterns.append(re_path(r"^.*", home_with_region_redirect))

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -15,15 +15,17 @@ from django.contrib.auth.decorators import login_required as base_login_required
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.db.migrations.executor import MigrationExecutor
 from django.db.models import Q
-from django.http import HttpRequest, HttpResponse, HttpResponseNotAllowed, JsonResponse
+from django.http import HttpRequest, HttpResponse, HttpResponseNotAllowed, HttpResponseServerError, JsonResponse
 from django.shortcuts import redirect, render
+from django.template import loader
 from django.views.decorators.cache import never_cache
 from django.views.decorators.clickjacking import xframe_options_exempt
-from django.views.decorators.csrf import csrf_exempt, csrf_protect
+from django.views.decorators.csrf import csrf_exempt, csrf_protect, requires_csrf_token
 from django.views.decorators.http import require_http_methods
 
 import structlog
 from opentelemetry import trace
+from prometheus_client import REGISTRY, CollectorRegistry, generate_latest, multiprocess
 
 from posthog.api.capture import capture_internal
 from posthog.api.secret_revocation import NON_PERSONAL_SECRET_PREFIXES
@@ -801,3 +803,29 @@ def replay_player_frame(request: HttpRequest) -> HttpResponse:
     policy instead of the app's. CSPMiddleware supplies that policy.
     """
     return render(request, "replay_player_frame/index.html")
+
+
+@requires_csrf_token
+def handler500(request: HttpRequest) -> HttpResponse:
+    """
+    500 error handler.
+
+    Templates: :template:`500.html`
+    Context: request
+    """
+    template = loader.get_template("500.html")
+    return HttpResponseServerError(template.render({"request": request}, request))
+
+
+def metrics_view(request: HttpRequest) -> HttpResponse:
+    """Metrics endpoint that aggregates from all processes using multiprocess mode."""
+    registry = CollectorRegistry()
+    # If prometheus_multiproc_dir is set, collect from all processes
+    if "prometheus_multiproc_dir" in os.environ or "PROMETHEUS_MULTIPROC_DIR" in os.environ:
+        multiprocess.MultiProcessCollector(registry)
+    else:
+        # Fallback to default registry if multiprocess not configured
+        registry = REGISTRY
+
+    metrics_output = generate_latest(registry)
+    return HttpResponse(metrics_output, content_type="text/plain; charset=utf-8; version=0.0.4")


### PR DESCRIPTION
## Problem

Contributors must read request handling and initialization code to understand the root route order.

This follows #99479, which extracts the GitHub webhook handler.

Closes #99553

## Changes

- The root URL configuration now contains imports and one ordered route list, including Django's imported error-handler binding.
- Frontend rendering, integration connection, and toolbar authorization move into modules named for those responsibilities.
- Existing operational and test view modules receive the metrics, server-error, and event-deletion views.
- A small Enterprise adapter preserves optional loading and router registration before URL evaluation.
- Conditional entries replace route-list mutations while preserving paths, names, precedence, and DEBUG/TEST/EU gates.

The view moves preserve behavior. No visible UI changes.

Before:

```mermaid
flowchart LR
    A[Root URL configuration] --> B[Inline request handlers]
    A --> C[Imported views]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    class A phYellow;
    class B,C phBlue;
```

After:

```mermaid
flowchart LR
    A[Root route list] --> B[Frontend and authorization views]
    A --> C[Operational, test, and product views]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    class A phYellow;
    class B,C phBlue;
```

## How did you test this code?

- Existing URL, API routing, toolbar, and startup-import tests exercise redirects and lazy initialization.
- New settings-matrix tests catch exposed development endpoints, duplicate codec routes, and an EU override hidden behind the API router.
- Local validation includes repository-wide mypy, preflight, and a before/after comparison in 12 fresh-process configurations and 23 isolated request cases.
- Live cloud redirects were not tested. CI patch coverage remains pending.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Added [root URL routing guidance](https://github.com/PostHog/posthog/blob/chore/declarative-root-urlconf/docs/internal/url-routing.md).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

Codex implemented the refactor using Git, GitHub CLI, gh stack, Flox, hogli, and Semgrep.
The open-PR search found no equivalent root URL extraction.
CodeRabbit's local pass is paused; this PR opens without one.
The change uses repository code and no private session material.

Skills invoked: splitting-oversized-modules, stacking-prs, writing-tests, improving-drf-endpoints, writing-user-facing-copy, running-ci-preflight, writing-pr-descriptions, and ponytail.
