### PR TITLE
fix(google_search_console): retry token-refresh transport errors inline

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/google_search_console.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/google_search_console.py
@@ -10,7 +10,7 @@ from django.db import OperationalError, close_old_connections
 
 import requests
 import structlog
-from google.auth.exceptions import RefreshError
+from google.auth.exceptions import RefreshError, TransportError
 from google.auth.transport.requests import AuthorizedSession
 from google.oauth2.credentials import Credentials as OAuthCredentials
 
@@ -373,6 +373,24 @@ def _query_search_analytics(
             wait = QUOTA_BACKOFF_BASE_SECONDS * (2**attempt)
             logger.warning(
                 "GSC token refresh transient error, backing off",
+                site_url=site_url,
+                attempt=attempt,
+                wait_seconds=wait,
+            )
+            time.sleep(wait)
+            continue
+        except TransportError:
+            # Raised by AuthorizedSession's internal token-refresh request when the underlying
+            # HTTP call itself fails (connection reset, proxy error, DNS failure, timeout) before
+            # any response exists — google-auth wraps `requests.RequestException` in this class
+            # rather than raising it directly, so it never reaches the ConnectionError/Timeout
+            # handling above. Always a network-layer failure, same transient class, so retry
+            # inline like a 5xx rather than crashing the activity on the first blip.
+            if attempt == QUOTA_MAX_RETRIES:
+                raise
+            wait = QUOTA_BACKOFF_BASE_SECONDS * (2**attempt)
+            logger.warning(
+                "GSC token refresh transport error, backing off",
                 site_url=site_url,
                 attempt=attempt,
                 wait_seconds=wait,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/tests/test_google_search_console.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/tests/test_google_search_console.py
@@ -6,7 +6,7 @@ from unittest import mock
 from django.db import OperationalError
 
 import requests
-from google.auth.exceptions import RefreshError
+from google.auth.exceptions import RefreshError, TransportError
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.googlesearchconsole import (
     GoogleSearchConsoleSourceConfig,
@@ -945,6 +945,39 @@ def test_query_permanent_token_refresh_error_bubbles_without_retry(monkeypatch):
         _query_search_analytics(session, "sc-domain:example.com", "2026-04-15", "2026-04-15", ["date"], 0)
 
     assert session.post.call_count == 1
+
+
+def test_query_retries_token_refresh_transport_error_then_succeeds(monkeypatch):
+    monkeypatch.setattr(gsc.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(gsc, "_throttle", lambda _site: None)
+
+    session = mock.MagicMock()
+    session.post.side_effect = [
+        # AuthorizedSession wraps a network-layer failure (e.g. a proxy error) hit while
+        # refreshing the access token in this class, not RefreshError.
+        TransportError("Cannot connect to proxy."),
+        _fake_response(200, {"rows": [{"keys": ["2026-04-15"], "clicks": 1}]}),
+    ]
+
+    rows = _query_search_analytics(session, "sc-domain:example.com", "2026-04-15", "2026-04-15", ["date"], 0)
+
+    assert rows == [{"keys": ["2026-04-15"], "clicks": 1}]
+    assert session.post.call_count == 2
+
+
+def test_query_token_refresh_transport_error_bubbles_after_max_retries(monkeypatch):
+    monkeypatch.setattr(gsc.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(gsc, "_throttle", lambda _site: None)
+
+    session = mock.MagicMock()
+    session.post.side_effect = TransportError("Cannot connect to proxy.")
+
+    # A persistent token-refresh transport failure exhausts the inline budget and surfaces the
+    # real TransportError (retryable at the activity level).
+    with pytest.raises(TransportError):
+        _query_search_analytics(session, "sc-domain:example.com", "2026-04-15", "2026-04-15", ["date"], 0)
+
+    assert session.post.call_count == QUOTA_MAX_RETRIES + 1
 
 
 def test_throttle_spaces_requests_per_site(monkeypatch):


### PR DESCRIPTION
## Problem

A Google Search Console sync crashes when the OAuth token refresh hits a network failure (proxy error, connection reset, DNS blip), instead of retrying like other transient failures during the same request. Surfaced by [error tracking](https://us.posthog.com/project/2/error_tracking/01a094f9-8f19-7bf3-8f8d-ea60f94e37ee): a `TransportError` from a proxy tunnel failure while refreshing the token before a `searchAnalytics.query` call.

## Changes

- `_query_search_analytics` now catches `google.auth.exceptions.TransportError` and retries inline with backoff, same as the existing `ConnectionError`/`Timeout` handling.
- google-auth raises `TransportError` (not `RefreshError`) when the token-refresh HTTP call itself fails at the network layer, before any response exists. The existing `RefreshError` handling only covers failures where google-auth got a response back (invalid_grant, a 502 page, etc.), so this case fell through uncaught.
- Once the inline retry budget is spent, the real `TransportError` still bubbles so Temporal retries the activity, resuming from the last saved date.

This is a code fix, not a `NonRetryableErrors` change: the failure is a transient network blip, not a customer credential or config issue.

## How did you test this code?

Added two tests to `test_google_search_console.py`, mirroring the existing `ConnectionError` pair:
- `test_query_retries_token_refresh_transport_error_then_succeeds` — a transient `TransportError` retries inline and the call succeeds.
- `test_query_token_refresh_transport_error_bubbles_after_max_retries` — a persistent `TransportError` still bubbles after the retry budget, so Temporal can retry the activity.

Ran the full `google_search_console` test suite (216 passed), `ruff check`/`ruff format --check`, and `mypy` on the changed file — all clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal error-handling fix, no documented behavior changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking alert for the `google_search_console` warehouse source. Traced the stack trace through `google-auth`'s `oauth2/_client.py` and `auth/transport/requests.py` to confirm `TransportError` (not `RefreshError`) is what propagates when the token-refresh request fails at the network layer, then added the missing handling and matching tests. No PR review skill run yet (CodeRabbit pass paused per repo convention). Searched open PRs for `TransportError`, `google_search_console`, and `oauth2.googleapis.com`, and the maintainer's own open PRs — no existing PR addresses this root cause.