### PR TITLE
fix(stamphog): skip external contributor approvals

### DIFF
--- a/products/stamphog/README.md
+++ b/products/stamphog/README.md
@@ -48,3 +48,5 @@ Per-repo settings live on `StamphogRepoConfig` (synced via the GitHub App instal
 ## Security model, in one paragraph
 
 The sandbox runs an LLM over untrusted PR content, so it holds no long-lived secrets: it gets a per-run gateway token (a `phe_` scoped token pinned to `product=aio_stamphog` and capped at $5 on the Go ai-gateway, or an OAuth token scoped to `llm_gateway:read` + the server-mint marker on the legacy gateway's stamphog route), egress is fenced to an explicit domain allowlist, posted bodies are scrubbed and markdown-image-neutralized, and approvals are governed by a strict supersession protocol so no approval survives events it shouldn't (pushes, re-reviews, repo disable). Details and invariants: [AGENTS.md](AGENTS.md).
+
+StampHog can review and approve PRs from internal human authors and verified self-driving runs. External contributions can still be merged, but StampHog does not give them an automatic approval.

--- a/products/stamphog/backend/tasks/tasks.py
+++ b/products/stamphog/backend/tasks/tasks.py
@@ -103,21 +103,11 @@ STAMPHOG_LABEL_REREVIEW_KEY_PREFIX = "stamphog:label_rereview:"
 # PR body is trimmed to this at capture time so rows (and the digest LLM prompt) stay bounded.
 PR_BODY_EXCERPT_MAX_CHARS = 2000
 
-# Only these author associations may be auto-reviewed. A fork/external-contributor PR must never be:
-# an auto-approval could satisfy required reviews with zero human in the loop, and anyone could open
-# PRs to burn sandbox + LLM credits. (GitHub's association vocabulary; the trusted subset.)
+# Only internal human author associations may be auto-reviewed. External contributions can still be
+# merged, but an automated approval must not make them authoritative. (GitHub's trusted subset.)
 TRUSTED_AUTHOR_ASSOCIATIONS = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
 
-# CONTRIBUTOR additionally passes the payload gate — not because it is trusted, but because the field
-# is unreliable in App-delivered payloads: GitHub computes author_association with less context than a
-# user-token API call, and org members on private repos arrive downgraded to CONTRIBUTOR (observed on
-# real deliveries with members:read granted and public org membership). Hard-dropping it silently
-# disables reviews for legitimate authors, so CONTRIBUTOR falls through to
-# _author_lacks_write_permission — the authoritative installation-token gate every run must pass
-# anyway. The associations still dropped here (NONE, FIRST_TIME_CONTRIBUTOR, ...) are fork drive-bys
-# with no repo relationship at all; a fall-through would cost only a cached permission lookup, but
-# there is no legitimate case to admit.
-PAYLOAD_GATE_AUTHOR_ASSOCIATIONS = TRUSTED_AUTHOR_ASSOCIATIONS | {"CONTRIBUTOR"}
+PAYLOAD_GATE_AUTHOR_ASSOCIATIONS = TRUSTED_AUTHOR_ASSOCIATIONS
 
 # The association gate above is necessary but not sufficient: MEMBER says nothing about repo-level
 # access, and COLLABORATOR covers read/triage-only invites. Auto-approval must also require that the

--- a/products/stamphog/backend/tests/test_tasks.py
+++ b/products/stamphog/backend/tests/test_tasks.py
@@ -192,7 +192,7 @@ def test_unmatched_events_create_no_review_run(team, repo_config, mutate_payload
         ({"user_type": "Bot"}, False),
         ({"author_login": "renovate[bot]"}, False),
         ({"author_association": "NONE"}, False),
-        ({"author_association": "CONTRIBUTOR"}, True),
+        ({"author_association": "CONTRIBUTOR"}, False),
         ({"author_association": "FIRST_TIME_CONTRIBUTOR"}, False),
         ({"author_association": "MEMBER"}, True),
     ],
@@ -201,7 +201,7 @@ def test_unmatched_events_create_no_review_run(team, repo_config, mutate_payload
         "bot_type",
         "bot_login",
         "none",
-        "contributor_falls_through",
+        "contributor",
         "first_time_contributor",
         "member_proceeds",
     ],
@@ -210,9 +210,7 @@ def test_unmatched_events_create_no_review_run(team, repo_config, mutate_payload
 def test_review_path_skips_untrusted_bot_or_draft_prs(team, repo_config, pr_kwargs, expect_run):
     # Drafts, bot authors, and fork/external authors must be dropped before a sandbox is spent. The
     # fork/external drop is also a security boundary: an auto-approval must never satisfy required
-    # reviews for a PR no trusted member opened. CONTRIBUTOR is NOT dropped at the payload gate — App
-    # webhooks downgrade org members on private repos to CONTRIBUTOR, so it defers to the
-    # write-permission gate (write here, via the harness default).
+    # reviews for a PR no trusted member opened.
     mock_execute = _run_task(
         _pr_payload(**pr_kwargs), f"delivery-skip-{'-'.join(map(str, pr_kwargs.values()))}", team.id
     )
@@ -234,10 +232,8 @@ def test_review_path_skips_untrusted_bot_or_draft_prs(team, repo_config, pr_kwar
         ("write", "MEMBER", True),
         ("read", "MEMBER", False),
         ("none", "MEMBER", False),
-        ("write", "CONTRIBUTOR", True),
-        ("read", "CONTRIBUTOR", False),
     ],
-    ids=["admin", "write", "read_only", "no_access", "contributor_with_write", "contributor_read_only"],
+    ids=["admin", "write", "read_only", "no_access"],
 )
 @pytest.mark.django_db(databases=PRODUCT_DATABASES)
 def test_review_path_requires_author_write_permission(
@@ -245,8 +241,6 @@ def test_review_path_requires_author_write_permission(
 ):
     # author_association alone can't prove push access (org MEMBERs and triage/read COLLABORATORs pass
     # it), so a trusted-association author below write must still be dropped before a run is queued.
-    # The CONTRIBUTOR rows pin the payload-gate fall-through to this gate: a downgraded org member with
-    # write gets reviewed, a genuine read-only contributor still never mints a run.
     mock_execute = _run_task(
         _pr_payload(author_association=author_association),
         f"delivery-perm-{author_permission}-{author_association}",
@@ -318,15 +312,19 @@ def test_disabled_repo_skip_retracts_stale_approvals_on_head_change(team, repo_c
     mock_execute.assert_not_called()
 
 
+@pytest.mark.parametrize("author_association", ["NONE", "CONTRIBUTOR"], ids=["none", "contributor"])
 @pytest.mark.django_db(databases=PRODUCT_DATABASES)
-def test_untrusted_author_skip_retracts_stale_approvals_on_head_change(team, repo_config):
-    # An author who loses their trusted association (left the org, collaborator removed) can still
-    # push to an approved PR; the payload-only skip must retract the standing approval, not just
-    # drop the event — otherwise the old approval keeps satisfying required reviews.
-    _run_task(_pr_payload(), "delivery-assoc-approved", team.id)
+def test_untrusted_author_skip_retracts_stale_approvals_on_head_change(team, repo_config, author_association):
+    # An untrusted author can push to an approved PR. The payload-only skip must retract the standing
+    # approval, or it keeps satisfying required reviews.
+    _run_task(_pr_payload(), f"delivery-assoc-approved-{author_association}", team.id)
 
     with patch("products.stamphog.backend.tasks.tasks.dismiss_stale_approvals_for_head", return_value=1) as dismiss:
-        _run_task(_pr_payload(action="synchronize", author_association="NONE"), "delivery-assoc-revoked", team.id)
+        _run_task(
+            _pr_payload(action="synchronize", author_association=author_association),
+            f"delivery-assoc-{author_association}",
+            team.id,
+        )
 
     dismiss.assert_called_once()
     with team_scope(team.id):


### PR DESCRIPTION
## Problem

External contributor PRs can receive an automatic StampHog approval. That approval can act as authoritative review without an internal author or verified self-driving provenance.

**Why:** Maintainers can accept external contributions, but automatic authority must come from an internal human author or a verified self-driving run.

## Changes

- StampHog skips PRs with GitHub's `CONTRIBUTOR` author association before it starts a review.
- Verified self-driving runs keep their separate attested review path.
- The test matrix confirms contributor PRs cannot queue a review or retain an older approval after a push.

```mermaid
flowchart LR
    A[External contributor PR] --> B[Write permission check]
    B --> C[StampHog approval]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phYellow;
    class B,C phBlue;
```

```mermaid
flowchart LR
    A[External contributor PR] --> B[Maintainer review]
    C[Internal human PR] --> D[Write permission check]
    D --> E[StampHog approval]
    F[Verified self-driving PR] --> G[Attested review path]
    G --> E
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A,C,F phYellow;
    class B,D,E,G phBlue;
```

## How did you test this code?

- `uv run pytest products/stamphog/backend/tests/test_tasks.py -q` checks that contributor PRs do not start a review and retract older approvals after a push.
- `uv run ruff check` and `uv run ruff format --check` passed for the changed Python files.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the StampHog README with the automatic-approval policy.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- PostHog Slack app used repository and GitHub tools.
- Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, `/writing-pr-descriptions`, and `/reviewing-with-coderabbit`.
- CodeRabbit is paused. This PR opened without a local CodeRabbit pass.
- The open PR and issue search found no matching work.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/D0AGC0X66LF/p1789198317715339?thread_ts=1789198317.715339&cid=D0AGC0X66LF)*