### PR TITLE
fix(deletes): keep one row per key in the adhoc deletes dictionary

### DIFF
--- a/posthog/dags/deletes.py
+++ b/posthog/dags/deletes.py
@@ -307,7 +307,15 @@ class AdhocEventDeletesDictionary(Dictionary):
 
     @property
     def query(self) -> str:
-        return f"SELECT team_id, uuid, created_at FROM {self.source.qualified_name} WHERE (team_id, uuid) not in (SELECT team_id, uuid FROM {self.source.qualified_name} WHERE is_deleted = 1)"
+        # Grouped rather than filtered with NOT IN: the source is a ReplacingMergeTree, so a key
+        # inserted twice reads as two rows until a merge collapses them. The dictionary keeps one
+        # row per key whichever way, but which one it keeps follows the order the source rows
+        # arrive, and that order is not stable when a host parses a staged Parquet in parallel.
+        # max(is_deleted) = 0 is the same exclusion the NOT IN subquery made, on one scan.
+        return (
+            f"SELECT team_id, uuid, max(created_at) AS created_at FROM {self.source.qualified_name} "
+            f"GROUP BY team_id, uuid HAVING max(is_deleted) = 0"
+        )
 
     def staged(self) -> StagedDictionary:
         return StagedDictionary(

--- a/posthog/dags/tests/test_deletes.py
+++ b/posthog/dags/tests/test_deletes.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from functools import partial
 from typing import cast
 from uuid import UUID
@@ -13,6 +13,7 @@ from clickhouse_driver import Client
 from dagster import build_op_context
 
 from posthog.clickhouse.cluster import ClickhouseCluster, LightweightDeleteMutationRunner
+from posthog.dags.common.staged_dictionary import create_on_every_cluster
 from posthog.dags.deletes import (
     _DELETE_PREDICATE,
     AdhocEventDeletesDictionary,
@@ -788,6 +789,71 @@ def test_a_rerun_stages_over_the_previous_runs_object(cluster: ClickhouseCluster
         from_source_table = cluster.any_host(dictionary.load).result()
 
         assert from_staged_object == from_source_table
+    finally:
+        cluster.any_host(dictionary.drop).result()
+        cluster.any_host(table.drop).result()
+
+
+@pytest.mark.django_db
+def test_the_adhoc_dictionary_holds_one_row_per_key_when_the_source_has_duplicates(cluster: ClickhouseCluster):
+    # The source is a ReplacingMergeTree, so a uuid requested twice reads as two rows until a merge
+    # collapses them. A dictionary keeps one row per key either way, but a source query that emits
+    # both leaves the winner to the order the rows arrive, and that order is not stable when a host
+    # parses a staged Parquet in parallel. Two clusters then disagree and the run is blocked.
+    adhoc = AdhocEventDeletesDictionary(source=AdhocEventDeletesTable())
+    team_id = 424244
+    uuid = UUID(int=13)
+    earlier = datetime(2026, 8, 28, 9, 0, 0, tzinfo=UTC)
+    later = datetime(2026, 8, 28, 11, 0, 0, tzinfo=UTC)
+
+    def insert_duplicate_requests(client: Client) -> None:
+        client.execute(
+            "INSERT INTO adhoc_events_deletion (team_id, uuid, created_at) VALUES",
+            [(team_id, uuid, earlier), (team_id, uuid, later)],
+        )
+
+    def read_back(client: Client) -> list:
+        return client.execute(f"SELECT count(), max(created_at) FROM {adhoc.qualified_name} WHERE team_id = {team_id}")
+
+    try:
+        cluster.any_host(insert_duplicate_requests).result()
+        cluster.any_host(partial(adhoc.create, shards=1, max_execution_time=0, max_memory_usage=0)).result()
+        cluster.any_host(adhoc.load).result()
+
+        [[held, created_at]] = cluster.any_host(read_back).result()
+
+        assert held == 1
+        assert created_at == later
+    finally:
+        cluster.any_host(adhoc.drop).result()
+        cluster.any_host(
+            lambda client: client.execute(f"DELETE FROM adhoc_events_deletion WHERE team_id = {team_id}")
+        ).result()
+
+
+@pytest.mark.django_db
+def test_creating_on_a_second_cluster_points_it_at_the_staged_object(cluster: ClickhouseCluster):
+    # A cluster that shares no Keeper with the source table never receives it, so its dictionary
+    # has to read the staged object. A call site that hands it the source query instead leaves it
+    # loading from a table it cannot see, and the dictionary fails or comes back empty.
+    table = PendingDeletesTable(timestamp=datetime(2026, 8, 26, 10, 11, 14))
+    dictionary = PendingDeletesDictionary(source=table)
+    sibling = cluster.sibling(django_settings.CLICKHOUSE_SINGLE_SHARD_CLUSTER)
+    context = build_op_context()
+
+    def show_create(client: Client) -> str:
+        [[query]] = client.execute(f"SHOW CREATE DICTIONARY {dictionary.qualified_name}")
+        return query
+
+    try:
+        cluster.any_host(table.create).result()
+        cluster.any_host(partial(_insert_pending_deletes, table)).result()
+
+        create_on_every_cluster(
+            context, [cluster, sibling], dictionary, shards=1, max_execution_time=0, max_memory_usage=0
+        )
+
+        assert dictionary.staged().key in sibling.any_host(show_create).result()
     finally:
         cluster.any_host(dictionary.drop).result()
         cluster.any_host(table.drop).result()


### PR DESCRIPTION
## Problem

The weekly `deletes_job` stops before it deletes anything, so queued event-erasure requests stay unapplied.

- The run fails at `load_and_verify_adhoc_event_deletes_dictionary`, which blocks a sweep unless every host holds the same dictionary rows.
- `adhoc_events_deletion` is a `ReplacingMergeTree`, so a uuid requested twice reads as two rows until a merge collapses them.
- The dictionary source query emitted both rows. A ClickHouse dictionary keeps one row per key, so the surviving `created_at` followed the order the rows arrived in.
- Hosts reading the replicated table arrive in primary-key order and agree. Hosts on the events cluster load a staged Parquet in parallel, so each one picks a different winner.
- A staged export held about 29% more rows than distinct keys, which is how many keys were open to this.

The gate was correct both times it fired. It reported the disagreement without naming the cause.

## Changes

- The dictionary source groups by `(team_id, uuid)` and takes `max(created_at)`, so every host loads one deterministic row per key.
- `max(is_deleted) = 0` reproduces the exclusion the `NOT IN` subquery made, on one table scan rather than two.
- `max` rather than `argMax(created_at, deleted_at)`: `deleted_at` is zero on every live row, so `argMax` breaks ties arbitrarily and reintroduces the nondeterminism. The delete predicate only calls `dictHas` on this dictionary, so `created_at` is never read.
- Nothing user-visible changes. `deletes_job` is a Dagster job.

The staged object keeps its stable per-dictionary key. An earlier revision of this PR scoped that key per run, to stop one run replacing an object another run is still loading. That is a real hazard, since nothing limits `deletes_job` concurrency, but per-run objects are not an option here, so it needs a different answer and is out of scope.

> [!NOTE]
> A separate bug surfaced during the same investigation and is not fixed here. When `placement_for` cannot resolve the cluster holding an optional target, `_assert_no_rows_behind_the_proxy` probes the Distributed proxy on the job's own cluster. That probe returns false when the proxy is absent there, so the target is dropped and the job reports success having never swept it.

## How did you test this code?

Automated tests only. No manual verification against a multi-cluster topology, because no local or CI topology defines a second cluster for these targets.

- `test_the_adhoc_dictionary_holds_one_row_per_key_when_the_source_has_duplicates` catches a source query that lets read order choose between duplicate rows. No existing test put two rows for one key into the source.
- `test_creating_on_a_second_cluster_points_it_at_the_staged_object` catches a call site that hands the far cluster the source query instead of the staged one, which leaves it reading a table it cannot see. No existing test exercised `create_on_every_cluster`.

Ran locally against the dev stack: `posthog/dags/tests/test_deletes.py` and `uv run mypy --cache-fine-grained .`. Everything else is left to CI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) investigated three production `deletes_job` runs from Dagster debug exports, then wrote the fix. Skills invoked: `/writing-pr-descriptions`, `/reviewing-with-coderabbit`. The CodeRabbit CLI pass is paused, so this PR opened without a local pass.

No open PR covers this. `gh pr list --state open --search "adhoc_events_deletion dictionary"` and a search for staged-dictionary work returned nothing related.

The first hypothesis was a concurrent-run collision on the shared staging key. A second run 12 minutes later, with no overlap and an identical checksum on the replicated side, ruled it out. Duplicates were then dismissed too, wrongly: a duplicate key does not change a dictionary's `element_count`, so identical counts across hosts looked like evidence against it. Counting rows against distinct keys in the staged object settled it. The per-run staging key that came out of the first hypothesis was reverted before review.

Row counts from the production deletion queue are deliberately left out of this description and the commit message.
