### PR TITLE
chore(projects): trim project move logging comments

### DIFF
--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -2015,7 +2015,6 @@ class ProjectViewSet(
             project.organization_id = target_organization.id
             project.save()
 
-            # Record the arrival for the receiving organization.
             log_activity(
                 organization_id=cast(UUIDT, target_organization_id),
                 team_id=project.pk,
@@ -2027,8 +2026,6 @@ class ProjectViewSet(
                 detail=Detail(name="moved to another organization", changes=[project_change]),
             )
 
-            # Record the departure for the losing organization. Its members can no longer reach the
-            # project, so this org-scoped entry is their only readable record of who moved it and where.
             log_activity(
                 organization_id=current_organization.id,
                 team_id=None,
@@ -2037,7 +2034,6 @@ class ProjectViewSet(
                 scope="Project",
                 item_id=project.pk,
                 activity="updated",
-                # Name the project itself; the losing org can no longer resolve it any other way.
                 detail=Detail(name=str(project.name), changes=[project_change]),
             )
 
@@ -2045,7 +2041,6 @@ class ProjectViewSet(
                 team.organization_id = target_organization.id
                 team.save()
 
-                # One departure entry per environment, so the losing org sees which ones left.
                 log_activity(
                     organization_id=current_organization.id,
                     team_id=None,

--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -2026,6 +2026,8 @@ class ProjectViewSet(
                 detail=Detail(name="moved to another organization", changes=[project_change]),
             )
 
+            # Record departure for the losing organization. Its members can no longer reach this
+            # project, so an org-scoped audit entry is their only readable record.
             log_activity(
                 organization_id=current_organization.id,
                 team_id=None,

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -1533,7 +1533,6 @@ def team_api_test_factory():
             self.user.current_team = self.team
             self.user.current_organization = self.organization
             self.user.save()
-            # This user stays behind in the source organization
             outsider = User.objects.create_and_join(self.organization, "outsider@posthog.com", None)
             outsider.current_team = self.team
             outsider.current_organization = self.organization
@@ -1544,11 +1543,9 @@ def team_api_test_factory():
             )
             assert res.status_code == status.HTTP_200_OK, res.json()
 
-            # A member of the target organization keeps the project and follows it across
             self.user.refresh_from_db()
             assert self.user.current_team == self.team
             assert self.user.current_organization == other_org
-            # Everyone else loses the pointer instead of keeping a project they cannot reach
             outsider.refresh_from_db()
             assert outsider.current_team_id is None and outsider.current_organization_id is None
 
@@ -1563,28 +1560,22 @@ def team_api_test_factory():
             )
             assert res.status_code == status.HTTP_200_OK, res.json()
 
-            # The losing organization keeps a readable record even though it can no longer reach the project
             source_project_logs = ActivityLog.objects.filter(
                 organization_id=source_org.id, scope="Project", item_id=str(self.project.pk)
             )
             assert source_project_logs.count() == 1
             source_project_log = source_project_logs.get()
             assert source_project_log.detail is not None
-            # The row names the project that left, not action text, so the losing org can read it
             assert source_project_log.detail["name"] == self.project.name
 
-            # And one entry per environment that left, so the source org sees which ones moved
             source_team_logs = ActivityLog.objects.filter(
                 organization_id=source_org.id, scope="Team", item_id=str(self.team.pk)
             )
             assert source_team_logs.count() == 1
 
-            # The receiving organization still gets its arrival entry
             assert ActivityLog.objects.filter(organization_id=other_org.id, scope="Project").count() == 1
 
         def test_change_organization_to_same_organization_is_rejected(self):
-            # organization_id arrives from the request body as a string, so a same-org request must
-            # still be caught by the guard, or it writes false move entries in the activity log.
             self.organization_membership.level = OrganizationMembership.Level.ADMIN
             self.organization_membership.save()
 
@@ -1597,7 +1588,6 @@ def team_api_test_factory():
 
             assert res.status_code == status.HTTP_400_BAD_REQUEST, res.json()
             assert res.json()["detail"] == "Project is already in the target organization."
-            # A no-op move must not write audit rows
             assert ActivityLog.objects.count() == logs_before
 
         def _assert_replay_config_is(self, expected: dict[str, Any] | None) -> HttpResponse:

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -1484,6 +1484,13 @@ def team_api_test_factory():
             other_org_membership.save()
             return other_org, other_org_membership
 
+        def _create_user_that_stays_in_source_organization(self) -> User:
+            outsider = User.objects.create_and_join(self.organization, "outsider@posthog.com", None)
+            outsider.current_team = self.team
+            outsider.current_organization = self.organization
+            outsider.save()
+            return outsider
+
         def test_cant_change_organization_if_not_admin_of_target_org(self):
             other_org, _ = self._create_other_org_and_team(OrganizationMembership.Level.MEMBER)
             res = self.client.post(
@@ -1533,19 +1540,18 @@ def team_api_test_factory():
             self.user.current_team = self.team
             self.user.current_organization = self.organization
             self.user.save()
-            outsider = User.objects.create_and_join(self.organization, "outsider@posthog.com", None)
-            outsider.current_team = self.team
-            outsider.current_organization = self.organization
-            outsider.save()
+            outsider = self._create_user_that_stays_in_source_organization()
 
             res = self.client.post(
                 f"/api/projects/{self.team.project.id}/change_organization/", {"organization_id": other_org.id}
             )
             assert res.status_code == status.HTTP_200_OK, res.json()
 
+            # A member of the target organization keeps the project and follows it across.
             self.user.refresh_from_db()
             assert self.user.current_team == self.team
             assert self.user.current_organization == other_org
+            # Everyone else loses the pointer instead of keeping a project they cannot reach.
             outsider.refresh_from_db()
             assert outsider.current_team_id is None and outsider.current_organization_id is None
 
@@ -1560,19 +1566,23 @@ def team_api_test_factory():
             )
             assert res.status_code == status.HTTP_200_OK, res.json()
 
+            # The losing organization keeps a readable record even though it can no longer reach the project.
             source_project_logs = ActivityLog.objects.filter(
                 organization_id=source_org.id, scope="Project", item_id=str(self.project.pk)
             )
             assert source_project_logs.count() == 1
             source_project_log = source_project_logs.get()
             assert source_project_log.detail is not None
+            # The row names the project that left, not action text, so the losing org can read it.
             assert source_project_log.detail["name"] == self.project.name
 
+            # And one entry per environment that left, so the source org sees which ones moved.
             source_team_logs = ActivityLog.objects.filter(
                 organization_id=source_org.id, scope="Team", item_id=str(self.team.pk)
             )
             assert source_team_logs.count() == 1
 
+            # The receiving organization still gets its arrival entry.
             assert ActivityLog.objects.filter(organization_id=other_org.id, scope="Project").count() == 1
 
         def test_change_organization_to_same_organization_is_rejected(self):
@@ -1588,6 +1598,7 @@ def team_api_test_factory():
 
             assert res.status_code == status.HTTP_400_BAD_REQUEST, res.json()
             assert res.json()["detail"] == "Project is already in the target organization."
+            # A no-op move must not write audit rows.
             assert ActivityLog.objects.count() == logs_before
 
         def _assert_replay_config_is(self, expected: dict[str, Any] | None) -> HttpResponse:


### PR DESCRIPTION
## Problem

- People who maintain project move logging must scan comments that repeat activity calls.

## Changes

- Removes narration from project move activity logging.
- Preserves test-flow comments and names the source-organization setup in a test helper.
- This is a mechanical change. It does not alter behavior or API contracts.

## How did you test this code?

- Ran `pytest -q posthog/api/test/test_team.py::TestTeamAPI::test_change_organization_reconciles_current_project_of_affected_users`.
- Ran `ruff check posthog/api/test/test_team.py`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No docs update. The behavior and workflow do not change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- PostHog Slack app made this behavior-neutral cleanup from the linked task.
- Skills: `/writing-code-comments`, `/writing-pr-descriptions`, and `/authoring-scouts`.
- CodeRabbit local pass is paused.
- Related PR and issue searches found no match.
- Public artifact check: The changes contain no private task content.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0C0LU050GN/p1789168288835789?thread_ts=1789168288.835789&cid=C0C0LU050GN)*