### PR TITLE
chore(nodejs): skip oxlint error on ignored files

### DIFF
--- a/hogli.yaml
+++ b/hogli.yaml
@@ -828,7 +828,7 @@ quality:
         description: Format JavaScript/TypeScript files (frontend)
     format:nodejs:
         cmd: pnpm --dir nodejs exec eslint --fix "$@" && pnpm --dir nodejs exec oxlint -c .oxlintrc.nodejs.json
-            --fix "$@" && pnpm --dir nodejs exec prettier --write "$@"
+            --fix --no-error-on-unmatched-pattern "$@" && pnpm --dir nodejs exec prettier --write "$@"
         description: Format nodejs JavaScript files
     format:rust:
         cmd: rustfmt


### PR DESCRIPTION
## Problem

- Developers cannot commit changes that touch only oxlint-ignored nodejs files, such as `.mjs` scripts or `nodejs/bin/`.
- The pre-commit hook fails with "No files found to lint".
- [Migrate nodejs linting to Oxlint](https://github.com/PostHog/posthog/pull/99329) added oxlint to that hook.
- Oxlint exits 1 when its ignore patterns remove every staged path.

## Changes

- `format:nodejs` passes `--no-error-on-unmatched-pattern` to oxlint, so these commits pass again.
- Oxlint [documents the flag](https://oxc.rs/docs/guide/usage/linter/cli) for this case.
- `format:js` [already passes it](https://github.com/PostHog/posthog/blob/468e40efa4868ff3ce62d2f97babb300fff9a8dd/hogli.yaml#L825-L828) to oxlint and oxfmt.
- A narrower lint-staged glob would duplicate the ignore list and skip prettier on `.mjs` files.

## How did you test this code?

`pnpm exec lint-staged --no-stash` in a local worktree, with probe files staged:

| Staged files | Hook result |
| --- | --- |
| Ignored `.mjs` only, before the fix | Fails: "No files found to lint" |
| Ignored `.mjs` only, after the fix | Passes |
| Ignored `.mjs` and a clean `.ts` | Passes |
| A `.ts` with a floating promise | Fails on `typescript(no-floating-promises)` |

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code wrote this fix after an audit of the Oxlint migration found the hook failure.
- Skills: `/debugging-ci-failures`, `/writing-pr-descriptions`, `/reviewing-with-coderabbit`.
- The CodeRabbit pass is paused, so the PR opened without a local pass.
- Duplicate search found no open PR for this.
- The audit found no other breakage, and [the merge commit's checks](https://github.com/PostHog/posthog/commit/7b722918d7cb00146ef0d4bb75e8b687cd1d509d) show no failures.

https://claude.ai/code/session_017C58vJciB92g1S48oixScw
