### PR TITLE
feat(desktop): support report claims and multiple prs

### DIFF
--- a/products/desktop/apps/mobile/src/app/inbox/[...id].tsx
+++ b/products/desktop/apps/mobile/src/app/inbox/[...id].tsx
@@ -6,6 +6,7 @@ import {
   inboxStatusLabel,
   parseConventionalCommitTitle,
 } from "@posthog/core/inbox/reportPresentation";
+import { primaryReportPullRequest } from "@posthog/core/inbox/reportPullRequests";
 import {
   DISMISSAL_REASON_OPTIONS,
   SIGNALS_PR_REFUNDS_FLAG,
@@ -517,10 +518,10 @@ export default function ReportDetailScreen() {
             </Text>
           </View>
           <Text className="text-[12px] text-gray-9">Updated {timeDisplay}</Text>
-          {report.implementation_pr_url ? (
+          {primaryReportPullRequest(report).url ? (
             <View className="ml-auto">
               <PrStatusBadge
-                prUrl={report.implementation_pr_url}
+                prUrl={primaryReportPullRequest(report).url}
                 hideWhenUnresolved
                 size="sm"
               />

--- a/products/desktop/apps/mobile/src/features/inbox/components/ReportFeedbackFooter.tsx
+++ b/products/desktop/apps/mobile/src/features/inbox/components/ReportFeedbackFooter.tsx
@@ -1,4 +1,5 @@
 import { Text } from "@components/text";
+import { reportPullRequests } from "@posthog/core/inbox/reportPullRequests";
 import type { SignalReport } from "@posthog/shared/domain-types";
 import * as Haptics from "expo-haptics";
 import { ThumbsDown, ThumbsUp } from "phosphor-react-native";
@@ -45,7 +46,7 @@ export function ReportFeedbackFooter({ report }: { report: SignalReport }) {
         priority: report.priority ?? null,
         actionability: report.actionability ?? null,
         sentiment: next,
-        has_pr: !!report.implementation_pr_url,
+        has_pr: reportPullRequests(report).length > 0,
         surface: "detail_footer",
       });
     },
@@ -61,7 +62,7 @@ export function ReportFeedbackFooter({ report }: { report: SignalReport }) {
       priority: report.priority ?? null,
       actionability: report.actionability ?? null,
       sentiment,
-      has_pr: !!report.implementation_pr_url,
+      has_pr: reportPullRequests(report).length > 0,
       surface: "detail_footer",
       note: trimmed.slice(0, FEEDBACK_NOTE_MAX_LENGTH),
     });

--- a/products/desktop/apps/mobile/src/features/inbox/components/ReportListRow.tsx
+++ b/products/desktop/apps/mobile/src/features/inbox/components/ReportListRow.tsx
@@ -3,6 +3,7 @@ import {
   humanizeReportTitle,
   parseConventionalCommitTitle,
 } from "@posthog/core/inbox/reportPresentation";
+import { primaryReportPullRequest } from "@posthog/core/inbox/reportPullRequests";
 import type { SignalReport } from "@posthog/shared/domain-types";
 import { memo } from "react";
 import { Pressable, View } from "react-native";
@@ -103,10 +104,10 @@ function ReportListRowComponent({ report, onPress }: ReportListRowProps) {
         </View>
       </View>
 
-      {report.implementation_pr_url ? (
+      {primaryReportPullRequest(report).url ? (
         <View className="self-center">
           <PrStatusBadge
-            prUrl={report.implementation_pr_url}
+            prUrl={primaryReportPullRequest(report).url}
             hideWhenUnresolved
             size="sm"
           />

--- a/products/desktop/apps/mobile/src/features/inbox/components/SwipeableReportCard.tsx
+++ b/products/desktop/apps/mobile/src/features/inbox/components/SwipeableReportCard.tsx
@@ -4,6 +4,7 @@ import {
   inboxStatusLabel,
   parseConventionalCommitTitle,
 } from "@posthog/core/inbox/reportPresentation";
+import { primaryReportPullRequest } from "@posthog/core/inbox/reportPullRequests";
 import type {
   SignalReport,
   SignalReportPriority,
@@ -304,10 +305,10 @@ function CardContent({
             </View>
           </>
         )}
-        {report.implementation_pr_url ? (
+        {primaryReportPullRequest(report).url ? (
           <View className="ml-auto">
             <PrStatusBadge
-              prUrl={report.implementation_pr_url}
+              prUrl={primaryReportPullRequest(report).url}
               hideWhenUnresolved
               size="sm"
             />

--- a/products/desktop/apps/mobile/src/features/inbox/reportVerdictAction.ts
+++ b/products/desktop/apps/mobile/src/features/inbox/reportVerdictAction.ts
@@ -1,5 +1,9 @@
 import { canCreateImplementationPr } from "@posthog/core/inbox/reportActions";
 import { parsePrUrl } from "@posthog/core/inbox/reportPresentation";
+import {
+  hasActiveReportPullRequest,
+  primaryReportPullRequest,
+} from "@posthog/core/inbox/reportPullRequests";
 import type { SignalReport } from "@posthog/shared/domain-types";
 
 export type ReportVerdictAction =
@@ -17,22 +21,18 @@ export function isReportAwaitingInput(report: SignalReport): boolean {
 }
 
 /**
- * The implementation PR to link to, or null. A merged PR is history, not live
- * work. `implementation_pr_url` flows in from task-run output, so it is only
- * trusted as a canonical GitHub PR URL — anything else is not presented as
- * "View PR".
+ * Only active, valid GitHub links can offer the review action.
  */
 function liveImplementationPrUrl(report: SignalReport): string | null {
-  if (report.implementation_pr_merged) return null;
-  const url = report.implementation_pr_url;
+  if (!hasActiveReportPullRequest(report)) return null;
+  const url = primaryReportPullRequest(report).url;
   if (!url || !parsePrUrl(url)) return null;
   return url;
 }
 
 /**
  * The one action the verdict banner offers: open the live PR, start the fix, or
- * nothing. Mobile has no continuable-task lookup, so an existing PR is read from
- * `implementation_pr_url` alone.
+ * nothing.
  */
 export function resolveReportVerdictAction(
   report: SignalReport,

--- a/products/desktop/docs/REPORT-PULL-REQUESTS.md
+++ b/products/desktop/docs/REPORT-PULL-REQUESTS.md
@@ -1,0 +1,17 @@
+# Report pull requests
+
+Desktop, web-host, and mobile inbox surfaces read the report's `pull_requests` collection through the shared report PR helpers.
+The collection includes artefact links and legacy task-output PRs supplied by the backend.
+When a server omits the collection, the helpers fall back to `implementation_pr_url`, `implementation_pr_state`, and `implementation_pr_merged`.
+An explicitly empty collection takes precedence over legacy fields.
+
+The primary PR is deterministic: unfinished PRs first, then merged, then closed, with URL ordering for ties.
+The desktop report detail selector lets a reviewer choose another PR.
+GitHub links, checks, files, and comments follow that selection; switching PRs resets review-panel state.
+
+Task continuation uses PR attachment attribution to identify the internal task, including automatically created `agent_run` associations.
+Agent prompts use the claim, attach PRs, and release workflow and carry the returned claim ID.
+Claim display names are not displayed by this change.
+
+This client update depends on the report claims and PR API in PostHog/posthog#97846.
+Deploy that backend before releasing the desktop update.

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -4884,7 +4884,7 @@ ${commonInstructions}
 
 ${repositoryWorkspaceInstructions}
 
-If the work you are being asked to do already has an open pull request — for example, the inbox report you fetched links an implementation PR (its \`implementation_pr_url\`), or this same thread already produced a PR that you are now being asked to revise — do NOT open a second PR. Check that PR out with \`gh pr checkout <url>\`, continue on its branch, and commit your changes to it with the \`git_signed_commit\` tool (if the branch is behind its base, call \`git_signed_merge\` first). A PR is only the one to continue if it is for this same request; if the thread merely mentions an unrelated or older PR, ignore it. Only open a new, separate PR when the change is genuinely distinct from the existing one.
+If the work you are being asked to do already has an open pull request — for example, the inbox report you fetched links an implementation PR (its \`pull_requests\`), or this same thread already produced a PR that you are now being asked to revise — do NOT open a second PR. Check that PR out with \`gh pr checkout <url>\`, continue on its branch, and commit your changes to it with the \`git_signed_commit\` tool (if the branch is behind its base, call \`git_signed_merge\` first). A PR is only the one to continue if it is for this same request; if the thread merely mentions an unrelated or older PR, ignore it. Only open a new, separate PR when the change is genuinely distinct from the existing one.
 
 Otherwise, after completing the requested changes:
 1. Pick a new branch name prefixed with \`posthog/\` (e.g. \`posthog/fix-login-redirect\`)

--- a/products/desktop/packages/api-client/endpoint-allowlist.json
+++ b/products/desktop/packages/api-client/endpoint-allowlist.json
@@ -68,7 +68,7 @@
     "MCPToolApprovalStateEnum",
     "OAuthRedirectResponse",
     "PaginatedHogFlowMinimalList",
-    "PaginatedTaskDetailDTOList",
+    "PaginatedTaskListItemList",
     "PaginatedTaskRunDetailDTOList",
     "PaginatedTaskSummaryDTOList",
     "PatchedExternalDataSourceBulkUpdateSchemas",

--- a/products/desktop/packages/api-client/src/generated.ts
+++ b/products/desktop/packages/api-client/src/generated.ts
@@ -82,6 +82,7 @@ export namespace Schemas {
         | "count_pageviews"
         | "uniq_urls"
         | "uniq_page_screen_autocaptures";
+    export type FilterLogicalOperator = "AND" | "OR";
     export type CustomBotField =
         | "$raw_user_agent"
         | "$ip"
@@ -97,25 +98,32 @@ export namespace Schemas {
         | "$geoip_country_code"
         | "$referrer"
         | "$referring_domain";
-    export type CustomBotMatcher = "contains" | "regex" | "cidr";
-    export type CustomBotDefinition = {
-        category?: (string | null) | undefined;
+    export type CustomBotMatcher = "contains" | "regex" | "exact" | "cidr";
+    export type CustomBotCondition = {
         id: string;
         /**
-         * The event property this rule reads.
+         * The event property this condition reads.
          */
         key: CustomBotField;
         matcher: CustomBotMatcher;
-        /**
-         * Reported by `$virt_bot_name` and `$virt_bot_operator` when the rule matches.
-         */
-        name: string;
         /**
          * Matched against the property named by `key`.
          */
         pattern: string;
     };
-    export type FilterLogicalOperator = "AND" | "OR";
+    export type CustomBotRule = {
+        category?: (string | null) | undefined;
+        /**
+         * Whether every condition must match (AND) or any one of them (OR).
+         */
+        combiner: FilterLogicalOperator;
+        id: string;
+        items: Array<CustomBotCondition>;
+        /**
+         * Reported by `$virt_bot_name` and `$virt_bot_operator` when the rule matches.
+         */
+        name: string;
+    };
     export type CustomChannelField =
         | "utm_source"
         | "utm_medium"
@@ -185,7 +193,7 @@ export namespace Schemas {
         bounceRateDurationSeconds: number | null;
         bounceRatePageViewMode: BounceRatePageViewMode | null;
         convertToProjectTimezone: boolean | null;
-        customBotDefinitions: Array<CustomBotDefinition> | null;
+        customBotDefinitions: Array<CustomBotRule> | null;
         customChannelTypeRules: Array<CustomChannelRule> | null;
         dataWarehouseEventsModifiers: Array<DataWarehouseEventsModifier> | null;
         debug: boolean | null;
@@ -225,6 +233,8 @@ export namespace Schemas {
         time_elapsed: number;
     };
     export type QueryStatus = {
+        budget_remaining_bytes?: (number | null) | undefined;
+        bytes_read?: (number | null) | undefined;
         complete?: (boolean | null) | undefined;
         dashboard_id?: (number | null) | undefined;
         end_time?: (string | null) | undefined;
@@ -329,6 +339,7 @@ export namespace Schemas {
     }>;
     export type AccountsQuery = Partial<{
         allRolesUnassigned: boolean | null;
+        assignedOnly: boolean | null;
         assignedToUserIds: Array<number> | null;
         filterExpression: string | null;
         includeIgnored: boolean | null;
@@ -4770,6 +4781,24 @@ export namespace Schemas {
         xAxisColumn: string | null;
     }>;
     /**
+     * * `auto` - auto
+     * * `manual` - manual
+     */
+    export type BreakdownColorConfigSourceEnum = "auto" | "manual";
+    export type BreakdownColorConfig = {
+        /**
+         * The breakdown value this color applies to, as it appears in the chart legend.
+         */
+        breakdownValue: string;
+        /**
+         * Palette slot to color the value with, as `preset-1` upwards. Not a CSS color: a hex value is rejected. Null leaves the value on its default color.
+         */
+        colorToken: string | null;
+        breakdownType?: (string | null) | undefined;
+        breakdownProperty?: (string | null) | undefined;
+        source?: (BreakdownColorConfigSourceEnum | NullEnum) | undefined;
+    };
+    /**
      * * `distinct_id` - User ID (default)
      * * `device_id` - Device ID
      */
@@ -4868,6 +4897,16 @@ export namespace Schemas {
         showTicks: boolean | null;
         startAtZero: boolean | null;
     }>;
+    export type Summary = "total" | "average" | "latest";
+    export type MetricChartSettings = Partial<{
+        changeDecreaseColor: string | null;
+        changeIncreaseColor: string | null;
+        colorByDirection: boolean | null;
+        lineDecreaseColor: string | null;
+        lineIncreaseColor: string | null;
+        showChange: boolean | null;
+        summary: Summary | null;
+    }>;
     export type SliceContent = "labels" | "values" | "none";
     export type ValueDisplay = "absolute" | "percentage";
     export type PieChartSettings = Partial<{
@@ -4888,6 +4927,7 @@ export namespace Schemas {
         heatmap: HeatmapSettings | null;
         leftYAxisSettings: YAxisSettings | null;
         legendPosition: LegendPosition | null;
+        metric: MetricChartSettings | null;
         pie: PieChartSettings | null;
         resultCustomizations: Record<string, ResultCustomizationByValue> | null;
         rightYAxisSettings: YAxisSettings | null;
@@ -4908,6 +4948,11 @@ export namespace Schemas {
         yAxis: Array<ChartAxis> | null;
         yAxisAtZero: boolean | null;
     }>;
+    /**
+     * * `posthog-gateway` - posthog-gateway
+     * * `own-subscription` - own-subscription
+     */
+    export type ClaudeModelAccessEnum = "posthog-gateway" | "own-subscription";
     /**
      * * `claude` - claude
      */
@@ -5054,6 +5099,10 @@ export namespace Schemas {
          * Request body for creating a new task run
          */
         benjamin_enabled?: (boolean | null) | undefined;
+        /**
+         * Request body for creating a new task run
+         */
+        claude_model_access?: (ClaudeModelAccessEnum | NullEnum) | undefined;
     };
     /**
      * * `codex` - codex
@@ -5166,6 +5215,10 @@ export namespace Schemas {
          * Request body for creating a new task run
          */
         benjamin_enabled?: (boolean | null) | undefined;
+        /**
+         * Request body for creating a new task run
+         */
+        claude_model_access?: (ClaudeModelAccessEnum | NullEnum) | undefined;
     };
     export type PropertyGroupOperatorEnum = "AND" | "OR";
     export type CohortFilter = {
@@ -5764,7 +5817,7 @@ export namespace Schemas {
         /**
          * Serializer mixin that handles tags for objects.
          */
-        breakdown_colors?: unknown | undefined;
+        breakdown_colors?: (Array<BreakdownColorConfig> | null) | undefined;
         /**
          * Serializer mixin that handles tags for objects.
          */
@@ -6447,32 +6500,6 @@ export namespace Schemas {
               > | null)
             | undefined;
     };
-    export type Response14 = {
-        columns?: (Array<unknown> | null) | undefined;
-        error?: (string | null) | undefined;
-        hasMore?: (boolean | null) | undefined;
-        hogql?: (string | null) | undefined;
-        limit?: (number | null) | undefined;
-        modifiers?: (HogQLQueryModifiers | null) | undefined;
-        offset?: (number | null) | undefined;
-        query_status?: (QueryStatus | null) | undefined;
-        resolved_compare_date_range?:
-            | (ResolvedDateRangeResponse | null)
-            | undefined;
-        resolved_date_range?: (ResolvedDateRangeResponse | null) | undefined;
-        results: Array<Array<MarketingAnalyticsItem>>;
-        samplingRate?: (SamplingRate | null) | undefined;
-        timings?: (Array<QueryTiming> | null) | undefined;
-        types?: (Array<unknown> | null) | undefined;
-        used_data_warehouse_sources?:
-            | (Array<DataWarehouseSourceUsage> | null)
-            | undefined;
-        warnings?:
-            | (Array<
-                  DataWarehouseSyncWarning | AccessControlFilterWarning
-              > | null)
-            | undefined;
-    };
     export type VolumeBucket = { label: string; value: number };
     export type ErrorTrackingIssueAggregations = {
         occurrences: number;
@@ -6508,6 +6535,7 @@ export namespace Schemas {
         | "linear"
         | "github"
         | "gitlab"
+        | "helpscout"
         | "meta-ads"
         | "instagram"
         | "clickup"
@@ -6584,7 +6612,7 @@ export namespace Schemas {
         source?: (string | null) | undefined;
         status: ErrorTrackingIssueStatus;
     };
-    export type Response15 = {
+    export type Response14 = {
         columns?: (Array<string> | null) | undefined;
         error?: (string | null) | undefined;
         hasMore?: (boolean | null) | undefined;
@@ -6632,7 +6660,7 @@ export namespace Schemas {
         severity?: (ErrorTrackingQueryIssueSeverity | null) | undefined;
         status: ErrorTrackingIssueStatus;
     };
-    export type Response16 = {
+    export type Response15 = {
         columns?: (Array<string> | null) | undefined;
         error?: (string | null) | undefined;
         hasMore?: (boolean | null) | undefined;
@@ -6656,7 +6684,7 @@ export namespace Schemas {
               > | null)
             | undefined;
     };
-    export type Response17 = {
+    export type Response16 = {
         credible_intervals: Record<string, Array<number>>;
         expected_loss: number;
         funnels_query?: (FunnelsQuery | null) | undefined;
@@ -6669,7 +6697,7 @@ export namespace Schemas {
         variants: Array<ExperimentVariantFunnelsBaseStats>;
         warnings?: (Array<DataWarehouseSyncWarning> | null) | undefined;
     };
-    export type Response18 = {
+    export type Response17 = {
         count_query?: (TrendsQuery | null) | undefined;
         credible_intervals: Record<string, Array<number>>;
         exposure_query?: (TrendsQuery | null) | undefined;
@@ -6731,7 +6759,7 @@ export namespace Schemas {
         traceName?: (string | null) | undefined;
         webSearchCost?: (number | null) | undefined;
     };
-    export type Response19 = {
+    export type Response18 = {
         columns?: (Array<string> | null) | undefined;
         error?: (string | null) | undefined;
         hasMore?: (boolean | null) | undefined;
@@ -6755,7 +6783,7 @@ export namespace Schemas {
               > | null)
             | undefined;
     };
-    export type Response21 = {
+    export type Response20 = {
         columns?: (Array<unknown> | null) | undefined;
         error?: (string | null) | undefined;
         hasMore?: (boolean | null) | undefined;
@@ -6780,7 +6808,7 @@ export namespace Schemas {
               > | null)
             | undefined;
     };
-    export type Response22 = {
+    export type Response21 = {
         columns: Array<unknown>;
         error?: (string | null) | undefined;
         hasMore?: (boolean | null) | undefined;
@@ -6810,7 +6838,7 @@ export namespace Schemas {
               > | null)
             | undefined;
     };
-    export type Response23 = {
+    export type Response22 = {
         error?: (string | null) | undefined;
         hasMore: boolean;
         hogql?: (string | null) | undefined;
@@ -7645,6 +7673,7 @@ export namespace Schemas {
         | "content"
         | "term";
     export type IntegrationFilter = Partial<{
+        includeNonIntegrated: boolean | null;
         integrationSourceIds: Array<string> | null;
     }>;
     export type MarketingAnalyticsOrderByEnum = "ASC" | "DESC";
@@ -7770,75 +7799,6 @@ export namespace Schemas {
         >;
         response?:
             | (MarketingAnalyticsAggregatedQueryResponse | null)
-            | undefined;
-        sampling?: (WebAnalyticsSampling | null) | undefined;
-        samplingFactor?: (number | null) | undefined;
-        select?: (Array<string> | null) | undefined;
-        tags?: (QueryLogTags | null) | undefined;
-        useSessionsTable?: (boolean | null) | undefined;
-        version?: (number | null) | undefined;
-    };
-    export type NonIntegratedConversionsTableQueryResponse = {
-        columns?: (Array<unknown> | null) | undefined;
-        error?: (string | null) | undefined;
-        hasMore?: (boolean | null) | undefined;
-        hogql?: (string | null) | undefined;
-        limit?: (number | null) | undefined;
-        modifiers?: (HogQLQueryModifiers | null) | undefined;
-        offset?: (number | null) | undefined;
-        query_status?: (QueryStatus | null) | undefined;
-        resolved_compare_date_range?:
-            | (ResolvedDateRangeResponse | null)
-            | undefined;
-        resolved_date_range?: (ResolvedDateRangeResponse | null) | undefined;
-        results: Array<Array<MarketingAnalyticsItem>>;
-        samplingRate?: (SamplingRate | null) | undefined;
-        timings?: (Array<QueryTiming> | null) | undefined;
-        types?: (Array<unknown> | null) | undefined;
-        used_data_warehouse_sources?:
-            | (Array<DataWarehouseSourceUsage> | null)
-            | undefined;
-        warnings?:
-            | (Array<
-                  DataWarehouseSyncWarning | AccessControlFilterWarning
-              > | null)
-            | undefined;
-    };
-    export type NonIntegratedConversionsTableQuery = {
-        aggregation_group_type_index?: (number | null) | undefined;
-        compareFilter?: (CompareFilter | null) | undefined;
-        conversionGoal?:
-            | (ActionConversionGoal | CustomEventConversionGoal | null)
-            | undefined;
-        dataColorTheme?: (number | null) | undefined;
-        dateRange?: (DateRange | null) | undefined;
-        doPathCleaning?: (boolean | null) | undefined;
-        draftConversionGoal?:
-            | (
-                  | ConversionGoalFilter1
-                  | ConversionGoalFilter2
-                  | ConversionGoalFilter3
-                  | null
-              )
-            | undefined;
-        filterTestAccounts?: (boolean | null) | undefined;
-        includeRevenue?: (boolean | null) | undefined;
-        interval?: (IntervalType | null) | undefined;
-        kind?: string | undefined;
-        limit?: (number | null) | undefined;
-        modifiers?: (HogQLQueryModifiers | null) | undefined;
-        offset?: (number | null) | undefined;
-        orderBy?:
-            | (Array<Array<string | MarketingAnalyticsOrderByEnum>> | null)
-            | undefined;
-        properties: Array<
-            | EventPropertyFilter
-            | PersonPropertyFilter
-            | SessionPropertyFilter
-            | CohortPropertyFilter
-        >;
-        response?:
-            | (NonIntegratedConversionsTableQueryResponse | null)
             | undefined;
         sampling?: (WebAnalyticsSampling | null) | undefined;
         samplingFactor?: (number | null) | undefined;
@@ -8277,10 +8237,9 @@ export namespace Schemas {
                   | Response16
                   | Response17
                   | Response18
-                  | Response19
+                  | Response20
                   | Response21
                   | Response22
-                  | Response23
                   | null
               )
             | undefined;
@@ -8330,7 +8289,6 @@ export namespace Schemas {
             | SessionsQuery
             | MarketingAnalyticsTableQuery
             | MarketingAnalyticsAggregatedQuery
-            | NonIntegratedConversionsTableQuery
             | ErrorTrackingQuery
             | ErrorTrackingIssueCorrelationQuery
             | ExperimentFunnelsQuery
@@ -10299,6 +10257,7 @@ export namespace Schemas {
      * * `Freshchat` - Freshchat
      * * `Freshservice` - Freshservice
      * * `Fulcrum` - Fulcrum
+     * * `GainsightCs` - GainsightCs
      * * `GainsightPx` - GainsightPx
      * * `GitBook` - GitBook
      * * `Glassfrog` - Glassfrog
@@ -11299,6 +11258,11 @@ export namespace Schemas {
      * * `Tenjin` - Tenjin
      * * `Folk` - Folk
      * * `Cybersource` - Cybersource
+     * * `GoogleAdSense` - GoogleAdSense
+     * * `Sequenzy` - Sequenzy
+     * * `Skio` - Skio
+     * * `Smartlead` - Smartlead
+     * * `Substack` - Substack
      */
     export type ExternalDataSourceTypeEnum =
         | "Ashby"
@@ -11633,6 +11597,7 @@ export namespace Schemas {
         | "Freshchat"
         | "Freshservice"
         | "Fulcrum"
+        | "GainsightCs"
         | "GainsightPx"
         | "GitBook"
         | "Glassfrog"
@@ -12632,7 +12597,12 @@ export namespace Schemas {
         | "RecallAI"
         | "Tenjin"
         | "Folk"
-        | "Cybersource";
+        | "Cybersource"
+        | "GoogleAdSense"
+        | "Sequenzy"
+        | "Skio"
+        | "Smartlead"
+        | "Substack";
     /**
      * * `web` - web
      * * `api` - api
@@ -12975,6 +12945,7 @@ export namespace Schemas {
          * * `Freshchat` - Freshchat
          * * `Freshservice` - Freshservice
          * * `Fulcrum` - Fulcrum
+         * * `GainsightCs` - GainsightCs
          * * `GainsightPx` - GainsightPx
          * * `GitBook` - GitBook
          * * `Glassfrog` - Glassfrog
@@ -13975,6 +13946,11 @@ export namespace Schemas {
          * * `Tenjin` - Tenjin
          * * `Folk` - Folk
          * * `Cybersource` - Cybersource
+         * * `GoogleAdSense` - GoogleAdSense
+         * * `Sequenzy` - Sequenzy
+         * * `Skio` - Skio
+         * * `Smartlead` - Smartlead
+         * * `Substack` - Substack
          */
         source_type: ExternalDataSourceTypeEnum;
         /**
@@ -14175,7 +14151,7 @@ export namespace Schemas {
          */
         evaluation_contexts?: Array<unknown> | undefined;
         /**
-         * Dashboard of saved usage insights for this flag, or null if it has none. Flags do not get one on creation; create it with POST /api/projects/{project_id}/feature_flags/{id}/dashboard/.
+         * Legacy dashboard of saved usage insights for this flag, or null if it has none. New flags show usage charts inline instead. The dashboard creation endpoint is deprecated and will be removed after September 25, 2026.
          */
         usage_dashboard: number | null;
         /**
@@ -14465,7 +14441,7 @@ export namespace Schemas {
          */
         type: HogFlowActionTypeEnum;
         /**
-         * Type-specific config keyed by action type. trigger: {type: event|webhook|manual|batch|schedule|tracking_pixel|internal-event, filters?}. internal-event requires filters.events naming one or more allowed event ids, and runs once for each matching event on the internal-events stream. Runs are person-less, so person-dependent steps are rejected. $slack_message_received takes filters: {properties: [<cond>]} over the message properties (channel, user, bot_id, text, subtype, is_thread_reply), and requires an exact-match channel filter; without one it runs on every message in every connected channel. $github_event_received takes filters: {properties: [<cond>]} over the delivery properties (repository, event_type, action, sender, bot_sender, own_app, author_association, actor_access, title, body, review_state, branch, repository_visibility), and requires exact-match repository and event_type filters; without them it runs on every delivery from every connected repository. webhook and manual triggers also require template_id: 'template-source-webhook', and tracking_pixel requires template_id: 'template-source-webhook-pixel'. filters shape: {events: [{id, name, type:'events', properties:[<cond>]}], properties:[<cond>], actions:[...], filter_test_accounts:<bool>}. <cond>: {key, value, operator, type: event|person|group}, or {key: 'id', type: 'cohort', value: <cohort_id>, operator: 'in'} to reference a cohort. batch triggers may set filters.audience_type: 'persons' (default) or 'accounts'. An accounts audience fans out one run per customer analytics account and takes account filters instead: properties entries of type 'account_custom_property' (key = definition id), plus tag_names: [<str>], assigned_to_user_ids: [<int>], all_roles_unassigned: <bool>. function*: {template_id, inputs: {<key>: {value: <str>}}}. Wrap values in {value:...} to enable hog templating ({person.x}, {event.x}); flat strings won't interpolate. function_email also accepts tracking_enabled?: <bool> (default true) - when false, no open pixel is injected, links are not rewritten, and the send skips ESP-level open/click tracking, so opens and clicks are not recorded for that step (delivery/bounce/unsubscribe still are). Dictionary input values are template strings too — write booleans/numbers as single-expression templates ('{true}', '{42}'), which evaluate to the typed value. delay: waits a fixed span or until a per-person/-event date — set EXACTLY ONE of delay_duration or delay_until. {delay_duration: '<number><unit>'} where unit is s|m|h|d. Fractions OK ('1.5d'=36h). Per-unit max s<=60, m<=60, h<=24, d<=30; values above are SILENTLY CLAMPED. Max 30d. delay_until: {expression: '<SQL>', offset?: '<±number><unit>'} waits until the date expression evaluates to (an ISO string, unix seconds, or a date value all resolve to the same instant); offset is a signed duration shifting it ('-1d' a day before, '2h' two hours after). expression is compiled server-side, so any bytecode sent with it is discarded. A person property is person.properties.<key>; an event property is properties.<key>, as the 'event.' prefix resolves to nothing and aborts the run. Optional timezone (IANA name), use_person_timezone (read $geoip_time_zone) and fallback_timezone decide which zone a date with no offset of its own is read in; a date that states an offset, and unix seconds, ignore them. Default UTC. Optional sibling max_delay_duration (default 30d, same '<number><unit>' format) caps how far past the step's start the wait may run. conditional_branch: {conditions: [{filters}, ...]}. Index N matches the 'branch' edge with index:N. random_cohort_branch: {cohorts: [{percentage: <number>, name?}, ...]}. Index N matches the 'branch' edge with index:N; percentages are relative weights, so they should sum to 100 but a total above or below that still splits traffic in the given proportions. wait_until_condition: {condition: {filters}, events?: [{filters: {events: [{id, name, type: 'events'}], actions?: [...]}, name?}], max_wait_duration: <duration>} (same rules as delay). Continues when condition.filters match OR any events entry fires; each events entry must target at least one event or action. On resolution (a condition match or any events entry firing) it advances via the 'branch' edge with index:0; the max_wait_duration timeout falls through the 'continue' edge. exit: {reason}.
+         * Type-specific config keyed by action type. trigger: {type: event|webhook|manual|batch|schedule|tracking_pixel|internal-event, filters?}. internal-event requires filters.events naming one or more allowed event ids, and runs once for each matching event on the internal-events stream. Runs are person-less, so person-dependent steps are rejected. $slack_message_received takes filters: {properties: [<cond>]} over the message properties (channel, user, bot_id, text, subtype, is_thread_reply), and requires an exact-match channel filter; without one it runs on every message in every connected channel. $github_event_received takes filters: {properties: [<cond>]} over the delivery properties (repository, event_type, action, sender, bot_sender, own_app, author_association, actor_access, title, body, review_state, branch, repository_visibility), and requires exact-match repository and event_type filters; without them it runs on every delivery from every connected repository. webhook and manual triggers also require template_id: 'template-source-webhook', and tracking_pixel requires template_id: 'template-source-webhook-pixel'. filters shape: {events: [{id, name, type:'events', properties:[<cond>]}], properties:[<cond>], actions:[...], filter_test_accounts:<bool>}. <cond>: {key, value, operator, type: event|person|group}, or {key: 'id', type: 'cohort', value: <cohort_id>, operator: 'in'} to reference a cohort. batch triggers may set filters.audience_type: 'persons' (default) or 'accounts'. An accounts audience fans out one run per customer analytics account and takes account filters instead: properties entries of type 'account_custom_property' (key = definition id), plus tag_names: [<str>], assignment_status: 'all'|'assigned'|'unassigned', and assigned_to_user_ids: [<int>] when assignment_status is 'assigned'. all_roles_unassigned remains accepted for workflows saved before assignment_status was added. function*: {template_id, inputs: {<key>: {value: <str>}}}. Wrap values in {value:...} to enable hog templating ({person.x}, {event.x}); flat strings won't interpolate. function_email also accepts tracking_enabled?: <bool> (default true) - when false, no open pixel is injected, links are not rewritten, and the send skips ESP-level open/click tracking, so opens and clicks are not recorded for that step (delivery/bounce/unsubscribe still are). Dictionary input values are template strings too — write booleans/numbers as single-expression templates ('{true}', '{42}'), which evaluate to the typed value. delay: waits a fixed span or until a per-person/-event date — set EXACTLY ONE of delay_duration or delay_until. {delay_duration: '<number><unit>'} where unit is s|m|h|d. Fractions OK ('1.5d'=36h). Per-unit max s<=60, m<=60, h<=24, d<=30; values above are SILENTLY CLAMPED. Max 30d. delay_until: {expression: '<SQL>', offset?: '<±number><unit>'} waits until the date expression evaluates to (an ISO string, unix seconds, or a date value all resolve to the same instant); offset is a signed duration shifting it ('-1d' a day before, '2h' two hours after). expression is compiled server-side, so any bytecode sent with it is discarded. A person property is person.properties.<key>; an event property is properties.<key>, as the 'event.' prefix resolves to nothing and aborts the run. Optional timezone (IANA name), use_person_timezone (read $geoip_time_zone) and fallback_timezone decide which zone a date with no offset of its own is read in; a date that states an offset, and unix seconds, ignore them. Default UTC. Optional sibling max_delay_duration (default 30d, same '<number><unit>' format) caps how far past the step's start the wait may run. conditional_branch: {conditions: [{filters}, ...]}. Index N matches the 'branch' edge with index:N. random_cohort_branch: {cohorts: [{percentage: <number>, name?}, ...]}. Index N matches the 'branch' edge with index:N; percentages are relative weights, so they should sum to 100 but a total above or below that still splits traffic in the given proportions. wait_until_condition: {condition: {filters}, events?: [{filters: {events: [{id, name, type: 'events'}], actions?: [...]}, name?}], max_wait_duration: <duration>} (same rules as delay). Continues when condition.filters match OR any events entry fires; each events entry must target at least one event or action. On resolution (a condition match or any events entry firing) it advances via the 'branch' edge with index:0; the max_wait_duration timeout falls through the 'continue' edge. exit: {reason}.
          */
         config:
             | Record<string, unknown>
@@ -14996,6 +14972,7 @@ export namespace Schemas {
      * * `google-pubsub` - Google Pubsub
      * * `google-search-console` - Google Search Console
      * * `google-sheets` - Google Sheets
+     * * `helpscout` - Helpscout
      * * `hubspot` - Hubspot
      * * `instagram` - Instagram
      * * `intercom` - Intercom
@@ -15045,6 +15022,7 @@ export namespace Schemas {
         | "google-pubsub"
         | "google-search-console"
         | "google-sheets"
+        | "helpscout"
         | "hubspot"
         | "instagram"
         | "intercom"
@@ -15678,7 +15656,10 @@ export namespace Schemas {
          * When True, in-app callouts inviting members to enable AI training are shown.
          */
         is_ai_training_cta_shown: boolean | null;
-        is_hipaa: boolean | null;
+        /**
+         * Whether the organization has a countersigned Business Associate Agreement on file. When true, AI training stays opted out and cannot be changed.
+         */
+        has_signed_baa: boolean;
         default_experiment_stats_method?:
             | (
                   | OrganizationDefaultExperimentStatsMethodEnum
@@ -16213,11 +16194,129 @@ export namespace Schemas {
          */
         origin_key?: (string | null) | undefined;
     };
-    export type PaginatedTaskDetailDTOList = {
+    /**
+     * Basic list response for a task, returned when the list is asked for ``basic=true``.
+     *
+     * A surface that renders only a summary of each task asks for the basic payload and gets this
+     * smaller shape. It drops the full ``description`` body, which dominates the list payload, and
+     * replaces it with ``description_preview`` (the first characters) so a feed can still show a
+     * prompt snippet. The default list response keeps the full ``description``, and ``retrieve``
+     * always returns it. A client uses the ``search`` query parameter to match description text
+     * server-side.
+     */
+    export type TaskBasic = {
+        id: string;
+        task_number: number | null;
+        slug: string;
+        title: string;
+        title_manually_set: boolean;
+        origin_product: string;
+        /**
+         * Agent protocol and harness used for this task's runs.
+         *
+         * * `acp` - ACP
+         * * `pi` - Pi
+         */
+        runtime: TaskRuntimeEnum;
+        repository: string | null;
+        repositories: Array<string>;
+        github_integration: number | null;
+        github_user_integration: string | null;
+        signal_report: string | null;
+        json_schema: Record<string, unknown> | null;
+        internal: boolean;
+        archived: boolean;
+        archived_at: string | null;
+        /**
+         * Basic list response for a task, returned when the list is asked for ``basic=true``.
+         *
+         * A surface that renders only a summary of each task asks for the basic payload and gets this
+         * smaller shape. It drops the full ``description`` body, which dominates the list payload, and
+         * replaces it with ``description_preview`` (the first characters) so a feed can still show a
+         * prompt snippet. The default list response keeps the full ``description``, and ``retrieve``
+         * always returns it. A client uses the ``search`` query parameter to match description text
+         * server-side.
+         */
+        latest_run?: (TaskRunDetailDTO | null) | undefined;
+        /**
+         * Basic list response for a task, returned when the list is asked for ``basic=true``.
+         *
+         * A surface that renders only a summary of each task asks for the basic payload and gets this
+         * smaller shape. It drops the full ``description`` body, which dominates the list payload, and
+         * replaces it with ``description_preview`` (the first characters) so a feed can still show a
+         * prompt snippet. The default list response keeps the full ``description``, and ``retrieve``
+         * always returns it. A client uses the ``search`` query parameter to match description text
+         * server-side.
+         */
+        created_at?: (string | null) | undefined;
+        /**
+         * Basic list response for a task, returned when the list is asked for ``basic=true``.
+         *
+         * A surface that renders only a summary of each task asks for the basic payload and gets this
+         * smaller shape. It drops the full ``description`` body, which dominates the list payload, and
+         * replaces it with ``description_preview`` (the first characters) so a feed can still show a
+         * prompt snippet. The default list response keeps the full ``description``, and ``retrieve``
+         * always returns it. A client uses the ``search`` query parameter to match description text
+         * server-side.
+         */
+        updated_at?: (string | null) | undefined;
+        /**
+         * Basic list response for a task, returned when the list is asked for ``basic=true``.
+         *
+         * A surface that renders only a summary of each task asks for the basic payload and gets this
+         * smaller shape. It drops the full ``description`` body, which dominates the list payload, and
+         * replaces it with ``description_preview`` (the first characters) so a feed can still show a
+         * prompt snippet. The default list response keeps the full ``description``, and ``retrieve``
+         * always returns it. A client uses the ``search`` query parameter to match description text
+         * server-side.
+         */
+        last_activity_at?: (string | null) | undefined;
+        /**
+         * Basic list response for a task, returned when the list is asked for ``basic=true``.
+         *
+         * A surface that renders only a summary of each task asks for the basic payload and gets this
+         * smaller shape. It drops the full ``description`` body, which dominates the list payload, and
+         * replaces it with ``description_preview`` (the first characters) so a feed can still show a
+         * prompt snippet. The default list response keeps the full ``description``, and ``retrieve``
+         * always returns it. A client uses the ``search`` query parameter to match description text
+         * server-side.
+         */
+        created_by?: (TaskUserBasicInfo | null) | undefined;
+        ci_prompt: string | null;
+        /**
+         * Basic list response for a task, returned when the list is asked for ``basic=true``.
+         *
+         * A surface that renders only a summary of each task asks for the basic payload and gets this
+         * smaller shape. It drops the full ``description`` body, which dominates the list payload, and
+         * replaces it with ``description_preview`` (the first characters) so a feed can still show a
+         * prompt snippet. The default list response keeps the full ``description``, and ``retrieve``
+         * always returns it. A client uses the ``search`` query parameter to match description text
+         * server-side.
+         */
+        channel?: (string | null) | undefined;
+        slack_thread_references: Array<SlackThreadReferenceDTO>;
+        /**
+         * Basic list response for a task, returned when the list is asked for ``basic=true``.
+         *
+         * A surface that renders only a summary of each task asks for the basic payload and gets this
+         * smaller shape. It drops the full ``description`` body, which dominates the list payload, and
+         * replaces it with ``description_preview`` (the first characters) so a feed can still show a
+         * prompt snippet. The default list response keeps the full ``description``, and ``retrieve``
+         * always returns it. A client uses the ``search`` query parameter to match description text
+         * server-side.
+         */
+        origin_key?: (string | null) | undefined;
+        /**
+         * First 1000 characters of the description, so a summary surface can show a prompt snippet without the full body. Open the task for the complete text.
+         */
+        description_preview: string;
+    };
+    export type TaskListItem = TaskDetailDTO | TaskBasic;
+    export type PaginatedTaskListItemList = {
         count: number;
         next?: (string | null) | undefined;
         previous?: (string | null) | undefined;
-        results: Array<TaskDetailDTO>;
+        results: Array<TaskListItem>;
     };
     export type PaginatedTaskRunDetailDTOList = {
         count: number;
@@ -17899,7 +17998,7 @@ export namespace Schemas {
         description: string;
         pinned: boolean;
         filters: DashboardFiltersOpenApi;
-        breakdown_colors: unknown;
+        breakdown_colors: Array<BreakdownColorConfig> | null;
         data_color_theme_id: number | null;
         tags: Array<string>;
         restriction_level: RestrictionLevelEnum;
@@ -19500,6 +19599,7 @@ export namespace Schemas {
         error: string;
         type: string;
         code: string;
+        retry_token: string;
         reason: DesktopAccessReasonEnum;
         attr: string;
         missing_artifact_ids: Array<string>;
@@ -19714,7 +19814,7 @@ export namespace Schemas {
         | "is_not_set";
     export type _LogPropertyFilter = {
         /**
-         * Attribute key. For type "log", use "message". For "log_attribute"/"log_resource_attribute", use the attribute key (e.g. "k8s.container.name").
+         * Attribute key. For type "log", use "message" for the body text, or a log column: "pattern" and "pattern_version" (the patterns pivot), "severity_level", "service_name", "trace_id", "span_id". For "log_attribute"/"log_resource_attribute", use the attribute key (e.g. "k8s.container.name").
          */
         key: string;
         /**
@@ -19853,6 +19953,7 @@ export namespace Endpoints {
         parameters: {
             query: Partial<{
                 completed: "any" | "open" | "completed";
+                created_by: number;
                 cursor: string;
                 item_id: string;
                 kind: "any" | "comment" | "task";
@@ -20839,7 +20940,7 @@ export namespace Endpoints {
         responses: { 200: Schemas.SurveyStatsResponse };
     };
     /**
-     * Get a list of tasks for the current project, with optional filtering by origin product, stage, organization, repository, created_by, and the workflow (hog_flow_id) that created the task.
+     * Get a list of tasks for the current project, with optional filtering by origin product, stage, organization, repository, created_by, and the workflow (hog_flow_id) that created the task. By default, each row includes description. Pass basic=true for a summary row that omits description and includes description_preview, its first 1000 characters. Use the search parameter to match description text server-side.
      */
     export type get_Tasks_list = {
         method: "GET";
@@ -20849,6 +20950,7 @@ export namespace Endpoints {
             query: Partial<{
                 all_team_tasks: boolean;
                 archived: "true" | "false" | "all";
+                basic: boolean;
                 channel: string;
                 ci_status: "passing" | "failing" | "pending" | "none";
                 commented_by: number;
@@ -20898,7 +21000,7 @@ export namespace Endpoints {
             }>;
             path: { project_id: string };
         };
-        responses: { 200: Schemas.PaginatedTaskDetailDTOList };
+        responses: { 200: Schemas.PaginatedTaskListItemList };
     };
     /**
      * API for managing tasks within a project. Tasks represent units of work to be performed by an agent.
@@ -20909,11 +21011,12 @@ export namespace Endpoints {
         requestFormat: "json";
         parameters: {
             path: { project_id: string };
-
+            header: Partial<{ "X-PostHog-Warm-Retry": string }>;
             body: Schemas.TaskCreate;
         };
         responses: {
             201: Schemas.TaskDetailDTO;
+            402: Schemas.TaskRunErrorResponse;
             403: Schemas.TaskRunErrorResponse;
             429: Schemas.TaskRunErrorResponse;
             503: Schemas.TaskRunErrorResponse;
@@ -20980,12 +21083,13 @@ export namespace Endpoints {
         requestFormat: "json";
         parameters: {
             path: { id: string; project_id: string };
-
+            header: Partial<{ "X-PostHog-Warm-Retry": string }>;
             body: Schemas.TaskRunCreateRequestSchema;
         };
         responses: {
             200: Schemas.TaskDetailDTO;
             400: Schemas.TaskRunErrorResponse;
+            402: Schemas.TaskRunErrorResponse;
             403: Schemas.TaskRunErrorResponse;
             404: unknown;
             429: Schemas.TaskRunErrorResponse;

--- a/products/desktop/packages/api-client/src/hogFlowLoops.ts
+++ b/products/desktop/packages/api-client/src/hogFlowLoops.ts
@@ -164,7 +164,7 @@ export async function listHogFlowTasks(
   projectId: string,
   hogFlowId: string,
   options: { limit: number },
-): Promise<Schemas.PaginatedTaskDetailDTOList> {
+): Promise<Schemas.PaginatedTaskListItemList> {
   return client.get("/api/projects/{project_id}/tasks/", {
     path: { project_id: projectId },
     query: {

--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -3209,6 +3209,7 @@ export class PostHogAPIClient {
 
     const data = await this.withCloudUsageLimitCheck(() =>
       this.api.post(`/api/projects/{project_id}/tasks/`, {
+        header: {},
         path: { project_id: teamId.toString() },
         body: {
           ...taskOptions,
@@ -4138,6 +4139,7 @@ export class PostHogAPIClient {
 
     const data = await this.withCloudUsageLimitCheck(() =>
       this.api.post(`/api/projects/{project_id}/tasks/{id}/run/`, {
+        header: {},
         path: { project_id: teamId.toString(), id: taskId },
         body,
       }),

--- a/products/desktop/packages/core/src/inbox/inboxQuery.ts
+++ b/products/desktop/packages/core/src/inbox/inboxQuery.ts
@@ -1,3 +1,4 @@
+import { reportPullRequests } from "@posthog/core/inbox/reportPullRequests";
 import type {
   SignalReport,
   SignalReportsQueryParams,
@@ -188,7 +189,7 @@ function queryAcceptsReport(
   }
   if (
     params.has_implementation_pr !== undefined &&
-    params.has_implementation_pr !== Boolean(report.implementation_pr_url)
+    params.has_implementation_pr !== reportPullRequests(report).length > 0
   ) {
     return false;
   }

--- a/products/desktop/packages/core/src/inbox/refundEligibility.ts
+++ b/products/desktop/packages/core/src/inbox/refundEligibility.ts
@@ -1,3 +1,4 @@
+import { reportPullRequests } from "@posthog/core/inbox/reportPullRequests";
 import type { SignalReport } from "@posthog/shared/types";
 
 // Copy per backend `refund_ineligibility_reason`. `already_refunded` and
@@ -27,7 +28,7 @@ export function computeRefundEligibility(
 ): RefundEligibility {
   const canRefund =
     flagEnabled &&
-    !!report.implementation_pr_url &&
+    reportPullRequests(report).length > 0 &&
     !report.refund &&
     !report.billing_exempt_reason;
 

--- a/products/desktop/packages/core/src/inbox/reportActions.test.ts
+++ b/products/desktop/packages/core/src/inbox/reportActions.test.ts
@@ -44,7 +44,7 @@ describe("buildCreatePrReportPrompt", () => {
 
   it("tells the agent to continue an existing linked PR instead of opening a duplicate", () => {
     const prompt = buildCreatePrReportPrompt({ reportId: "abc123" });
-    expect(prompt).toContain("implementation_pr_url");
+    expect(prompt).toContain("pull_requests");
     expect(prompt).toMatch(/gh pr checkout/i);
     expect(prompt).toMatch(/do not open a second PR/i);
   });

--- a/products/desktop/packages/core/src/inbox/reportActions.ts
+++ b/products/desktop/packages/core/src/inbox/reportActions.ts
@@ -1,3 +1,4 @@
+import { hasActiveReportPullRequest } from "@posthog/core/inbox/reportPullRequests";
 import { buildDiscussReportPrompt as buildSharedDiscussReportPrompt } from "@posthog/shared";
 import { buildInboxDeeplink } from "@posthog/shared/deeplink";
 import type { SignalReport } from "@posthog/shared/types";
@@ -22,7 +23,7 @@ export function canCreateImplementationPr(
   }
   // A merged PR doesn't block: a report that outlived its fix (evidence kept
   // arriving) legitimately gets another attempt.
-  if (report.implementation_pr_url && !report.implementation_pr_merged) {
+  if (hasActiveReportPullRequest(report)) {
     return false;
   }
   if (report.already_addressed === true) return false;
@@ -62,7 +63,7 @@ export function buildCreatePrReportPrompt({
   const reportRef = reportUrl
     ? `${reportId} ([inbox item](${reportUrl}))`
     : reportId;
-  const base = `Act on PostHog inbox report ${reportRef}. Use the inbox MCP tools to fetch the report, its contributing findings, any suggested reviewers, and any implementation PR already linked to it; investigate the root cause; and implement the fix.\n\nIf the report already has a linked implementation PR (check the report's \`implementation_pr_url\`) and it is still open, you are iterating on existing work: check that PR out with \`gh pr checkout <url>\`, continue on its branch, and commit your changes to that same PR. Do NOT open a second PR for the same fix. Otherwise, open a PR. Only open a separate PR alongside an existing one when the user's feedback clearly asks for a distinct change.\n\nIf you can't fetch the report, stop and report that instead of guessing what it contains.`;
+  const base = `Act on PostHog inbox report ${reportRef}. Use the inbox MCP tools to fetch the report, its contributing findings, any suggested reviewers, and any implementation PR already linked to it; investigate the root cause; and implement the fix.\n\nInspect every entry in the report's \`pull_requests\` collection and its state. If a relevant PR is open or draft, you are iterating on existing work: check that PR out with \`gh pr checkout <url>\`, continue on its branch, and commit your changes to that same PR. Do NOT open a second PR for the same fix. Otherwise, open a PR. Related changes may use a stack of PRs. Claim the report with the inbox claim tool, retain its claim_id, and attach all known PR URLs together through that same tool. Use takeover only when the user asks to take over another claim.\n\nIf you can't fetch the report, stop and report that instead of guessing what it contains.`;
   const trimmedFeedback = feedback?.trim();
   if (!trimmedFeedback) return base;
   return `${base}\n\nAdditional feedback from the user (take this into account, including any questions raised in the report thread):\n${trimmedFeedback}`;

--- a/products/desktop/packages/core/src/inbox/reportChannelScope.ts
+++ b/products/desktop/packages/core/src/inbox/reportChannelScope.ts
@@ -1,3 +1,4 @@
+import { reportPullRequests } from "@posthog/core/inbox/reportPullRequests";
 import type { SignalReport, SignalReportPriority } from "@posthog/shared/types";
 
 import {
@@ -51,9 +52,9 @@ function matchesReportStatusFilter(
 ): boolean {
   if (filter === "all") return true;
   if (filter === "archived") return isDismissedReport(report);
-  if (filter === "needs-review") return !!report.implementation_pr_url;
+  if (filter === "needs-review") return reportPullRequests(report).length > 0;
   if (filter === "ready") {
-    return report.status === "ready" && !report.implementation_pr_url;
+    return report.status === "ready" && reportPullRequests(report).length === 0;
   }
   return (
     isQueuedRunReport(report) ||
@@ -149,7 +150,7 @@ const PRIORITY_RANK: Record<SignalReportPriority, number> = {
  */
 function reportNeedsPerson(report: SignalReport): boolean {
   return (
-    !!report.implementation_pr_url ||
+    reportPullRequests(report).length > 0 ||
     report.status === "ready" ||
     report.status === "pending_input" ||
     report.status === "failed"

--- a/products/desktop/packages/core/src/inbox/reportInboxSections.ts
+++ b/products/desktop/packages/core/src/inbox/reportInboxSections.ts
@@ -1,3 +1,4 @@
+import { reportPullRequests } from "@posthog/core/inbox/reportPullRequests";
 import type { SignalReport } from "@posthog/shared/types";
 
 /**
@@ -13,7 +14,7 @@ export interface InboxReportSections {
 }
 
 function hasImplementationPr(report: SignalReport): boolean {
-  return !!report.implementation_pr_url?.trim();
+  return reportPullRequests(report).length > 0;
 }
 
 function isActionable(report: SignalReport): boolean {

--- a/products/desktop/packages/core/src/inbox/reportMembership.ts
+++ b/products/desktop/packages/core/src/inbox/reportMembership.ts
@@ -1,3 +1,7 @@
+import {
+  primaryReportPullRequest,
+  reportPullRequests,
+} from "@posthog/core/inbox/reportPullRequests";
 import type { InboxReviewerScope } from "@posthog/shared/analytics-events";
 import type { SignalReport } from "@posthog/shared/types";
 
@@ -166,7 +170,7 @@ export function inboxScopeApplies(tab: InboxTabKey): boolean {
  * the PostHog Cloud inbox.
  */
 export function isPullRequestReport(report: SignalReport): boolean {
-  return report.status === "ready" && !!report.implementation_pr_url;
+  return report.status === "ready" && reportPullRequests(report).length > 0;
 }
 
 // ── Runs-tab partitioning ─────────────────────────────────────────────────
@@ -264,7 +268,7 @@ export function isReportTabReport(report: SignalReport): boolean {
   // Any report carrying a PR belongs to the Pull requests tab, even once it has
   // been merged/closed (`resolved`) — those just drop out of the inbox here
   // rather than reappearing as a Report.
-  if (report.implementation_pr_url) return false;
+  if (primaryReportPullRequest(report).url) return false;
   if (isAgentRunReport(report)) return false;
   return true;
 }

--- a/products/desktop/packages/core/src/inbox/reportPullRequests.test.ts
+++ b/products/desktop/packages/core/src/inbox/reportPullRequests.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasActiveReportPullRequest,
+  hasMergedReportPullRequest,
+  primaryReportPullRequest,
+  reportPullRequests,
+} from "./reportPullRequests";
+
+describe("report pull request consumers", () => {
+  const pr = (url: string, state: "open" | "closed" | "merged") => ({
+    id: url,
+    url,
+    state,
+    merged: state === "merged",
+    claim_id: null,
+    attached_at: null,
+    attached_by: null,
+  });
+  const report = {
+    implementation_pr_url: "https://github.com/example/app/pull/1",
+    implementation_pr_merged: true,
+    pull_requests: [
+      pr("https://github.com/example/app/pull/1", "merged"),
+      pr("https://github.com/example/app/pull/2", "open"),
+    ],
+  };
+  it("uses all linked PRs even when the legacy primary has merged", () => {
+    expect(reportPullRequests(report)).toHaveLength(2);
+    expect(primaryReportPullRequest(report).url).toBe(
+      "https://github.com/example/app/pull/2",
+    );
+    expect(hasActiveReportPullRequest(report)).toBe(true);
+    expect(hasMergedReportPullRequest(report)).toBe(true);
+  });
+  it("does not resurrect stale legacy fields when the collection is empty", () => {
+    const empty = { ...report, pull_requests: [] };
+    expect(reportPullRequests(empty)).toEqual([]);
+    expect(primaryReportPullRequest(empty).url).toBe("");
+    expect(hasActiveReportPullRequest(empty)).toBe(false);
+  });
+  it("supports old servers but does not treat a closed PR as active", () => {
+    expect(
+      reportPullRequests({
+        implementation_pr_url: report.implementation_pr_url,
+      }),
+    ).toHaveLength(1);
+    expect(
+      hasActiveReportPullRequest({
+        pull_requests: [pr(report.implementation_pr_url, "closed")],
+      }),
+    ).toBe(false);
+    expect(
+      primaryReportPullRequest({
+        implementation_pr_url: report.implementation_pr_url,
+        implementation_pr_state: "unknown",
+        implementation_pr_merged: true,
+      }).state,
+    ).toBe("merged");
+  });
+  it("selects the same primary regardless of attachment order", () => {
+    expect(primaryReportPullRequest(report)).toEqual(
+      primaryReportPullRequest({
+        ...report,
+        pull_requests: [...report.pull_requests].reverse(),
+      }),
+    );
+  });
+});

--- a/products/desktop/packages/core/src/inbox/reportPullRequests.ts
+++ b/products/desktop/packages/core/src/inbox/reportPullRequests.ts
@@ -1,0 +1,72 @@
+import type { SignalReport } from "@posthog/shared/types";
+
+type ReportWithPullRequests = Pick<
+  SignalReport,
+  | "pull_requests"
+  | "implementation_pr_url"
+  | "implementation_pr_state"
+  | "implementation_pr_merged"
+>;
+
+export type ReportPullRequest = {
+  id: string | null;
+  url: string;
+  state: "unknown" | "draft" | "open" | "closed" | "merged";
+  merged: boolean;
+};
+
+export function reportPullRequests(
+  report: ReportWithPullRequests | null | undefined,
+): readonly ReportPullRequest[] {
+  if (report?.pull_requests !== undefined) {
+    return report.pull_requests;
+  }
+  return report?.implementation_pr_url
+    ? [
+        {
+          id: null,
+          url: report.implementation_pr_url,
+          state: report.implementation_pr_merged
+            ? "merged"
+            : (report.implementation_pr_state ?? "unknown"),
+          merged: report.implementation_pr_merged ?? false,
+        },
+      ]
+    : [];
+}
+
+export function primaryReportPullRequest(
+  report: ReportWithPullRequests | null | undefined,
+): ReportPullRequest {
+  const rank = (pr: ReportPullRequest): number =>
+    pr.state === "merged" ? 1 : pr.state === "closed" ? 2 : 0;
+  return (
+    [...reportPullRequests(report)].sort(
+      (a, b) =>
+        rank(a) - rank(b) ||
+        a.url.toLowerCase().localeCompare(b.url.toLowerCase()),
+    )[0] ?? { id: null, url: "", state: "unknown", merged: false }
+  );
+}
+
+export function hasActiveReportPullRequest(
+  report: ReportWithPullRequests | null | undefined,
+): boolean {
+  return reportPullRequests(report).some(
+    (pr) => !pr.merged && pr.state !== "closed" && pr.state !== "merged",
+  );
+}
+
+export function hasMergedReportPullRequest(
+  report: ReportWithPullRequests | null | undefined,
+): boolean {
+  if (report?.pull_requests === undefined) {
+    return (
+      report?.implementation_pr_merged === true ||
+      report?.implementation_pr_state === "merged"
+    );
+  }
+  return reportPullRequests(report).some(
+    (pr) => pr.merged || pr.state === "merged",
+  );
+}

--- a/products/desktop/packages/shared/src/domain-types.ts
+++ b/products/desktop/packages/shared/src/domain-types.ts
@@ -742,7 +742,29 @@ export interface SignalReportChart {
   size?: SignalReportChartSize | null;
 }
 
+export interface SignalReportPullRequest {
+  id: string | null;
+  url: string;
+  state: SignalReportPrState;
+  merged: boolean;
+  claim_id: string | null;
+  attached_at: string | null;
+  attached_by: {
+    kind: "user" | "task" | "agent" | "system";
+    user: {
+      id: number;
+      uuid: string;
+      first_name: string;
+      last_name: string;
+      email: string;
+    } | null;
+    agent: string | null;
+    task_id: string | null;
+  } | null;
+}
+
 export interface SignalReport {
+  pull_requests?: readonly SignalReportPullRequest[];
   id: string;
   title: string | null;
   summary: string | null;

--- a/products/desktop/packages/ui/src/features/canvas/components/ReportFeedRow.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ReportFeedRow.tsx
@@ -4,6 +4,7 @@ import {
   deriveHeadline,
   humanizeReportTitle,
 } from "@posthog/core/inbox/reportPresentation";
+import { primaryReportPullRequest } from "@posthog/core/inbox/reportPullRequests";
 import { Button, Card, CardContent } from "@posthog/quill";
 import { formatRelativeTimeShort } from "@posthog/shared";
 import type { SignalReport } from "@posthog/shared/types";
@@ -54,7 +55,7 @@ export function ReportFeedRow({
                 <span className="min-w-0 truncate font-semibold text-sm leading-snug">
                   {title}
                 </span>
-                {report.implementation_pr_url && (
+                {primaryReportPullRequest(report).url && (
                   <GitPullRequestIcon
                     size={13}
                     className="shrink-0 text-(--gray-9)"
@@ -76,7 +77,7 @@ export function ReportFeedRow({
               onClick={(event) => event.stopPropagation()}
               onKeyDown={(event) => event.stopPropagation()}
             >
-              {report.implementation_pr_url && !archived && (
+              {primaryReportPullRequest(report).url && !archived && (
                 <Button
                   type="button"
                   variant="outline"

--- a/products/desktop/packages/ui/src/features/canvas/components/ReportRow.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ReportRow.tsx
@@ -1,6 +1,7 @@
 import { GitPullRequestIcon } from "@phosphor-icons/react";
 import { isDismissedReport } from "@posthog/core/inbox/reportMembership";
 import { humanizeReportTitle } from "@posthog/core/inbox/reportPresentation";
+import { primaryReportPullRequest } from "@posthog/core/inbox/reportPullRequests";
 import type { SignalReport } from "@posthog/shared/types";
 import { ReportRestoreButton } from "@posthog/ui/features/inbox/components/ReportRestoreButton";
 import { ReportStateMonogram } from "@posthog/ui/features/inbox/components/ReportStateMonogram";
@@ -30,7 +31,7 @@ export function ReportRow({
         onClick={() => onOpen(report.id)}
         endContent={
           <span className="flex items-center gap-1">
-            {report.implementation_pr_url && (
+            {primaryReportPullRequest(report).url && (
               <GitPullRequestIcon
                 size={13}
                 className="text-(--gray-9)"

--- a/products/desktop/packages/ui/src/features/inbox/components/AgentRunDetail.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/AgentRunDetail.tsx
@@ -12,6 +12,7 @@ import {
   deriveHeadline,
   parsePrUrl,
 } from "@posthog/core/inbox/reportPresentation";
+import { primaryReportPullRequest } from "@posthog/core/inbox/reportPullRequests";
 import {
   Button,
   DropdownMenu,
@@ -137,7 +138,7 @@ function RunOutputWidget({ report }: { report: SignalReport }) {
 }
 
 function RunOutputReadyCard({ report }: { report: SignalReport }) {
-  const prUrl = report.implementation_pr_url;
+  const prUrl = primaryReportPullRequest(report).url;
   const isPr = !!prUrl;
   const prRef = prUrl ? parsePrUrl(prUrl) : null;
   const sourceMeta = getSourceProductMeta(report.source_products?.[0]);

--- a/products/desktop/packages/ui/src/features/inbox/components/DismissReportDialog.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/DismissReportDialog.tsx
@@ -1,4 +1,5 @@
 import { EyeSlashIcon, PauseIcon } from "@phosphor-icons/react";
+import { hasActiveReportPullRequest } from "@posthog/core/inbox/reportPullRequests";
 import {
   Button,
   Dialog,
@@ -95,9 +96,7 @@ function DismissReportDialogBody({
   const pausesReport = reason != null && isDismissalReasonSnooze(reason);
   const reportNoun = selectedCount > 1 ? "reports" : "report";
   const title = report.title?.trim() ? report.title : "Untitled report";
-  const hasOpenPr =
-    Boolean(report.implementation_pr_url) &&
-    report.implementation_pr_merged !== true;
+  const hasOpenPr = hasActiveReportPullRequest(report);
 
   return (
     <>

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxPaneRow.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxPaneRow.tsx
@@ -3,6 +3,7 @@ import {
   humanizeReportTitle,
   parsePrUrl,
 } from "@posthog/core/inbox/reportPresentation";
+import { primaryReportPullRequest } from "@posthog/core/inbox/reportPullRequests";
 import { AutocompleteItem, Button, cn } from "@posthog/quill";
 import { formatRelativeAge } from "@posthog/shared";
 import type { SignalReport } from "@posthog/shared/types";
@@ -33,9 +34,7 @@ export function InboxPaneRow({
   // row is a button, whose wrapper truncates on one line, so the preview has to
   // opt back into wrapping.
   const headline = deriveHeadline(report.summary);
-  const pr = report.implementation_pr_url
-    ? parsePrUrl(report.implementation_pr_url)
-    : null;
+  const pr = parsePrUrl(primaryReportPullRequest(report).url);
 
   return (
     <InboxReportContextMenu report={report}>

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxReportContextMenuContent.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxReportContextMenuContent.tsx
@@ -15,6 +15,7 @@ import {
   canCreateImplementationPr,
   canResolveReport,
 } from "@posthog/core/inbox/reportActions";
+import { hasActiveReportPullRequest } from "@posthog/core/inbox/reportPullRequests";
 import {
   ContextMenuContent,
   ContextMenuGroup,
@@ -73,7 +74,10 @@ export function InboxReportContextMenuContent({
     isLoading: reportTasksLoading,
     isError: reportTasksFailed,
   } = useReportTasks(report.id, report.status);
-  const continuableTask = findContinuableImplementationTask(reportTasks);
+  const continuableTask = findContinuableImplementationTask(
+    reportTasks,
+    report,
+  );
   const cloudRepository = extractRepoSelectionRepository(artefacts?.results);
   const { createPrReport, isCreatingPr } = useCreatePrReport({
     reportId: report.id,
@@ -85,9 +89,7 @@ export function InboxReportContextMenuContent({
   const isDismissed = report.status === "suppressed";
   const readOnly =
     report.status === "resolved" || (isDismissed && report.refund != null);
-  const hasOpenPr =
-    Boolean(report.implementation_pr_url) &&
-    report.implementation_pr_merged !== true;
+  const hasOpenPr = hasActiveReportPullRequest(report);
   const canCreatePr = canCreateImplementationPr(report, {
     hasLiveImplementationTask: continuableTask !== null,
     isTaskLookupPending: reportTasksLoading || reportTasksFailed,

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxReportRowView.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxReportRowView.tsx
@@ -9,6 +9,10 @@ import {
   parseConventionalCommitTitle,
   parsePrUrl,
 } from "@posthog/core/inbox/reportPresentation";
+import {
+  hasMergedReportPullRequest,
+  primaryReportPullRequest,
+} from "@posthog/core/inbox/reportPullRequests";
 import { dismissalReasonLabel } from "@posthog/shared/dismissalReasons";
 import type { SignalReport } from "@posthog/shared/types";
 import { ConventionalCommitScopeTag } from "@posthog/ui/features/inbox/components/ConventionalCommitScopeTag";
@@ -39,7 +43,7 @@ export function InboxReportRowView({
 }: InboxReportRowViewProps): React.JSX.Element {
   const conventionalTitle = parseConventionalCommitTitle(report.title);
   const headline = deriveHeadline(report.summary);
-  const prUrl = report.implementation_pr_url ?? null;
+  const prUrl = primaryReportPullRequest(report).url ?? null;
   const pr = prUrl ? parsePrUrl(prUrl) : null;
   const isTerminal =
     report.status === "resolved" || report.status === "suppressed";
@@ -48,11 +52,11 @@ export function InboxReportRowView({
   // no work left either way, and its PR close can lag or fail, so its stale draft flag says nothing.
   const isDraftPr =
     !isTerminal &&
-    report.implementation_pr_state === "draft" &&
-    report.implementation_pr_merged !== true;
+    primaryReportPullRequest(report).state === "draft" &&
+    primaryReportPullRequest(report).merged !== true;
   const isShipped =
     report.status === "resolved" &&
-    (report.implementation_pr_merged === true ||
+    (hasMergedReportPullRequest(report) ||
       report.dismissal_reason === "pr_merged");
   const borderClass =
     pr || report.status === "resolved"
@@ -165,25 +169,25 @@ export function InboxReportRowView({
               type="button"
               onClick={() => onOpenPr(prUrl)}
               title={
-                report.implementation_pr_merged
+                primaryReportPullRequest(report).merged
                   ? "This report's earlier PR merged, but evidence kept arriving"
                   : isDraftPr
                     ? "Open the draft pull request on GitHub"
                     : "Open the pull request on GitHub"
               }
               className={
-                report.implementation_pr_merged || isDraftPr
+                primaryReportPullRequest(report).merged || isDraftPr
                   ? "flex items-center gap-1 rounded border border-(--gray-6) px-1.5 py-0.5 font-mono text-[12px] text-gray-11 hover:bg-(--gray-3) hover:text-gray-12"
                   : "flex items-center gap-1 rounded border border-(--accent-7) bg-(--accent-2) px-1.5 py-0.5 font-mono text-(--accent-11) text-[12px] hover:bg-(--accent-3)"
               }
             >
-              {report.implementation_pr_merged ? (
+              {primaryReportPullRequest(report).merged ? (
                 <GitMergeIcon size={11} />
               ) : (
                 <GitPullRequestIcon size={11} />
               )}
               #{pr.number}
-              {report.implementation_pr_merged
+              {primaryReportPullRequest(report).merged
                 ? " merged"
                 : isDraftPr
                   ? " draft"

--- a/products/desktop/packages/ui/src/features/inbox/components/PullRequestCard.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/PullRequestCard.tsx
@@ -6,6 +6,7 @@ import {
   parseConventionalCommitTitle,
   parsePrUrl,
 } from "@posthog/core/inbox/reportPresentation";
+import { primaryReportPullRequest } from "@posthog/core/inbox/reportPullRequests";
 import { Button } from "@posthog/quill";
 import type {
   SignalReport,
@@ -103,9 +104,9 @@ export function PullRequestCardView({
             sourceProducts={report.source_products}
             className=""
           />
-          {report.implementation_pr_url && (
+          {primaryReportPullRequest(report).url && (
             <PrDiffStats
-              prUrl={report.implementation_pr_url}
+              prUrl={primaryReportPullRequest(report).url}
               hideWhileLoading
             />
           )}
@@ -120,10 +121,10 @@ export function PullRequestCardView({
 
   return (
     <div className={inboxCardClassName({ isSelected })} {...rootProps}>
-      {report.implementation_pr_url && (
+      {primaryReportPullRequest(report).url && (
         <InboxCardTopRight>
           <ReportImplementationPrLink
-            prUrl={report.implementation_pr_url}
+            prUrl={primaryReportPullRequest(report).url}
             size="sm"
           />
         </InboxCardTopRight>
@@ -192,8 +193,8 @@ export function PullRequestCard({
   const { prefetch, pointerHandlers } =
     useInboxReportDetailPrefetch(detailRoute);
   const navigate = useNavigate();
-  const prRef = report.implementation_pr_url
-    ? parsePrUrl(report.implementation_pr_url)
+  const prRef = primaryReportPullRequest(report).url
+    ? parsePrUrl(primaryReportPullRequest(report).url)
     : null;
   const { data: artefactsResp } = useInboxReportArtefacts(report.id, {
     staleTime: 5 * 60 * 1000,

--- a/products/desktop/packages/ui/src/features/inbox/components/PullRequestDetail.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/PullRequestDetail.test.tsx
@@ -1,0 +1,133 @@
+import type { SignalReport } from "@posthog/shared/types";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { PullRequestDetailContent } from "./PullRequestDetail";
+
+vi.mock("./ReportDetail", () => ({
+  ReportChatLayout: ({ children }: { children: ReactNode }) => children,
+}));
+vi.mock("./InboxDetailFrame", () => ({
+  InboxDetailFrame: ({
+    metaSuffix,
+    primaryAction,
+    secondaryTab,
+    belowSummary,
+  }: {
+    metaSuffix: ReactNode;
+    primaryAction: ReactNode;
+    secondaryTab?: { content: ReactNode };
+    belowSummary: ReactNode;
+  }) => (
+    <>
+      {metaSuffix}
+      {primaryAction}
+      {secondaryTab?.content}
+      {belowSummary}
+    </>
+  ),
+}));
+vi.mock("./ReportDetailActions", () => ({
+  ReportDetailActions: ({ prUrl }: { prUrl: string }) => (
+    <a href={prUrl}>Open selected PR</a>
+  ),
+}));
+vi.mock("./utils/ReportTrackerIssueLink", () => ({
+  ReportTrackerIssueLink: () => null,
+}));
+vi.mock("@posthog/ui/features/pr-review/PrFilesChangedSection", () => ({
+  PrFilesChangedSection: ({ prUrl }: { prUrl: string }) => (
+    <a href={`${prUrl}/files`}>Selected files</a>
+  ),
+}));
+vi.mock("@posthog/ui/features/pr-review/PrDecisionBlock", () => ({
+  PrDecisionBlock: ({ prUrl }: { prUrl: string }) => (
+    <a href={`${prUrl}/checks`}>Selected checks</a>
+  ),
+}));
+vi.mock("@posthog/ui/features/pr-review/PrCommentsSection", () => ({
+  PrCommentsSection: ({ prUrl }: { prUrl: string }) => {
+    const [draft, setDraft] = useState("");
+    return (
+      <>
+        <a href={prUrl}>Selected comments</a>
+        <input
+          aria-label="Comment draft"
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+        />
+      </>
+    );
+  },
+}));
+
+const first = "https://github.com/example/app/pull/1";
+const second = "https://github.com/example/app/pull/2";
+const report: SignalReport = {
+  id: "report-with-stack",
+  title: "Example fix",
+  summary: "Synthetic report",
+  status: "ready",
+  total_weight: 1,
+  signal_count: 1,
+  artefact_count: 0,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  implementation_pr_url: first,
+  pull_requests: [
+    {
+      id: "one",
+      url: first,
+      state: "merged",
+      merged: true,
+      claim_id: null,
+      attached_at: null,
+      attached_by: null,
+    },
+    {
+      id: "two",
+      url: second,
+      state: "open",
+      merged: false,
+      claim_id: null,
+      attached_at: null,
+      attached_by: null,
+    },
+  ],
+};
+
+describe("report PR selection", () => {
+  it("switches every review surface and clears the previous PR's draft", async () => {
+    const user = userEvent.setup();
+    render(<PullRequestDetailContent report={report} />);
+    expect(
+      screen.getByRole("link", { name: "Open selected PR" }),
+    ).toHaveAttribute("href", second);
+    fireEvent.change(screen.getByRole("textbox", { name: "Comment draft" }), {
+      target: { value: "Only for PR two" },
+    });
+    await user.click(screen.getByRole("combobox", { name: "Pull request" }));
+    await user.click(
+      await screen.findByRole("option", { name: "example/app#1 (merged)" }),
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByRole("link", { name: "Open selected PR" }),
+      ).toHaveAttribute("href", first),
+    );
+    expect(
+      screen.getByRole("link", { name: "Selected files" }),
+    ).toHaveAttribute("href", `${first}/files`);
+    expect(
+      screen.getByRole("link", { name: "Selected checks" }),
+    ).toHaveAttribute("href", `${first}/checks`);
+    expect(
+      screen.getByRole("link", { name: "Selected comments" }),
+    ).toHaveAttribute("href", first);
+    expect(screen.getByRole("textbox", { name: "Comment draft" })).toHaveValue(
+      "",
+    );
+  });
+});

--- a/products/desktop/packages/ui/src/features/inbox/components/PullRequestDetail.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/PullRequestDetail.tsx
@@ -1,5 +1,9 @@
 import { GitPullRequestIcon, MagnifyingGlassIcon } from "@phosphor-icons/react";
 import { parsePrUrl } from "@posthog/core/inbox/reportPresentation";
+import {
+  primaryReportPullRequest,
+  reportPullRequests,
+} from "@posthog/core/inbox/reportPullRequests";
 import type { SignalReport } from "@posthog/shared/types";
 import { ReportFeedbackFooter } from "@posthog/ui/features/inbox/components/detail/ReportFeedbackFooter";
 import { InboxDetailFrame } from "@posthog/ui/features/inbox/components/InboxDetailFrame";
@@ -14,6 +18,8 @@ import { ReportTrackerIssueLink } from "@posthog/ui/features/inbox/components/ut
 import { PrCommentsSection } from "@posthog/ui/features/pr-review/PrCommentsSection";
 import { PrDecisionBlock } from "@posthog/ui/features/pr-review/PrDecisionBlock";
 import { PrFilesChangedSection } from "@posthog/ui/features/pr-review/PrFilesChangedSection";
+import { useState } from "react";
+import { ReportPullRequestSelector } from "./ReportPullRequestSelector";
 
 interface PullRequestDetailProps {
   reportId: string;
@@ -45,10 +51,12 @@ export function PullRequestDetail({
  * from them into one line.
  */
 export function PullRequestDetailContent({ report }: { report: SignalReport }) {
-  const prRef = report.implementation_pr_url
-    ? parsePrUrl(report.implementation_pr_url)
-    : null;
-  const prUrl = prRef ? report.implementation_pr_url : null;
+  const [selectedUrl, setSelectedUrl] = useState<string | null>(null);
+  const prs = reportPullRequests(report);
+  const selectedPr =
+    prs.find((pr) => pr.url === selectedUrl) ??
+    primaryReportPullRequest(report);
+  const prUrl = parsePrUrl(selectedPr.url) ? selectedPr.url : null;
 
   return (
     <ReportChatLayout report={report}>
@@ -59,7 +67,15 @@ export function PullRequestDetailContent({ report }: { report: SignalReport }) {
           prUrl ? (
             <>
               <InboxMetaSeparator />
-              <ReportImplementationPrLink prUrl={prUrl} size="md" />
+              {prs.length > 1 ? (
+                <ReportPullRequestSelector
+                  pullRequests={prs}
+                  value={prUrl}
+                  onValueChange={setSelectedUrl}
+                />
+              ) : (
+                <ReportImplementationPrLink prUrl={prUrl} size="md" />
+              )}
               <ReportTrackerIssueLink report={report} />
             </>
           ) : (
@@ -84,15 +100,17 @@ export function PullRequestDetailContent({ report }: { report: SignalReport }) {
                     <PrDiffStats prUrl={prUrl} hideWhileLoading />
                   </>
                 ),
-                content: <PrFilesChangedSection prUrl={prUrl} bare />,
+                content: (
+                  <PrFilesChangedSection key={prUrl} prUrl={prUrl} bare />
+                ),
               }
             : undefined
         }
         belowSummary={
           prUrl && (
             <>
-              <PrDecisionBlock prUrl={prUrl} />
-              <PrCommentsSection prUrl={prUrl} />
+              <PrDecisionBlock key={`decision:${prUrl}`} prUrl={prUrl} />
+              <PrCommentsSection key={`comments:${prUrl}`} prUrl={prUrl} />
             </>
           )
         }

--- a/products/desktop/packages/ui/src/features/inbox/components/PullRequestsTab.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/PullRequestsTab.tsx
@@ -1,5 +1,6 @@
 import { GitPullRequestIcon } from "@phosphor-icons/react";
 import { isPullRequestReport } from "@posthog/core/inbox/reportMembership";
+import { reportPullRequests } from "@posthog/core/inbox/reportPullRequests";
 import type { SignalReport } from "@posthog/shared/types";
 import { InboxReportListTab } from "@posthog/ui/features/inbox/components/InboxReportListTab";
 import { PullRequestCard } from "@posthog/ui/features/inbox/components/PullRequestCard";
@@ -47,7 +48,7 @@ function PullRequestsBatchProvider({
   const prUrls = useMemo(
     () =>
       reports
-        .map((report) => report.implementation_pr_url)
+        .flatMap((report) => reportPullRequests(report).map((pr) => pr.url))
         .filter((url): url is string => !!url),
     [reports],
   );

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.tsx
@@ -78,7 +78,7 @@ export function ReportChatSidebar({
   );
   const taskId =
     findPendingStartedTaskId(reportTasks, startedTaskId) ??
-    findContinuableImplementationTask(reportTasks)?.id ??
+    findContinuableImplementationTask(reportTasks, report)?.id ??
     findLatestDiscussionTask(reportTasks)?.id ??
     null;
   const openTask = useOpenTask();

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportChatToggle.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportChatToggle.tsx
@@ -23,7 +23,7 @@ export function ReportChatToggle({ report }: { report: SignalReport }) {
   const { data: reportTasks } = useReportTasks(report.id, report.status);
   const hasConversation =
     findPendingStartedTaskId(reportTasks, startedTaskId) !== null ||
-    findContinuableImplementationTask(reportTasks) !== null ||
+    findContinuableImplementationTask(reportTasks, report) !== null ||
     findLatestDiscussionTask(reportTasks) !== null;
   const actionLabel = chatOpen
     ? "Close chat"

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportDetailActions.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportDetailActions.tsx
@@ -8,6 +8,7 @@ import {
 } from "@phosphor-icons/react";
 import { canResolveReport } from "@posthog/core/inbox/reportActions";
 import { parsePrUrl } from "@posthog/core/inbox/reportPresentation";
+import { primaryReportPullRequest } from "@posthog/core/inbox/reportPullRequests";
 import {
   Button,
   DropdownMenu,
@@ -47,7 +48,7 @@ export function ReportDetailActions({
   // The report's own PR (open or merged) backs the GitHub item, so a merged
   // fix stays reachable from the page even after the banner demotes it to
   // history.
-  const prUrl = prUrlProp ?? report.implementation_pr_url ?? null;
+  const prUrl = prUrlProp ?? primaryReportPullRequest(report).url ?? null;
   // Resolved reports are terminal (their PR already merged), so the work actions
   // drop out; only the read-only overflow menu (copy link, PR link) stays.
   const isResolved = report.status === "resolved";

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportPage.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportPage.tsx
@@ -1,4 +1,5 @@
 import { isDismissedReport } from "@posthog/core/inbox/reportMembership";
+import { reportPullRequests } from "@posthog/core/inbox/reportPullRequests";
 import type { SignalReport } from "@posthog/shared/types";
 import { useTriageFocusEnabled } from "@posthog/ui/features/feature-flags/useTriageFocusEnabled";
 import { DismissedReportDetailContent } from "@posthog/ui/features/inbox/components/DismissedReportDetail";
@@ -69,7 +70,7 @@ function ReportPageContent({ report }: { report: SignalReport }) {
   const archived = isDismissedReport(report);
   const triageEnabled = useTriageFocusEnabled();
   useInboxTriageHotkey({ enabled: triageEnabled });
-  const hasPr = Boolean(report.implementation_pr_url);
+  const hasPr = reportPullRequests(report).length > 0;
   return (
     <ReportPageContext value={report}>
       {!archived && (

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportPullRequestSelector.stories.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportPullRequestSelector.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { ReportPullRequestSelector } from "./ReportPullRequestSelector";
+
+const meta: Meta<typeof ReportPullRequestSelector> = {
+  title: "Inbox/ReportPullRequestSelector",
+  component: ReportPullRequestSelector,
+  args: {
+    value: "https://github.com/example/app/pull/2",
+    pullRequests: [
+      {
+        id: "merged",
+        url: "https://github.com/example/app/pull/1",
+        state: "merged",
+        merged: true,
+      },
+      {
+        id: "open",
+        url: "https://github.com/example/app/pull/2",
+        state: "open",
+        merged: false,
+      },
+      {
+        id: "closed",
+        url: "https://github.com/example/app/pull/3",
+        state: "closed",
+        merged: false,
+      },
+    ],
+  },
+  render: function Preview(args) {
+    const [value, setValue] = useState(args.value);
+    return (
+      <ReportPullRequestSelector
+        {...args}
+        value={value}
+        onValueChange={(next) => {
+          if (next) setValue(next);
+        }}
+      />
+    );
+  },
+};
+export default meta;
+type Story = StoryObj<typeof ReportPullRequestSelector>;
+export const Stack: Story = {};
+export const Narrow: Story = {
+  decorators: [
+    (Story) => (
+      <div className="w-64">
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportPullRequestSelector.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportPullRequestSelector.tsx
@@ -1,0 +1,48 @@
+import { parsePrUrl } from "@posthog/core/inbox/reportPresentation";
+import type { ReportPullRequest } from "@posthog/core/inbox/reportPullRequests";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@posthog/quill";
+
+export interface ReportPullRequestSelectorProps {
+  pullRequests: readonly ReportPullRequest[];
+  value: string;
+  onValueChange: (value: string | null) => void;
+}
+
+function pullRequestLabel(url: string): string {
+  const ref = parsePrUrl(url);
+  return ref ? `${ref.repoSlug}#${ref.number}` : url;
+}
+
+export function ReportPullRequestSelector({
+  pullRequests,
+  value,
+  onValueChange,
+}: ReportPullRequestSelectorProps) {
+  const selected = pullRequests.find((pr) => pr.url === value);
+  return (
+    <Select value={value} onValueChange={onValueChange}>
+      <SelectTrigger
+        aria-label="Pull request"
+        data-attr="inbox-report-select-pull-request"
+        className="min-w-0 max-w-full"
+      >
+        <SelectValue className="truncate">
+          {pullRequestLabel(value)} ({selected?.state})
+        </SelectValue>
+      </SelectTrigger>
+      <SelectContent>
+        {pullRequests.map((pr) => (
+          <SelectItem key={pr.url} value={pr.url}>
+            {pullRequestLabel(pr.url)} ({pr.state})
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
@@ -5,6 +5,10 @@ import {
   inboxScopeTriggerLabel,
 } from "@posthog/core/inbox/reportMembership";
 import { parsePrUrl } from "@posthog/core/inbox/reportPresentation";
+import {
+  hasActiveReportPullRequest,
+  primaryReportPullRequest,
+} from "@posthog/core/inbox/reportPullRequests";
 import { Button } from "@posthog/quill";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { SignalReport } from "@posthog/shared/types";
@@ -132,7 +136,10 @@ export function ReportTriageFocus({
     isLoading: reportTasksLoading,
     isError: reportTasksFailed,
   } = useReportTasks(reportId ?? "", report?.status ?? "candidate");
-  const continuableTask = findContinuableImplementationTask(reportTasks);
+  const continuableTask = findContinuableImplementationTask(
+    reportTasks,
+    report,
+  );
   const canCreatePr =
     report?.status === "ready" &&
     canCreateImplementationPr(report, {
@@ -140,9 +147,9 @@ export function ReportTriageFocus({
       // A failed lookup leaves task state unknown, same as a pending one.
       isTaskLookupPending: reportTasksLoading || reportTasksFailed,
     });
-  const livePrUrl = report?.implementation_pr_merged
-    ? null
-    : report?.implementation_pr_url;
+  const livePrUrl = hasActiveReportPullRequest(report)
+    ? primaryReportPullRequest(report).url
+    : null;
   const existingPrUrl =
     livePrUrl ?? (continuableTask ? getTaskPrUrl(continuableTask) : null);
   const canOpenPr =

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
@@ -12,6 +12,10 @@ import {
   canResolveReport,
 } from "@posthog/core/inbox/reportActions";
 import { parsePrUrl } from "@posthog/core/inbox/reportPresentation";
+import {
+  hasActiveReportPullRequest,
+  primaryReportPullRequest,
+} from "@posthog/core/inbox/reportPullRequests";
 import { deriveReportVerdict } from "@posthog/core/inbox/reportVerdict";
 import {
   Button,
@@ -137,7 +141,7 @@ export function ReportVerdictBanner({
 
   // Structural dedupe guard: re-engaging a report that already has live
   // implementation work (an open PR, or a run still in flight) should continue
-  // that task rather than spin up a duplicate PR. `report.implementation_pr_url`
+  // that task rather than spin up a duplicate PR. `primaryReportPullRequest(report).url`
   // alone is unreliable here — it can be stale or not yet set — so we also look
   // at the linked implementation task's own state.
   const {
@@ -145,7 +149,10 @@ export function ReportVerdictBanner({
     isLoading: reportTasksLoading,
     isError: reportTasksFailed,
   } = useReportTasks(report.id, report.status);
-  const continuableTask = findContinuableImplementationTask(reportTasks);
+  const continuableTask = findContinuableImplementationTask(
+    reportTasks,
+    report,
+  );
   const canCreatePr = canCreateImplementationPr(report, {
     hasLiveImplementationTask: continuableTask !== null,
     // A failed lookup leaves task state unknown, same as a pending one. Reading it
@@ -155,14 +162,15 @@ export function ReportVerdictBanner({
   // A merged PR is history, not live work: the report only still exists
   // because evidence kept arriving after the fix, so it reads by its own
   // state (usually "needs your decision" again) rather than "review the PR".
-  const livePrUrl = report.implementation_pr_merged
-    ? null
-    : report.implementation_pr_url;
+  const livePrUrl = hasActiveReportPullRequest(report)
+    ? primaryReportPullRequest(report).url
+    : null;
   // The merged PR is history, not live work, but history the reader needs
   // visible: it explains why an already-fixed issue is asking for a decision.
   const mergedPr =
-    report.implementation_pr_merged && report.implementation_pr_url
-      ? parsePrUrl(report.implementation_pr_url)
+    primaryReportPullRequest(report).merged &&
+    primaryReportPullRequest(report).url
+      ? parsePrUrl(primaryReportPullRequest(report).url)
       : null;
   const existingPrUrl =
     livePrUrl ?? (continuableTask ? getTaskPrUrl(continuableTask) : null);
@@ -630,9 +638,9 @@ export function ReportVerdictBanner({
       verdict={verdict}
       details={
         mergedPr &&
-        report.implementation_pr_url && (
+        primaryReportPullRequest(report).url && (
           <a
-            href={report.implementation_pr_url}
+            href={primaryReportPullRequest(report).url}
             target="_blank"
             rel="noreferrer"
             className="inline-flex items-center gap-1 text-[13px] text-gray-10 hover:underline"

--- a/products/desktop/packages/ui/src/features/inbox/components/ResolveReportDialog.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ResolveReportDialog.tsx
@@ -1,3 +1,4 @@
+import { hasActiveReportPullRequest } from "@posthog/core/inbox/reportPullRequests";
 import {
   Button,
   Dialog,
@@ -48,9 +49,7 @@ export function ResolveReportDialog({
   const [note, setNote] = useState(initialNote);
   const fieldId = useId();
   const title = report.title?.trim() ? report.title : "Untitled report";
-  const hasOpenPr =
-    Boolean(report.implementation_pr_url) &&
-    report.implementation_pr_merged !== true;
+  const hasOpenPr = hasActiveReportPullRequest(report);
 
   return (
     <Dialog

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useReportFeedbackTracker.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useReportFeedbackTracker.ts
@@ -1,4 +1,5 @@
 import { reportAgeHours } from "@posthog/core/inbox/engagement";
+import { reportPullRequests } from "@posthog/core/inbox/reportPullRequests";
 import type {
   InboxReportActionSurface,
   InboxReportFeedbackSentiment,
@@ -28,7 +29,7 @@ export function useReportFeedbackTracker(
       report_age_hours: reportAgeHours(report.created_at),
       priority: report.priority ?? null,
       actionability: report.actionability ?? null,
-      has_pr: !!report.implementation_pr_url,
+      has_pr: reportPullRequests(report).length > 0,
       surface,
     }),
     [report, surface],

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useReportTasks.test.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useReportTasks.test.ts
@@ -168,6 +168,49 @@ describe("findContinuableImplementationTask", () => {
       prUrl: "https://gh/pr/9",
     });
     expect(findContinuableImplementationTask([entry(withPr)])).toBe(withPr);
+    const linkedPr = {
+      id: "linked",
+      url: "https://github.com/example/app/pull/2",
+      state: "open" as const,
+      merged: false,
+      claim_id: null,
+      attached_at: null,
+      attached_by: {
+        kind: "task" as const,
+        task_id: withPr.id,
+        user: null,
+        agent: null,
+      },
+    };
+    expect(
+      findContinuableImplementationTask([entry(withPr)], {
+        pull_requests: [linkedPr],
+      }),
+    ).toBe(withPr);
+    expect(
+      findContinuableImplementationTask([entry(withPr, "other")], {
+        pull_requests: [linkedPr],
+      }),
+    ).toBe(withPr);
+    expect(
+      findContinuableImplementationTask([entry(withPr)], {
+        pull_requests: [{ ...linkedPr, state: "merged", merged: true }],
+      }),
+    ).toBeNull();
+    expect(
+      findContinuableImplementationTask([entry(withPr)], {
+        pull_requests: [
+          {
+            ...linkedPr,
+            attached_by: {
+              ...linkedPr.attached_by,
+              kind: "agent",
+              task_id: null,
+            },
+          },
+        ],
+      }),
+    ).toBeNull();
   });
 
   it("returns a still-running implementation task with no PR yet", () => {

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useReportTasks.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useReportTasks.ts
@@ -2,6 +2,7 @@ import { requestErrorStatus } from "@posthog/api-client/fetcher";
 import type { PostHogAPIClient } from "@posthog/api-client/posthog-client";
 import { humanizeIdentifier } from "@posthog/core/inbox/activityLog";
 import type {
+  SignalReport,
   SignalReportStatus,
   Task,
   TaskRunArtefactContent,
@@ -175,13 +176,24 @@ function isTaskPrMerged(task: Task): boolean {
  */
 export function findContinuableImplementationTask(
   reportTasks: ReportTaskData[] | undefined,
+  report?: Pick<SignalReport, "pull_requests"> | null,
 ): Task | null {
   if (!reportTasks) return null;
   const implementation = reportTasks.filter(
     (t) => t.purpose === "implementation",
   );
-  const withPr = implementation.find(
-    (t) => getTaskPrUrl(t.task) && !isTaskPrMerged(t.task),
+  const withPr = reportTasks.find((t) =>
+    report?.pull_requests !== undefined
+      ? report.pull_requests.some(
+          (pr) =>
+            pr.attached_by?.task_id === t.task.id &&
+            !pr.merged &&
+            pr.state !== "closed" &&
+            pr.state !== "merged",
+        )
+      : t.purpose === "implementation" &&
+        getTaskPrUrl(t.task) &&
+        !isTaskPrMerged(t.task),
   );
   if (withPr) return withPr.task;
   const running = implementation.find((t) => {

--- a/products/desktop/packages/ui/src/features/loops/loopHogFlowMapping.ts
+++ b/products/desktop/packages/ui/src/features/loops/loopHogFlowMapping.ts
@@ -624,9 +624,7 @@ function loopRunStatus(status: unknown): LoopSchemas.LoopRunStatusEnum {
  * still lists (as not started) so a fire that queued a task is visible before
  * the sandbox picks it up.
  */
-export function taskToLoopRun(
-  task: Schemas.TaskDetailDTO,
-): LoopSchemas.LoopRun {
+export function taskToLoopRun(task: Schemas.TaskListItem): LoopSchemas.LoopRun {
   const run = task.latest_run ?? null;
   const status = loopRunStatus(run?.status);
   const createdAt = run?.created_at ?? task.created_at ?? "";


### PR DESCRIPTION
## Problem

Desktop and mobile inboxes need to handle every PR attached to a report after #97846 introduces report claims and multiple PR links.

## Changes

- Read the PR collection consistently across inbox lists, badges, actions, canvas rows, and mobile, with fallback for older servers.
- Select a PR in desktop report details; GitHub links, checks, files, and comments follow that selection.
- Continue internal tasks using PR attachment attribution and carry claim IDs through the agent workflow.
- Regenerate API types, including the task-list response rename. Claim display names remain undisplayed.

![PR selector with synthetic data](https://raw.githubusercontent.com/PostHog/pr-assets/9a966e31544f17ab3b95c6dbb719e79bd397db5f/2026/09/b73afee1-2947-4d58-9510-4246b0bb6d30.png)

This PR targets #97846 temporarily. Retarget to master after it merges; deploy the backend before releasing this client update.

## How did you test this code?

Core and UI inbox suites, loop mapping tests, desktop typecheck, lint, and scoped preflight passed. Storybook browser checks covered selection and narrow layout.
Regression tests cover collection precedence, legacy merged flags, task attribution, and switching PR review targets without retaining another PR's comment draft.
Full Electron/GitHub workflows were not rerun for this client-only follow-up.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Added `products/desktop/docs/REPORT-PULL-REQUESTS.md` covering compatibility, selection, task attribution, and deployment order.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

Codex used shell, GitHub CLI, and browser tools. Skills: posthog-desktop, stacking-prs, writing-tests, writing-code-comments, writing-user-facing-copy, writing-pr-descriptions, and running-ci-preflight. Opened without a local CodeRabbit pass while that check is paused.
The deferred desktop patch was restored and updated for newer callers and API types. Committed fixtures and the screenshot contain invented example data.
