### PR TITLE
chore(warehouse-sources): promote the Freshdesk source to GA

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/freshdesk/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/freshdesk/source.py
@@ -83,7 +83,7 @@ Your **domain** is the subdomain in your Freshdesk URL — e.g. `acme` for `acme
 Your **API key** is on your Freshdesk profile settings page (click your profile picture → **Profile settings**; the API key is shown in the right sidebar).""",
             iconPath="/static/services/freshdesk.png",
             docsUrl="https://posthog.com/docs/cdp/sources/freshdesk",
-            releaseStatus=ReleaseStatus.ALPHA,
+            releaseStatus=ReleaseStatus.GA,
             fields=cast(
                 list[FieldType],
                 [


### PR DESCRIPTION
## Problem

Anyone browsing the data warehouse source catalog sees Freshdesk marked "Alpha", which reads as untested and discourages teams from connecting it. The connector has met our promotion bar for a while.

- Live for 3.1 months, past the 3-month threshold.
- Import error rate over the last 7 days is 0.0%, against a 2.5% ceiling.

## Changes

- The Freshdesk tile in the new-source catalog loses its alpha label and `/api/public_source_configs/` reports `releaseStatus: "ga"` for it.
- `releaseStatus` on `FreshdeskSource.get_source_config` moves from `ReleaseStatus.ALPHA` to `ReleaseStatus.GA`.

Nothing else is coupled to the stage here. The source carries no `unreleasedSource` flag and no `dwh-freshdesk` feature flag, so there is no gating to remove. Sync logic, schemas, and endpoint settings are untouched.

## How did you test this code?

No new tests. The change is one metadata value that no test asserts, and adding one would only restate the declaration.

- Ran `ruff check` and `ruff format --check` on the freshdesk source package.
- Not run: the warehouse source test suites, which need a database this sandbox does not have.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The posthog.com doc does not state the release stage.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude Opus 5 through PostHog Desktop. Skills invoked: `/implementing-warehouse-sources` for the release-status conventions, `/writing-pr-descriptions` for this body. The CodeRabbit CLI pass is paused, so this PR opened without a local review pass.

No duplicate: searched open PRs for "Freshdesk", "releaseStatus" and "promote", and listed every open PR from the maintainer whose branches carry both hand-written and automated work. Nothing addresses this promotion.

Public artifact: the diff and this description carry no material from the agent session beyond the two aggregate metrics quoted above.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
