### PR TITLE
fix(warehouse-sources): skip invalid kernel rows

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/kernel/kernel.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/kernel/kernel.py
@@ -48,7 +48,7 @@ def _build_url(path: str, params: dict[str, Any]) -> str:
     return f"{KERNEL_BASE_URL}{path}?{query}" if query else f"{KERNEL_BASE_URL}{path}"
 
 
-def _extract_items(body: Any) -> list[dict[str, Any]]:
+def _extract_items(body: Any) -> list[Any]:
     """Pull the row list out of a Kernel list response.
 
     Kernel signals pagination through headers (X-Has-More / X-Next-Offset), so the body is
@@ -73,7 +73,7 @@ def _redact_sensitive_fields(item: Any) -> Any:
 
     Kernel objects are written to the warehouse verbatim, so env vars and token-bearing
     live-view / CDP URLs would otherwise be queryable by any project user. `item` is untyped
-    JSON, so non-dict rows pass through untouched.
+    JSON. The caller skips non-dict rows because Arrow cannot serialize them as table rows.
     """
     if not isinstance(item, dict):
         return item
@@ -174,7 +174,8 @@ def get_rows(
             continue
 
         for item in items:
-            batcher.batch(_redact_sensitive_fields(item))
+            if isinstance(item, dict):
+                batcher.batch(_redact_sensitive_fields(item))
 
         if batcher.should_yield():
             yield batcher.get_table()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/kernel/tests/test_kernel.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/kernel/tests/test_kernel.py
@@ -198,6 +198,16 @@ class TestGetRows:
         assert rows == [{"id": "b1", "region": "us"}]
 
     @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_non_dict_rows_are_skipped(self, mock_session: Any) -> None:
+        mock_session.return_value.get.return_value = _response(
+            [{"id": "b1"}, "unexpected", None, ["nested"]], has_more=False
+        )
+
+        rows = self._collect("browsers")
+
+        assert rows == [{"id": "b1"}]
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
     def test_unexpected_response_shape_raises(self, mock_session: Any) -> None:
         mock_session.return_value.get.return_value = _response({"unexpected": [{"id": "a1"}]}, has_more=False)
 


### PR DESCRIPTION
## Problem

A Kernel API response can include a non-object member. This stops a warehouse sync when Arrow serializes the response.

## Changes

- The source skips non-object members after it calculates pagination offsets.
- Valid API objects continue to load when a response includes an invalid member.

## How did you test this code?

- `uv run hogli test products/warehouse_sources/backend/temporal/data_imports/sources/kernel/tests/test_kernel.py` covers a mixed page and prevents invalid members from reaching Arrow.
- `uv run mypy --cache-fine-grained .`
- `uv run hogli ci:preflight --fix`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This importer validation does not change a documented user workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- PostHog Slack app authored this change.
- Invoked `/writing-tests`, `/writing-code-comments`, `/running-ci-preflight`, `/writing-pr-descriptions`, `/reviewing-with-coderabbit`, and `/writing-user-facing-copy`.
- The open-PR search found no matching work.
- CodeRabbit is paused, so this draft opened without a local pass.
- This PR contains no private context data.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0C0LU050GN/p1789153591251339?thread_ts=1789153591.251339&cid=C0C0LU050GN)*