### PR TITLE
fix(cursor): stop blaming the key when the credential probe fails

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cursor/cursor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cursor/cursor.py
@@ -15,6 +15,7 @@ from posthog.dataclasses import frozen
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.cursor.settings import (
     CURSOR_ENDPOINTS,
@@ -122,12 +123,37 @@ def _fetch(
     return response.json()
 
 
-def validate_credentials(api_key: str) -> bool:
-    try:
-        response = _make_session(api_key).get(f"{CURSOR_BASE_URL}/teams/members", timeout=10)
-        return response.status_code == 200
-    except Exception:
-        return False
+# Shared with `CursorSource.get_non_retryable_errors` so the same rejection reads the same way
+# whether it surfaces while connecting the source or mid-sync.
+KEY_REJECTED_MESSAGE = (
+    "Your Cursor Admin API key is invalid or has been revoked. Create a new key in your Cursor "
+    "dashboard settings, then reconnect."
+)
+KEY_FORBIDDEN_MESSAGE = (
+    "Your Cursor Admin API key does not have access to this data. Admin API keys must be created "
+    "by a team admin, and some endpoints require an Enterprise plan."
+)
+# `validate_via_probe` reports a transport failure as a `None` status, so anything Cursor did not
+# answer itself leaves the key unjudged. Calling it invalid sends someone off to mint a replacement
+# that fails the same way.
+PROBE_FAILED_MESSAGE = "PostHog couldn't check your Admin API key with Cursor. Wait a few minutes and try again."
+
+
+def validate_credentials(api_key: str) -> tuple[bool, str | None]:
+    # Redirects stay off for the same reason `_make_session` pins them off: `requests` keeps custom
+    # headers on a cross-host redirect.
+    ok, status = validate_via_probe(
+        lambda: _make_session(api_key),
+        f"{CURSOR_BASE_URL}/teams/members",
+        allow_redirects=False,
+    )
+    if ok:
+        return True, None
+    if status == 401:
+        return False, KEY_REJECTED_MESSAGE
+    if status == 403:
+        return False, KEY_FORBIDDEN_MESSAGE
+    return False, PROBE_FAILED_MESSAGE
 
 
 def _usage_event_id(item: dict[str, Any]) -> str:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cursor/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cursor/source.py
@@ -19,6 +19,8 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.sch
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.typings import SourceInputs, SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.cursor.cursor import (
     CURSOR_BASE_URL,
+    KEY_FORBIDDEN_MESSAGE,
+    KEY_REJECTED_MESSAGE,
     CursorResumeConfig,
     cursor_source,
     validate_credentials as validate_cursor_credentials,
@@ -82,8 +84,8 @@ You need a Cursor team plan (Business or Enterprise). A team admin can create an
             # An invalid or revoked Admin API key surfaces as a requests HTTPError when `_fetch`
             # calls `raise_for_status()`. Retrying can never satisfy a credential problem, so stop
             # the sync. Match the stable status text and base host, not the per-request path.
-            f"401 Client Error: Unauthorized for url: {CURSOR_BASE_URL}": "Your Cursor Admin API key is invalid or has been revoked. Create a new key in your Cursor dashboard settings, then reconnect.",
-            f"403 Client Error: Forbidden for url: {CURSOR_BASE_URL}": "Your Cursor Admin API key does not have access to this data. Admin API keys must be created by a team admin, and some endpoints require an Enterprise plan.",
+            f"401 Client Error: Unauthorized for url: {CURSOR_BASE_URL}": KEY_REJECTED_MESSAGE,
+            f"403 Client Error: Forbidden for url: {CURSOR_BASE_URL}": KEY_FORBIDDEN_MESSAGE,
         }
 
     def get_schemas(
@@ -120,10 +122,7 @@ You need a Cursor team plan (Business or Enterprise). A team admin can create an
         schema_name: Optional[str] = None,
         api_version: str | None = None,
     ) -> tuple[bool, str | None]:
-        if validate_cursor_credentials(config.api_key):
-            return True, None
-
-        return False, "Invalid Cursor Admin API key"
+        return validate_cursor_credentials(config.api_key)
 
     def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[CursorResumeConfig]:
         return ResumableSourceManager[CursorResumeConfig](inputs, CursorResumeConfig)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cursor/tests/test_cursor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cursor/tests/test_cursor.py
@@ -116,20 +116,28 @@ class TestCursorTransport:
     def test_has_next_page_across_response_shapes(self, data, page, items_count, expected):
         assert _has_next_page(data, page, items_count, 100) is expected
 
-    @parameterized.expand([(200, True), (401, False), (403, False)])
+    @parameterized.expand(
+        [
+            (200, (True, None)),
+            (401, (False, cursor.KEY_REJECTED_MESSAGE)),
+            (403, (False, cursor.KEY_FORBIDDEN_MESSAGE)),
+            # A Cursor-side failure leaves the key unjudged, so it must not be blamed on the key.
+            (500, (False, cursor.PROBE_FAILED_MESSAGE)),
+        ]
+    )
     def test_validate_credentials_maps_status(self, status_code, expected):
         session = mock.Mock()
         session.get.return_value = _response(status_code)
 
         with mock.patch.object(cursor, "make_tracked_session", return_value=session):
-            assert validate_credentials("key_test") is expected
+            assert validate_credentials("key_test") == expected
 
-    def test_validate_credentials_false_on_connection_error(self):
+    def test_validate_credentials_does_not_blame_the_key_when_cursor_is_unreachable(self):
         session = mock.Mock()
         session.get.side_effect = requests.ConnectionError("boom")
 
         with mock.patch.object(cursor, "make_tracked_session", return_value=session):
-            assert validate_credentials("key_test") is False
+            assert validate_credentials("key_test") == (False, cursor.PROBE_FAILED_MESSAGE)
 
     def test_session_masks_credentials_and_sends_basic_auth(self):
         # The tracked transport logs and samples requests; without redaction the raw key and the

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cursor/tests/test_cursor_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cursor/tests/test_cursor_source.py
@@ -7,6 +7,7 @@ from posthog.schema import (
     SourceFieldInputConfig,
 )
 
+from products.warehouse_sources.backend.temporal.data_imports.sources.cursor.cursor import KEY_REJECTED_MESSAGE
 from products.warehouse_sources.backend.temporal.data_imports.sources.cursor.source import CursorSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.cursor import CursorSourceConfig
 
@@ -68,10 +69,10 @@ class TestCursorSource:
         assert [t["name"] for t in tables] == ["members", "daily_usage", "usage_events", "spend"]
         assert all(t["description"] for t in tables)
 
-    @parameterized.expand([(True, (True, None)), (False, (False, "Invalid Cursor Admin API key"))])
-    def test_validate_credentials(self, valid, expected):
+    @parameterized.expand([((True, None),), ((False, KEY_REJECTED_MESSAGE),)])
+    def test_validate_credentials(self, probe_result):
         with mock.patch(
             "products.warehouse_sources.backend.temporal.data_imports.sources.cursor.source.validate_cursor_credentials",
-            return_value=valid,
+            return_value=probe_result,
         ):
-            assert self.source.validate_credentials(self.config, self.team_id) == expected
+            assert self.source.validate_credentials(self.config, self.team_id) == probe_result


### PR DESCRIPTION
## Problem

Someone connecting a Cursor source sees "Invalid Cursor Admin API key" whenever the credential probe does not return 200, even when their key is fine.

- The probe collapsed every outcome to a boolean: a timeout, a DNS failure, a Cursor 5xx and a real 401 all produced the same message.
- The message named no next step, so it sends someone off to mint a replacement key that fails the same way.
- A 403 (a genuine key that is not a team admin's, or a team without the required plan) also read as an invalid key.

## Changes

- The wizard now says which of three things happened: Cursor rejected the key, the key has no access to the data, or PostHog could not reach Cursor.
- `validate_credentials` returns `(bool, message)` and maps 401, 403 and everything else, including a transport failure, to its own message.
- The 401 and 403 strings move into `cursor.py`, and `get_non_retryable_errors` now uses them, so the same rejection reads the same way when connecting and mid-sync.
- The hand-rolled probe moves to the shared `validate_via_probe` helper. Redirects stay off, since the session sends the credential on a custom header.

No new strings were invented for 401 and 403: both reuse the wording the sync path already shipped. The unreachable message matches the OpenAI source's equivalent.

Nothing changes visually beyond the text in the wizard's error banner.

## How did you test this code?

- Extended `test_validate_credentials_maps_status` with a 500 case: a Cursor-side failure used to report a bad key, and now reports that the check did not complete.
- Renamed and tightened the connection-error test to assert the same message, which is the regression for an unreachable Cursor.
- Ran the source's unit tests locally. Not run: anything needing a database or a live Cursor account, so the probe was exercised through a mocked session only.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented behavior changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triage of failed source-creation attempts across every warehouse source. Most messages were already clear and actionable and got no change; this source's was one of the few that misattributed the failure.
- Tools: Claude Code. Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.
- CodeRabbit CLI pass: paused, so this PR opened without a local pass.
- No duplicate: `gh pr list --state open --search "cursor"` and a pass over the maintainer's open PRs found nothing touching this source's credential validation.
- Public artifact: the triage input was a set of error strings the product shows to users. No customer values reached the code, the tests or this description.
