### PR TITLE
fix(cloudzero): explain why the API key was rejected

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cloudzero/cloudzero.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cloudzero/cloudzero.py
@@ -15,6 +15,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.res
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.typing import EndpointResource
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.source_helpers import validate_via_probe
 
 CLOUDZERO_BASE_URL = "https://api.cloudzero.com"
 
@@ -163,9 +164,26 @@ def cloudzero_source(
     )
 
 
-def validate_credentials(api_key: str) -> bool:
-    res = make_tracked_session(redact_values=(api_key,)).get(
+# Shared with `CloudzeroSource.get_non_retryable_errors` so the same rejection reads the same way
+# whether it surfaces while connecting the source or mid-sync.
+KEY_REJECTED_MESSAGE = (
+    "CloudZero rejected your API key. Check the key is correct and has the billing:read_costs and "
+    "billing:read_dimensions scopes, then reconnect."
+)
+# `validate_via_probe` reports a transport failure as a `None` status, so anything CloudZero did not
+# answer itself leaves the key unjudged. Calling it invalid sends someone off to mint a replacement
+# that fails the same way.
+PROBE_FAILED_MESSAGE = "PostHog couldn't check your API key with CloudZero. Wait a few minutes and try again."
+
+
+def validate_credentials(api_key: str) -> tuple[bool, str | None]:
+    ok, status = validate_via_probe(
+        lambda: make_tracked_session(redact_values=(api_key,)),
         f"{CLOUDZERO_BASE_URL}/v2/billing/dimensions",
         headers={"Authorization": api_key},
     )
-    return res.status_code == 200
+    if ok:
+        return True, None
+    if status in (401, 403):
+        return False, KEY_REJECTED_MESSAGE
+    return False, PROBE_FAILED_MESSAGE

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cloudzero/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cloudzero/source.py
@@ -12,6 +12,7 @@ from posthog.schema import (
 )
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.cloudzero.cloudzero import (
+    KEY_REJECTED_MESSAGE,
     CloudzeroResumeConfig,
     cloudzero_source,
     validate_credentials as validate_cloudzero_credentials,
@@ -59,8 +60,8 @@ class CloudzeroSource(ResumableSource[CloudzeroSourceConfig, CloudzeroResumeConf
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
-            "403 Client Error: Forbidden": "CloudZero authentication failed. Please check your API key and its assigned scopes.",
-            "Unauthorized": "CloudZero authentication failed. Please check your API key and its assigned scopes.",
+            "403 Client Error: Forbidden": KEY_REJECTED_MESSAGE,
+            "Unauthorized": KEY_REJECTED_MESSAGE,
             "410 Client Error: Gone": (
                 "CloudZero's paged result cache expired (results are only valid for 24 hours). "
                 "Please retry the sync to start a fresh query."
@@ -92,10 +93,7 @@ class CloudzeroSource(ResumableSource[CloudzeroSourceConfig, CloudzeroResumeConf
         schema_name: Optional[str] = None,
         api_version: str | None = None,
     ) -> tuple[bool, str | None]:
-        if validate_cloudzero_credentials(config.api_key):
-            return True, None
-
-        return False, "Invalid credentials"
+        return validate_cloudzero_credentials(config.api_key)
 
     def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[CloudzeroResumeConfig]:
         return ResumableSourceManager[CloudzeroResumeConfig](inputs, CloudzeroResumeConfig)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cloudzero/tests/test_cloudzero.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cloudzero/tests/test_cloudzero.py
@@ -9,6 +9,8 @@ from parameterized import parameterized
 from requests import Response
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.cloudzero.cloudzero import (
+    KEY_REJECTED_MESSAGE,
+    PROBE_FAILED_MESSAGE,
     CloudzeroResumeConfig,
     _rolling_incremental_start_date,
     cloudzero_source,
@@ -231,12 +233,16 @@ class TestCloudzeroSourceTransport:
 class TestValidateCredentials:
     @parameterized.expand(
         [
-            ("ok", 200, True),
-            ("forbidden", 403, False),
-            ("unauthorized", 401, False),
+            ("ok", 200, (True, None)),
+            ("forbidden", 403, (False, KEY_REJECTED_MESSAGE)),
+            ("unauthorized", 401, (False, KEY_REJECTED_MESSAGE)),
+            # A CloudZero-side failure leaves the key unjudged, so it must not be blamed on the key.
+            ("server_error", 500, (False, PROBE_FAILED_MESSAGE)),
         ]
     )
-    def test_status_code_maps_to_validity(self, _name: str, status_code: int, expected: bool) -> None:
+    def test_status_code_maps_to_validity(
+        self, _name: str, status_code: int, expected: tuple[bool, str | None]
+    ) -> None:
         with patch(
             "products.warehouse_sources.backend.temporal.data_imports.sources.cloudzero.cloudzero.make_tracked_session"
         ) as mock_make_session:
@@ -244,7 +250,15 @@ class TestValidateCredentials:
             mock_response.status_code = status_code
             mock_make_session.return_value.get.return_value = mock_response
 
-            assert validate_credentials("test-key") is expected
+            assert validate_credentials("test-key") == expected
+
+    def test_does_not_blame_the_key_when_cloudzero_is_unreachable(self) -> None:
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.cloudzero.cloudzero.make_tracked_session"
+        ) as mock_make_session:
+            mock_make_session.return_value.get.side_effect = ConnectionError("boom")
+
+            assert validate_credentials("test-key") == (False, PROBE_FAILED_MESSAGE)
 
     def test_sends_raw_api_key_without_bearer_prefix(self) -> None:
         with patch(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cloudzero/tests/test_cloudzero_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cloudzero/tests/test_cloudzero_source.py
@@ -7,6 +7,7 @@ from parameterized import parameterized
 from products.warehouse_sources.backend.temporal.data_imports.sources.cloudzero.canonical_descriptions import (
     CANONICAL_DESCRIPTIONS,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.cloudzero.cloudzero import KEY_REJECTED_MESSAGE
 from products.warehouse_sources.backend.temporal.data_imports.sources.cloudzero.settings import ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.cloudzero.source import (
     CloudzeroSource,
@@ -59,18 +60,16 @@ class TestGetSchemas:
 class TestValidateCredentials:
     @parameterized.expand(
         [
-            ("valid", True, (True, None)),
-            ("invalid", False, (False, "Invalid credentials")),
+            ("valid", (True, None)),
+            ("invalid", (False, KEY_REJECTED_MESSAGE)),
         ]
     )
-    def test_plumbs_transport_result(
-        self, _name: str, transport_result: bool, expected: tuple[bool, str | None]
-    ) -> None:
+    def test_plumbs_transport_result(self, _name: str, transport_result: tuple[bool, str | None]) -> None:
         with patch(
             "products.warehouse_sources.backend.temporal.data_imports.sources.cloudzero.source.validate_cloudzero_credentials",
             return_value=transport_result,
         ) as mocked:
-            assert CloudzeroSource().validate_credentials(_config(), team_id=1) == expected
+            assert CloudzeroSource().validate_credentials(_config(), team_id=1) == transport_result
         mocked.assert_called_once_with("key")
 
 


### PR DESCRIPTION
## Problem

Someone connecting a CloudZero source who gets it wrong sees "Invalid credentials", which names neither the source, the problem, nor a next step.

- The probe collapsed every outcome to a boolean, so a timeout, a CloudZero 5xx and a real 401 all produced that one string.
- The request carried no timeout, so an unresponsive CloudZero could hold the connect request open for as long as the socket lived.
- A transport error escaped `validate_credentials` instead of failing the check, so the raw exception decided what the user saw.

## Changes

- The wizard now says CloudZero rejected the key and which two scopes it needs, or that PostHog could not reach CloudZero.
- `validate_credentials` returns `(bool, message)` and maps 401 and 403 to the rejection, everything else to the unreachable message.
- The probe moves to the shared `validate_via_probe` helper, which adds the 10 second timeout and contains any transport error.
- `get_non_retryable_errors` reuses the same rejection string, so a scope problem reads the same way when connecting and mid-sync. Its text changes from a generic "check your API key and its assigned scopes" to one naming `billing:read_costs` and `billing:read_dimensions`, the scopes the wizard's caption already asks for.

Nothing changes visually beyond the text in the wizard's error banner.

## How did you test this code?

- Extended `test_status_code_maps_to_validity` with a 500 case: a CloudZero-side failure used to report invalid credentials, and now reports that the check did not complete.
- Added an unreachable-host case, which used to raise out of `validate_credentials` rather than return a message.
- Ran the source's unit tests locally. Not run: anything needing a database or a live CloudZero account, so the probe was exercised through a mocked session only.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented behavior changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triage of failed source-creation attempts across every warehouse source. Most messages were already clear and actionable and got no change; this source's was the least useful of them.
- Tools: Claude Code. Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.
- CodeRabbit CLI pass: paused, so this PR opened without a local pass.
- No duplicate: `gh pr list --state open --search "cloudzero"` returned nothing, and a pass over the maintainer's open PRs found nothing touching this source.
- Public artifact: the triage input was a set of error strings the product shows to users. No customer values reached the code, the tests or this description.
