### PR TITLE
fix(personhog): resolve identity only in the identity service

### DIFF
--- a/rust/personhog-identity/src/storage/mod.rs
+++ b/rust/personhog-identity/src/storage/mod.rs
@@ -18,6 +18,7 @@ pub const DB_QUERY_DURATION: &str = "personhog_identity_db_query_duration_ms";
 pub trait IdentityStorage: Send + Sync {
     /// Batch-resolve (team_id, distinct_id) keys to persons on the primary.
     /// Returns a map keyed by (team_id, distinct_id); unresolved keys are absent.
+    /// Persons carry identity only (no properties): the leader owns those.
     async fn resolve_distinct_ids(
         &self,
         keys: &[(i64, String)],

--- a/rust/personhog-identity/src/storage/postgres/mod.rs
+++ b/rust/personhog-identity/src/storage/postgres/mod.rs
@@ -57,18 +57,22 @@ pub(crate) async fn begin_timed(pool: &PgPool) -> sqlx::Result<Transaction<'_, P
 }
 
 /// Decode a person from a row whose SELECT list uses the canonical aliases
-/// (`team_id::bigint AS team_id`, `properties::text AS properties`, the
-/// `is_user_id` boolean CASE, …). Shared by every submodule that selects
-/// person rows — the table name is interpolated at runtime, so the queries
-/// cannot use the compile-time sqlx macros and their generated row types.
+/// (`team_id::bigint AS team_id`, the `is_user_id` boolean CASE, …). Shared
+/// by every submodule that selects person rows — the table name is
+/// interpolated at runtime, so the queries cannot use the compile-time sqlx
+/// macros and their generated row types.
+///
+/// Properties are never read. The identity service resolves identity only;
+/// the partition leader owns person properties, and a primary-sourced copy
+/// would lag it by writer apply lag.
 pub(super) fn person_from_row(row: &PgRow) -> Result<Person, sqlx::Error> {
     Ok(Person {
         id: row.try_get("id")?,
         uuid: row.try_get("uuid")?,
         team_id: row.try_get("team_id")?,
-        properties: row.try_get("properties")?,
-        properties_last_updated_at: row.try_get("properties_last_updated_at")?,
-        properties_last_operation: row.try_get("properties_last_operation")?,
+        properties: None,
+        properties_last_updated_at: None,
+        properties_last_operation: None,
         created_at: row.try_get("created_at")?,
         version: row.try_get("version")?,
         is_identified: row.try_get("is_identified")?,
@@ -82,9 +86,6 @@ pub(super) fn person_from_row(row: &PgRow) -> Result<Person, sqlx::Error> {
 pub(super) fn person_columns(p: &str) -> String {
     format!(
         "{p}.id, {p}.uuid, {p}.team_id::bigint AS team_id, \
-         {p}.properties::text AS properties, \
-         {p}.properties_last_updated_at::text AS properties_last_updated_at, \
-         {p}.properties_last_operation::text AS properties_last_operation, \
          {p}.created_at, {p}.version, {p}.is_identified, \
          CASE WHEN {p}.is_user_id IS NULL THEN NULL ELSE ({p}.is_user_id != 0) END AS is_user_id, \
          {p}.last_seen_at"

--- a/rust/personhog-identity/tests/storage_tests.rs
+++ b/rust/personhog-identity/tests/storage_tests.rs
@@ -152,7 +152,10 @@ async fn creates_stub_with_deterministic_uuid_and_version_zero() {
     assert!(created);
     assert_eq!(person.uuid, person_uuid(ctx.team_id, "user-1"));
     assert_eq!(person.version, Some(0));
-    assert_eq!(person.properties.as_deref(), Some("{}"));
+    assert!(
+        person.properties.is_none(),
+        "identity never reads properties; the leader owns them"
+    );
     assert!(!person.is_identified);
     assert_eq!(
         person.created_at,
@@ -553,7 +556,6 @@ async fn deleted_person_is_revived_above_the_tombstone_on_recreate() {
     assert!(created, "a revival is a creation to the caller");
     assert_eq!(person.id, person_id, "revival keeps the row, not a new one");
     assert_eq!(person.version, Some(8), "revived above the tombstone");
-    assert_eq!(person.properties.as_deref(), Some("{}"));
     assert_eq!(
         ctx.distinct_id_state("revive-me").await,
         Some((person_id, false, Some(4))),


### PR DESCRIPTION
## Problem

- Anyone reading person properties off an identity service answer got a stale copy. The partition leader owns properties, and the primary the identity service reads lags it by writer apply lag.
- The identity service selected `properties`, `properties_last_updated_at`, and `properties_last_operation` on every resolve, stub-create, and winners select, and returned them on the resolve and get-or-create responses.
- Nothing in the service reads those columns. They rode along because one column list serves every person select.

## Changes

- Identity answers carry identity only. Resolve and the found branch of get-or-create return persons with empty properties. Created persons still carry the leader's document when initial properties were applied, or the fresh stub's empty set.
- The column list in `rust/personhog-identity/src/storage/postgres/mod.rs` drops the three properties columns, and the row decoder fills them with `None`. The storage trait doc states the contract.
- Mechanical: two Postgres-backed storage tests that asserted `properties == "{}"` now assert the field is absent.

> [!NOTE]
> The Node client still decodes these fields into `InternalPerson` today. On master the store only serves them at the check grade, where the personless step discards properties, so nothing folds onto them. The client-side follow-up that makes this a type-level contract ships separately. The service serves no production traffic.

## How did you test this code?

- `cargo clippy -p personhog-identity --all-targets -- -D warnings` and `cargo test -p personhog-identity` pass locally, including the Postgres-backed storage tests against a local persons database.
- No new tests. The changed assertions in `tests/storage_tests.rs` catch the column list regaining properties.
- Not run: the service against a live cluster with this build.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code at the assignee's direction. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`. The change came out of reading the top query on the dev persons cluster in pgapi and asking why the identity resolve returned properties. No open PR covers this; a search for `identity properties resolve` found nothing. The CodeRabbit local pass is paused, so the PR opened without one.

https://claude.ai/code/session_01PMccrmfb7LqGEmxT5zhfZ2
