### PR TITLE
fix(appsflyer): recognize raw-data 400 rejections after the export redirect

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/appsflyer/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/appsflyer/source.py
@@ -62,6 +62,9 @@ class AppsFlyerSource(SimpleSource[AppsFlyerSourceConfig]):
             # used up, the date range predates the raw-data lookback limit, or the row cap is
             # invalid. None of those change if we send the identical call again.
             "400 Client Error: Bad Request for url: https://hq1.appsflyer.com": "AppsFlyer rejected the report request. Your account's daily quota for this report may be used up, which resets at 00:00 UTC. Otherwise please check that your subscription includes this report.",
+            # Raw-data pulls redirect to a signed download URL on this host once the request is
+            # accepted, so a raw-data rejection surfaces here instead of on hq1.appsflyer.com.
+            "400 Client Error: Bad Request for url: https://rawdata.appsflyer.com": "AppsFlyer rejected the report request. Your account's daily quota for this report may be used up, which resets at 00:00 UTC. Otherwise please check that your subscription includes this report.",
             # AppsFlyer overloads 416 as a catch-all for request/authorization validation failures on
             # the aggregate Pull API (e.g. the account isn't authorized for this report or app id). The
             # request shape is fixed, so retrying the identical call can never satisfy it.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/appsflyer/tests/test_appsflyer_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/appsflyer/tests/test_appsflyer_source.py
@@ -32,6 +32,9 @@ class TestAppsFlyerSource:
             "404 Client Error: Not Found for url: https://hq1.appsflyer.com/api/agg-data/export/app/nope/daily_report/v5",
             "416 Client Error: Requested Range Not Satisfiable for url: https://hq1.appsflyer.com/api/agg-data/export/app/id123/geo_by_date_report/v5?from=2024-01-01&to=2024-01-05",
             "400 Client Error: Bad Request for url: https://hq1.appsflyer.com/api/raw-data/export/app/id123/installs_report/v5?from=2024-01-01&to=2024-01-07",
+            # Raw-data pulls redirect to a signed download URL on a different host once accepted,
+            # so a rejection there carries that host instead of hq1.appsflyer.com.
+            "400 Client Error: Bad Request for url: https://rawdata.appsflyer.com/export/token/abc123",
         ],
     )
     def test_non_retryable_errors_match_auth_failures(self, observed_error):


### PR DESCRIPTION
## Problem

A raw-data AppsFlyer sync (installs, in-app events, ad revenue) that gets a `400` from AppsFlyer keeps retrying instead of stopping, because the error is never recognized as non-retryable.

- The Pull API redirects a raw-data export request from `hq1.appsflyer.com` to a signed download URL on `rawdata.appsflyer.com`.
- `requests` follows the redirect and raises `HTTPError` with the *final* URL, so a rejected raw-data request reads `400 Client Error: Bad Request for url: https://rawdata.appsflyer.com/export/token/...`.
- `AppsFlyerSource.get_non_retryable_errors()` only matched `for url: https://hq1.appsflyer.com`, so this shape fell through as retryable.
- Confirmed live in [error tracking](https://us.posthog.com/project/2/error_tracking/01a0920e-9b8a-7fb3-bdb1-6693517cc483): the same `HTTPError` recurring across multiple import attempts, all landing in `_open_report`.

## Changes

- `get_non_retryable_errors()` gains a second `400` pattern matching the `rawdata.appsflyer.com` host, mapped to the same "check your daily quota / subscription" message as the existing `hq1.appsflyer.com` pattern.
- Everything else (401/403/404/416 handling, retry logic for 429/5xx) is unchanged.

## How did you test this code?

- Extended `test_non_retryable_errors_match_auth_failures` in `test_appsflyer_source.py` with the redirected-host URL shape observed in production. Without the fix, this case fails to match any pattern.
- Ran `products/warehouse_sources/backend/temporal/data_imports/sources/appsflyer/tests/test_appsflyer_source.py` locally: 15 passed.
- Ran `ruff check` and `ruff format --check` on both changed files: clean.
- Not run: a live sync against AppsFlyer, and the broader `mypy` pass.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an [error tracking issue](https://us.posthog.com/project/2/error_tracking/01a0920e-9b8a-7fb3-bdb1-6693517cc483) delivered by webhook.

- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- CodeRabbit CLI pass: paused, so this PR opened without a local pass.
- No duplicate: searched open PRs for `appsflyer`, `rawdata.appsflyer`, and the maintainer's own open PR list. [#99373](https://github.com/PostHog/posthog/pull/99373) touches Cody/Marketo streaming, not this. [#99343](https://github.com/PostHog/posthog/pull/99343) (merged) fixed an unrelated AppsFlyer streaming bug. Nothing open addresses this redirect/matching gap.
- Public artifact: no customer data, host, or account identifier appears in the diff or this description. The token value in the test fixture is invented.