### PR TITLE
fix(funnels): stop a later step consuming an optional step's event

### DIFF
--- a/funnel-udf/src/steps.rs
+++ b/funnel-udf/src/steps.rs
@@ -255,10 +255,14 @@ impl AggregateFunnelRow {
             let mut in_match_window = previous_timestamp != 0.0
                 && event.timestamp - previous_timestamp <= args.conversion_window_limit as f64;
 
-            // Go backwards until you hit a match or you get to the previous mandatory step
+            // Go backwards until you hit a match or you get to the previous mandatory step.
+            // Do not skip over an optional step that this same event matches. The event belongs
+            // to that step, so a later step must not consume it. Without this guard one event
+            // fills two steps, and the earlier step reports no conversions at all.
             while previous_step_index > 0
                 && (previous_timestamp == 0.0 || !in_match_window)
                 && args.optional_steps.contains(&(previous_step_index as i8))
+                && !event.steps.contains(&(previous_step_index as i8))
             {
                 previous_step_index -= 1;
                 previous_timestamp = vars.entered_timestamp[previous_step_index].timestamp;
@@ -335,5 +339,46 @@ impl AggregateFunnelRow {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    fn steps_bitfield(num_steps: usize, optional_steps: &[i8], events: &[(f64, &[i8])]) -> u32 {
+        let value: Vec<String> = events
+            .iter()
+            .enumerate()
+            .map(|(i, (timestamp, steps))| {
+                format!(
+                    r#"{{"timestamp":{timestamp},"uuid":"00000000-0000-0000-0000-{:012}","breakdown":"","steps":{steps:?}}}"#,
+                    i + 1
+                )
+            })
+            .collect();
+        let line = format!(
+            r#"{{"num_steps":{num_steps},"conversion_window_limit":3600,"breakdown_attribution_type":"first_touch","funnel_order_type":"ordered","prop_vals":[""],"optional_steps":{optional_steps:?},"value":[{}]}}"#,
+            value.join(",")
+        );
+        run(&parse_args(&line).unwrap())[0].4
+    }
+
+    // Steps 2, 3 and 4 are optional and step 1 is required, so step 4 may skip back to step 1.
+    #[rstest]
+    // The events at t=2 and t=4 match both step 2 and step 4. Step 4 must leave the first one
+    // for step 2, otherwise step 2 converts nobody.
+    #[case(
+        &[(1.0, &[1][..]), (2.0, &[2, 4][..]), (3.0, &[3][..]), (4.0, &[2, 4][..])],
+        0b1111
+    )]
+    // Nothing matches step 2 or step 3, so step 4 still skips back to step 1.
+    #[case(&[(1.0, &[1][..]), (2.0, &[4][..])], 0b1001)]
+    fn skipping_optional_steps_leaves_events_that_match_them(
+        #[case] events: &[(f64, &[i8])],
+        #[case] expected_bitfield: u32,
+    ) {
+        assert_eq!(steps_bitfield(4, &[2, 3, 4], events), expected_bitfield);
     }
 }


### PR DESCRIPTION
## Problem

A funnel step marked optional can report zero conversions, although the event happened for every person the funnel counts. Marking the same step required reports the real number.

- The skip logic walks backward over optional steps to find where a later step attaches.
- It also walked over optional steps that the current event itself matched.
- One event then filled two steps. The later step took the event, and the earlier optional step converted nobody.
- A funnel reaches this state when one event sits on two steps and every step between them is optional. A run of optional steps at the end of a funnel makes that easy to build.

## Changes

- An optional step now keeps the event that matches it. A funnel that lists one event on an optional step, and again on a later step, reports both steps correctly.
- The back-off loop in the steps UDF stops at an optional step that the current event matches.
- Nothing else changes. When no single event matches two steps, the walk behaves as before.

> [!NOTE]
> This PR changes source only. `funnel-udf` ships as committed binaries under `posthog/user_scripts`, so the fix reaches ClickHouse only after the `build.sh` and `udf_versioner.py` release described in `funnel-udf/README.md`.

> [!WARNING]
> A related behavior stays as it is. When a funnel reaches a later step by skipping an optional step, a later occurrence of that optional step still does not count, because the furthest-step record never moves backward. That needs a product decision, because it moves numbers on existing funnels.
>
> This is not a rare edge case. On the funnel that prompted this PR, it accounts for about a third of the people the optional step drops. The duplicate-event cause that this PR fixes accounts for the rest. It deserves a follow-up rather than closing with this PR.

## How did you test this code?

- Two cases added to `funnel-udf/src/steps.rs`, both over the back-off across optional steps. No existing test covered one event matching two optional steps.
  - Case 1 catches this regression. Without the guard the bitfield reads `0b1001` instead of `0b1111`, because step 4 consumed the event that step 2 should have kept.
  - Case 2 guards the opposite direction. A later step must still skip over optional steps when no event matches them.
- Ran `cargo test`, `cargo fmt --check` and `cargo clippy` in `funnel-udf`. Tests pass and the changed lines are clean.
- Not run: the Python funnel suites. They reach the UDF through the committed binary, which this PR does not rebuild, so they would exercise the old behavior either way.
- Not run: `hogli ci:preflight`. `hogli` is not on the PATH in this environment.
- No workflow under `.github/workflows` builds or tests `funnel-udf`, so CI does not run these Rust tests.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

- An agent wrote this PR while investigating a support ticket about an optional funnel step reporting zero.
- Skills invoked: `writing-tests`, `writing-code-comments`, `writing-pr-descriptions`, `reviewing-with-coderabbit`, `writing-simplified-technical-english`.
- The CodeRabbit pass is paused, so this PR opened without a local pass.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

