### PR TITLE
feat(desktop): add OpenTUI harness CLI

### DIFF
--- a/products/desktop/apps/cli/README.md
+++ b/products/desktop/apps/cli/README.md
@@ -1,0 +1,31 @@
+# hog-tui prototype
+
+`hog-tui` is an OpenTUI terminal interface for the PostHog harness.
+
+## Requirements
+
+- Node.js 26.4.0 or later. `hog-tui` restarts itself with Node's `--experimental-ffi` flag.
+- An existing harness login. Run `hog /login` before starting `hog-tui`.
+
+## Run
+
+From `products/desktop/`:
+
+```sh
+pnpm --filter @posthog/cli build
+pnpm --filter @posthog/cli start
+```
+
+Use `hog-tui --cwd <path>` to set the working directory. Use `hog-tui --continue` to continue the most recent session for that directory.
+
+## Controls
+
+- Enter sends the prompt.
+- Shift+Enter inserts a new line.
+- Ctrl+C stops the active turn. Ctrl+C exits when the session is idle.
+
+The prompt supports the standard harness tools, prompts, skills, MCP servers, and Pi session commands.
+
+## Prototype limits
+
+Interactive extension dialogs are not part of this prototype. Desktop-only task context is not part of this prototype.

--- a/products/desktop/apps/cli/package.json
+++ b/products/desktop/apps/cli/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@posthog/cli",
+  "version": "0.0.0-dev",
+  "private": true,
+  "description": "Terminal interface for the PostHog harness",
+  "type": "module",
+  "bin": {
+    "hog-tui": "dist/bin.js"
+  },
+  "engines": {
+    "node": ">=26.4.0"
+  },
+  "scripts": {
+    "build": "tsup && pnpm build:types",
+    "build:types": "tsc --emitDeclarationOnly --declaration --noEmit false --outDir dist --rootDir src",
+    "start": "node dist/bin.js",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "clean": "node ../../scripts/rimraf.mjs dist .turbo"
+  },
+  "dependencies": {
+    "@earendil-works/pi-coding-agent": "catalog:",
+    "@opentui/core": "0.5.10",
+    "@posthog/harness": "workspace:*",
+    "web-tree-sitter": "0.25.10"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsup": "^8.5.1",
+    "typescript": "^5.5.0",
+    "vitest": "^4.1.8"
+  },
+  "files": [
+    "dist/**/*"
+  ]
+}

--- a/products/desktop/apps/cli/src/app.ts
+++ b/products/desktop/apps/cli/src/app.ts
@@ -1,0 +1,289 @@
+import { stat } from "node:fs/promises";
+import { resolve } from "node:path";
+import {
+  BoxRenderable,
+  CliRenderEvents,
+  type CliRenderer,
+  createCliRenderer,
+  defaultTextareaKeyBindings,
+  type KeyEvent,
+  ScrollBoxRenderable,
+  TextareaRenderable,
+  TextRenderable,
+} from "@opentui/core";
+import { type CliState, HarnessController } from "./controller.js";
+import type { TranscriptItem } from "./transcript.js";
+
+interface CliOptions {
+  cwd: string;
+  continueSession: boolean;
+  help: boolean;
+}
+
+function usage(): string {
+  return [
+    "Usage: hog-tui [--cwd <path>] [--continue] [--help]",
+    "",
+    "Start a terminal session for the PostHog harness.",
+    "",
+    "Options:",
+    "  --cwd <path>  Set the working directory.",
+    "  --continue    Continue the most recent session for the working directory.",
+    "  --help        Show this help.",
+    "",
+    "Controls:",
+    "  Enter         Send the prompt.",
+    "  Shift+Enter   Insert a new line.",
+    "  Ctrl+C        Stop the active turn, or exit when idle.",
+  ].join("\n");
+}
+
+function parseOptions(args: string[]): CliOptions {
+  let cwd = process.cwd();
+  let continueSession = false;
+  let help = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--cwd") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) {
+        throw new Error("--cwd requires a path.");
+      }
+      cwd = value;
+      index += 1;
+      continue;
+    }
+    if (argument === "--continue") {
+      continueSession = true;
+      continue;
+    }
+    if (argument === "--help") {
+      help = true;
+      continue;
+    }
+    throw new Error(`Unknown option: ${argument}`);
+  }
+
+  return { cwd: resolve(cwd), continueSession, help };
+}
+
+function formatTranscriptItem(item: TranscriptItem): string {
+  if (item.kind === "user") {
+    return `You\n${item.text}`;
+  }
+  if (item.kind === "assistant") {
+    return `Assistant\n${item.text}`;
+  }
+  if (item.kind === "tool") {
+    return `${item.name}: ${item.state}`;
+  }
+  if (item.kind === "error") {
+    return `Error\n${item.text}`;
+  }
+  return item.text;
+}
+
+class CliView {
+  private readonly transcript: TextRenderable;
+  private readonly status: TextRenderable;
+  private readonly composer: TextareaRenderable;
+  private submit: (() => void) | undefined;
+
+  constructor(renderer: CliRenderer) {
+    const layout = new BoxRenderable(renderer, {
+      height: "100%",
+      flexDirection: "column",
+      padding: 1,
+      gap: 1,
+    });
+    const header = new TextRenderable(renderer, {
+      content: "hog-tui",
+      height: 1,
+      fg: "#f9b65b",
+    });
+    const transcriptBox = new ScrollBoxRenderable(renderer, {
+      flexGrow: 1,
+      border: true,
+      borderColor: "#666666",
+      padding: 1,
+      stickyScroll: true,
+      stickyStart: "bottom",
+      scrollY: true,
+    });
+    this.transcript = new TextRenderable(renderer, {
+      content: "Start a conversation.",
+      wrapMode: "word",
+    });
+    this.status = new TextRenderable(renderer, {
+      content: "Ready",
+      height: 1,
+      fg: "#aaaaaa",
+    });
+    const composerBox = new BoxRenderable(renderer, {
+      height: 4,
+      border: true,
+      borderColor: "#666666",
+      focusedBorderColor: "#f9b65b",
+    });
+    this.composer = new TextareaRenderable(renderer, {
+      height: "100%",
+      placeholder: "Write a prompt",
+      wrapMode: "word",
+      keyBindings: [
+        ...defaultTextareaKeyBindings,
+        { name: "return", action: "submit" },
+        { name: "return", shift: true, action: "newline" },
+      ],
+      onSubmit: () => this.submit?.(),
+    });
+
+    transcriptBox.add(this.transcript);
+    layout.add(header);
+    layout.add(transcriptBox);
+    composerBox.add(this.composer);
+    layout.add(this.status);
+    layout.add(composerBox);
+    renderer.root.add(layout);
+  }
+
+  setSubmit(submit: () => void): void {
+    this.submit = submit;
+  }
+
+  render(state: CliState): void {
+    this.transcript.content = state.transcript.length
+      ? state.transcript.map(formatTranscriptItem).join("\n\n")
+      : "Start a conversation.";
+    this.status.content = state.status;
+  }
+
+  prompt(): string {
+    return this.composer.plainText;
+  }
+
+  clearPrompt(): void {
+    this.composer.editBuffer.setText("");
+  }
+
+  focusComposer(): void {
+    this.composer.focus();
+  }
+
+  showStartupError(): void {
+    this.transcript.content =
+      "Error\nCould not start the session. Check hog /login, then try again.";
+    this.status.content = "Session unavailable";
+  }
+}
+
+async function ensureDirectory(cwd: string): Promise<void> {
+  const cwdStat = await stat(cwd).catch((error: unknown) => {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(`Working directory does not exist: ${cwd}`);
+    }
+    throw error;
+  });
+  if (!cwdStat.isDirectory()) {
+    throw new Error(`Working directory is not a directory: ${cwd}`);
+  }
+}
+
+export async function main(args: string[]): Promise<void> {
+  let options: CliOptions;
+  try {
+    options = parseOptions(args);
+  } catch (error) {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : "Invalid command."}\n\n${usage()}\n`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  if (options.help) {
+    process.stdout.write(`${usage()}\n`);
+    return;
+  }
+
+  try {
+    await ensureDirectory(options.cwd);
+  } catch (error) {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : "Invalid working directory."}\n`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const renderer = await createCliRenderer({
+    screenMode: "alternate-screen",
+    exitOnCtrlC: false,
+    clearOnShutdown: true,
+    consoleMode: "disabled",
+  });
+  const view = new CliView(renderer);
+  let controller: HarnessController | undefined;
+  let resolveExit: (() => void) | undefined;
+  const exit = new Promise<void>((resolveExitPromise) => {
+    resolveExit = resolveExitPromise;
+  });
+  let exiting = false;
+  const requestExit = (): void => {
+    if (exiting) {
+      return;
+    }
+    exiting = true;
+    resolveExit?.();
+  };
+  const interrupt = (): void => {
+    void (async () => {
+      const result = controller ? await controller.abortOrExit() : "exit";
+      if (result === "exit") {
+        requestExit();
+      }
+    })();
+  };
+  const handleCtrlC = (event: KeyEvent): void => {
+    if (event.name !== "c" || !event.ctrl) {
+      return;
+    }
+    event.preventDefault();
+    interrupt();
+  };
+  const handleSignal = (): void => requestExit();
+
+  renderer.keyInput.on("keypress", handleCtrlC);
+  renderer.on(CliRenderEvents.DESTROY, requestExit);
+  process.once("SIGINT", interrupt);
+  process.once("SIGTERM", handleSignal);
+  process.once("SIGHUP", handleSignal);
+  renderer.start();
+
+  try {
+    controller = new HarnessController(
+      { cwd: options.cwd, continueSession: options.continueSession },
+      (state) => view.render(state),
+      () => view.focusComposer(),
+      requestExit,
+    );
+    view.setSubmit(() => {
+      void controller?.submit(view.prompt(), () => view.clearPrompt());
+    });
+    await controller.start();
+    view.focusComposer();
+    await exit;
+  } catch {
+    view.showStartupError();
+    view.focusComposer();
+    await exit;
+  } finally {
+    process.off("SIGINT", interrupt);
+    process.off("SIGTERM", handleSignal);
+    process.off("SIGHUP", handleSignal);
+    renderer.keyInput.off("keypress", handleCtrlC);
+    renderer.off(CliRenderEvents.DESTROY, requestExit);
+    await controller?.dispose();
+    renderer.destroy();
+  }
+}

--- a/products/desktop/apps/cli/src/bin.ts
+++ b/products/desktop/apps/cli/src/bin.ts
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+
+const minimumNodeVersion = [26, 4, 0] as const;
+
+function hasSupportedNodeVersion(version: string): boolean {
+  const [major = 0, minor = 0, patch = 0] = version
+    .replace(/^v/, "")
+    .split(".")
+    .map(Number);
+  const [minimumMajor, minimumMinor, minimumPatch] = minimumNodeVersion;
+
+  return (
+    major > minimumMajor ||
+    (major === minimumMajor &&
+      (minor > minimumMinor ||
+        (minor === minimumMinor && patch >= minimumPatch)))
+  );
+}
+
+function hasExperimentalFfi(): boolean {
+  return process.execArgv.includes("--experimental-ffi");
+}
+
+async function respawnWithExperimentalFfi(): Promise<number> {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(
+      process.execPath,
+      [
+        "--experimental-ffi",
+        "--disable-warning=ExperimentalWarning",
+        ...process.execArgv,
+        process.argv[1],
+        ...process.argv.slice(2),
+      ],
+      {
+        env: { ...process.env, HOG_TUI_FFI_RESPAWNED: "1" },
+        stdio: "inherit",
+      },
+    );
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      resolvePromise(code ?? (signal ? 1 : 0));
+    });
+  });
+}
+
+async function run(): Promise<void> {
+  if (!hasSupportedNodeVersion(process.versions.node)) {
+    process.stderr.write("hog-tui requires Node.js 26.4.0 or later.\n");
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!hasExperimentalFfi()) {
+    if (process.env.HOG_TUI_FFI_RESPAWNED === "1") {
+      process.stderr.write(
+        "hog-tui could not enable Node.js experimental FFI.\n",
+      );
+      process.exitCode = 1;
+      return;
+    }
+    process.exitCode = await respawnWithExperimentalFfi();
+    return;
+  }
+
+  const { main } = await import("./app.js");
+  await main(process.argv.slice(2));
+}
+
+void run().catch((error) => {
+  const detail = error instanceof Error ? error.message : "Unknown error";
+  process.stderr.write(
+    `hog-tui could not start: ${detail}\nInstall the CLI dependencies, then try again.\n`,
+  );
+  process.exitCode = 1;
+});

--- a/products/desktop/apps/cli/src/controller.ts
+++ b/products/desktop/apps/cli/src/controller.ts
@@ -1,0 +1,225 @@
+import { resolve } from "node:path";
+import {
+  type AgentSession,
+  type AgentSessionRuntime,
+  getAgentDir,
+  SessionManager,
+} from "@earendil-works/pi-coding-agent";
+import { createHarnessRuntime } from "@posthog/harness";
+import {
+  createPiRuntimeTrustResolver,
+  readPiProjectTrust,
+} from "@posthog/harness/project-trust";
+import {
+  appendTranscriptError,
+  projectSessionMessages,
+  projectTranscriptEvent,
+  type TranscriptItem,
+} from "./transcript.js";
+
+export interface CliState {
+  transcript: readonly TranscriptItem[];
+  status: string;
+  promptActive: boolean;
+}
+
+export interface HarnessControllerOptions {
+  cwd: string;
+  continueSession: boolean;
+}
+
+export class HarnessController {
+  private runtime: AgentSessionRuntime | undefined;
+  private session: AgentSession | undefined;
+  private unsubscribe: (() => void) | undefined;
+  private state: CliState = {
+    transcript: [],
+    status: "Ready",
+    promptActive: false,
+  };
+
+  constructor(
+    private readonly options: HarnessControllerOptions,
+    private readonly onStateChange: (state: CliState) => void,
+    private readonly onTurnSettled: () => void,
+    private readonly onExit: () => void,
+  ) {}
+
+  get isPromptActive(): boolean {
+    return this.state.promptActive;
+  }
+
+  async start(): Promise<void> {
+    const cwd = resolve(this.options.cwd);
+    const agentDir = getAgentDir();
+    const trust = readPiProjectTrust(cwd, cwd, agentDir);
+    const sessionManager = this.options.continueSession
+      ? SessionManager.continueRecent(cwd)
+      : SessionManager.create(cwd);
+
+    this.runtime = await createHarnessRuntime({
+      cwd,
+      sessionManager,
+      projectTrusted: createPiRuntimeTrustResolver(
+        cwd,
+        trust.trusted,
+        agentDir,
+      ),
+    });
+    this.runtime.setRebindSession(async (session) => {
+      await this.rebindSession(session);
+    });
+    await this.rebindSession(this.runtime.session);
+
+    if (
+      this.runtime.diagnostics.some((diagnostic) => diagnostic.type === "error")
+    ) {
+      this.updateState({
+        transcript: appendTranscriptError(
+          this.state.transcript,
+          "Some extensions did not load. Use /reload, then try again.",
+        ),
+      });
+    }
+  }
+
+  async submit(prompt: string, onAccepted: () => void): Promise<void> {
+    const session = this.session;
+    if (!session || this.state.promptActive || !prompt.trim()) {
+      return;
+    }
+
+    this.updateState({ promptActive: true, status: "Working" });
+    let accepted = false;
+
+    try {
+      await session.prompt(prompt, {
+        preflightResult: (success) => {
+          if (success) {
+            accepted = true;
+            onAccepted();
+          }
+        },
+      });
+    } catch {
+      this.updateState({
+        transcript: appendTranscriptError(
+          this.state.transcript,
+          "The request could not start. Check hog /login, then try again.",
+        ),
+        status: "Ready",
+      });
+    } finally {
+      if (!accepted || session.isIdle) {
+        this.settleTurn();
+      }
+    }
+  }
+
+  async abortOrExit(): Promise<"aborted" | "exit"> {
+    const session = this.session;
+    if (!session || (session.isIdle && !this.state.promptActive)) {
+      return "exit";
+    }
+
+    this.updateState({ status: "Stopping" });
+    try {
+      await session.abort();
+    } catch {
+      this.updateState({
+        transcript: appendTranscriptError(
+          this.state.transcript,
+          "Could not stop the request. Try Ctrl+C again.",
+        ),
+        status: "Ready",
+      });
+      this.onTurnSettled();
+    }
+    return "aborted";
+  }
+
+  async dispose(): Promise<void> {
+    this.unsubscribe?.();
+    this.unsubscribe = undefined;
+    await this.runtime?.dispose();
+    this.runtime = undefined;
+    this.session = undefined;
+  }
+
+  private async rebindSession(session: AgentSession): Promise<void> {
+    const runtime = this.runtime;
+    if (!runtime) {
+      return;
+    }
+
+    this.unsubscribe?.();
+    this.session = session;
+    await session.bindExtensions({
+      mode: "print",
+      commandContextActions: {
+        waitForIdle: () => session.waitForIdle(),
+        newSession: async (newSessionOptions) =>
+          runtime.newSession(newSessionOptions),
+        fork: async (entryId, forkOptions) => {
+          const result = await runtime.fork(entryId, forkOptions);
+          return { cancelled: result.cancelled };
+        },
+        navigateTree: async (targetId, navigateOptions) => {
+          const result = await session.navigateTree(targetId, {
+            summarize: navigateOptions?.summarize,
+            customInstructions: navigateOptions?.customInstructions,
+            replaceInstructions: navigateOptions?.replaceInstructions,
+            label: navigateOptions?.label,
+          });
+          return { cancelled: result.cancelled };
+        },
+        switchSession: async (sessionPath, switchOptions) =>
+          runtime.switchSession(sessionPath, switchOptions),
+        reload: async () => {
+          await session.reload();
+        },
+      },
+      abortHandler: () => {
+        void session.abort();
+      },
+      shutdownHandler: this.onExit,
+      onError: () => {
+        this.updateState({
+          transcript: appendTranscriptError(
+            this.state.transcript,
+            "An extension failed. Use /reload, then try again.",
+          ),
+        });
+      },
+    });
+
+    this.updateState({
+      transcript: projectSessionMessages(session.state.messages),
+      status: "Ready",
+      promptActive: false,
+    });
+    this.unsubscribe = session.subscribe((event) => {
+      this.updateState({
+        transcript: projectTranscriptEvent(this.state.transcript, event),
+      });
+      if (event.type === "agent_settled") {
+        this.settleTurn();
+      }
+    });
+    this.onTurnSettled();
+  }
+
+  private settleTurn(): void {
+    if (!this.state.promptActive && this.state.status === "Ready") {
+      return;
+    }
+
+    this.updateState({ promptActive: false, status: "Ready" });
+    this.onTurnSettled();
+  }
+
+  private updateState(change: Partial<CliState>): void {
+    this.state = { ...this.state, ...change };
+    this.onStateChange(this.state);
+  }
+}

--- a/products/desktop/apps/cli/src/transcript.test.ts
+++ b/products/desktop/apps/cli/src/transcript.test.ts
@@ -1,0 +1,57 @@
+import type { AgentSessionEvent } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import { projectTranscriptEvent } from "./transcript.js";
+
+function event(value: unknown): AgentSessionEvent {
+  return value as AgentSessionEvent;
+}
+
+describe("projectTranscriptEvent", () => {
+  it("keeps streamed assistant text when the completed message contains the same text", () => {
+    const transcript = [
+      event({
+        type: "message_update",
+        message: { timestamp: 1 },
+        assistantMessageEvent: { type: "text_delta", delta: "Hello" },
+      }),
+      event({
+        type: "message_end",
+        message: {
+          role: "assistant",
+          timestamp: 1,
+          content: [{ type: "text", text: "Hello" }],
+        },
+      }),
+    ].reduce(projectTranscriptEvent, []);
+
+    expect(transcript).toEqual([
+      { id: "assistant-1", kind: "assistant", text: "Hello" },
+    ]);
+  });
+
+  it("updates the matching tool when parallel tools finish out of order", () => {
+    const transcript = [
+      event({
+        type: "tool_execution_start",
+        toolCallId: "read",
+        toolName: "read",
+      }),
+      event({
+        type: "tool_execution_start",
+        toolCallId: "grep",
+        toolName: "grep",
+      }),
+      event({
+        type: "tool_execution_end",
+        toolCallId: "grep",
+        toolName: "grep",
+        isError: false,
+      }),
+    ].reduce(projectTranscriptEvent, []);
+
+    expect(transcript).toEqual([
+      { id: "tool-read", kind: "tool", name: "read", state: "running" },
+      { id: "tool-grep", kind: "tool", name: "grep", state: "completed" },
+    ]);
+  });
+});

--- a/products/desktop/apps/cli/src/transcript.ts
+++ b/products/desktop/apps/cli/src/transcript.ts
@@ -1,0 +1,208 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { AgentSessionEvent } from "@earendil-works/pi-coding-agent";
+
+export type TranscriptItem =
+  | { id: string; kind: "user" | "assistant"; text: string }
+  | {
+      id: string;
+      kind: "tool";
+      name: string;
+      state: "running" | "completed" | "failed";
+    }
+  | { id: string; kind: "status" | "error"; text: string };
+
+function messageText(message: AgentMessage): string {
+  if (message.role !== "user" && message.role !== "assistant") {
+    return "";
+  }
+
+  if (typeof message.content === "string") {
+    return message.content;
+  }
+
+  return message.content
+    .filter((block) => block.type === "text")
+    .map((block) => block.text)
+    .join("");
+}
+
+function appendStatus(
+  transcript: readonly TranscriptItem[],
+  id: string,
+  text: string,
+): TranscriptItem[] {
+  return [...transcript, { id, kind: "status", text }];
+}
+
+function appendAssistantError(
+  transcript: readonly TranscriptItem[],
+  message: AgentMessage,
+): TranscriptItem[] {
+  if (message.role !== "assistant" || message.stopReason !== "error") {
+    return [...transcript];
+  }
+
+  return [
+    ...transcript,
+    {
+      id: `error-${transcript.length}`,
+      kind: "error",
+      text: "The request failed. Check hog /login, then try again.",
+    },
+  ];
+}
+
+function projectMessageEnd(
+  transcript: readonly TranscriptItem[],
+  message: AgentMessage,
+): TranscriptItem[] {
+  if (message.role === "user") {
+    const text = messageText(message);
+    return text
+      ? [...transcript, { id: `user-${message.timestamp}`, kind: "user", text }]
+      : [...transcript];
+  }
+
+  if (message.role !== "assistant") {
+    return [...transcript];
+  }
+
+  const id = `assistant-${message.timestamp}`;
+  const text = messageText(message);
+  const existingIndex = transcript.findIndex((item) => item.id === id);
+  const projected = [...transcript];
+
+  if (text) {
+    if (existingIndex === -1) {
+      projected.push({ id, kind: "assistant", text });
+    } else {
+      projected[existingIndex] = { id, kind: "assistant", text };
+    }
+  }
+
+  return appendAssistantError(projected, message);
+}
+
+export function projectTranscriptEvent(
+  transcript: readonly TranscriptItem[],
+  event: AgentSessionEvent,
+): TranscriptItem[] {
+  if (event.type === "message_update") {
+    const update = event.assistantMessageEvent;
+    if (update.type !== "text_delta" || !update.delta) {
+      return [...transcript];
+    }
+
+    const id = `assistant-${event.message.timestamp}`;
+    const existingIndex = transcript.findIndex((item) => item.id === id);
+    if (existingIndex === -1) {
+      return [...transcript, { id, kind: "assistant", text: update.delta }];
+    }
+
+    const projected = [...transcript];
+    const existing = projected[existingIndex];
+    if (!existing || existing.kind !== "assistant") {
+      return projected;
+    }
+    projected[existingIndex] = {
+      ...existing,
+      text: `${existing.text}${update.delta}`,
+    };
+    return projected;
+  }
+
+  if (event.type === "message_end") {
+    return projectMessageEnd(transcript, event.message);
+  }
+
+  if (event.type === "tool_execution_start") {
+    return [
+      ...transcript,
+      {
+        id: `tool-${event.toolCallId}`,
+        kind: "tool",
+        name: event.toolName,
+        state: "running",
+      },
+    ];
+  }
+
+  if (event.type === "tool_execution_end") {
+    const id = `tool-${event.toolCallId}`;
+    const existingIndex = transcript.findIndex((item) => item.id === id);
+    const tool = {
+      id,
+      kind: "tool" as const,
+      name: event.toolName,
+      state: event.isError ? ("failed" as const) : ("completed" as const),
+    };
+
+    if (existingIndex === -1) {
+      return [...transcript, tool];
+    }
+
+    const projected = [...transcript];
+    projected[existingIndex] = tool;
+    return projected;
+  }
+
+  if (event.type === "compaction_start") {
+    return appendStatus(
+      transcript,
+      `status-${transcript.length}`,
+      "Compacting context",
+    );
+  }
+
+  if (event.type === "compaction_end") {
+    return appendStatus(
+      transcript,
+      `status-${transcript.length}`,
+      event.errorMessage ? "Context compaction failed" : "Context compacted",
+    );
+  }
+
+  if (event.type === "auto_retry_start") {
+    return appendStatus(
+      transcript,
+      `status-${transcript.length}`,
+      `Retrying request (${event.attempt} of ${event.maxAttempts})`,
+    );
+  }
+
+  if (event.type === "auto_retry_end" && !event.success) {
+    return appendTranscriptError(
+      transcript,
+      "The request could not be retried. Check your connection and hog /login.",
+    );
+  }
+
+  if (event.type === "summarization_retry_scheduled") {
+    return appendStatus(
+      transcript,
+      `status-${transcript.length}`,
+      `Retrying summary (${event.attempt} of ${event.maxAttempts})`,
+    );
+  }
+
+  return [...transcript];
+}
+
+export function appendTranscriptError(
+  transcript: readonly TranscriptItem[],
+  text: string,
+): TranscriptItem[] {
+  return [
+    ...transcript,
+    { id: `error-${transcript.length}`, kind: "error", text },
+  ];
+}
+
+export function projectSessionMessages(
+  messages: readonly AgentMessage[],
+): TranscriptItem[] {
+  return messages.reduce<TranscriptItem[]>(
+    (transcript, message) => projectMessageEnd(transcript, message),
+    [],
+  );
+}

--- a/products/desktop/apps/cli/tsconfig.json
+++ b/products/desktop/apps/cli/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "lib": ["ESNext"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "types": ["node"],
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/products/desktop/apps/cli/tsup.config.ts
+++ b/products/desktop/apps/cli/tsup.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from "tsup";
+
+const shared = {
+  format: ["esm"],
+  sourcemap: true,
+  target: "node26",
+};
+
+export default defineConfig([
+  {
+    ...shared,
+    entry: ["src/bin.ts"],
+    clean: true,
+    outDir: "dist",
+    external: ["./app.js"],
+  },
+  {
+    ...shared,
+    entry: ["src/app.ts"],
+    clean: false,
+    outDir: "dist",
+    external: ["@opentui/core"],
+  },
+]);

--- a/products/desktop/apps/cli/vitest.config.ts
+++ b/products/desktop/apps/cli/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+import { trunkTestOptions } from "../../vitest.config.base";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    ...trunkTestOptions,
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    exclude: ["**/node_modules/**", "**/dist/**"],
+  },
+});

--- a/products/desktop/pnpm-lock.yaml
+++ b/products/desktop/pnpm-lock.yaml
@@ -1776,6 +1776,34 @@ importers:
         specifier: npm:rolldown-vite@7.3.1
         version: rolldown-vite@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@25.2.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0)
 
+  apps/cli:
+    dependencies:
+      '@earendil-works/pi-coding-agent':
+        specifier: 'catalog:'
+        version: 0.84.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@opentui/core':
+        specifier: 0.5.10
+        version: 0.5.10(typescript@5.9.3)(web-tree-sitter@0.25.10(@types/emscripten@1.41.5))
+      '@posthog/harness':
+        specifier: workspace:*
+        version: link:../../packages/harness
+      web-tree-sitter:
+        specifier: 0.25.10
+        version: 0.25.10(@types/emscripten@1.41.5)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.0
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(@swc/core@1.15.43)(jiti@2.7.0)(postcss@8.5.23)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@22.20.0)(typescript@5.9.3))(vite@7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
+
 packages:
 
   '@adobe/css-tools@4.4.4':
@@ -16317,6 +16345,82 @@ packages:
     resolution: {integrity: sha512-2YMAriaYHX9wrBY2k7H0epSo+dyCaCZg/vOtt+nEDXM9ul480gkXz/9SkwpOeHcD2H5qqDG8lWDSBwpTcZpa6w==}
     peerDependencies:
       '@types/emscripten': '>=1.39.6'
+
+  '@opentui/core-darwin-arm64@0.5.10':
+    resolution: {integrity: sha512-Vyb+nTbhab8ZcRy5gg1loEEGwRcIbjAeVRIBfHBcbFDqmITBOg7x2gqJ+x/TnoOy4uwMhCmICUN2wiyREw3r1Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@opentui/core-darwin-x64@0.5.10':
+    resolution: {integrity: sha512-tTFLcM7Oj1gTyhm/bUdAt3C6grZdCxPk6+/g2azcZBUlI3/62LwbeRS6HbQKFFmm+1fUmX8cq6kWrtul885mVg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@opentui/core-linux-arm64-musl@0.5.10':
+    resolution: {integrity: sha512-dGMphDKexSdeYqwl0wgoFBP88Ta/cdi1Zc1mk29/ENkSCGz+74zlCHgqTHRNGLmI8W5TfuUtCyktQH11/Z+TBQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@opentui/core-linux-arm64@0.5.10':
+    resolution: {integrity: sha512-ncJXcgudhBf2GdJyF3xVQN/Ec+1F7GOL+pRrURmgBYSj2v1w6EyoDQFAACtPTK2c3R38W6fvZwL4JSLlm4EFXQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@opentui/core-linux-x64-musl@0.5.10':
+    resolution: {integrity: sha512-Oj4H9hApuvuTKPWxh4SoZAgGJorR7vbvnrZA/cAkSMAk2VGSoHRRcqeXQbcH8IcdjVZ0KFpv8Zkl/D5Ye+2mew==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@opentui/core-linux-x64@0.5.10':
+    resolution: {integrity: sha512-5qtYaOgwVycZD1GaGshTRsi0rXPAmVExO03N1JQaHu+NYxK/vXSOc7Bu4QW0sPXx3Sp0SpzpP+FHjXABfoK66g==}
+    cpu: [x64]
+    os: [linux]
+
+  '@opentui/core-win32-arm64@0.5.10':
+    resolution: {integrity: sha512-A9VhgvTxQoUdZ+8LmUumEng1sQNbj9QQQT3NYG9mSxI54qTANi7vOWNSphMiY6RMVsr22pgm6nUvSSvJXv7Jog==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@opentui/core-win32-x64@0.5.10':
+    resolution: {integrity: sha512-u3KHa7kEeWrmKVDRJYpxSGO+g5E9cMGlrmTsPN3GVPHUmQMiREUawLXUvsU8+IHaQnqG3Q5nuE1yf4fPBzS+Qw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@opentui/core@0.5.10':
+    resolution: {integrity: sha512-C3a2UbmefeAjIxAgm4BqjuSxKT4oqutfvYFwVvUgMxmGRHkNbBc/s7sukV0JgwcxFcV3uMFrXxo+E+BQtvuOiw==}
+    peerDependencies:
+      web-tree-sitter: 0.25.10
+
+  bun-ffi-structs@0.3.1:
+    resolution: {integrity: sha512-3gM7PpVWLyrwxWjcilSiGuhWanhZivvo6l0u573NziPH6f/gwk6McbaYgn7oJWov6pKGRTDbrg94W5DcJsKTtQ==}
+    peerDependencies:
+      typescript: ^5
+
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
+    engines: {node: '>=0.3.1'}
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  marked@17.0.1:
+    resolution: {integrity: sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  web-tree-sitter@0.25.10:
+    resolution: {integrity: sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==}
+    peerDependencies:
+      '@types/emscripten': ^1.40.0
+    peerDependenciesMeta:
+      '@types/emscripten':
+        optional: true
 
 snapshots:
 
@@ -32968,3 +33072,66 @@ snapshots:
     dependencies:
       '@types/emscripten': 1.41.5
       type-fest: 5.6.0
+  '@opentui/core-darwin-arm64@0.5.10':
+    optional: true
+
+  '@opentui/core-darwin-x64@0.5.10':
+    optional: true
+
+  '@opentui/core-linux-arm64-musl@0.5.10':
+    optional: true
+
+  '@opentui/core-linux-arm64@0.5.10':
+    optional: true
+
+  '@opentui/core-linux-x64-musl@0.5.10':
+    optional: true
+
+  '@opentui/core-linux-x64@0.5.10':
+    optional: true
+
+  '@opentui/core-win32-arm64@0.5.10':
+    optional: true
+
+  '@opentui/core-win32-x64@0.5.10':
+    optional: true
+
+  '@opentui/core@0.5.10(typescript@5.9.3)(web-tree-sitter@0.25.10(@types/emscripten@1.41.5))':
+    dependencies:
+      bun-ffi-structs: 0.3.1(typescript@5.9.3)
+      diff: 9.0.0
+      marked: 17.0.1
+      string-width: 7.2.0
+      strip-ansi: 7.1.2
+      web-tree-sitter: 0.25.10(@types/emscripten@1.41.5)
+    optionalDependencies:
+      '@opentui/core-darwin-arm64': 0.5.10
+      '@opentui/core-darwin-x64': 0.5.10
+      '@opentui/core-linux-arm64': 0.5.10
+      '@opentui/core-linux-arm64-musl': 0.5.10
+      '@opentui/core-linux-x64': 0.5.10
+      '@opentui/core-linux-x64-musl': 0.5.10
+      '@opentui/core-win32-arm64': 0.5.10
+      '@opentui/core-win32-x64': 0.5.10
+    transitivePeerDependencies:
+      - typescript
+
+  bun-ffi-structs@0.3.1(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
+  diff@9.0.0: {}
+
+  emoji-regex@10.6.0: {}
+
+  marked@17.0.1: {}
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  web-tree-sitter@0.25.10(@types/emscripten@1.41.5):
+    optionalDependencies:
+      '@types/emscripten': 1.41.5

--- a/products/desktop/pnpm-lock.yaml
+++ b/products/desktop/pnpm-lock.yaml
@@ -145,6 +145,34 @@ importers:
         specifier: ^2.9.16
         version: 2.9.18
 
+  apps/cli:
+    dependencies:
+      '@earendil-works/pi-coding-agent':
+        specifier: 'catalog:'
+        version: 0.84.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@opentui/core':
+        specifier: 0.5.10
+        version: 0.5.10(typescript@5.9.3)(web-tree-sitter@0.25.10(@types/emscripten@1.41.5))
+      '@posthog/harness':
+        specifier: workspace:*
+        version: link:../../packages/harness
+      web-tree-sitter:
+        specifier: 0.25.10
+        version: 0.25.10(@types/emscripten@1.41.5)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.0
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(@swc/core@1.15.43)(jiti@2.7.0)(postcss@8.5.23)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@22.20.0)(typescript@5.9.3))(vite@7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
+
   apps/code:
     dependencies:
       '@inversifyjs/strongly-typed':
@@ -1775,34 +1803,6 @@ importers:
       vite:
         specifier: npm:rolldown-vite@7.3.1
         version: rolldown-vite@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@25.2.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0)
-
-  apps/cli:
-    dependencies:
-      '@earendil-works/pi-coding-agent':
-        specifier: 'catalog:'
-        version: 0.84.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@opentui/core':
-        specifier: 0.5.10
-        version: 0.5.10(typescript@5.9.3)(web-tree-sitter@0.25.10(@types/emscripten@1.41.5))
-      '@posthog/harness':
-        specifier: workspace:*
-        version: link:../../packages/harness
-      web-tree-sitter:
-        specifier: 0.25.10
-        version: 0.25.10(@types/emscripten@1.41.5)
-    devDependencies:
-      '@types/node':
-        specifier: ^22.0.0
-        version: 22.20.0
-      tsup:
-        specifier: ^8.5.1
-        version: 8.5.1(@swc/core@1.15.43)(jiti@2.7.0)(postcss@8.5.23)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
-      typescript:
-        specifier: ^5.5.0
-        version: 5.9.3
-      vitest:
-        specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@22.20.0)(typescript@5.9.3))(vite@7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
 
 packages:
 
@@ -5160,6 +5160,53 @@ packages:
   '@opentelemetry/semantic-conventions@1.41.1':
     resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
     engines: {node: '>=14'}
+
+  '@opentui/core-darwin-arm64@0.5.10':
+    resolution: {integrity: sha512-Vyb+nTbhab8ZcRy5gg1loEEGwRcIbjAeVRIBfHBcbFDqmITBOg7x2gqJ+x/TnoOy4uwMhCmICUN2wiyREw3r1Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@opentui/core-darwin-x64@0.5.10':
+    resolution: {integrity: sha512-tTFLcM7Oj1gTyhm/bUdAt3C6grZdCxPk6+/g2azcZBUlI3/62LwbeRS6HbQKFFmm+1fUmX8cq6kWrtul885mVg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@opentui/core-linux-arm64-musl@0.5.10':
+    resolution: {integrity: sha512-dGMphDKexSdeYqwl0wgoFBP88Ta/cdi1Zc1mk29/ENkSCGz+74zlCHgqTHRNGLmI8W5TfuUtCyktQH11/Z+TBQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@opentui/core-linux-arm64@0.5.10':
+    resolution: {integrity: sha512-ncJXcgudhBf2GdJyF3xVQN/Ec+1F7GOL+pRrURmgBYSj2v1w6EyoDQFAACtPTK2c3R38W6fvZwL4JSLlm4EFXQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@opentui/core-linux-x64-musl@0.5.10':
+    resolution: {integrity: sha512-Oj4H9hApuvuTKPWxh4SoZAgGJorR7vbvnrZA/cAkSMAk2VGSoHRRcqeXQbcH8IcdjVZ0KFpv8Zkl/D5Ye+2mew==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@opentui/core-linux-x64@0.5.10':
+    resolution: {integrity: sha512-5qtYaOgwVycZD1GaGshTRsi0rXPAmVExO03N1JQaHu+NYxK/vXSOc7Bu4QW0sPXx3Sp0SpzpP+FHjXABfoK66g==}
+    cpu: [x64]
+    os: [linux]
+
+  '@opentui/core-win32-arm64@0.5.10':
+    resolution: {integrity: sha512-A9VhgvTxQoUdZ+8LmUumEng1sQNbj9QQQT3NYG9mSxI54qTANi7vOWNSphMiY6RMVsr22pgm6nUvSSvJXv7Jog==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@opentui/core-win32-x64@0.5.10':
+    resolution: {integrity: sha512-u3KHa7kEeWrmKVDRJYpxSGO+g5E9cMGlrmTsPN3GVPHUmQMiREUawLXUvsU8+IHaQnqG3Q5nuE1yf4fPBzS+Qw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@opentui/core@0.5.10':
+    resolution: {integrity: sha512-C3a2UbmefeAjIxAgm4BqjuSxKT4oqutfvYFwVvUgMxmGRHkNbBc/s7sukV0JgwcxFcV3uMFrXxo+E+BQtvuOiw==}
+    peerDependencies:
+      web-tree-sitter: 0.25.10
 
   '@oxc-parser/binding-android-arm-eabi@0.120.0':
     resolution: {integrity: sha512-WU3qtINx802wOl8RxAF1v0VvmC2O4D9M8Sv486nLeQ7iPHVmncYZrtBhB4SYyX+XZxj2PNnCcN+PW21jHgiOxg==}
@@ -9758,6 +9805,11 @@ packages:
     resolution: {integrity: sha512-q2hn7Mbo2nFNkVekPiHFx6Nfo3hURmES3tfBn+k5Pqxl2RkmP3QGqZUhH/q9Pch/4G05NRhPjDlVj1O8q4Txvw==}
     engines: {node: '>=14.0.0'}
 
+  bun-ffi-structs@0.3.1:
+    resolution: {integrity: sha512-3gM7PpVWLyrwxWjcilSiGuhWanhZivvo6l0u573NziPH6f/gwk6McbaYgn7oJWov6pKGRTDbrg94W5DcJsKTtQ==}
+    peerDependencies:
+      typescript: ^5
+
   bun-types@1.3.14:
     resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
 
@@ -10540,6 +10592,10 @@ packages:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
 
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
+    engines: {node: '>=0.3.1'}
+
   diffable-html@4.1.0:
     resolution: {integrity: sha512-++kyNek+YBLH8cLXS+iTj/Hiy2s5qkRJEJ8kgu/WHbFrVY2vz9xPFUT+fii2zGF0m1CaojDlQJjkfrCt7YWM1g==}
 
@@ -10783,6 +10839,9 @@ packages:
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
     engines: {node: '>=12'}
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -12982,6 +13041,11 @@ packages:
     engines: {node: '>= 20'}
     hasBin: true
 
+  marked@17.0.1:
+    resolution: {integrity: sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   marked@18.0.5:
     resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
     engines: {node: '>= 20'}
@@ -15156,6 +15220,10 @@ packages:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
 
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
   string-width@8.2.2:
     resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
     engines: {node: '>=20'}
@@ -16081,6 +16149,14 @@ packages:
   web-tree-sitter@0.24.7:
     resolution: {integrity: sha512-CdC/TqVFbXqR+C51v38hv6wOPatKEUGxa39scAeFSm98wIhZxAYonhRQPSMmfZ2w7JDI0zQDdzdmgtNk06/krQ==}
 
+  web-tree-sitter@0.25.10:
+    resolution: {integrity: sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==}
+    peerDependencies:
+      '@types/emscripten': ^1.40.0
+    peerDependenciesMeta:
+      '@types/emscripten':
+        optional: true
+
   web-vitals@6.2.1:
     resolution: {integrity: sha512-rLcLXA2sx6+9dE88NHFubwTtGxpK4yYBLj6qHPdFoCaLr0cXGb4efOqtKLlm4loGA4OEKHIQKMKzZkKyOh5ctw==}
 
@@ -16345,82 +16421,6 @@ packages:
     resolution: {integrity: sha512-2YMAriaYHX9wrBY2k7H0epSo+dyCaCZg/vOtt+nEDXM9ul480gkXz/9SkwpOeHcD2H5qqDG8lWDSBwpTcZpa6w==}
     peerDependencies:
       '@types/emscripten': '>=1.39.6'
-
-  '@opentui/core-darwin-arm64@0.5.10':
-    resolution: {integrity: sha512-Vyb+nTbhab8ZcRy5gg1loEEGwRcIbjAeVRIBfHBcbFDqmITBOg7x2gqJ+x/TnoOy4uwMhCmICUN2wiyREw3r1Q==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@opentui/core-darwin-x64@0.5.10':
-    resolution: {integrity: sha512-tTFLcM7Oj1gTyhm/bUdAt3C6grZdCxPk6+/g2azcZBUlI3/62LwbeRS6HbQKFFmm+1fUmX8cq6kWrtul885mVg==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@opentui/core-linux-arm64-musl@0.5.10':
-    resolution: {integrity: sha512-dGMphDKexSdeYqwl0wgoFBP88Ta/cdi1Zc1mk29/ENkSCGz+74zlCHgqTHRNGLmI8W5TfuUtCyktQH11/Z+TBQ==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@opentui/core-linux-arm64@0.5.10':
-    resolution: {integrity: sha512-ncJXcgudhBf2GdJyF3xVQN/Ec+1F7GOL+pRrURmgBYSj2v1w6EyoDQFAACtPTK2c3R38W6fvZwL4JSLlm4EFXQ==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@opentui/core-linux-x64-musl@0.5.10':
-    resolution: {integrity: sha512-Oj4H9hApuvuTKPWxh4SoZAgGJorR7vbvnrZA/cAkSMAk2VGSoHRRcqeXQbcH8IcdjVZ0KFpv8Zkl/D5Ye+2mew==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@opentui/core-linux-x64@0.5.10':
-    resolution: {integrity: sha512-5qtYaOgwVycZD1GaGshTRsi0rXPAmVExO03N1JQaHu+NYxK/vXSOc7Bu4QW0sPXx3Sp0SpzpP+FHjXABfoK66g==}
-    cpu: [x64]
-    os: [linux]
-
-  '@opentui/core-win32-arm64@0.5.10':
-    resolution: {integrity: sha512-A9VhgvTxQoUdZ+8LmUumEng1sQNbj9QQQT3NYG9mSxI54qTANi7vOWNSphMiY6RMVsr22pgm6nUvSSvJXv7Jog==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@opentui/core-win32-x64@0.5.10':
-    resolution: {integrity: sha512-u3KHa7kEeWrmKVDRJYpxSGO+g5E9cMGlrmTsPN3GVPHUmQMiREUawLXUvsU8+IHaQnqG3Q5nuE1yf4fPBzS+Qw==}
-    cpu: [x64]
-    os: [win32]
-
-  '@opentui/core@0.5.10':
-    resolution: {integrity: sha512-C3a2UbmefeAjIxAgm4BqjuSxKT4oqutfvYFwVvUgMxmGRHkNbBc/s7sukV0JgwcxFcV3uMFrXxo+E+BQtvuOiw==}
-    peerDependencies:
-      web-tree-sitter: 0.25.10
-
-  bun-ffi-structs@0.3.1:
-    resolution: {integrity: sha512-3gM7PpVWLyrwxWjcilSiGuhWanhZivvo6l0u573NziPH6f/gwk6McbaYgn7oJWov6pKGRTDbrg94W5DcJsKTtQ==}
-    peerDependencies:
-      typescript: ^5
-
-  diff@9.0.0:
-    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
-    engines: {node: '>=0.3.1'}
-
-  emoji-regex@10.6.0:
-    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
-
-  marked@17.0.1:
-    resolution: {integrity: sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==}
-    engines: {node: '>= 20'}
-    hasBin: true
-
-  string-width@7.2.0:
-    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
-    engines: {node: '>=18'}
-
-  web-tree-sitter@0.25.10:
-    resolution: {integrity: sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==}
-    peerDependencies:
-      '@types/emscripten': ^1.40.0
-    peerDependenciesMeta:
-      '@types/emscripten':
-        optional: true
 
 snapshots:
 
@@ -20460,6 +20460,50 @@ snapshots:
   '@opentelemetry/semantic-conventions@1.39.0': {}
 
   '@opentelemetry/semantic-conventions@1.41.1': {}
+
+  '@opentui/core-darwin-arm64@0.5.10':
+    optional: true
+
+  '@opentui/core-darwin-x64@0.5.10':
+    optional: true
+
+  '@opentui/core-linux-arm64-musl@0.5.10':
+    optional: true
+
+  '@opentui/core-linux-arm64@0.5.10':
+    optional: true
+
+  '@opentui/core-linux-x64-musl@0.5.10':
+    optional: true
+
+  '@opentui/core-linux-x64@0.5.10':
+    optional: true
+
+  '@opentui/core-win32-arm64@0.5.10':
+    optional: true
+
+  '@opentui/core-win32-x64@0.5.10':
+    optional: true
+
+  '@opentui/core@0.5.10(typescript@5.9.3)(web-tree-sitter@0.25.10(@types/emscripten@1.41.5))':
+    dependencies:
+      bun-ffi-structs: 0.3.1(typescript@5.9.3)
+      diff: 9.0.0
+      marked: 17.0.1
+      string-width: 7.2.0
+      strip-ansi: 7.1.2
+      web-tree-sitter: 0.25.10(@types/emscripten@1.41.5)
+    optionalDependencies:
+      '@opentui/core-darwin-arm64': 0.5.10
+      '@opentui/core-darwin-x64': 0.5.10
+      '@opentui/core-linux-arm64': 0.5.10
+      '@opentui/core-linux-arm64-musl': 0.5.10
+      '@opentui/core-linux-x64': 0.5.10
+      '@opentui/core-linux-x64-musl': 0.5.10
+      '@opentui/core-win32-arm64': 0.5.10
+      '@opentui/core-win32-x64': 0.5.10
+    transitivePeerDependencies:
+      - typescript
 
   '@oxc-parser/binding-android-arm-eabi@0.120.0':
     optional: true
@@ -24907,6 +24951,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  bun-ffi-structs@0.3.1(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
   bun-types@1.3.14:
     dependencies:
       '@types/node': 24.12.0
@@ -25649,6 +25697,8 @@ snapshots:
 
   diff@8.0.4: {}
 
+  diff@9.0.0: {}
+
   diffable-html@4.1.0:
     dependencies:
       htmlparser2: 3.10.1
@@ -25873,6 +25923,8 @@ snapshots:
       - supports-color
 
   emittery@0.13.1: {}
+
+  emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
 
@@ -28618,6 +28670,8 @@ snapshots:
   markdown-table@3.0.4: {}
 
   marked@16.4.2: {}
+
+  marked@17.0.1: {}
 
   marked@18.0.5: {}
 
@@ -31699,6 +31753,12 @@ snapshots:
       emoji-regex: 9.2.2
       strip-ansi: 7.2.0
 
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
   string-width@8.2.2:
     dependencies:
       get-east-asian-width: 1.6.0
@@ -32734,6 +32794,10 @@ snapshots:
 
   web-tree-sitter@0.24.7: {}
 
+  web-tree-sitter@0.25.10(@types/emscripten@1.41.5):
+    optionalDependencies:
+      '@types/emscripten': 1.41.5
+
   web-vitals@6.2.1: {}
 
   webcrypto-core@1.9.2:
@@ -33072,66 +33136,3 @@ snapshots:
     dependencies:
       '@types/emscripten': 1.41.5
       type-fest: 5.6.0
-  '@opentui/core-darwin-arm64@0.5.10':
-    optional: true
-
-  '@opentui/core-darwin-x64@0.5.10':
-    optional: true
-
-  '@opentui/core-linux-arm64-musl@0.5.10':
-    optional: true
-
-  '@opentui/core-linux-arm64@0.5.10':
-    optional: true
-
-  '@opentui/core-linux-x64-musl@0.5.10':
-    optional: true
-
-  '@opentui/core-linux-x64@0.5.10':
-    optional: true
-
-  '@opentui/core-win32-arm64@0.5.10':
-    optional: true
-
-  '@opentui/core-win32-x64@0.5.10':
-    optional: true
-
-  '@opentui/core@0.5.10(typescript@5.9.3)(web-tree-sitter@0.25.10(@types/emscripten@1.41.5))':
-    dependencies:
-      bun-ffi-structs: 0.3.1(typescript@5.9.3)
-      diff: 9.0.0
-      marked: 17.0.1
-      string-width: 7.2.0
-      strip-ansi: 7.1.2
-      web-tree-sitter: 0.25.10(@types/emscripten@1.41.5)
-    optionalDependencies:
-      '@opentui/core-darwin-arm64': 0.5.10
-      '@opentui/core-darwin-x64': 0.5.10
-      '@opentui/core-linux-arm64': 0.5.10
-      '@opentui/core-linux-arm64-musl': 0.5.10
-      '@opentui/core-linux-x64': 0.5.10
-      '@opentui/core-linux-x64-musl': 0.5.10
-      '@opentui/core-win32-arm64': 0.5.10
-      '@opentui/core-win32-x64': 0.5.10
-    transitivePeerDependencies:
-      - typescript
-
-  bun-ffi-structs@0.3.1(typescript@5.9.3):
-    dependencies:
-      typescript: 5.9.3
-
-  diff@9.0.0: {}
-
-  emoji-regex@10.6.0: {}
-
-  marked@17.0.1: {}
-
-  string-width@7.2.0:
-    dependencies:
-      emoji-regex: 10.6.0
-      get-east-asian-width: 1.6.0
-      strip-ansi: 7.2.0
-
-  web-tree-sitter@0.25.10(@types/emscripten@1.41.5):
-    optionalDependencies:
-      '@types/emscripten': 1.41.5


### PR DESCRIPTION
## Problem

Terminal users cannot run the PostHog Pi harness through an OpenTUI interface.

The existing `hog` command owns the native Pi interface, so an OpenTUI prototype needs a separate host.

## Changes

- Terminal users can start a full-screen OpenTUI session with the same PostHog tools and skills.
- The new `hog-tui` host embeds the standard harness runtime and keeps native Pi sessions.
- The CLI reads saved project trust and never trusts project files by default.
- The CLI requires Node.js 26.4 because OpenTUI uses the experimental Node FFI API.
- The existing `hog` command does not change.

Before:

```mermaid
flowchart LR
    User{{Terminal user}} --> Hog[hog]
    Hog --> Pi[Pi native TUI]
    Pi --> Harness[PostHog harness]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class User phYellow;
    class Hog,Pi,Harness phBlue;
```

After:

```mermaid
flowchart LR
    User{{Terminal user}} --> Tui[hog-tui OpenTUI host]
    Tui --> Runtime[PostHog harness runtime]
    Runtime --> Session[Pi session]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class User phYellow;
    class Tui,Runtime,Session phBlue;
```

![hog-tui](https://raw.githubusercontent.com/PostHog/pr-assets/7ac27c0eb4331b42534882fd40a6fc05a232800b/2026/09/1e9dfc01-875e-43b8-ae86-edff89d70014.png)

## How did you test this code?

- `pnpm typecheck`
- `./node_modules/.bin/biome check apps/cli`
- `pnpm --filter @posthog/cli test`
- `pnpm --filter @posthog/cli build`
- `uv run hogli ci:preflight --strict`
- Ran the built CLI in a pseudo-terminal with Node.js 26.5.0.
- Checked startup, prompt submission errors, Ctrl+C exit, and terminal restoration.
- Not checked: a successful model response, because the sandbox had no CLI credentials.

The transcript tests prevent duplicate streamed text and incorrect updates when parallel tools finish out of order.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The CLI README documents setup, controls, runtime requirements, and prototype limits.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- PostHog Desktop used Explore, Plan, and General subagents.
- Skills: posthog-desktop, subagent-orchestration, writing-simplified-technical-english, writing-tests, writing-user-facing-copy, writing-code-comments, running-ci-preflight, reviewing-with-coderabbit, and writing-pr-descriptions.
- The CodeRabbit pass is paused. The PR opened without a local pass.
- The duplicate PR search found no matching open PR.
- The change uses repository code and public OpenTUI documentation only.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*