### PR TITLE
feat(desktop): track clicks across the spaces navigation and project menu

### DIFF
--- a/products/desktop/packages/shared/src/analytics-events.ts
+++ b/products/desktop/packages/shared/src/analytics-events.ts
@@ -1205,14 +1205,20 @@ export interface ChannelActionProperties {
   target_channel_id?: string;
   /**
    * For nav_click: which destination ("home"|"activity"|"inbox"|"canvas"|"agents"|"files"|"settings").
-   * A space's own sidebar rows name their page: "new_session"|"feed"|"context"|"loops".
+   * A space's own sidebar rows send their page key, which is what the
+   * breadcrumb and the route use: "new_session"|"home"|"context"|"loops".
+   * `home` is the space's feed, and the row reads "Feed".
    */
   nav_target?: string;
   /** For mention_member: the tagged teammate's user uuid. */
   mentioned_user_id?: string;
   /** For new_task_suggestion: the starter-prompt card label. */
   suggestion_label?: string;
-  /** For activity_tab_change and space_tab_change: the tab landed on. */
+  /**
+   * The tab landed on: for activity_tab_change its own name, for
+   * space_tab_change the kind the tab lists ("task" reads "Sessions",
+   * "canvas" reads "Canvases").
+   */
   tab?: string;
   /** For activity_unreads_toggle: the state being entered. */
   enabled?: boolean;

--- a/products/desktop/packages/shared/src/analytics-events.ts
+++ b/products/desktop/packages/shared/src/analytics-events.ts
@@ -333,10 +333,7 @@ export interface ProjectMenuActionProperties {
   action: ProjectMenuAction;
   /** The rail draws the trigger as an icon, the code sidebar as a footer row. */
   appearance: "row" | "icon";
-  /**
-   * For switch_project / switch_organization: whether the pick was the one
-   * already current, which closes the menu without moving anywhere.
-   */
+  /** For switch_project / switch_organization: whether the pick moved anywhere. */
   changed?: boolean;
 }
 
@@ -1205,20 +1202,14 @@ export interface ChannelActionProperties {
   target_channel_id?: string;
   /**
    * For nav_click: which destination ("home"|"activity"|"inbox"|"canvas"|"agents"|"files"|"settings").
-   * A space's own sidebar rows send their page key, which is what the
-   * breadcrumb and the route use: "new_session"|"home"|"context"|"loops".
-   * `home` is the space's feed, and the row reads "Feed".
+   * A space's sidebar rows send their page key, where "home" is the row labelled "Feed".
    */
   nav_target?: string;
   /** For mention_member: the tagged teammate's user uuid. */
   mentioned_user_id?: string;
   /** For new_task_suggestion: the starter-prompt card label. */
   suggestion_label?: string;
-  /**
-   * The tab landed on: for activity_tab_change its own name, for
-   * space_tab_change the kind the tab lists ("task" reads "Sessions",
-   * "canvas" reads "Canvases").
-   */
+  /** The tab landed on; space_tab_change sends the kind it lists ("task" reads "Sessions"). */
   tab?: string;
   /** For activity_unreads_toggle: the state being entered. */
   enabled?: boolean;

--- a/products/desktop/packages/shared/src/analytics-events.ts
+++ b/products/desktop/packages/shared/src/analytics-events.ts
@@ -313,6 +313,33 @@ export interface SidebarNavItemClickedProperties {
   layout?: SidebarLayout;
 }
 
+/** Every row of the account / project / org menu, plus opening it. */
+export type ProjectMenuAction =
+  | "open"
+  | "switch_project"
+  | "switch_organization"
+  | "create_project"
+  | "create_organization"
+  | "discord"
+  | "changelog"
+  | "website"
+  | "privacy_policy"
+  | "keyboard_shortcuts"
+  | "archived"
+  | "settings"
+  | "log_out";
+
+export interface ProjectMenuActionProperties {
+  action: ProjectMenuAction;
+  /** The rail draws the trigger as an icon, the code sidebar as a footer row. */
+  appearance: "row" | "icon";
+  /**
+   * For switch_project / switch_organization: whether the pick was the one
+   * already current, which closes the menu without moving anywhere.
+   */
+  changed?: boolean;
+}
+
 export type TaskListSurface = "sidebar" | "space" | "saved_search";
 
 export interface TaskListGroupingChangedProperties {
@@ -1149,7 +1176,13 @@ type ChannelActionType =
   | "mention_member"
   | "view_activity"
   | "open_mention"
-  | "activity_tab_change";
+  | "activity_tab_change"
+  /** Sessions ↔ Canvases in a space's sidebar list. */
+  | "space_tab_change"
+  | "expand_channel"
+  | "activity_unreads_toggle"
+  | "activity_mark_all_read"
+  | "activity_load_more";
 
 type TaskFeedActionType = "create" | "update" | "delete" | "open";
 
@@ -1170,14 +1203,19 @@ export interface ChannelActionProperties {
   task_id?: string;
   /** For file_task: destination channel when different from `channel_id`. */
   target_channel_id?: string;
-  /** For nav_click: which destination ("home"|"activity"|"inbox"|"canvas"|"agents"|"files"|"settings"). */
+  /**
+   * For nav_click: which destination ("home"|"activity"|"inbox"|"canvas"|"agents"|"files"|"settings").
+   * A space's own sidebar rows name their page: "new_session"|"feed"|"context"|"loops".
+   */
   nav_target?: string;
   /** For mention_member: the tagged teammate's user uuid. */
   mentioned_user_id?: string;
   /** For new_task_suggestion: the starter-prompt card label. */
   suggestion_label?: string;
-  /** For activity_tab_change: the tab landed on. */
+  /** For activity_tab_change and space_tab_change: the tab landed on. */
   tab?: string;
+  /** For activity_unreads_toggle: the state being entered. */
+  enabled?: boolean;
   /** Whether the underlying mutation resolved successfully. */
   success?: boolean;
   /** For auto_archive_update: the selected inactivity window. Null disables it. */
@@ -1714,6 +1752,7 @@ export const ANALYTICS_EVENTS = {
   CANVAS_RENDERED: "Canvas rendered",
   CANVAS_RUNTIME_ERROR: "Canvas runtime error",
   CONTEXT_ACTION: "Context action",
+  PROJECT_MENU_ACTION: "Project menu action",
 
   // Autoresearch events
   AUTORESEARCH_ARMED: "Autoresearch armed",
@@ -1926,6 +1965,7 @@ export type EventPropertyMap = {
   [ANALYTICS_EVENTS.CANVAS_RENDERED]: CanvasRenderedProperties;
   [ANALYTICS_EVENTS.CANVAS_RUNTIME_ERROR]: CanvasRuntimeErrorProperties;
   [ANALYTICS_EVENTS.CONTEXT_ACTION]: ContextActionProperties;
+  [ANALYTICS_EVENTS.PROJECT_MENU_ACTION]: ProjectMenuActionProperties;
 
   // Autoresearch events
   [ANALYTICS_EVENTS.AUTORESEARCH_ARMED]: AutoresearchArmedProperties;

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityFeedList.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityFeedList.tsx
@@ -156,6 +156,10 @@ export function ActivityFeedList({
   };
 
   const markAllRead = () => {
+    track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+      action_type: "activity_mark_all_read",
+      surface: "activity_panel",
+    });
     markTasksRead(activityReadPayload(unreadItems));
   };
 

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityFeedList.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityFeedList.tsx
@@ -184,7 +184,7 @@ export function ActivityFeedList({
           onClear={() => setQuery("")}
           actions={
             <>
-              <ActivityUnreadsToggle />
+              <ActivityUnreadsToggle surface="activity_panel" />
               <ActivityActionsMenu
                 loadedUnreadCount={unreadItems.length}
                 totalUnreadCount={unreadCount}

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityUnreadsToggle.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityUnreadsToggle.tsx
@@ -1,9 +1,18 @@
 import { Label, Switch } from "@posthog/quill";
+import {
+  ANALYTICS_EVENTS,
+  type ChannelsSurface,
+} from "@posthog/shared/analytics-events";
 import { useActivityFilterStore } from "@posthog/ui/features/canvas/stores/activityFilterStore";
+import { track } from "@posthog/ui/shell/analytics";
 import { useId } from "react";
 
 /** Narrows both Activity surfaces down to what hasn't been read yet. */
-export function ActivityUnreadsToggle() {
+export function ActivityUnreadsToggle({
+  surface,
+}: {
+  surface: ChannelsSurface;
+}) {
   const switchId = useId();
   const unreadsOnly = useActivityFilterStore((state) => state.unreadsOnly);
   const setUnreadsOnly = useActivityFilterStore(
@@ -17,7 +26,14 @@ export function ActivityUnreadsToggle() {
         id={switchId}
         size="sm"
         checked={unreadsOnly}
-        onCheckedChange={setUnreadsOnly}
+        onCheckedChange={(next: boolean) => {
+          setUnreadsOnly(next);
+          track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+            action_type: "activity_unreads_toggle",
+            surface,
+            enabled: next,
+          });
+        }}
       />
     </div>
   );

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityView.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityView.tsx
@@ -105,6 +105,10 @@ export function ActivityView() {
     [markTasksRead],
   );
   const markAllRead = useCallback(() => {
+    track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+      action_type: "activity_mark_all_read",
+      surface: "activity",
+    });
     markTasksRead(activityReadPayload(unreadItems));
   }, [markTasksRead, unreadItems]);
   useEffect(() => {
@@ -122,7 +126,13 @@ export function ActivityView() {
         variant="outline"
         loading={taskActivity.isFetchingNextPage}
         disabled={taskActivity.isFetchingNextPage}
-        onClick={() => void taskActivity.fetchNextPage()}
+        onClick={() => {
+          track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+            action_type: "activity_load_more",
+            surface: "activity",
+          });
+          void taskActivity.fetchNextPage();
+        }}
       >
         Load more
       </Button>
@@ -206,7 +216,7 @@ export function ActivityView() {
             </p>
           </div>
           <div className="flex shrink-0 items-center gap-2">
-            <ActivityUnreadsToggle />
+            <ActivityUnreadsToggle surface="activity" />
             <ActivityActionsMenu
               loadedUnreadCount={unreadItems.length}
               totalUnreadCount={unreadCount}

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.tsx
@@ -46,12 +46,6 @@ const CHANNEL_TABS: readonly {
   { value: "canvas", label: "Canvases" },
 ];
 
-/** What a tab is called in analytics, so a rename here doesn't rewrite history. */
-const CHANNEL_TAB_EVENT_NAME: Record<ChannelTab, string> = {
-  task: "sessions",
-  canvas: "canvases",
-};
-
 function ChannelTabs({
   tab,
   onTabChange,
@@ -138,11 +132,13 @@ export function ChannelSidebar({ channelId }: { channelId: string }) {
   const tab = chosenTab.channelId === channelId ? chosenTab.tab : "task";
   const setTab = (next: ChannelTab) => {
     setChosenTab({ channelId, tab: next });
+    // Only a real change, the way the list's own grouping control reports.
+    if (next === tab) return;
     track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
       action_type: "space_tab_change",
       surface: "sidebar",
       channel_id: channelId,
-      tab: CHANNEL_TAB_EVENT_NAME[next],
+      tab: next,
     });
   };
 
@@ -191,9 +187,8 @@ export function ChannelSidebar({ channelId }: { channelId: string }) {
       depth={0}
       label={channelPageLabel(page)}
       isActive={pathname === to}
-      // The page key, not its label: renaming the row shouldn't split the
-      // series. `home` is the space's feed, and reads as "Feed" in the list.
-      onClick={navigateTo(page === "home" ? "feed" : page, onClick)}
+      // The page key, not its label: renaming a row shouldn't split the series.
+      onClick={navigateTo(page, onClick)}
     />
   );
 

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.tsx
@@ -15,6 +15,7 @@ import {
   TabsTrigger,
 } from "@posthog/quill";
 import { LOOPS_FLAG } from "@posthog/shared";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { ChannelBackRow } from "@posthog/ui/features/canvas/components/ChannelBackRow";
 import { ChannelItemsPane } from "@posthog/ui/features/canvas/components/ChannelItemsPane";
 import { ChannelsFab } from "@posthog/ui/features/canvas/components/ChannelsFab";
@@ -28,6 +29,7 @@ import { SHORTCUTS } from "@posthog/ui/features/command/keyboard-shortcuts";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { SidebarKbdHint } from "@posthog/ui/features/sidebar/components/items/SidebarKbdHint";
 import { SidebarItem } from "@posthog/ui/features/sidebar/components/SidebarItem";
+import { track } from "@posthog/ui/shell/analytics";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
 import { useMemo, useState } from "react";
 
@@ -43,6 +45,12 @@ const CHANNEL_TABS: readonly {
   { value: "task", label: "Sessions" },
   { value: "canvas", label: "Canvases" },
 ];
+
+/** What a tab is called in analytics, so a rename here doesn't rewrite history. */
+const CHANNEL_TAB_EVENT_NAME: Record<ChannelTab, string> = {
+  task: "sessions",
+  canvas: "canvases",
+};
 
 function ChannelTabs({
   tab,
@@ -128,7 +136,15 @@ export function ChannelSidebar({ channelId }: { channelId: string }) {
     tab: "task" as ChannelTab,
   });
   const tab = chosenTab.channelId === channelId ? chosenTab.tab : "task";
-  const setTab = (next: ChannelTab) => setChosenTab({ channelId, tab: next });
+  const setTab = (next: ChannelTab) => {
+    setChosenTab({ channelId, tab: next });
+    track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+      action_type: "space_tab_change",
+      surface: "sidebar",
+      channel_id: channelId,
+      tab: CHANNEL_TAB_EVENT_NAME[next],
+    });
+  };
 
   const { channels } = useChannels();
   // By type, not by name: the list relabels the personal channel on the way in,
@@ -152,6 +168,16 @@ export function ChannelSidebar({ channelId }: { channelId: string }) {
     return task ? `task:${task[1]}` : null;
   }, [pathname]);
 
+  const navigateTo = (target: string, go: () => void) => () => {
+    track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+      action_type: "nav_click",
+      surface: "sidebar",
+      channel_id: channelId,
+      nav_target: target,
+    });
+    go();
+  };
+
   // Label comes from the shared space-page table, so a sidebar row and the
   // header breadcrumb for the same page can never disagree. No icon: this is a
   // short list of words, and glyphs here only compete with the status dots
@@ -165,7 +191,9 @@ export function ChannelSidebar({ channelId }: { channelId: string }) {
       depth={0}
       label={channelPageLabel(page)}
       isActive={pathname === to}
-      onClick={onClick}
+      // The page key, not its label: renaming the row shouldn't split the
+      // series. `home` is the space's feed, and reads as "Feed" in the list.
+      onClick={navigateTo(page === "home" ? "feed" : page, onClick)}
     />
   );
 
@@ -180,12 +208,12 @@ export function ChannelSidebar({ channelId }: { channelId: string }) {
           depth={0}
           label="New session"
           isActive={pathname === `${base}/new`}
-          onClick={() =>
+          onClick={navigateTo("new_session", () => {
             void navigate({
               to: "/spaces/$channelId/new",
               params: { channelId },
-            })
-          }
+            });
+          })}
           // ⌘N inside a space lands on this same route (openTaskInput scopes to
           // the channel you're in), so the row can claim the key.
           endHint={<SidebarKbdHint keys={SHORTCUTS.NEW_TASK} />}

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -339,6 +339,18 @@ function SpaceAttentionDot({
 }
 
 /**
+ * The caret opens a space onto its sessions without entering it, so it reports
+ * on its own rather than as a nav click.
+ */
+function trackSpaceDisclosure(channelId: string, expanded: boolean): void {
+  track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+    action_type: expanded ? "collapse_channel" : "expand_channel",
+    surface: "sidebar",
+    channel_id: channelId,
+  });
+}
+
+/**
  * The tree's disclosure caret, in its own fixed slot ahead of the space glyph.
  * Always drawn: a control that only appears on hover moves the row's contents
  * as the pointer crosses the list, and leaves the tree invisible to anyone who
@@ -418,6 +430,12 @@ function useOpenSpaceTask(): (spaceId: string, taskId: string) => void {
   const setCurrentChannel = useCurrentChannelStore((s) => s.setCurrentChannel);
 
   return (spaceId, taskId) => {
+    track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+      action_type: "open_task",
+      surface: "sidebar",
+      channel_id: spaceId,
+      task_id: taskId,
+    });
     keepListForRoute(spaceId);
     // Still scoped: the space is where the session lives, so anything that then
     // asks for the channel pane opens on the right one.
@@ -611,7 +629,14 @@ function ViewAllRow({
     <SpaceRowSurface
       asOption={asOption}
       optionValue={viewAllValue(spaceId)}
-      onClick={onOpenSpace}
+      onClick={() => {
+        track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+          action_type: "view_more_tasks",
+          surface: "sidebar",
+          channel_id: spaceId,
+        });
+        onOpenSpace();
+      }}
       className={cn("pl-8 text-[13px]", ROW_LABEL_TONE)}
     >
       {/* The arrow takes the slot a session's status dot has, so the guide's
@@ -1218,7 +1243,10 @@ const ChannelSection = memo(
                       <SpaceDisclosure
                         expanded={expanded}
                         spaceName={channel.name}
-                        onToggle={() => onToggleExpanded(channel.id)}
+                        onToggle={() => {
+                          trackSpaceDisclosure(channel.id, expanded);
+                          onToggleExpanded(channel.id);
+                        }}
                       />
                     )}
                     {glyph}
@@ -1603,7 +1631,10 @@ const PersonalChannelRow = memo(function PersonalChannelRow({
             <SpaceDisclosure
               expanded={expanded}
               spaceName={PERSONAL_CHANNEL_LABEL}
-              onToggle={() => onToggleExpanded(meChannel.id)}
+              onToggle={() => {
+                trackSpaceDisclosure(meChannel.id, expanded);
+                onToggleExpanded(meChannel.id);
+              }}
             />
           )}
           {glyph}

--- a/products/desktop/packages/ui/src/features/canvas/components/NavRail.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/NavRail.tsx
@@ -317,7 +317,14 @@ function NavRailImpl() {
             label="Search"
             shortcut={formatHotkey(SHORTCUTS.COMMAND_MENU)}
             isActive={false}
-            onClick={toggleCommandMenu}
+            onClick={() => {
+              track(ANALYTICS_EVENTS.SIDEBAR_NAV_ITEM_CLICKED, {
+                item: "search",
+                in_more: false,
+                layout: "channels",
+              });
+              toggleCommandMenu();
+            }}
           />
           <NavIcon
             icon={<GearSix size={16} />}

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannelItems.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannelItems.tsx
@@ -6,6 +6,7 @@ import {
   type ChannelWorkspaceFacts,
 } from "@posthog/core/canvas/channelItems";
 import { formatBulkResult } from "@posthog/core/sidebar/selection";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { useArchivedTaskIds } from "@posthog/ui/features/archive/useArchivedTaskIds";
 import { useArchiveTask } from "@posthog/ui/features/archive/useArchiveTask";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
@@ -26,6 +27,7 @@ import { useTaskViewed } from "@posthog/ui/features/sidebar/useTaskViewed";
 import { useTasks } from "@posthog/ui/features/tasks/useTasks";
 import { useWorkspaces } from "@posthog/ui/features/workspace/useWorkspace";
 import { toast } from "@posthog/ui/primitives/toast";
+import { track } from "@posthog/ui/shell/analytics";
 import { useNavigate } from "@tanstack/react-router";
 import { useMemo } from "react";
 
@@ -160,11 +162,25 @@ export function useChannelItems(channelId: string): {
     () => ({
       open: (item) => {
         if (item.kind === "canvas") {
+          // Canvases report as dashboard opens, the same event the canvases
+          // pane fires, so the two entry points can be compared.
+          track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
+            action_type: "open",
+            surface: "sidebar",
+            channel_id: channelId,
+            dashboard_id: item.id,
+          });
           void navigate({
             to: "/spaces/$channelId/dashboards/$dashboardId",
             params: { channelId, dashboardId: item.id },
           });
         } else {
+          track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+            action_type: "open_task",
+            surface: "sidebar",
+            channel_id: channelId,
+            task_id: item.id,
+          });
           void navigate({
             to: "/spaces/$channelId/tasks/$taskId",
             params: { channelId, taskId: item.id },

--- a/products/desktop/packages/ui/src/features/sidebar/components/ProjectSwitcher.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/ProjectSwitcher.tsx
@@ -223,7 +223,8 @@ export function ProjectSwitcher({
     goToSettings("shortcuts");
   };
 
-  const handleOpenExternal = (url: string) => {
+  const handleOpenExternal = (action: ProjectMenuAction, url: string) => {
+    trackMenu(action);
     openExternalUrl(url);
     setPopoverOpen(false);
   };
@@ -390,20 +391,18 @@ export function ProjectSwitcher({
               </DropdownMenuSubTrigger>
               <DropdownMenuSubContent side="right" sideOffset={4}>
                 <DropdownMenuItem
-                  onClick={() => {
-                    trackMenu("website");
-                    handleOpenExternal(EXTERNAL_LINKS.website);
-                  }}
+                  onClick={() =>
+                    handleOpenExternal("website", EXTERNAL_LINKS.website)
+                  }
                 >
                   <ArrowSquareOut size={14} className="text-gray-11" />
                   Website
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
-                  onClick={() => {
-                    trackMenu("privacy_policy");
-                    handleOpenExternal(EXTERNAL_LINKS.privacy);
-                  }}
+                  onClick={() =>
+                    handleOpenExternal("privacy_policy", EXTERNAL_LINKS.privacy)
+                  }
                 >
                   <ShieldCheck size={14} className="text-gray-11" />
                   Privacy Policy

--- a/products/desktop/packages/ui/src/features/sidebar/components/ProjectSwitcher.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/ProjectSwitcher.tsx
@@ -31,6 +31,10 @@ import {
   ItemTitle,
 } from "@posthog/quill";
 import { EXTERNAL_LINKS } from "@posthog/shared";
+import {
+  ANALYTICS_EVENTS,
+  type ProjectMenuAction,
+} from "@posthog/shared/analytics-events";
 import { useArchivedTaskIds } from "@posthog/ui/features/archive/useArchivedTaskIds";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
@@ -52,6 +56,7 @@ import {
   SearchableMenuFlyout,
 } from "@posthog/ui/primitives/SearchableMenuFlyout";
 import { navigateToArchived } from "@posthog/ui/router/navigationBridge";
+import { track } from "@posthog/ui/shell/analytics";
 import { openExternalUrl } from "@posthog/ui/shell/openExternal";
 import { isMac } from "@posthog/ui/utils/platform";
 import { getPostHogUrl } from "@posthog/ui/utils/urls";
@@ -75,10 +80,23 @@ export function ProjectSwitcher({
 }: ProjectSwitcherProps = {}) {
   const [popoverOpen, setPopoverOpen] = useState(false);
 
+  const trackMenu = (
+    action: ProjectMenuAction,
+    properties?: { changed: boolean },
+  ): void => {
+    track(ANALYTICS_EVENTS.PROJECT_MENU_ACTION, {
+      action,
+      appearance,
+      ...properties,
+    });
+  };
+
   const holdPeek = useHoldSidebarPeek();
   const handleOpenChange = (next: boolean): void => {
     setPopoverOpen(next);
     holdPeek(next);
+    // Only the way in: a menu dismissed without a pick is not an action.
+    if (next) trackMenu("open");
   };
 
   const currentOrgId = useAuthStateValue((state) => state.currentOrgId);
@@ -151,6 +169,7 @@ export function ProjectSwitcher({
   );
 
   const handleProjectSelect = (projectId: number) => {
+    trackMenu("switch_project", { changed: projectId !== currentProjectId });
     if (projectId !== currentProjectId) {
       selectProjectMutation.mutate(projectId);
     }
@@ -158,6 +177,7 @@ export function ProjectSwitcher({
   };
 
   const handleOrgSelect = (orgId: string) => {
+    trackMenu("switch_organization", { changed: orgId !== currentOrgId });
     if (orgId !== currentOrgId) {
       switchOrgMutation.mutate(orgId);
     }
@@ -165,18 +185,21 @@ export function ProjectSwitcher({
   };
 
   const handleCreateProject = () => {
+    trackMenu("create_project");
     const url = getPostHogUrl("/organization/create-project");
     if (url) openExternalUrl(url);
     setPopoverOpen(false);
   };
 
   const handleCreateOrg = () => {
+    trackMenu("create_organization");
     const url = getPostHogUrl("/create-organization");
     if (url) openExternalUrl(url);
     setPopoverOpen(false);
   };
 
   const handleArchived = () => {
+    trackMenu("archived");
     setPopoverOpen(false);
     navigateToArchived();
   };
@@ -190,9 +213,15 @@ export function ProjectSwitcher({
     openSettings(category);
   };
 
-  const handleSettings = () => goToSettings("general");
+  const handleSettings = () => {
+    trackMenu("settings");
+    goToSettings("general");
+  };
 
-  const handleKeyboardShortcuts = () => goToSettings("shortcuts");
+  const handleKeyboardShortcuts = () => {
+    trackMenu("keyboard_shortcuts");
+    goToSettings("shortcuts");
+  };
 
   const handleOpenExternal = (url: string) => {
     openExternalUrl(url);
@@ -200,16 +229,19 @@ export function ProjectSwitcher({
   };
 
   const handleDiscord = () => {
+    trackMenu("discord");
     openExternalUrl(EXTERNAL_LINKS.discord);
     setPopoverOpen(false);
   };
 
   const handleViewChangelog = () => {
+    trackMenu("changelog");
     useWhatsNewStore.getState().open();
     setPopoverOpen(false);
   };
 
   const handleLogout = () => {
+    trackMenu("log_out");
     setPopoverOpen(false);
     logoutMutation.mutate();
   };
@@ -358,14 +390,20 @@ export function ProjectSwitcher({
               </DropdownMenuSubTrigger>
               <DropdownMenuSubContent side="right" sideOffset={4}>
                 <DropdownMenuItem
-                  onClick={() => handleOpenExternal(EXTERNAL_LINKS.website)}
+                  onClick={() => {
+                    trackMenu("website");
+                    handleOpenExternal(EXTERNAL_LINKS.website);
+                  }}
                 >
                   <ArrowSquareOut size={14} className="text-gray-11" />
                   Website
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
-                  onClick={() => handleOpenExternal(EXTERNAL_LINKS.privacy)}
+                  onClick={() => {
+                    trackMenu("privacy_policy");
+                    handleOpenExternal(EXTERNAL_LINKS.privacy);
+                  }}
                 >
                   <ShieldCheck size={14} className="text-gray-11" />
                   Privacy Policy


### PR DESCRIPTION
## Problem

A teammate asked whether anyone clicks the "Canvases" tab in a space, and where people open canvases from in the desktop app. The data could not answer it: the space sidebar in the Spaces layout fires no analytics at all, so its rows ("New session", Feed, Context, Loops), its Sessions/Canvases tabs, and the session and canvas rows under them are invisible. The account/project menu is dark end to end, and the spaces tree's caret and "View all" leaf report nothing.

Canvas views themselves are captured, so we can see that they happen and that they happen in a space — but not which control got the reader there.

## Changes

Nothing changes on screen. Each control below now reports a click, reusing the existing `Channel action` / `Dashboard action` / `Sidebar nav item clicked` events so the new rows sit beside the ones already collected:

- **Space sidebar** — the New session, Feed, Context and Loops rows report as `nav_click` with a `nav_target`; the Sessions/Canvases tabs report as a new `space_tab_change` with the tab landed on. This is the question that started the work.
- **Opening a row from that list** — a session reports `open_task`, a canvas reports a `Dashboard action` `open` with `surface: "sidebar"`, which is the same event the canvases pane already fires, so the two entry points are directly comparable.
- **Nav rail** — the Search button, the one destination in the rail that reported nothing.
- **Spaces tree** — the disclosure caret (`expand_channel` / `collapse_channel`) and the "View all" leaf (`view_more_tasks`), plus opening a session from the tree.
- **Activity** — the Unreads toggle, "Mark all as read" and "Load more", each carrying the surface so the panel and the full-page view stay distinguishable.
- **Project menu** — a new `Project menu action` event covering opening the menu, project and organization switches (with whether the pick changed anything), create project/org, Discord, changelog, website, privacy policy, keyboard shortcuts, Archived, Settings and Log out.

Event names and property shapes are added to the typed registry in `packages/shared/src/analytics-events.ts`, so every call site is checked at compile time.

## How did you test this code?

Automated only — this agent could not drive the desktop app. `pnpm --filter @posthog/shared typecheck` and `pnpm --filter @posthog/ui typecheck` pass, `biome check` is clean on the touched files, and the existing suites for the touched features pass (`vitest run src/features/canvas src/features/sidebar`, 129 files). No tests were added: these are capture calls on existing handlers, and I could not name a regression a new test would catch that the type-checked event registry does not.

Not checked: that the events arrive in PostHog from a running build. Worth confirming on the next desktop release before anyone builds an insight on the new names.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app from a Slack thread asking where canvases get viewed in the desktop app. The analysis behind it came first: canvas views are captured, all of them desktop and all inside a space, but the entry point could only be inferred from what happened just before each view. That gap is what this PR closes.

No repo skills applied to this area. The CodeRabbit CLI pass is paused, so this opened without a local review pass.

Two design decisions worth a reviewer's attention: canvas opens reuse `Dashboard action` rather than a new channel action, so the sidebar and the canvases pane report the same event with different surfaces; and the Activity unreads toggle takes a `surface` prop rather than guessing, because both Activity surfaces render it.

No material from the originating Slack thread — quoted, paraphrased, or as sample data — is in this diff.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1789166441356459)*
