### PR TITLE
fix(flags): remap group type indices when copying flags across projects

### DIFF
--- a/products/feature_flags/backend/api/organization_feature_flag.py
+++ b/products/feature_flags/backend/api/organization_feature_flag.py
@@ -22,6 +22,7 @@ from posthog.api.utils import ErrorResponseSerializer, action
 from posthog.constants import AvailableFeature
 from posthog.models import Team, User
 from posthog.models.filters.filter import Filter
+from posthog.models.group_type_mapping import get_group_types_for_project
 from posthog.rate_limit import CopyFlagsBurstRateThrottle, CopyFlagsSustainedRateThrottle
 from posthog.user_permissions import UserPermissions
 from posthog.utils import safe_int
@@ -57,6 +58,19 @@ SCHEDULED_DEPENDENCY_COPY_PERMISSION_ERROR = (
 )
 TARGET_DEPENDENCY_CREATE_PERMISSION_WARNING = "Cannot automatically copy dependencies because you do not have permission to create feature flags in one or more target projects."
 EXISTING_TARGET_SCHEDULE_DEPENDENCY_WARNING = "Pending scheduled changes already attached to the target flag were left unchanged and may change this copied flag later."
+MISSING_TARGET_GROUP_TYPE_ERROR = (
+    "Cannot copy this flag because the target project does not have these group types: {group_types}. "
+    "Group types are numbered separately in each project, so the copied flag would match a different group type. "
+    "Capture an event for the missing group types in the target project, then copy the flag again."
+)
+MISSING_TARGET_GROUP_TYPE_SCHEDULE_WARNING = (
+    "Skipped a scheduled change because the target project does not have these group types: {group_types}."
+)
+
+
+def _is_group_type_index(value: Any) -> bool:
+    # bool is a subclass of int, so reject it before the int check.
+    return isinstance(value, int) and not isinstance(value, bool)
 
 
 @dataclass(frozen=True)
@@ -1298,6 +1312,11 @@ class OrganizationFeatureFlagView(
             **filters,
         }
 
+        source_project_id = source_flag.team.project_id
+        missing_group_types = self._remap_group_type_indices(filters, source_project_id, target_team.project_id)
+        if missing_group_types:
+            raise ValueError(MISSING_TARGET_GROUP_TYPE_ERROR.format(group_types=", ".join(missing_group_types)))
+
         # reference correct destination cohort ids in the flag
         for group in filters.get("groups", []) or []:
             props = group.get("properties", [])
@@ -1411,6 +1430,7 @@ class OrganizationFeatureFlagView(
                         source_dependency_keys,
                         disabled_source_dependency_keys,
                         target_team,
+                        source_project_id,
                     )
                     schedule_dependency_warnings.extend(copied_schedule_dependency_warnings)
             except Exception as e:
@@ -1560,8 +1580,9 @@ class OrganizationFeatureFlagView(
         source_dependency_keys: dict[str, str],
         disabled_source_dependency_keys: set[str],
         target_team: Team,
+        source_project_id: int,
     ) -> list[str]:
-        """Copy pending schedules, remapping cohort IDs and flag dependencies for the target project."""
+        """Copy pending schedules, remapping cohort IDs, group type indices and flag dependencies for the target project."""
         # Validate user has permission to create schedules in target project
         user_access_control = UserAccessControl(user, target_flag.team)
         user_access_level = user_access_control.get_user_access_level(target_flag)
@@ -1591,6 +1612,16 @@ class OrganizationFeatureFlagView(
         for schedule in source_schedules:
             # Remap cohort IDs in schedule payload
             updated_payload = self._remap_cohort_ids_in_payload(schedule.payload, cohort_mapping, cohort_cache)
+            payload_filters = self._get_schedule_payload_filters(updated_payload)
+            if payload_filters is not None:
+                missing_group_types = self._remap_group_type_indices(
+                    payload_filters, source_project_id, target_team.project_id
+                )
+                if missing_group_types:
+                    schedule_dependency_warnings.append(
+                        MISSING_TARGET_GROUP_TYPE_SCHEDULE_WARNING.format(group_types=", ".join(missing_group_types))
+                    )
+                    continue
             schedule_dependency_context = schedule_dependency_contexts_by_id.get(cast(int, schedule.id))
             if schedule_dependency_context is None:
                 schedule_dependency_context = ScheduledChangeDependencyContext({}, set())
@@ -1699,6 +1730,62 @@ class OrganizationFeatureFlagView(
             restricted_target_dependency_keys,
             disabled_source_dependency_keys,
         )
+
+    def _iter_group_type_index_slots(self, filters: dict[str, Any]) -> list[tuple[dict[str, Any], str]]:
+        """Collect every dict entry in `filters` that holds a group type index."""
+        slots: list[tuple[dict[str, Any], str]] = []
+        if _is_group_type_index(filters.get("aggregation_group_type_index")):
+            slots.append((filters, "aggregation_group_type_index"))
+        for group in self._iter_filter_groups(filters):
+            if _is_group_type_index(group.get("aggregation_group_type_index")):
+                slots.append((group, "aggregation_group_type_index"))
+            for prop in self._iter_group_properties(group):
+                if prop.get("type") == "group" and _is_group_type_index(prop.get("group_type_index")):
+                    slots.append((prop, "group_type_index"))
+        return slots
+
+    def _remap_group_type_indices(
+        self, filters: dict[str, Any], source_project_id: int, target_project_id: int
+    ) -> list[str]:
+        """Rewrite the group type indices in `filters` to the target project's indices for the same group types.
+
+        A project numbers its group types in the order they first arrive, so index 1 can be
+        "organization" in one project and "company" in the next. Copying the index unchanged keeps
+        the rule readable but makes it evaluate a different group type in the target project.
+
+        Returns the source group types that the target project does not have. Nothing is rewritten
+        in that case, so the caller must reject the copy rather than write a misdirected index.
+        """
+        slots = self._iter_group_type_index_slots(filters)
+        if not slots:
+            return []
+
+        source_names_by_index = {
+            group_type["group_type_index"]: group_type["group_type"]
+            for group_type in get_group_types_for_project(source_project_id, caller_tag="copy_feature_flags")
+        }
+        target_indices_by_name = {
+            group_type["group_type"]: group_type["group_type_index"]
+            for group_type in get_group_types_for_project(target_project_id, caller_tag="copy_feature_flags")
+        }
+
+        missing_group_types: list[str] = []
+        remapped_slots: list[tuple[dict[str, Any], str, int]] = []
+        for container, key in slots:
+            source_index = container[key]
+            source_name = source_names_by_index.get(source_index)
+            target_index = target_indices_by_name.get(source_name) if source_name is not None else None
+            if target_index is None:
+                missing_group_types.append(f'"{source_name}"' if source_name else f"index {source_index}")
+                continue
+            remapped_slots.append((container, key, target_index))
+
+        if missing_group_types:
+            return sorted(set(missing_group_types))
+
+        for container, key, target_index in remapped_slots:
+            container[key] = target_index
+        return []
 
     def _remap_cohort_ids_in_payload(
         self,

--- a/products/feature_flags/backend/api/organization_feature_flag.py
+++ b/products/feature_flags/backend/api/organization_feature_flag.py
@@ -22,7 +22,7 @@ from posthog.api.utils import ErrorResponseSerializer, action
 from posthog.constants import AvailableFeature
 from posthog.models import Team, User
 from posthog.models.filters.filter import Filter
-from posthog.models.group_type_mapping import get_group_types_for_project
+from posthog.models.group_type_mapping import GroupTypesUnavailable, get_group_types_for_projects
 from posthog.rate_limit import CopyFlagsBurstRateThrottle, CopyFlagsSustainedRateThrottle
 from posthog.user_permissions import UserPermissions
 from posthog.utils import safe_int
@@ -59,17 +59,20 @@ SCHEDULED_DEPENDENCY_COPY_PERMISSION_ERROR = (
 TARGET_DEPENDENCY_CREATE_PERMISSION_WARNING = "Cannot automatically copy dependencies because you do not have permission to create feature flags in one or more target projects."
 EXISTING_TARGET_SCHEDULE_DEPENDENCY_WARNING = "Pending scheduled changes already attached to the target flag were left unchanged and may change this copied flag later."
 MISSING_TARGET_GROUP_TYPE_ERROR = (
-    "Cannot copy this flag because the target project does not have these group types: {group_types}. "
-    "Group types are numbered separately in each project, so the copied flag would match a different group type. "
+    "The target project does not have these group types: {group_types}. "
+    "Group types are numbered separately in each project, so the copy would match a different group type. "
     "Capture an event for the missing group types in the target project, then copy the flag again."
 )
-MISSING_TARGET_GROUP_TYPE_SCHEDULE_WARNING = (
-    "Skipped a scheduled change because the target project does not have these group types: {group_types}."
+UNKNOWN_SOURCE_GROUP_TYPE_ERROR = (
+    "The source project does not have these group type numbers: {group_type_indices}. "
+    "Set the group type again on the source flag's release conditions, then copy the flag again."
 )
+GROUP_TYPES_UNAVAILABLE_ERROR = "The group types could not be read. Try the copy again in a moment."
+SKIPPED_SCHEDULE_GROUP_TYPE_WARNING = "Skipped a scheduled change. {reason}"
 
 
 def _is_group_type_index(value: Any) -> bool:
-    # bool is a subclass of int, so reject it before the int check.
+    # bool is a subclass of int, so exclude it explicitly.
     return isinstance(value, int) and not isinstance(value, bool)
 
 
@@ -476,6 +479,7 @@ class OrganizationFeatureFlagView(
     def copy_flags(self, request, *args, **kwargs):
         serializer = CopyFlagsRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
+        self._group_types_by_project_id: dict[int, list[dict[str, Any]]] = {}
         body = serializer.validated_data
         feature_flag_key = body.get("feature_flag_key")
         from_project = body.get("from_project")
@@ -1313,9 +1317,7 @@ class OrganizationFeatureFlagView(
         }
 
         source_project_id = source_flag.team.project_id
-        missing_group_types = self._remap_group_type_indices(filters, source_project_id, target_team.project_id)
-        if missing_group_types:
-            raise ValueError(MISSING_TARGET_GROUP_TYPE_ERROR.format(group_types=", ".join(missing_group_types)))
+        self._remap_group_type_indices(filters, source_project_id, target_team.project_id)
 
         # reference correct destination cohort ids in the flag
         for group in filters.get("groups", []) or []:
@@ -1614,13 +1616,12 @@ class OrganizationFeatureFlagView(
             updated_payload = self._remap_cohort_ids_in_payload(schedule.payload, cohort_mapping, cohort_cache)
             payload_filters = self._get_schedule_payload_filters(updated_payload)
             if payload_filters is not None:
-                missing_group_types = self._remap_group_type_indices(
-                    payload_filters, source_project_id, target_team.project_id
-                )
-                if missing_group_types:
-                    schedule_dependency_warnings.append(
-                        MISSING_TARGET_GROUP_TYPE_SCHEDULE_WARNING.format(group_types=", ".join(missing_group_types))
-                    )
+                try:
+                    self._remap_group_type_indices(payload_filters, source_project_id, target_team.project_id)
+                except ValueError as error:
+                    # Skip the one schedule rather than fail the whole copy, which matches how an
+                    # unremappable flag dependency is handled below.
+                    schedule_dependency_warnings.append(SKIPPED_SCHEDULE_GROUP_TYPE_WARNING.format(reason=error))
                     continue
             schedule_dependency_context = schedule_dependency_contexts_by_id.get(cast(int, schedule.id))
             if schedule_dependency_context is None:
@@ -1744,48 +1745,81 @@ class OrganizationFeatureFlagView(
                     slots.append((prop, "group_type_index"))
         return slots
 
+    def _get_group_types_by_project_id(self, project_ids: list[int]) -> dict[int, list[dict[str, Any]]]:
+        """Read each project's group types once per request.
+
+        One copy needs this lookup for every target project, every copied dependency flag and every
+        scheduled change, and a project's group types do not change inside one request.
+
+        The batch read is used instead of `get_group_types_for_project` because that helper answers
+        an unreachable mapping store with an empty list. Here an empty list means "the project has
+        no such group type", so it would reject a copy the target project can in fact accept.
+        """
+        unread = sorted(set(project_ids) - self._group_types_by_project_id.keys())
+        if unread:
+            try:
+                self._group_types_by_project_id.update(
+                    get_group_types_for_projects(unread, caller_tag="copy_feature_flags")
+                )
+            except GroupTypesUnavailable as error:
+                raise ValueError(GROUP_TYPES_UNAVAILABLE_ERROR) from error
+        return self._group_types_by_project_id
+
     def _remap_group_type_indices(
         self, filters: dict[str, Any], source_project_id: int, target_project_id: int
-    ) -> list[str]:
+    ) -> None:
         """Rewrite the group type indices in `filters` to the target project's indices for the same group types.
 
         A project numbers its group types in the order they first arrive, so index 1 can be
         "organization" in one project and "company" in the next. Copying the index unchanged keeps
         the rule readable but makes it evaluate a different group type in the target project.
 
-        Returns the source group types that the target project does not have. Nothing is rewritten
-        in that case, so the caller must reject the copy rather than write a misdirected index.
+        Raises ValueError when a group type cannot be matched, before anything is rewritten.
         """
         slots = self._iter_group_type_index_slots(filters)
         if not slots:
-            return []
+            return
 
+        group_types_by_project_id = self._get_group_types_by_project_id([source_project_id, target_project_id])
         source_names_by_index = {
             group_type["group_type_index"]: group_type["group_type"]
-            for group_type in get_group_types_for_project(source_project_id, caller_tag="copy_feature_flags")
+            for group_type in group_types_by_project_id[source_project_id]
         }
         target_indices_by_name = {
             group_type["group_type"]: group_type["group_type_index"]
-            for group_type in get_group_types_for_project(target_project_id, caller_tag="copy_feature_flags")
+            for group_type in group_types_by_project_id[target_project_id]
         }
 
-        missing_group_types: list[str] = []
+        unknown_source_indices: set[int] = set()
+        missing_target_group_types: set[str] = set()
         remapped_slots: list[tuple[dict[str, Any], str, int]] = []
         for container, key in slots:
             source_index = container[key]
             source_name = source_names_by_index.get(source_index)
-            target_index = target_indices_by_name.get(source_name) if source_name is not None else None
+            if source_name is None:
+                unknown_source_indices.add(source_index)
+                continue
+            target_index = target_indices_by_name.get(source_name)
             if target_index is None:
-                missing_group_types.append(f'"{source_name}"' if source_name else f"index {source_index}")
+                missing_target_group_types.add(source_name)
                 continue
             remapped_slots.append((container, key, target_index))
 
-        if missing_group_types:
-            return sorted(set(missing_group_types))
+        if unknown_source_indices:
+            raise ValueError(
+                UNKNOWN_SOURCE_GROUP_TYPE_ERROR.format(
+                    group_type_indices=", ".join(str(index) for index in sorted(unknown_source_indices))
+                )
+            )
+        if missing_target_group_types:
+            raise ValueError(
+                MISSING_TARGET_GROUP_TYPE_ERROR.format(
+                    group_types=", ".join(f'"{name}"' for name in sorted(missing_target_group_types))
+                )
+            )
 
         for container, key, target_index in remapped_slots:
             container[key] = target_index
-        return []
 
     def _remap_cohort_ids_in_payload(
         self,

--- a/products/feature_flags/backend/api/test/test_organization_feature_flag.py
+++ b/products/feature_flags/backend/api/test/test_organization_feature_flag.py
@@ -22,6 +22,7 @@ from posthog.models.organization import Organization
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.team.team import Team
 from posthog.models.utils import generate_random_token_personal, hash_key_value
+from posthog.test.persons import create_group_type_mapping
 
 from products.cohorts.backend.models.cohort import Cohort
 from products.cohorts.backend.models.util import sort_cohorts_topologically
@@ -31,6 +32,7 @@ from products.experiments.backend.models.experiment import Experiment
 from products.feature_flags.backend.api.organization_feature_flag import (
     EXISTING_TARGET_SCHEDULE_DEPENDENCY_WARNING,
     MAX_COPY_FLAGS_TARGET_PROJECTS,
+    MISSING_TARGET_GROUP_TYPE_ERROR,
     TARGET_COPY_PERMISSION_ERROR,
     OrganizationFeatureFlagView,
 )
@@ -2968,6 +2970,93 @@ class TestOrganizationFeatureFlagCopy(APIBaseTest, QueryMatchingTest):
         )
         existing_flag.refresh_from_db()
         self.assertEqual(existing_flag.filters, {"groups": [{"rollout_percentage": 10}]})
+
+    def _create_group_flag_to_copy(self, group_type_index: int) -> FeatureFlag:
+        return FeatureFlag.objects.create(
+            team=self.team_1,
+            created_by=self.user,
+            key="group-flag-to-copy",
+            filters={
+                "groups": [
+                    {
+                        "properties": [
+                            {
+                                "key": "$group_key",
+                                "type": "group",
+                                "value": "acme",
+                                "operator": "exact",
+                                "group_type_index": group_type_index,
+                            }
+                        ],
+                        "rollout_percentage": 100,
+                        "aggregation_group_type_index": group_type_index,
+                    }
+                ],
+                "aggregation_group_type_index": group_type_index,
+            },
+        )
+
+    def test_copy_feature_flag_remaps_group_type_index_to_target_project(self):
+        create_group_type_mapping(
+            team=self.team_1, project_id=self.team_1.project_id, group_type="organization", group_type_index=0
+        )
+        create_group_type_mapping(
+            team=self.team_1, project_id=self.team_1.project_id, group_type="company", group_type_index=1
+        )
+        create_group_type_mapping(
+            team=self.team_2, project_id=self.team_2.project_id, group_type="company", group_type_index=0
+        )
+        create_group_type_mapping(
+            team=self.team_2, project_id=self.team_2.project_id, group_type="organization", group_type_index=1
+        )
+        cache.clear()
+        flag_to_copy = self._create_group_flag_to_copy(group_type_index=1)
+
+        response = self.client.post(
+            f"/api/organizations/{self.organization.id}/feature_flags/copy_flags",
+            {
+                "feature_flag_key": flag_to_copy.key,
+                "from_project": self.team_1.id,
+                "target_project_ids": [self.team_2.id],
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["failed"], [])
+        copied_flag = FeatureFlag.objects.get(key=flag_to_copy.key, team=self.team_2)
+        self.assertEqual(copied_flag.filters["aggregation_group_type_index"], 0)
+        self.assertEqual(copied_flag.filters["groups"][0]["aggregation_group_type_index"], 0)
+        self.assertEqual(copied_flag.filters["groups"][0]["properties"][0]["group_type_index"], 0)
+        self.assertEqual(copied_flag.filters["groups"][0]["properties"][0]["value"], "acme")
+
+    def test_copy_feature_flag_fails_when_target_project_has_no_matching_group_type(self):
+        create_group_type_mapping(
+            team=self.team_1, project_id=self.team_1.project_id, group_type="company", group_type_index=1
+        )
+        cache.clear()
+        flag_to_copy = self._create_group_flag_to_copy(group_type_index=1)
+
+        response = self.client.post(
+            f"/api/organizations/{self.organization.id}/feature_flags/copy_flags",
+            {
+                "feature_flag_key": flag_to_copy.key,
+                "from_project": self.team_1.id,
+                "target_project_ids": [self.team_2.id],
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["success"], [])
+        self.assertEqual(
+            response.json()["failed"],
+            [
+                {
+                    "project_id": self.team_2.id,
+                    "error_message": MISSING_TARGET_GROUP_TYPE_ERROR.format(group_types='"company"'),
+                }
+            ],
+        )
+        self.assertFalse(FeatureFlag.objects.filter(key=flag_to_copy.key, team=self.team_2).exists())
 
 
 class TestOrganizationFeatureFlagCopyPersonalAPIKey(APIBaseTest):

--- a/products/feature_flags/backend/api/test/test_organization_feature_flag.py
+++ b/products/feature_flags/backend/api/test/test_organization_feature_flag.py
@@ -18,6 +18,7 @@ from django.utils import timezone
 from parameterized import parameterized
 from rest_framework import status
 
+from posthog.models.group_type_mapping import GroupTypesUnavailable
 from posthog.models.organization import Organization
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.team.team import Team
@@ -31,9 +32,11 @@ from products.early_access_features.backend.models import EarlyAccessFeature
 from products.experiments.backend.models.experiment import Experiment
 from products.feature_flags.backend.api.organization_feature_flag import (
     EXISTING_TARGET_SCHEDULE_DEPENDENCY_WARNING,
+    GROUP_TYPES_UNAVAILABLE_ERROR,
     MAX_COPY_FLAGS_TARGET_PROJECTS,
     MISSING_TARGET_GROUP_TYPE_ERROR,
     TARGET_COPY_PERMISSION_ERROR,
+    UNKNOWN_SOURCE_GROUP_TYPE_ERROR,
     OrganizationFeatureFlagView,
 )
 from products.feature_flags.backend.encrypted_flag_payloads import REDACTED_PAYLOAD_VALUE
@@ -3029,10 +3032,28 @@ class TestOrganizationFeatureFlagCopy(APIBaseTest, QueryMatchingTest):
         self.assertEqual(copied_flag.filters["groups"][0]["properties"][0]["group_type_index"], 0)
         self.assertEqual(copied_flag.filters["groups"][0]["properties"][0]["value"], "acme")
 
-    def test_copy_feature_flag_fails_when_target_project_has_no_matching_group_type(self):
-        create_group_type_mapping(
-            team=self.team_1, project_id=self.team_1.project_id, group_type="company", group_type_index=1
-        )
+    @parameterized.expand(
+        [
+            (
+                "target_project_lacks_the_group_type",
+                [("company", 1)],
+                MISSING_TARGET_GROUP_TYPE_ERROR.format(group_types='"company"'),
+            ),
+            (
+                "source_project_lacks_the_group_type",
+                [],
+                UNKNOWN_SOURCE_GROUP_TYPE_ERROR.format(group_type_indices="1"),
+            ),
+        ]
+    )
+    def test_copy_feature_flag_fails_when_group_type_cannot_be_matched(self, _name, source_group_types, expected_error):
+        for group_type, group_type_index in source_group_types:
+            create_group_type_mapping(
+                team=self.team_1,
+                project_id=self.team_1.project_id,
+                group_type=group_type,
+                group_type_index=group_type_index,
+            )
         cache.clear()
         flag_to_copy = self._create_group_flag_to_copy(group_type_index=1)
 
@@ -3049,12 +3070,28 @@ class TestOrganizationFeatureFlagCopy(APIBaseTest, QueryMatchingTest):
         self.assertEqual(response.json()["success"], [])
         self.assertEqual(
             response.json()["failed"],
-            [
-                {
-                    "project_id": self.team_2.id,
-                    "error_message": MISSING_TARGET_GROUP_TYPE_ERROR.format(group_types='"company"'),
-                }
-            ],
+            [{"project_id": self.team_2.id, "error_message": expected_error}],
+        )
+        self.assertFalse(FeatureFlag.objects.filter(key=flag_to_copy.key, team=self.team_2).exists())
+
+    @patch("products.feature_flags.backend.api.organization_feature_flag.get_group_types_for_projects")
+    def test_copy_feature_flag_fails_when_group_types_cannot_be_read(self, mock_get_group_types):
+        mock_get_group_types.side_effect = GroupTypesUnavailable([self.team_1.project_id])
+        flag_to_copy = self._create_group_flag_to_copy(group_type_index=1)
+
+        response = self.client.post(
+            f"/api/organizations/{self.organization.id}/feature_flags/copy_flags",
+            {
+                "feature_flag_key": flag_to_copy.key,
+                "from_project": self.team_1.id,
+                "target_project_ids": [self.team_2.id],
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.json()["failed"],
+            [{"project_id": self.team_2.id, "error_message": GROUP_TYPES_UNAVAILABLE_ERROR}],
         )
         self.assertFalse(FeatureFlag.objects.filter(key=flag_to_copy.key, team=self.team_2).exists())
 
@@ -3179,6 +3216,79 @@ class TestOrganizationFeatureFlagCopySchedules(APIBaseTest):
         }
         data.update(overrides)
         return self.client.post(f"/api/organizations/{self.organization.id}/feature_flags/copy_flags", data)
+
+    def _create_group_release_condition_schedule(self, group_type_index: int) -> ScheduledChange:
+        return ScheduledChange.objects.create(
+            record_id=str(self.feature_flag.id),
+            model_name=ScheduledChange.AllowedModels.FEATURE_FLAG,
+            payload={
+                "operation": "add_release_condition",
+                "value": {
+                    "groups": [
+                        {
+                            "properties": [],
+                            "rollout_percentage": 100,
+                            "aggregation_group_type_index": group_type_index,
+                        }
+                    ],
+                    "payloads": {},
+                    "multivariate": None,
+                    "aggregation_group_type_index": group_type_index,
+                },
+            },
+            scheduled_at=timezone.now() + timedelta(days=1),
+            team=self.team_1,
+            created_by=self.user,
+        )
+
+    def test_copy_flag_remaps_group_type_index_in_scheduled_change(self):
+        create_group_type_mapping(
+            team=self.team_1, project_id=self.team_1.project_id, group_type="organization", group_type_index=0
+        )
+        create_group_type_mapping(
+            team=self.team_1, project_id=self.team_1.project_id, group_type="company", group_type_index=1
+        )
+        create_group_type_mapping(
+            team=self.team_2, project_id=self.team_2.project_id, group_type="company", group_type_index=0
+        )
+        create_group_type_mapping(
+            team=self.team_2, project_id=self.team_2.project_id, group_type="organization", group_type_index=1
+        )
+        cache.clear()
+        self._create_group_release_condition_schedule(group_type_index=1)
+
+        response = self._post_copy_flag(copy_schedule=True)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertNotIn("schedule_copy_warning", response.json()["success"][0])
+        copied_flag = FeatureFlag.objects.get(key=self.feature_flag_key, team=self.team_2)
+        target_schedule = ScheduledChange.objects.get(
+            record_id=str(copied_flag.id),
+            model_name=ScheduledChange.AllowedModels.FEATURE_FLAG,
+            team=self.team_2,
+        )
+        self.assertEqual(target_schedule.payload["value"]["aggregation_group_type_index"], 0)
+        self.assertEqual(target_schedule.payload["value"]["groups"][0]["aggregation_group_type_index"], 0)
+
+    def test_copy_flag_skips_scheduled_change_when_target_lacks_group_type(self):
+        create_group_type_mapping(
+            team=self.team_1, project_id=self.team_1.project_id, group_type="company", group_type_index=1
+        )
+        cache.clear()
+        self._create_group_release_condition_schedule(group_type_index=1)
+
+        response = self._post_copy_flag(copy_schedule=True)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("company", response.json()["success"][0]["schedule_copy_warning"])
+        copied_flag = FeatureFlag.objects.get(key=self.feature_flag_key, team=self.team_2)
+        self.assertFalse(
+            ScheduledChange.objects.filter(
+                record_id=str(copied_flag.id),
+                model_name=ScheduledChange.AllowedModels.FEATURE_FLAG,
+                team=self.team_2,
+            ).exists()
+        )
 
     def test_copy_flag_without_schedules(self):
         """Copying a flag without copy_schedule=True should not copy schedules."""


### PR DESCRIPTION
## Problem

- A group-based feature flag copied into another project silently targets the wrong group type. The release condition renders with the right text, so nothing on screen says the rule changed meaning.
- Group type indices are allocated per project, in the order group types first appear. Index 1 is "company" in one project and "organization" in the next.
- The copy carried `aggregation_group_type_index` and each property's `group_type_index` over verbatim, while it already remapped the other project-specific references: cohorts by name, flag dependencies by key.

## Changes

- A copied flag now aggregates by the group type the source flag named, not by whatever sits at the source's index in the target project. Group types are matched by name, the same way cohorts are.
- Three slots hold a project-specific index, and all three are rewritten: the flag-level `aggregation_group_type_index`, the per-condition-set one, and `group_type_index` on each `type: "group"` property. The same applies inside a copied scheduled change payload.
- The copy fails for a target project that has no group type with that name, and the message names it. Other target projects in a bulk copy still succeed.
- Failing beats copying the flag inactive with a warning. An inactive flag still holds a wrong index, and whoever enables it later sees nothing that says the condition was mistranslated.
- The lookup uses `get_group_types_for_projects`, not `get_group_types_for_project`. The per-project helper answers an unreachable mapping store with an empty list, which this code would read as "the target project has no such group type" and reject a copy the target can accept. The batch read re-confirms empty reads against the primary and raises `GroupTypesUnavailable`, and it is memoized per request so one copy does not repeat the lookup for every target project, dependency flag and scheduled change.
- Three distinct failures, so the message always names something the user can act on: the target project lacks the group type, the source project has no mapping at the index the flag holds, or the group types could not be read.
- A scheduled change whose payload cannot be remapped is skipped with a warning, which matches how an unremappable flag dependency is already handled. One bad schedule does not fail the copy.
- No frontend change. The copy modal already renders per-project failures, so the new error surfaces there.

## How did you test this code?

Cases added to `TestOrganizationFeatureFlagCopy` and `TestOrganizationFeatureFlagCopySchedules`:

- A flag carrying the index in all three slots is copied between two projects that allocate the same two group types in opposite order. Every slot lands on the target's index. No existing test exercised a group type index across projects, so this path had no cover.
- The same for a copied scheduled change payload, which is the worse failure of the two: it applies later, with no copy response for anyone to read.
- Each failure mode asserts its own message and that no flag is written to the target: target lacks the group type, source lacks it, and the mapping store is unreadable.
- A scheduled change the target cannot take is skipped, the warning names the group type, and the flag still copies.

Not done: no manual run through the UI. The stack's Node processes fail to build in this sandbox (`lz4` native build), so only the backend suites were exercised.

No OpenAPI regen: the change adds module constants and private methods, and touches no serializer field.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The copy endpoint's contract is unchanged apart from the new failure cases.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code (Opus 5) from a support report, and validated against a flag the reporter copied between two of their own projects.
- Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, `/writing-pr-descriptions`, `/reviewing-with-coderabbit`, `/review-code`.
- The CodeRabbit local pass is paused, so this PR opened without one. A `/review-code` pass ran afterwards; the fail-open lookup, the split failure messages and the scheduled change tests all come from it.
- Considered and not taken: moving `source_project_id` into `FeatureFlagCopySourceContext`. It reads better, but the signature it would tidy is already long for reasons this change did not create, so it belongs in its own diff.
- Also rejected: validating the index against the target project inside `FeatureFlagSerializer`, which would reject unrelated writes to flags already holding a stale index.
- Public artifact: nothing from the session reached the diff or this description. The test fixtures use invented group types and an invented group key.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
