### PR TITLE
fix(pgcollector): report a stale pg_stat_statements before querying it

### DIFF
--- a/rust/pgcollector/docs/deploy.md
+++ b/rust/pgcollector/docs/deploy.md
@@ -31,6 +31,8 @@ Nothing here requires a parameter-group change or a reboot.
   `ALTER EXTENSION pg_stat_statements UPDATE` there after a major upgrade. The
   collector reads the columns the installed version has and emits one
   `pgss_stale` event (plus a warning log) until the extension catches up.
+  Below 1.8 (the PG13 definition) `query_stats` and `aurora_plans` collect
+  nothing until the extension is updated.
 * `pg_proctab` — optional. Not installed anywhere today; `CREATE EXTENSION
   pg_proctab` in the maintenance database enables `system_cpu`,
   `system_memory`, `system_disk`, `backend_cpu`. Until then those four log one

--- a/rust/pgcollector/src/collectors/aurora_plans.rs
+++ b/rust/pgcollector/src/collectors/aurora_plans.rs
@@ -47,7 +47,17 @@ impl Collector for AuroraPlans {
         } else {
             ""
         };
-        let cols = statements::pgss_columns(statements::pgss_version(cx));
+        let ext = statements::pgss_version(cx);
+        if ext < statements::MIN_PGSS_VERSION {
+            return Ok(statements::empty(
+                self.name(),
+                KEY,
+                cx,
+                &extra,
+                Default::default(),
+            ));
+        }
+        let cols = statements::pgss_columns(ext);
         let src = Source {
             name: "aurora_plans",
             aux_name: "query_plans",

--- a/rust/pgcollector/src/collectors/query_stats.rs
+++ b/rust/pgcollector/src/collectors/query_stats.rs
@@ -65,9 +65,13 @@ impl Collector for QueryStats {
             ("pg_stat_statements(false)", "")
         };
         let ext = statements::pgss_version(cx);
-        let bundled = statements::bundled_pgss_version(cx.pg_version);
-        let report_stale = ext < bundled && !extra.warned_stale;
-        extra.warned_stale = ext < bundled;
+        let stale_event = statements::stale_report(cx, &mut extra);
+        if ext < statements::MIN_PGSS_VERSION {
+            let (mut snap, state) =
+                statements::empty(self.name(), KEY, cx, &extra, Default::default());
+            snap.events.extend(stale_event);
+            return Ok((snap, state));
+        }
         let cols = statements::pgss_columns(ext);
         let src = Source {
             name: "query_stats",
@@ -88,18 +92,7 @@ impl Collector for QueryStats {
             text_key: &["queryid", "datname"],
         };
         let (mut snap, state) = statements::collect(&src, cx, prev, extra, true).await?;
-        if report_stale {
-            let installed = format!("{}.{}", ext.0, ext.1);
-            let bundled = format!("{}.{}", bundled.0, bundled.1);
-            tracing::warn!(server = cx.target.server_id, instance = cx.target.instance, installed, bundled,
-                "pg_stat_statements is behind the server's bundled version; run ALTER EXTENSION pg_stat_statements UPDATE in the maintenance database");
-            snap.events.push(Event {
-                kind: "pgss_stale".into(),
-                subject: cx.target.instance.clone(),
-                before: Some(serde_json::json!({ "extversion": installed })),
-                after: Some(serde_json::json!({ "extversion": bundled, "hint": "run ALTER EXTENSION pg_stat_statements UPDATE in the maintenance database; newer columns are skipped until then" })),
-            });
-        }
+        snap.events.extend(stale_event);
         Ok((snap, state))
     }
 }

--- a/rust/pgcollector/src/collectors/statements.rs
+++ b/rust/pgcollector/src/collectors/statements.rs
@@ -215,6 +215,34 @@ pub fn bundled_pgss_version(pg_version: u32) -> (u32, u32) {
     }
 }
 
+/// Oldest extension `pgss_columns` can select from: 1.8 split exec and plan time and added `wal_*`.
+pub const MIN_PGSS_VERSION: (u32, u32) = (1, 8);
+
+/// Warns once per state and returns the `pgss_stale` event when the installed extension is
+/// behind the server's bundled one.
+pub fn stale_report(cx: &CollectCtx<'_>, extra: &mut Extra) -> Option<Event> {
+    let ext = pgss_version(cx);
+    let bundled = bundled_pgss_version(cx.pg_version);
+    let stale = ext < bundled;
+    let first_report = stale && !extra.warned_stale;
+    extra.warned_stale = stale;
+    if !first_report {
+        return None;
+    }
+    let installed = format!("{}.{}", ext.0, ext.1);
+    let bundled = format!("{}.{}", bundled.0, bundled.1);
+    tracing::warn!(server = cx.target.server_id, instance = cx.target.instance, installed, bundled,
+        "pg_stat_statements is behind the server's bundled version; run ALTER EXTENSION pg_stat_statements UPDATE in the maintenance database");
+    Some(Event {
+        kind: "pgss_stale".into(),
+        subject: cx.target.instance.clone(),
+        before: Some(serde_json::json!({ "extversion": installed })),
+        after: Some(
+            serde_json::json!({ "extversion": bundled, "hint": "run ALTER EXTENSION pg_stat_statements UPDATE in the maintenance database; newer columns are skipped until then" }),
+        ),
+    })
+}
+
 /// Falls back to the server's bundled version when the probe could not read `extversion`.
 pub fn pgss_version(cx: &CollectCtx<'_>) -> (u32, u32) {
     cx.caps


### PR DESCRIPTION
## Problem

- Anyone opening top queries in pgapi for a cluster whose `pg_stat_statements` is older than 1.8 still sees nothing, and pgapi events give no hint why: `query_stats` fails every tick with `column s.total_exec_time does not exist`.
- #99511 gated the column list on the extension version, but its stale report ran after the stats query. When the query failed, the warning and the `pgss_stale` event never landed.
- 1.8 is the oldest extension the column list supports. It split exec and plan time and added the `wal_*` columns, so no gating can read an older definition with one query shape.

## Changes

- A lagging extension now reports before the stats query, so the `pgss_stale` event and warning land even when the query cannot run.
- Below extension 1.8, `query_stats` and `aurora_plans` return an empty snapshot with the `pgss_stale` event instead of failing every tick. Stats resume on the next tick after `ALTER EXTENSION pg_stat_statements UPDATE` runs.
- `docs/deploy.md` notes the 1.8 floor.

## How did you test this code?

- `cargo test -p pgcollector` and `cargo clippy -p pgcollector --all-targets -- -D warnings` pass locally.
- No new tests. The change moves an existing report ahead of a query and adds a version guard; neither has a cheap seam without a live connection.
- Diagnosis came from the dev pgapi `collector_health` output after #99511 deployed: the error moved from `toplevel` to `total_exec_time`, and `events` showed no `pgss_stale`.
- Not run: the collector against a live cluster with this build.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`rust/pgcollector/docs/deploy.md` updated in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code at the assignee's direction, as a follow-up to #99511. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`. This commit was first pushed to the #99511 branch after that PR had merged, so it was moved to this branch. The CodeRabbit local pass is paused, so the PR opened without one.

https://claude.ai/code/session_01PMccrmfb7LqGEmxT5zhfZ2
