### PR TITLE
chore(warehouse-sources): promote the MailerLite source to GA

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mailerlite/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mailerlite/source.py
@@ -97,7 +97,7 @@ class MailerLiteSource(
             name=SchemaExternalDataSourceType.MAILER_LITE,
             category=DataWarehouseSourceCategory.MARKETING___EMAIL,
             label="MailerLite",
-            releaseStatus=ReleaseStatus.ALPHA,
+            releaseStatus=ReleaseStatus.GA,
             caption="""Enter your MailerLite API key to pull your MailerLite data into the PostHog Data warehouse.
 
 You can create an API key in your [MailerLite integrations settings](https://dashboard.mailerlite.com/integrations/api).""",


### PR DESCRIPTION
## Problem

Anyone browsing the data warehouse source catalog sees MailerLite marked "Alpha", which reads as untested and discourages teams from connecting it. The connector has met our promotion bar.

- Live for 3.1 months, past the 3-month threshold.
- Import error rate over the last 7 days is 0.0%, against a 2.5% ceiling.

## Changes

- The MailerLite tile in the new-source catalog loses its alpha label, and `/api/public_source_configs/` reports `releaseStatus: "ga"` for it.
- `releaseStatus` on `MailerLiteSource.get_source_config` moves from `ReleaseStatus.ALPHA` to `ReleaseStatus.GA`.

Nothing else is coupled to the stage here. The source carries no `unreleasedSource` flag and no `dwh-mailerlite` feature flag, so there is no gating to remove. The `v1` API version deprecation notice is independent of the release stage and stays as it is. Sync logic, schemas, webhook wiring, and endpoint settings are untouched.

## How did you test this code?

No new tests. The change is one metadata value that no test asserts, and adding one would only restate the declaration.

- Ran `ruff check` and `ruff format --check` on the mailerlite source package.
- Not run: the warehouse source test suites, which need a database this sandbox does not have.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The posthog.com doc does not state the release stage.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude Opus 5 through PostHog Desktop. Skills invoked: `/implementing-warehouse-sources` for the release-status conventions, `/writing-pr-descriptions` for this body. The CodeRabbit CLI pass is paused, so this PR opened without a local review pass.

No duplicate: searched open PRs for "MailerLite", "releaseStatus" and "promote", and listed every open PR from the maintainer, whose branches carry both hand-written and automated work. The only nearby PR is [#99601](https://github.com/PostHog/posthog/pull/99601), which promotes Freshdesk and does not touch MailerLite.

Public artifact: the diff and this description carry no material from the agent session beyond the two aggregate metrics quoted above.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
