### PR TITLE
fix(insights): show the timezone in trends chart tooltips

### DIFF
--- a/products/product_analytics/frontend/insights/shared/InsightSeriesTooltip.tsx
+++ b/products/product_analytics/frontend/insights/shared/InsightSeriesTooltip.tsx
@@ -7,6 +7,7 @@ import { SeriesGlyph } from 'lib/components/SeriesGlyph'
 import { parseDateInTimezone } from 'lib/utils/datetime'
 import { percentage } from 'lib/utils/numbers'
 import { alphabet } from 'lib/utils/strings'
+import { shortTimeZone } from 'lib/utils/timezones'
 import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import {
     FormattedDateOptions,
@@ -95,11 +96,16 @@ function formatRowValue(
 /** Spells out the weekday on daily buckets, matching the classic insight tooltip. */
 function formatHeaderDate(date: string | undefined, options: FormattedDateOptions): string {
     const formattedDate = getFormattedDate(date, options)
-    if (options.interval !== 'day' || typeof date !== 'string') {
+    if (typeof date !== 'string') {
         return formattedDate
     }
-    const parsed = parseDateInTimezone(date, options.timezone ?? 'UTC')
-    return parsed.isValid() ? `${parsed.format('dddd')}, ${formattedDate}` : formattedDate
+    const timezone = options.timezone ?? 'UTC'
+    const parsed = parseDateInTimezone(date, timezone)
+    const tzSuffix = ` (${shortTimeZone(timezone, parsed.isValid() ? parsed.toDate() : undefined) ?? 'UTC'})`
+    if (options.interval !== 'day') {
+        return `${formattedDate}${tzSuffix}`
+    }
+    return parsed.isValid() ? `${parsed.format('dddd')}, ${formattedDate}${tzSuffix}` : `${formattedDate}${tzSuffix}`
 }
 
 // ── SeriesLabel ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Hovering a trends chart shows a bucket date with no timezone, so a viewer cannot tell which timezone the points sit in. This affects every trends chart, in product analytics and web analytics.

The axis and tooltip already format dates in the project timezone, but the label never says which one. When trends charts moved to quill-charts, the rewritten tooltip dropped the timezone suffix the old Chart.js tooltip carried; a later change ported the weekday back but not the zone.

## Changes

- The tooltip header date now ends with the project timezone, e.g. `Monday, 13 Jan 2025 (UTC)`. It previously read `Monday, 13 Jan 2025`.
- The suffix resolves DST from the bucket date, so a summer bucket reads `EDT` and a winter one `EST`.
- Every trends chart tooltip is affected. No other tooltip surface changes.

![tooltip](https://raw.githubusercontent.com/PostHog/pr-assets/71d907cab783a7abb0b8b8f71953593b3c48a0c0/2026/09/d1e867d8-8e14-4b06-a975-47e4759e3b03.png)

## How did you test this code?

Verified in Storybook: the web analytics trends chart tooltip header shows the zone suffix (screenshot above). No automated test.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus 4.8). Skills invoked: `/writing-pr-descriptions`, `/writing-tests`. The fix restores a timezone suffix on the shared `InsightSeriesTooltip` header formatter (`formatHeaderDate`), lost when trends charts migrated from Chart.js to quill-charts. In the same session a Web Analytics on-graph timezone label was explored and then dropped at the author's request; only the tooltip fix remains. A unit test for the formatter was added and then removed at the author's request, so this ships without one. The CodeRabbit local pass is paused, so the PR opens without it.
