### PR TITLE
fix(warehouse-sources): check CDC primary keys under each table's schema

### DIFF
--- a/products/data_warehouse/frontend/scenes/NewSourceScene/NewSourceScene.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/NewSourceScene.tsx
@@ -31,7 +31,7 @@ import { ExternalDataSourceType, SourceConfig } from '~/queries/schema/schema-ge
 import { AccessControlLevel, AccessControlResourceType, Breadcrumb } from '~/types'
 
 import SchemaForm from '../../shared/components/forms/SchemaForm'
-import { supportsDirectQuery } from '../../shared/components/forms/schemaGroupingUtils'
+import { splitQualifiedTableName, supportsDirectQuery } from '../../shared/components/forms/schemaGroupingUtils'
 import SourceForm, { SourceAccessMethodSelector, getSourceQueryMode } from '../../shared/components/forms/SourceForm'
 import { SyncProgressStep } from '../../shared/components/forms/SyncProgressStep'
 import { WebhookSetupForm } from '../../shared/components/forms/WebhookSetupForm'
@@ -417,17 +417,21 @@ function CDCSelfManagedSetupDialog(): JSX.Element | null {
     const pubName = (payload.cdc_publication_name as string) || 'posthog_pub'
     const dbUser = (sourceConnectionDetails?.payload?.user as string) || '<your_user>'
 
-    const tableList =
+    // Discovery names a table `schema.table` when the source reads every schema, so each name has
+    // to be split before it goes into SQL. A source pinned to one schema lists bare names.
+    const qualifiedTables =
         cdcTableNames.length > 0
-            ? cdcTableNames.map((t) => `"${schema}"."${t}"`).join(', ')
-            : `"${schema}"."your_table"`
+            ? cdcTableNames.map((t) => splitQualifiedTableName(t, schema))
+            : [{ schemaName: schema, tableName: 'your_table' }]
+    const tableList = qualifiedTables.map(({ schemaName, tableName }) => `"${schemaName}"."${tableName}"`).join(', ')
+    const usageSchemas = [...new Set(qualifiedTables.map(({ schemaName }) => schemaName))]
 
     const sql = `-- 1. Grants for the PostHog user
 --    Reading a replication slot requires REPLICATION (or rds_replication on RDS).
 --    Run ONE of the lines below, depending on your environment:
 ALTER USER "${dbUser}" WITH REPLICATION;             -- self-hosted / most clouds
 -- GRANT rds_replication TO "${dbUser}";             -- AWS RDS
-GRANT USAGE ON SCHEMA "${schema}" TO "${dbUser}";
+${usageSchemas.map((schemaName) => `GRANT USAGE ON SCHEMA "${schemaName}" TO "${dbUser}";`).join('\n')}
 GRANT SELECT ON ${tableList} TO "${dbUser}";
 
 -- 2. Publication covering the ${cdcTableNames.length} selected table${cdcTableNames.length === 1 ? '' : 's'}
@@ -437,7 +441,7 @@ CREATE PUBLICATION "${pubName}" FOR TABLE ${tableList}
   WITH (publish_via_partition_root = true);
 
 -- Later, to add a new table to the publication:
--- ALTER PUBLICATION "${pubName}" ADD TABLE "${schema}"."new_table";`
+-- ALTER PUBLICATION "${pubName}" ADD TABLE "${usageSchemas[0]}"."new_table";`
 
     const handleCopy = async (): Promise<void> => {
         await copyToClipboard(sql, 'Setup SQL')

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/prerequisite_validator.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/prerequisite_validator.py
@@ -24,20 +24,25 @@ def validate_cdc_prerequisites(
     conn: psycopg.Connection,
     management_mode: Literal["posthog", "self_managed"],
     tables: list[str],
-    schema: str = "public",
+    schema: str | None = "public",
     slot_name: str | None = None,
     publication_name: str | None = None,
 ) -> list[str]:
     """Validate that the database is ready for CDC.
 
+    `schema` is the single schema the source is configured to read. Pass None when the source
+    reads every schema, because schema discovery then names each table `schema.table` and the
+    entries in `tables` carry their own schema.
+
     Returns a list of user-facing error messages. Empty list = valid.
     """
     errors: list[str] = []
+    qualified_tables = _resolve_table_schemas(tables, schema)
 
     errors.extend(_check_pg_version(conn))
     errors.extend(_check_wal_level(conn))
-    errors.extend(_check_tables_have_primary_keys(conn, schema, tables))
-    errors.extend(_check_select_permission(conn, schema, tables))
+    errors.extend(_check_tables_have_primary_keys(conn, qualified_tables))
+    errors.extend(_check_select_permission(conn, qualified_tables))
 
     if management_mode == "posthog":
         errors.extend(_check_replication_role(conn))
@@ -97,7 +102,24 @@ def _check_wal_level(conn: psycopg.Connection) -> list[str]:
     return []
 
 
-def _check_tables_have_primary_keys(conn: psycopg.Connection, schema: str, tables: list[str]) -> list[str]:
+def _resolve_table_schemas(tables: list[str], schema: str | None) -> list[tuple[str, str]]:
+    """Pair each table with the schema that holds it.
+
+    A source configured for one schema lists bare table names, so they all take that schema. A
+    source that reads every schema lists them as `schema.table`, which must be split before a
+    catalog lookup, because `relname` holds the table name alone.
+    """
+    if schema is not None:
+        return [(schema, table) for table in tables]
+
+    resolved: list[tuple[str, str]] = []
+    for table in tables:
+        schema_name, separator, table_name = table.partition(".")
+        resolved.append((schema_name, table_name) if separator else ("public", table))
+    return resolved
+
+
+def _check_tables_have_primary_keys(conn: psycopg.Connection, tables: list[tuple[str, str]]) -> list[str]:
     """Each target table must have a primary key.
 
     Uses pg_catalog rather than information_schema because information_schema views
@@ -109,7 +131,7 @@ def _check_tables_have_primary_keys(conn: psycopg.Connection, schema: str, table
 
     errors: list[str] = []
     with conn.cursor() as cur:
-        for table in tables:
+        for schema, table in tables:
             cur.execute(
                 sql.SQL(
                     "SELECT COUNT(*) FROM pg_index i "
@@ -124,11 +146,11 @@ def _check_tables_have_primary_keys(conn: psycopg.Connection, schema: str, table
     return errors
 
 
-def _check_select_permission(conn: psycopg.Connection, schema: str, tables: list[str]) -> list[str]:
+def _check_select_permission(conn: psycopg.Connection, tables: list[tuple[str, str]]) -> list[str]:
     """Check SELECT permission on target tables."""
     errors: list[str] = []
     with conn.cursor() as cur:
-        for table in tables:
+        for schema, table in tables:
             try:
                 cur.execute(
                     sql.SQL("SELECT 1 FROM {}.{} LIMIT 0").format(sql.Identifier(schema), sql.Identifier(table))

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_prerequisite_validator.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_prerequisite_validator.py
@@ -55,12 +55,15 @@ _WAL_REPLICA = ("wal_level", [("replica",)])
 # PK check uses pg_catalog (pg_index) — match on "indisprimary"
 _HAS_PK = ("indisprimary", [(1,)])
 _NO_PK = ("indisprimary", [(0,)])
+# The primary-key lookup is also a COUNT, so the slot-capacity patterns name their own relation.
+# This one matches only when the schema and the table reach pg_catalog as separate literals.
+_PK_ON_ANALYTICS_EVENTS = ("Literal('analytics'), SQL(' AND c.relname = '), Literal('events')", [(1,)])
 # Replication role check — the OR expression returns a single boolean
 _HAS_REPL_ROLE = ("rolreplication", [(True,)])
 _NO_REPL_ROLE = ("rolreplication", [(False,)])
 _MAX_SLOTS_10 = ("max_replication_slots", [("10",)])
-_SLOT_COUNT_2 = ("COUNT", [("2",)])
-_SLOT_COUNT_10 = ("COUNT", [("10",)])
+_SLOT_COUNT_2 = ("FROM pg_replication_slots", [("2",)])
+_SLOT_COUNT_10 = ("FROM pg_replication_slots", [("10",)])
 _SLOT_EXISTS = ("slot_name", [(1,)])
 _SLOT_NOT_EXISTS: tuple[str, list] = ("slot_name", [])
 _PUB_EXISTS = ("pubname", [(1,)])
@@ -112,6 +115,15 @@ class TestValidateCDCPrerequisites:
         conn = _mock_conn([_PG_15, _WAL_LOGICAL, _NO_PK, _HAS_REPL_ROLE, _MAX_SLOTS_10, _SLOT_COUNT_2])
         errors = validate_cdc_prerequisites(conn=conn, management_mode="posthog", tables=["orders"])
         assert any("primary key" in e for e in errors)
+
+    def test_qualified_table_is_checked_under_its_own_schema(self):
+        # A source with no single schema configured lists its tables as `schema.table`. A relname
+        # lookup for the whole string finds no primary key on a table that has one.
+        conn = _mock_conn([_PG_15, _WAL_LOGICAL, _PK_ON_ANALYTICS_EVENTS, _HAS_REPL_ROLE, _MAX_SLOTS_10, _SLOT_COUNT_2])
+        errors = validate_cdc_prerequisites(
+            conn=conn, management_mode="posthog", tables=["analytics.events"], schema=None
+        )
+        assert errors == []
 
     def test_no_replication_role(self):
         conn = _mock_conn([_PG_15, _WAL_LOGICAL, _HAS_PK, _NO_REPL_ROLE, _MAX_SLOTS_10, _SLOT_COUNT_2])

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -1479,7 +1479,9 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                 team_id=team_id,
             )
             try:
-                schema = config.schema.strip() if isinstance(config.schema, str) and config.schema.strip() else "public"
+                # A blank schema means discovery enumerated every schema and named each table
+                # `schema.table`, so the validator has to read the schema off each entry.
+                schema = config.schema.strip() if isinstance(config.schema, str) and config.schema.strip() else None
                 return validate_cdc_prerequisites(
                     conn=conn,
                     management_mode=management_mode,  # type: ignore[arg-type]


### PR DESCRIPTION
## Problem

- A user setting up self-managed CDC on a Postgres source sees verification fail for every table they selected, each reported as having no primary key.
- The tables do have primary keys, so the user audits a long table list by hand and deselects rows that were valid all along.
- Schema discovery names a table `schema.table` when no single schema is configured on the source.
- The prerequisite check looked that whole string up as a `relname`, which matches no catalog row. The SELECT-permission check failed the same way.

## Changes

- Verification now passes when the selected tables have primary keys, whatever schema holds them.
- The validator pairs each table with its own schema before the pg_catalog lookup.
- The Postgres source passes `schema=None` when no schema is configured, which tells the validator that the names carry their own schema.
- The setup SQL in the dialog now quotes `"schema"."table"` and grants USAGE on every schema the selection spans. It previously emitted `"public"."other_schema.table"`, which fails to run.
- Nothing looks different: the dialog layout is unchanged, only the generated SQL text and the pass or fail outcome differ.

## How did you test this code?

- Added one case to `test_prerequisite_validator.py`: a qualified table name must reach pg_catalog as separate schema and table literals. Without the split it reports a missing primary key for a table that has one.
- Ran that test file locally.
- Not run: anything needing a live Postgres, because this sandbox has none. The wizard dialog was not opened in a browser.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Found while reviewing session-summary observations of the data warehouse new-source onboarding flow. Users were blocked at the CDC verification step and fell back to manually auditing their table selection.
- Tools: Claude Code. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-ui-components`, `/writing-pr-descriptions`, `/reviewing-with-coderabbit`.
- CodeRabbit CLI pass: paused, so this PR opened without a local pass.
- No duplicate: searched open PRs for the CDC prerequisite check, qualified table names, and the primary-key error. [#99509](https://github.com/PostHog/posthog/pull/99509) is adjacent (bulk sync-method selection) but has a different root cause and does not touch these files.
- Public artifact: nothing in this diff carries material from the agent session. The schema and table names in the test are invented.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*