### PR TITLE
fix(navigation): keep click-opened submenus open on the way to them

### DIFF
--- a/frontend/src/lib/components/Account/NewAccountMenu.tsx
+++ b/frontend/src/lib/components/Account/NewAccountMenu.tsx
@@ -21,6 +21,7 @@ import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { DropdownMenuSeparator } from 'lib/ui/DropdownMenu/DropdownMenu'
 import { Label } from 'lib/ui/Label/Label'
 import { MenuOpenIndicator } from 'lib/ui/Menus/Menus'
+import { useClickSubmenu } from 'lib/ui/Menus/useClickSubmenu'
 import { cn } from 'lib/utils/css-classes'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { billingLogic } from 'scenes/billing/billingLogic'
@@ -66,6 +67,8 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
     const { guardAvailableFeature } = useValues(upgradeModalLogic)
     const { showCreateProjectModal } = useActions(globalModalsLogic)
     const { showCreateOrganizationModal } = useActions(globalModalsLogic)
+    const projectSubmenu = useClickSubmenu()
+    const organizationSubmenu = useClickSubmenu()
 
     const projectNameStartsWithEmoji = currentTeam?.name?.match(/^\p{Extended_Pictographic}/u) !== null
     const projectNameWithoutFirstEmoji = projectNameStartsWithEmoji
@@ -163,9 +166,9 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
                                 <DropdownMenuSeparator />
 
                                 {isAuthenticatedTeam(currentTeam) && (
-                                    <Menu.SubmenuRoot>
+                                    <Menu.SubmenuRoot {...projectSubmenu.rootProps}>
                                         <Menu.SubmenuTrigger
-                                            openOnHover={false}
+                                            {...projectSubmenu.triggerProps}
                                             render={
                                                 <ButtonPrimitive
                                                     menuItem
@@ -189,7 +192,10 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
                                                 className="z-[var(--z-popover)]"
                                                 collisionPadding={{ top: 50, bottom: 50 }}
                                             >
-                                                <Menu.Popup className="primitive-menu-content w-min max-w-[var(--available-width)]">
+                                                <Menu.Popup
+                                                    {...projectSubmenu.popupProps}
+                                                    className="primitive-menu-content w-min max-w-[var(--available-width)]"
+                                                >
                                                     {/* We need to add a div here to prevent the keydown event from bubbling up to the menu. */}
                                                     <div onKeyDown={(e) => e.stopPropagation()}>
                                                         <ProjectSwitcher dialog={false} />
@@ -262,9 +268,9 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
                                     )}
                                 </Label>
                                 <DropdownMenuSeparator />
-                                <Menu.SubmenuRoot>
+                                <Menu.SubmenuRoot {...organizationSubmenu.rootProps}>
                                     <Menu.SubmenuTrigger
-                                        openOnHover={false}
+                                        {...organizationSubmenu.triggerProps}
                                         render={
                                             <ButtonPrimitive
                                                 menuItem
@@ -294,7 +300,10 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
                                             className="z-[var(--z-popover)]"
                                             collisionPadding={{ top: 50, bottom: 50 }}
                                         >
-                                            <Menu.Popup className="primitive-menu-content w-min max-w-[var(--available-width)]">
+                                            <Menu.Popup
+                                                {...organizationSubmenu.popupProps}
+                                                className="primitive-menu-content w-min max-w-[var(--available-width)]"
+                                            >
                                                 {/* We need to add a div here to prevent the keydown event from bubbling up to the menu. */}
                                                 <div onKeyDown={(e) => e.stopPropagation()}>
                                                     <OrgSwitcher dialog={false} />

--- a/frontend/src/lib/components/Menus/ThemeMenu.tsx
+++ b/frontend/src/lib/components/Menus/ThemeMenu.tsx
@@ -8,6 +8,7 @@ import { Link } from 'lib/lemon-ui/Link/Link'
 import { themeLogic } from 'lib/logic/themeLogic'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { MenuOpenIndicator } from 'lib/ui/Menus/Menus'
+import { useClickSubmenu } from 'lib/ui/Menus/useClickSubmenu'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
@@ -17,15 +18,16 @@ export function ThemeMenu(): JSX.Element {
     const { themeMode } = useValues(userLogic)
     const { updateUser } = useActions(userLogic)
     const { customCssEnabled } = useValues(themeLogic)
+    const themeSubmenu = useClickSubmenu()
 
     function handleThemeChange(theme: UserTheme): void {
         updateUser({ theme_mode: theme })
     }
 
     return (
-        <Menu.SubmenuRoot>
+        <Menu.SubmenuRoot {...themeSubmenu.rootProps}>
             <Menu.SubmenuTrigger
-                openOnHover={false}
+                {...themeSubmenu.triggerProps}
                 render={
                     <ButtonPrimitive menuItem data-attr="more-menu-theme-button">
                         <IconPalette />
@@ -39,7 +41,7 @@ export function ThemeMenu(): JSX.Element {
             />
             <Menu.Portal>
                 <Menu.Positioner className="z-[var(--z-popover)]" collisionPadding={{ top: 50, bottom: 50 }}>
-                    <Menu.Popup className="primitive-menu-content">
+                    <Menu.Popup {...themeSubmenu.popupProps} className="primitive-menu-content">
                         <div className="primitive-menu-content-inner flex flex-col gap-px p-1">
                             <Menu.Item
                                 onClick={() => handleThemeChange('light')}

--- a/frontend/src/lib/ui/Menus/isPointInSafeTriangle.test.ts
+++ b/frontend/src/lib/ui/Menus/isPointInSafeTriangle.test.ts
@@ -1,0 +1,52 @@
+import { isPointInSafeTriangle, Point, Rect } from './isPointInSafeTriangle'
+
+describe('isPointInSafeTriangle', () => {
+    const submenuOnTheRight: Rect = { left: 200, right: 400, top: 100, bottom: 300 }
+    const leftOfSubmenu: Point = { x: 100, y: 110 }
+
+    it.each<[string, Point, Point, Rect, boolean]>([
+        ['a point on the diagonal towards the far corner', { x: 150, y: 200 }, leftOfSubmenu, submenuOnTheRight, true],
+        ['a point straight ahead of the anchor', { x: 150, y: 110 }, leftOfSubmenu, submenuOnTheRight, true],
+        ['a point past the diagonal to the far corner', { x: 150, y: 260 }, leftOfSubmenu, submenuOnTheRight, false],
+        ['a point heading away from the submenu', { x: 150, y: 50 }, leftOfSubmenu, submenuOnTheRight, false],
+        ['a point behind the anchor', { x: 50, y: 110 }, leftOfSubmenu, submenuOnTheRight, false],
+        ['a point inside the submenu itself', { x: 300, y: 200 }, leftOfSubmenu, submenuOnTheRight, false],
+        [
+            'a point just past the corner, within the edge tolerance',
+            { x: 199, y: 95 },
+            { x: 100, y: 95 },
+            submenuOnTheRight,
+            true,
+        ],
+        [
+            'a point heading to a submenu flipped to the left',
+            { x: 450, y: 200 },
+            { x: 500, y: 110 },
+            submenuOnTheRight,
+            true,
+        ],
+        [
+            'a point heading to a submenu below the anchor',
+            { x: 250, y: 250 },
+            { x: 210, y: 50 },
+            { left: 100, right: 400, top: 300, bottom: 500 },
+            true,
+        ],
+        [
+            'a point heading to a submenu above the anchor',
+            { x: 250, y: 350 },
+            { x: 210, y: 550 },
+            { left: 100, right: 400, top: 100, bottom: 300 },
+            true,
+        ],
+        [
+            'any point when the anchor is inside the submenu',
+            { x: 250, y: 250 },
+            { x: 250, y: 200 },
+            { left: 100, right: 400, top: 100, bottom: 300 },
+            false,
+        ],
+    ])('%s', (_description, point, anchor, target, expected) => {
+        expect(isPointInSafeTriangle(point, anchor, target)).toBe(expected)
+    })
+})

--- a/frontend/src/lib/ui/Menus/isPointInSafeTriangle.ts
+++ b/frontend/src/lib/ui/Menus/isPointInSafeTriangle.ts
@@ -1,0 +1,59 @@
+export interface Point {
+    x: number
+    y: number
+}
+
+export type Rect = Pick<DOMRectReadOnly, 'left' | 'right' | 'top' | 'bottom'>
+
+/** Extends the target edge past its corners, where the triangle is thinnest. */
+const EDGE_TOLERANCE_PX = 12
+
+/**
+ * Whether `point` lies in the triangle between `anchor` and the edge of `target` that faces it: the area a
+ * pointer travelling from `anchor` to any part of `target` moves through.
+ */
+export function isPointInSafeTriangle(point: Point, anchor: Point, target: Rect): boolean {
+    const edge = facingEdge(anchor, target)
+    return edge !== null && isPointInTriangle(point, anchor, edge[0], edge[1])
+}
+
+function facingEdge(anchor: Point, target: Rect): [Point, Point] | null {
+    if (anchor.x < target.left) {
+        return [
+            { x: target.left, y: target.top - EDGE_TOLERANCE_PX },
+            { x: target.left, y: target.bottom + EDGE_TOLERANCE_PX },
+        ]
+    }
+    if (anchor.x > target.right) {
+        return [
+            { x: target.right, y: target.top - EDGE_TOLERANCE_PX },
+            { x: target.right, y: target.bottom + EDGE_TOLERANCE_PX },
+        ]
+    }
+    if (anchor.y < target.top) {
+        return [
+            { x: target.left - EDGE_TOLERANCE_PX, y: target.top },
+            { x: target.right + EDGE_TOLERANCE_PX, y: target.top },
+        ]
+    }
+    if (anchor.y > target.bottom) {
+        return [
+            { x: target.left - EDGE_TOLERANCE_PX, y: target.bottom },
+            { x: target.right + EDGE_TOLERANCE_PX, y: target.bottom },
+        ]
+    }
+    return null
+}
+
+function isPointInTriangle(point: Point, a: Point, b: Point, c: Point): boolean {
+    const ab = sideOfLine(point, a, b)
+    const bc = sideOfLine(point, b, c)
+    const ca = sideOfLine(point, c, a)
+    const hasNegative = ab < 0 || bc < 0 || ca < 0
+    const hasPositive = ab > 0 || bc > 0 || ca > 0
+    return !(hasNegative && hasPositive)
+}
+
+function sideOfLine(point: Point, from: Point, to: Point): number {
+    return (point.x - to.x) * (from.y - to.y) - (from.x - to.x) * (point.y - to.y)
+}

--- a/frontend/src/lib/ui/Menus/useClickSubmenu.test.tsx
+++ b/frontend/src/lib/ui/Menus/useClickSubmenu.test.tsx
@@ -1,0 +1,116 @@
+import '@testing-library/jest-dom'
+
+import { Menu } from '@base-ui/react/menu'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import { SUBMENU_TRAVEL_STALL_MS, useClickSubmenu } from './useClickSubmenu'
+
+// The submenu sits to the right of the parent menu; "Invite members" sits right below the trigger row.
+const SUBMENU_RECT = { left: 200, right: 400, top: 0, bottom: 300, x: 200, y: 0, width: 200, height: 300 }
+
+function AccountMenuLikeHarness(): JSX.Element {
+    const submenu = useClickSubmenu()
+    return (
+        <Menu.Root open>
+            <Menu.Trigger>Account</Menu.Trigger>
+            <Menu.Portal>
+                <Menu.Positioner>
+                    <Menu.Popup>
+                        <Menu.SubmenuRoot {...submenu.rootProps}>
+                            <Menu.SubmenuTrigger {...submenu.triggerProps}>Project</Menu.SubmenuTrigger>
+                            <Menu.Portal>
+                                <Menu.Positioner>
+                                    <Menu.Popup {...submenu.popupProps} data-attr="submenu">
+                                        <Menu.Item>Project A</Menu.Item>
+                                    </Menu.Popup>
+                                </Menu.Positioner>
+                            </Menu.Portal>
+                        </Menu.SubmenuRoot>
+                        <Menu.Item>Invite members</Menu.Item>
+                    </Menu.Popup>
+                </Menu.Positioner>
+            </Menu.Portal>
+        </Menu.Root>
+    )
+}
+
+function clickTrigger(): void {
+    fireEvent.mouseDown(screen.getByText('Project'), { button: 0 })
+    act(() => jest.runOnlyPendingTimers())
+}
+
+function openSubmenu(): HTMLElement {
+    clickTrigger()
+    const popup = screen.getByTestId('submenu')
+    jest.spyOn(popup, 'getBoundingClientRect').mockReturnValue(SUBMENU_RECT as DOMRect)
+    return popup
+}
+
+function leaveTriggerTowards(x: number, y: number): void {
+    fireEvent.mouseLeave(screen.getByText('Project'), { clientX: 100, clientY: 15 })
+    fireEvent.mouseMove(screen.getByText('Invite members'), { clientX: x, clientY: y })
+}
+
+// Base UI marks a closing popup with `data-closed` at once and unmounts it after its exit transition.
+const submenu = (): HTMLElement | null => screen.queryByTestId('submenu')
+
+describe('useClickSubmenu', () => {
+    beforeEach(() => {
+        jest.useFakeTimers()
+        render(<AccountMenuLikeHarness />)
+    })
+
+    afterEach(() => {
+        cleanup()
+        jest.useRealTimers()
+    })
+
+    it('opens the submenu on click', () => {
+        expect(submenu()).not.toBeInTheDocument()
+        clickTrigger()
+        expect(submenu()).not.toHaveAttribute('data-closed')
+    })
+
+    it('keeps the submenu open while the pointer crosses a sibling item on its way to the submenu', () => {
+        openSubmenu()
+
+        leaveTriggerTowards(150, 100)
+        fireEvent.mouseMove(screen.getByText('Invite members'), { clientX: 190, clientY: 180 })
+
+        expect(submenu()).not.toHaveAttribute('data-closed')
+    })
+
+    it('closes the submenu when the pointer heads for a sibling item instead of the submenu', async () => {
+        openSubmenu()
+
+        leaveTriggerTowards(110, 250)
+
+        await waitFor(() => expect(submenu()).not.toBeInTheDocument())
+    })
+
+    it('closes the submenu when the pointer stalls on a sibling item on the way', async () => {
+        openSubmenu()
+
+        leaveTriggerTowards(150, 100)
+        act(() => jest.advanceTimersByTime(SUBMENU_TRAVEL_STALL_MS + 1))
+        fireEvent.mouseMove(screen.getByText('Invite members'), { clientX: 160, clientY: 110 })
+
+        await waitFor(() => expect(submenu()).not.toBeInTheDocument())
+    })
+
+    it('leaves the submenu open on a repeat click of its trigger', () => {
+        openSubmenu()
+
+        clickTrigger()
+
+        expect(submenu()).not.toHaveAttribute('data-closed')
+    })
+
+    it('still closes the submenu on Escape', async () => {
+        const popup = openSubmenu()
+
+        fireEvent.keyDown(popup, { key: 'Escape' })
+
+        await waitFor(() => expect(submenu()).not.toBeInTheDocument())
+    })
+})

--- a/frontend/src/lib/ui/Menus/useClickSubmenu.ts
+++ b/frontend/src/lib/ui/Menus/useClickSubmenu.ts
@@ -1,0 +1,84 @@
+import { Menu } from '@base-ui/react/menu'
+import { MouseEvent as ReactMouseEvent, RefCallback, useCallback, useEffect, useMemo, useRef } from 'react'
+
+import { isPointInSafeTriangle, Point } from './isPointInSafeTriangle'
+
+/** A pointer that pauses this long on the way is no longer travelling to the submenu. */
+export const SUBMENU_TRAVEL_STALL_MS = 200
+
+export interface ClickSubmenuProps {
+    rootProps: Pick<Menu.SubmenuRoot.Props, 'onOpenChange'>
+    triggerProps: Pick<Menu.SubmenuTrigger.Props, 'openOnHover' | 'onMouseLeave'>
+    popupProps: { ref: RefCallback<HTMLDivElement> }
+}
+
+interface Travel {
+    anchor: Point
+    lastMoveAt: number
+}
+
+/**
+ * Props for a Base UI submenu that opens on click.
+ *
+ * Base UI only protects hover-opened submenus with a safe polygon. A click-opened one closes as soon as the
+ * pointer grazes a sibling item on its way to the submenu, and a repeat click on the trigger toggles it closed.
+ * While the pointer travels through the triangle from where it left the trigger to the submenu, this hook stops
+ * mouse moves before they reach the parent menu's items. Leaving the triangle or stalling hands control back.
+ */
+export function useClickSubmenu(): ClickSubmenuProps {
+    const popupElement = useRef<HTMLDivElement | null>(null)
+    const travel = useRef<Travel | null>(null)
+
+    const handleDocumentMouseMove = useCallback((event: MouseEvent): void => {
+        const popup = popupElement.current
+        const current = travel.current
+        const now = performance.now()
+        const point = { x: event.clientX, y: event.clientY }
+        const stalled = current !== null && now - current.lastMoveAt > SUBMENU_TRAVEL_STALL_MS
+        if (
+            !popup ||
+            !current ||
+            stalled ||
+            !isPointInSafeTriangle(point, current.anchor, popup.getBoundingClientRect())
+        ) {
+            document.removeEventListener('mousemove', handleDocumentMouseMove, true)
+            travel.current = null
+            return
+        }
+        current.lastMoveAt = now
+        event.stopPropagation()
+    }, [])
+
+    const handleTriggerMouseLeave = useCallback(
+        (event: ReactMouseEvent<HTMLElement>): void => {
+            travel.current = { anchor: { x: event.clientX, y: event.clientY }, lastMoveAt: performance.now() }
+            document.addEventListener('mousemove', handleDocumentMouseMove, true)
+        },
+        [handleDocumentMouseMove]
+    )
+
+    const handleOpenChange = useCallback((open: boolean, details: Menu.SubmenuRoot.ChangeEventDetails): void => {
+        // Keep the submenu open on a repeat click of its trigger, like native menus do.
+        if (!open && details.reason === 'trigger-press') {
+            details.cancel()
+        }
+    }, [])
+
+    const setPopupElement = useCallback<RefCallback<HTMLDivElement>>((element) => {
+        popupElement.current = element
+    }, [])
+
+    useEffect(
+        () => () => document.removeEventListener('mousemove', handleDocumentMouseMove, true),
+        [handleDocumentMouseMove]
+    )
+
+    return useMemo(
+        () => ({
+            rootProps: { onOpenChange: handleOpenChange },
+            triggerProps: { openOnHover: false, onMouseLeave: handleTriggerMouseLeave },
+            popupProps: { ref: setPopupElement },
+        }),
+        [handleOpenChange, handleTriggerMouseLeave, setPopupElement]
+    )
+}


### PR DESCRIPTION
## Problem

Fixes https://github.com/PostHog/posthog/issues/98208

In the account menu, clicking the project or organization row opens a submenu to the right. If you then move the mouse diagonally towards an item lower in that list, the submenu closes before you reach it, because the pointer briefly passes over the row below the trigger ("Invite members" or "Billing"). Clicking the row again while the submenu is open closes it instead of leaving it open, so people often need three or four clicks to switch project. The same applies to the color theme submenu.

This started with #77075, which made these submenus open on click instead of hover. Base UI only protects hover-opened submenus from this kind of accidental close.

## Changes

- Added a small hook, `useClickSubmenu`, that keeps a click-opened submenu open while the mouse is travelling from the trigger towards it. Once the pointer clearly heads somewhere else, or stops moving for a moment, the submenu closes as before.
- Clicking the trigger again while its submenu is open now keeps it open, the way native menus behave.
- Used the hook for the project, organization and color theme submenus.

## How did you test this code?

- Unit tests render a real Base UI menu laid out like the account menu and check that the submenu stays open on the diagonal, still closes when moving straight down the list or pausing on another item, stays open on a repeat click, and still closes on Escape.
- Unit tests for the geometry helper.
- Manually: open the account menu, click the project row, move diagonally into the list. The submenu stays open.

## Automatic notifications