### PR TITLE
fix(csp): allow our own media in the app policy

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -1344,7 +1344,11 @@ class CSPMiddleware:
                 "worker-src 'self' blob:",
                 "child-src 'none'",
                 "object-src 'none'",
-                "media-src https://res.cloudinary.com",
+                # `'self'` carries the PostHog AI onboarding videos under /static/. Max hands-free
+                # needs the other two: it primes playback with a silent `data:` clip, then plays
+                # the TTS response from a blob URL. None of the three can execute, because
+                # media-src governs <audio> and <video> only.
+                "media-src 'self' data: blob: https://res.cloudinary.com",
                 # `https:` is here for the OAuth authorize page, which renders an application's icon
                 # from a URL its registrant supplied. There is no allowlist that covers those, so
                 # until we serve them ourselves the directive has to accept any host.


### PR DESCRIPTION
## Problem

Under enforcement, the PostHog AI onboarding videos would not play and Max hands-free would go silent. `media-src` names one origin, `https://res.cloudinary.com`, and nothing else — so the app's own audio and video violate our own policy.

The policy is report-only today, so the media still plays. The reports over the last week name our own origins on both regions:

- `https://us.posthog.com/static/posthog-ai-onboarding/*.mp4` and the EU equivalents, across several projects
- `data:` media, 22 documents

Across 14 days the only hosts blocked under `media-src` that belong to us are `us.posthog.com` and `eu.posthog.com`. The rest are third-party media on replay pages and browser extensions, which stay blocked.

## Changes

- The PostHog AI onboarding videos play under an enforced policy. `media-src` gains `'self'`, which covers `/static/posthog-ai-onboarding/*.mp4` in `frontend/public/`, rendered by `OnboardingTakeover.tsx`.
- Max hands-free keeps working under an enforced policy. It needs two more tokens: `data:` for the silent clip at `handsFreeLogic.ts:239` that unlocks autoplay, and `blob:` for the TTS response at `handsFreeLogic.ts:508`.
- Nothing looks different today, because the policy is report-only.
- None of the three widens the directive beyond media. `media-src` governs `<audio>` and `<video>` only, so nothing admitted here can execute, and a blob URL still needs script to mint it.
- `https://res.cloudinary.com` stays. Every cloudinary reference in the repo is an `image/upload` path, which `img-src` already covers, so the entry looks unused — but that removal carries its own argument and belongs in its own change.

## How did you test this code?

- No new tests. No test asserts the app's `media-src`, and an assertion on the directive text would pin the exact string and fail on every later edit.
- Not run: `TestCSPMiddleware` needs Postgres, which this sandbox does not have. CI covers it.
- The three consumers were read in the tree rather than inferred: `frontend/public/posthog-ai-onboarding/` holds the five `.mp4` files, and `handsFreeLogic.ts` builds both the `data:` primer and the `blob:` URL.
- Nothing is enforced today, so a wrong token here surfaces as a report rather than as broken playback.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The policy is internal and report-only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 5). Skills invoked: `/writing-pr-descriptions`, `/writing-tests`, `/reviewing-with-coderabbit`.
- CodeRabbit CLI pass: paused, so this PR opened without a local pass.
- No duplicate: searched open PRs for `media-src`. Nothing touches this directive. #92074 proposes a `font-src` change for the replay asset proxy, which is a different directive and a separate decision.
- Patch coverage: the changed line is a policy string that no test asserts, so the patch is uncovered by design.
- This came out of an audit of the app policy for external hostnames we could drop. The audit found more missing sources than removable ones. Two other candidates were examined and rejected: `frame-ancestors 'self'` has no same-origin framing in the app that the embeddable carve-out does not already handle, and `form-action` needs nothing, because the logout form posts to a relative `/logout` that redirects to a same-origin `/login`, so `'self'` already covers the chain.
- Public artifact: nothing here draws on non-public material.
