### PR TITLE
feat(replay-vision): ask for scanner lifecycle feedback

### DIFF
--- a/docs/internal/replay-vision-scanner-feedback.md
+++ b/docs/internal/replay-vision-scanner-feedback.md
@@ -1,0 +1,49 @@
+# Replay Vision scanner feedback
+
+Scanner feedback uses the existing PostHog JavaScript SDK and survey renderer.
+It does not change scanner confirmation, permissions, billing, or API behavior.
+
+## User experience
+
+- After a successful disable or delete in the web app, show an optional survey in the corner of the screen.
+- Ask for one reason. Offer an optional text question next. Store the reason even if the person closes the second question.
+- Show each survey once. Suppress all scanner feedback surveys for 30 days after any survey was shown, including one that was dismissed.
+- After a successful enable of an existing scanner, offer a **Share your goal** button in the success message. Do not open a survey automatically.
+- Offer that button at most once per person per browser session. Respect survey eligibility again when the person selects it.
+- Do not show a survey after a failed operation or when the SDK is unavailable. Do not wait for the SDK to load and then show a delayed prompt.
+- Do not request feedback for scanner creation, duplication, API calls, or automated changes.
+
+The SDK handles survey eligibility, the close button, response capture, and the waiting period.
+The integration passes `ignoreConditions: false` on every display call.
+Feedback failures must not reverse a successful scanner operation or show an operation error.
+
+## Survey definitions and rollout
+
+The definitions are API surveys. They cannot open automatically on a page visit.
+`SCANNER_FEEDBACK_SURVEY_IDS` in `scannerFeedback.ts` links each action to its definition.
+Keep the surveys as drafts until the integration is deployed and checked.
+
+Before launch, check each definition:
+
+- Disable reasons: cost, irrelevant findings, inaccurate findings, insufficient useful results, a break, no further need, or another reason.
+- Delete reasons: the same quality and cost categories, plus replacement and test cleanup.
+- Enable goals: find bugs, find user problems, check a change, monitor a flow, understand use, or another goal.
+- Use a once-only schedule. Set each waiting period to 30 days after any survey.
+- Enable partial responses and make the text question optional.
+
+Use survey audience controls for a small initial rollout.
+Launch the disable survey first, then the delete survey after checking dismissals and responses.
+End or archive a survey to stop new requests without a code deployment.
+Do not convert these definitions to automatically triggered popover surveys.
+
+## Measurement and privacy
+
+Use the standard `survey shown`, `survey sent`, and `survey dismissed` events.
+Each event carries `scanner_id`, `scanner_action`, `scanner_feedback_source`, and `project_id`.
+Do not attach scanner names, prompts, findings, recordings, or customer details.
+Ask people not to include private information in text responses.
+
+Compare reasons separately for disable and delete.
+Track shown-to-response and shown-to-dismissal rates, and check scanner operation errors during rollout.
+Use the existing scanner lifecycle events as the count of completed operations.
+Survey responses are a selected sample, not the reason for every disable or delete.

--- a/products/replay_vision/frontend/replay_scanners/ScannerFeedback.stories.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ScannerFeedback.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { SurveyQuestionType, SurveyType } from 'posthog-js'
+import { renderSurveysPreview } from 'posthog-js/dist/surveys-preview'
+import { useEffect, useRef } from 'react'
+
+const questions = {
+    disabled: {
+        question: 'Why did you disable this scanner?',
+        description: 'Optional. Your scanner is already disabled.',
+        choices: [
+            'Too expensive',
+            'Too many irrelevant findings',
+            'Missed issues or inaccurate findings',
+            'Not enough useful results',
+            'Taking a break',
+            'No longer needed',
+            'Other',
+        ],
+    },
+    deleted: {
+        question: 'Why did you delete this scanner?',
+        description: 'Optional. Your scanner is already deleted.',
+        choices: [
+            'Too expensive',
+            'Too many irrelevant findings',
+            'Missed issues or inaccurate findings',
+            'Not enough useful results',
+            'Replaced by another scanner',
+            'Only testing',
+            'No longer needed',
+            'Other',
+        ],
+    },
+    enabled: {
+        question: 'What do you want this scanner to help you do?',
+        choices: [
+            'Find bugs',
+            'Find where users get stuck',
+            'Check a recent change',
+            'Monitor a specific flow',
+            'Understand how people use the product',
+            'Other',
+        ],
+    },
+}
+
+function ScannerFeedbackPreview({ action }: { action: keyof typeof questions }): JSX.Element {
+    const container = useRef<HTMLDivElement>(null)
+    useEffect(() => {
+        if (!container.current) {
+            return
+        }
+        const parentElement = container.current
+        renderSurveysPreview({
+            survey: {
+                id: `scanner-feedback-preview-${action}`,
+                name: 'Scanner feedback preview',
+                type: SurveyType.API,
+                questions: [{ type: SurveyQuestionType.SingleChoice, ...questions[action], buttonText: 'Next' }],
+                appearance: { maxWidth: '340px' },
+            },
+            parentElement,
+            previewPageIndex: 0,
+            positionStyles: { position: 'fixed', right: '20px', bottom: '20px', left: 'auto', top: 'auto' },
+        })
+        return () => parentElement.replaceChildren()
+    }, [action])
+    return <div ref={container} />
+}
+
+const meta: Meta<typeof ScannerFeedbackPreview> = {
+    title: 'Replay Vision/Scanner feedback',
+    component: ScannerFeedbackPreview,
+    parameters: { layout: 'fullscreen' },
+    args: { action: 'disabled' },
+}
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Disabled: Story = {}
+export const Deleted: Story = { args: { action: 'deleted' } }
+export const Enabled: Story = { args: { action: 'enabled' } }

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
@@ -84,6 +84,7 @@ import {
     scannerStepUrlWithParams,
     UNVALIDATED_SCANNER_STEPS,
 } from './scannerEditorSceneLogic'
+import { requestScannerFeedback } from './scannerFeedback'
 import type { ObservationStatusStats } from './scannerStats'
 import { availableTagsFromStats, daysFromDateRange, deriveObservationStatusStats } from './scannerStats'
 import { findScannerTemplate, newScanner } from './scannerTemplates'
@@ -2104,7 +2105,15 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                     await visionScannersPartialUpdate(String(teamId), props.id, { enabled: next })
                     actions.toggleEnabledSuccess(next)
                     refreshVisionQuota()
-                    lemonToast.success(`Scanner ${next ? 'enabled' : 'disabled'}`)
+                    const feedbackOffered = requestScannerFeedback(
+                        next ? 'enabled' : 'disabled',
+                        props.id,
+                        'detail',
+                        teamId
+                    )
+                    if (!next || !feedbackOffered) {
+                        lemonToast.success(`Scanner ${next ? 'enabled' : 'disabled'}`)
+                    }
                 } catch (error: any) {
                     actions.setScannerValue('enabled', !next)
                     const verb = next ? 'enable' : 'disable'

--- a/products/replay_vision/frontend/replay_scanners/replayScannersLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannersLogic.test.ts
@@ -1,5 +1,6 @@
 import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
+import posthog, { DisplaySurveyType } from 'posthog-js'
 
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { addProductIntent } from 'lib/utils/product-intents'
@@ -19,6 +20,7 @@ import {
     resolveScannerOrderByKey,
     type ScannerOrderKey,
 } from './replayScannersLogic'
+import { SCANNER_FEEDBACK_SURVEY_IDS } from './scannerFeedback'
 import { ScannerConfig, ScannerType, ReplayScanner } from './types'
 
 jest.mock('lib/utils/product-intents', () => ({
@@ -73,6 +75,7 @@ describe('replayScannersLogic', () => {
     let logic: ReturnType<typeof replayScannersLogic.build>
 
     beforeEach(() => {
+        posthog.canRenderSurvey = jest.fn().mockReturnValue({ visible: false })
         useMocks({
             get: {
                 '/api/projects/:team/vision/scanners/': { results: [], count: 0 },
@@ -337,11 +340,19 @@ describe('replayScannersLogic', () => {
     })
 
     describe('delete refresh', () => {
-        it('deleteScannerSuccess refetches the page and the creators list', async () => {
-            await expectLogic(logic, () => logic.actions.deleteScannerSuccess('a')).toDispatchActions([
-                'loadScanners',
-                'loadCreators',
-            ])
+        it('a successful delete refreshes the list and asks for feedback', async () => {
+            jest.spyOn(posthog, 'canRenderSurvey').mockReturnValue({ visible: true })
+            const displaySurvey = jest.spyOn(posthog, 'displaySurvey').mockImplementation(() => {})
+            await expectLogic(logic, () => logic.actions.deleteScanner('a'))
+                .toDispatchActions(['deleteScannerSuccess', 'loadScanners', 'loadCreators'])
+                .toFinishAllListeners()
+            expect(displaySurvey).toHaveBeenCalledWith(
+                SCANNER_FEEDBACK_SURVEY_IDS.deleted,
+                expect.objectContaining({
+                    ignoreConditions: false,
+                    properties: expect.objectContaining({ scanner_id: 'a', scanner_action: 'deleted' }),
+                })
+            )
         })
     })
 
@@ -356,16 +367,83 @@ describe('replayScannersLogic', () => {
             })
         })
 
-        it('a persisted toggle completes without a success toast', async () => {
+        it.each([true, false])('a persisted disable respects survey eligibility: %s', async (eligible) => {
             const successToast = jest.spyOn(lemonToast, 'success')
+            jest.spyOn(posthog, 'canRenderSurvey').mockReturnValue({ visible: eligible })
+            const displaySurvey = jest.spyOn(posthog, 'displaySurvey').mockImplementation(() => {})
             logic.actions.loadScannersSuccess(scanners, scanners.length)
 
-            await expectLogic(logic, () => logic.actions.toggleScannerEnabled('a')).toDispatchActions([
-                'toggleScannerEnabledDone',
-            ])
+            await expectLogic(logic, () => logic.actions.toggleScannerEnabled('a')).toFinishAllListeners()
 
             expect(successToast).not.toHaveBeenCalled()
             expect(logic.values.togglingIds).toEqual([])
+            expect(displaySurvey.mock.calls).toEqual(
+                eligible
+                    ? [
+                          [
+                              SCANNER_FEEDBACK_SURVEY_IDS.disabled,
+                              {
+                                  displayType: DisplaySurveyType.Popover,
+                                  ignoreConditions: false,
+                                  ignoreDelay: true,
+                                  properties: {
+                                      scanner_id: 'a',
+                                      scanner_action: 'disabled',
+                                      scanner_feedback_source: 'list',
+                                      project_id: 997,
+                                  },
+                              },
+                          ],
+                      ]
+                    : []
+            )
+        })
+
+        it('offers enable feedback only on request and once per browser session', async () => {
+            sessionStorage.clear()
+            jest.spyOn(posthog, 'canRenderSurvey').mockReturnValue({ visible: true })
+            const displaySurvey = jest.spyOn(posthog, 'displaySurvey').mockImplementation(() => {})
+            const successToast = jest.spyOn(lemonToast, 'success')
+            logic.actions.loadScannersSuccess(scanners, scanners.length)
+
+            await expectLogic(logic, () => logic.actions.toggleScannerEnabled('b')).toFinishAllListeners()
+
+            expect(displaySurvey).not.toHaveBeenCalled()
+            expect(successToast).toHaveBeenCalledWith(
+                'Scanner enabled',
+                expect.objectContaining({
+                    button: expect.objectContaining({ label: 'Share your goal' }),
+                })
+            )
+            const options = successToast.mock.calls[0][1]
+            options?.button?.action()
+            expect(displaySurvey).toHaveBeenCalledWith(
+                SCANNER_FEEDBACK_SURVEY_IDS.enabled,
+                expect.objectContaining({
+                    ignoreConditions: false,
+                    properties: expect.objectContaining({ scanner_id: 'b', scanner_action: 'enabled' }),
+                })
+            )
+
+            logic.actions.loadScannersSuccess(scanners, scanners.length)
+            await expectLogic(logic, () => logic.actions.toggleScannerEnabled('b')).toFinishAllListeners()
+            expect(successToast).toHaveBeenCalledTimes(1)
+            sessionStorage.clear()
+        })
+
+        it('keeps a successful disable when the survey SDK fails', async () => {
+            jest.spyOn(posthog, 'canRenderSurvey').mockReturnValue({ visible: true })
+            jest.spyOn(posthog, 'displaySurvey').mockImplementation(() => {
+                throw new Error('Survey unavailable')
+            })
+            const errorToast = jest.spyOn(lemonToast, 'error')
+            logic.actions.loadScannersSuccess(scanners, scanners.length)
+
+            await expectLogic(logic, () => logic.actions.toggleScannerEnabled('a')).toFinishAllListeners()
+
+            expect(logic.values.scanners.find((scanner) => scanner.id === 'a')?.enabled).toBe(false)
+            expect(logic.values.togglingIds).toEqual([])
+            expect(errorToast).not.toHaveBeenCalled()
         })
 
         it('ignores a second toggle of the same scanner while one is in flight', async () => {
@@ -390,6 +468,8 @@ describe('replayScannersLogic', () => {
                 patch: { '/api/projects/:team/vision/scanners/:id/': () => [500, {}] },
             })
             const errorToast = jest.spyOn(lemonToast, 'error')
+            jest.spyOn(posthog, 'canRenderSurvey').mockReturnValue({ visible: true })
+            const displaySurvey = jest.spyOn(posthog, 'displaySurvey')
             logic.actions.loadScannersSuccess(scanners, scanners.length)
 
             await expectLogic(logic, () => logic.actions.toggleScannerEnabled('a')).toDispatchActions([
@@ -399,6 +479,7 @@ describe('replayScannersLogic', () => {
             expect(logic.values.scanners.find((s) => s.id === 'a')?.enabled).toBe(true)
             expect(logic.values.togglingIds).toEqual([])
             expect(errorToast).toHaveBeenCalledWith(expect.stringContaining('Failed to disable scanner'))
+            expect(displaySurvey).not.toHaveBeenCalled()
         })
 
         it('revertScannerEnabled flips the row back and clears the in-flight id', async () => {
@@ -448,6 +529,8 @@ describe('replayScannersLogic', () => {
         })
 
         it('a failed delete reverts the optimistic projection shift', async () => {
+            jest.spyOn(posthog, 'canRenderSurvey').mockReturnValue({ visible: true })
+            const displaySurvey = jest.spyOn(posthog, 'displaySurvey')
             useMocks({
                 // The quota GET must be mocked: `toFinishAllListeners` waits out the quota loader too.
                 get: { '/api/projects/:team/vision/quota/': quotaFixture },
@@ -463,6 +546,7 @@ describe('replayScannersLogic', () => {
 
             await expectLogic(logic, () => logic.actions.deleteScanner('a')).toFinishAllListeners()
 
+            expect(displaySurvey).not.toHaveBeenCalled()
             expect(quotaLogic.values.quota?.projected_monthly_credits).toBe(500)
             quotaLogic.unmount()
         })

--- a/products/replay_vision/frontend/replay_scanners/replayScannersLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannersLogic.ts
@@ -35,6 +35,7 @@ import type { ScannerStatsResponseApi, UserBasicApi, VisionScannersListParams } 
 import type { ScannerTypeEnumApi } from '../generated/api.schemas'
 import { refreshVisionQuota, visionQuotaLogic } from '../logics/visionQuotaLogic'
 import { csvParam, parseCsvParam, parseSortParam, serializeSortParam } from '../utils/urlParams'
+import { requestScannerFeedback } from './scannerFeedback'
 import {
     ENABLED_OPTIONS,
     EnabledFilter,
@@ -551,6 +552,7 @@ export const replayScannersLogic = kea<replayScannersLogicType>([
                 await visionScannersDestroy(String(teamId), id)
                 actions.deleteScannerSuccess(id)
                 lemonToast.success('Scanner deleted')
+                requestScannerFeedback('deleted', id, 'list', teamId)
             } catch (error: any) {
                 visionQuotaLogic.findMounted()?.actions.adjustProjectedMonthly(-delta)
                 lemonToast.error(`Failed to delete scanner${error.detail ? `: ${error.detail}` : ''}`)
@@ -611,6 +613,7 @@ export const replayScannersLogic = kea<replayScannersLogicType>([
             try {
                 await visionScannersPartialUpdate(String(teamId), id, { enabled })
                 actions.toggleScannerEnabledDone(id)
+                requestScannerFeedback(enabled ? 'enabled' : 'disabled', id, 'list', teamId)
             } catch (error: any) {
                 const verb = enabled ? 'enable' : 'disable'
                 lemonToast.error(`Failed to ${verb} scanner${error.detail ? `: ${error.detail}` : ''}`)

--- a/products/replay_vision/frontend/replay_scanners/scannerFeedback.ts
+++ b/products/replay_vision/frontend/replay_scanners/scannerFeedback.ts
@@ -1,0 +1,67 @@
+import posthog, { DisplaySurveyType } from 'posthog-js'
+
+import { lemonToast } from 'lib/lemon-ui/LemonToast'
+import { teamLogic } from 'scenes/teamLogic'
+
+export const SCANNER_FEEDBACK_SURVEY_IDS = {
+    disabled: '01a09222-52e9-0000-db25-4153580e8909',
+    deleted: '01a09222-68b1-0000-51b0-6a66a308d724',
+    enabled: '01a09222-811e-0000-fca9-eb93f708e5fb',
+} as const
+
+export function requestScannerFeedback(
+    action: keyof typeof SCANNER_FEEDBACK_SURVEY_IDS,
+    scannerId: string,
+    source: 'list' | 'detail',
+    teamId: number
+): boolean {
+    try {
+        const surveyId = SCANNER_FEEDBACK_SURVEY_IDS[action]
+        if (teamLogic.values.currentTeamId !== teamId || !posthog.canRenderSurvey(surveyId)?.visible) {
+            return false
+        }
+
+        const distinctId = posthog.get_distinct_id()
+        const display = (): void => {
+            try {
+                if (teamLogic.values.currentTeamId !== teamId || posthog.get_distinct_id() !== distinctId) {
+                    return
+                }
+                posthog.displaySurvey(surveyId, {
+                    displayType: DisplaySurveyType.Popover,
+                    ignoreConditions: false,
+                    ignoreDelay: true,
+                    properties: {
+                        scanner_id: scannerId,
+                        scanner_action: action,
+                        scanner_feedback_source: source,
+                        project_id: teamId,
+                    },
+                })
+            } catch {
+                return
+            }
+        }
+
+        if (action === 'enabled') {
+            const storageKey = `replay-vision-enable-feedback-offered:${distinctId}`
+            if (sessionStorage.getItem(storageKey)) {
+                return false
+            }
+            sessionStorage.setItem(storageKey, 'true')
+            lemonToast.success('Scanner enabled', {
+                toastId: 'replay-vision-enable-feedback',
+                button: {
+                    label: 'Share your goal',
+                    action: display,
+                    dataAttr: 'replay-vision-enable-feedback',
+                },
+            })
+        } else {
+            display()
+        }
+        return true
+    } catch {
+        return false
+    }
+}


### PR DESCRIPTION
## Problem

People can explain why they stop a Replay Vision scanner without delaying the action.

**Why:** Scanner actions show what changed, but not whether cost, findings, or a completed task caused the change.

## Changes

- Show optional SDK surveys after a successful disable or delete. Respect survey eligibility and the shared waiting period.
- Offer enable feedback through a **Share your goal** button, at most once per browser session. Do not open it automatically.
- Keep feedback failures separate from scanner operations. Survey definitions remain drafts until launch.

![Scanner deletion survey preview](https://raw.githubusercontent.com/PostHog/pr-assets/bbd50a4963f3c8dc5019b337e27de18e35b371f6/2026/09/e9c8bedd-70ab-4cee-8c1e-a3f7e18c1764.png)

## How did you test this code?

- Scanner logic tests cover eligibility, failed operations, successful deletion, SDK failure, and opt-in enable feedback.
- Frontend typecheck, scoped lint, formatting, and preflight have no failures.
- Survey preview stories checked at 1280px and 900px. The full scanner scene timed out; live survey delivery is not verified.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Added [scanner feedback behavior and rollout guidance](https://github.com/PostHog/posthog/blob/21cfceee678d9b40887f34ec75824e5c3567183f/docs/internal/replay-vision-scanner-feedback.md).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

No matching implementation pull request found. Human review and survey launch are still required.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

