### PR TITLE
fix(instagram): retry a connection reset mid-response body

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instagram/instagram.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instagram/instagram.py
@@ -231,7 +231,17 @@ class InstagramClient:
         return False
 
     @retry(
-        retry=retry_if_exception_type((InstagramRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+        retry=retry_if_exception_type(
+            (
+                InstagramRetryableError,
+                requests.ReadTimeout,
+                requests.ConnectionError,
+                # Raised instead of ConnectionError when the reset lands mid-body on a
+                # chunked response (see requests.models.Response.generate) — the same
+                # transient network blip, just caught at a different layer of urllib3.
+                requests.exceptions.ChunkedEncodingError,
+            )
+        ),
         stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
         wait=wait_exponential_jitter(initial=2, max=120),
         reraise=True,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instagram/tests/test_instagram.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instagram/tests/test_instagram.py
@@ -6,6 +6,7 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 from unittest import mock
 
+import requests
 import structlog
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
@@ -284,6 +285,25 @@ class TestInstagramTransport:
             client.get(client.build_url(ACCOUNT_ID))
 
         assert len(session.requested_urls) == MAX_RETRY_ATTEMPTS
+
+    def test_a_connection_reset_mid_response_body_is_retried(self) -> None:
+        # A reset that lands while urllib3 is still reading a chunked body surfaces as
+        # ChunkedEncodingError rather than ConnectionError, but it's the same transient
+        # network blip and must be retried the same way.
+        session = FakeSession()
+        session.get = mock.Mock(  # type: ignore[method-assign]
+            side_effect=[
+                requests.exceptions.ChunkedEncodingError("Connection broken: ConnectionResetError(104, ...)"),
+                FakeResponse(200, {"id": ACCOUNT_ID}),
+            ]
+        )
+        with mock.patch(f"{MODULE}.make_tracked_session", return_value=session):
+            client = InstagramClient("tok", "v23.0", LOGGER)
+
+        body = client.get(client.build_url(ACCOUNT_ID))
+
+        assert body == {"id": ACCOUNT_ID}
+        assert session.get.call_count == 2
 
     @pytest.mark.parametrize(
         "status_code,code,prefix",


### PR DESCRIPTION
## Problem

A customer's Instagram sync can crash outright when Meta's Graph API resets the connection mid-response, instead of retrying like other transient network failures do.

Error tracking: https://us.posthog.com/project/2/error_tracking/01a0950b-8fab-7550-8acd-0455947e2fdd

## Changes

- The Graph API client's retry decorator catches `requests.ReadTimeout` and `requests.ConnectionError`, but `requests` raises `ChunkedEncodingError` instead when the reset lands while a chunked response body is still streaming (see `requests.models.Response.generate`). That type fell through the filter and the sync failed outright rather than retrying.
- Add `requests.exceptions.ChunkedEncodingError` to the retried exception types in `InstagramClient.get`, alongside the existing transient network errors.
- Mechanical: no other behavior changes.

## How did you test this code?

Added `test_a_connection_reset_mid_response_body_is_retried`, which raises `ChunkedEncodingError` once then succeeds, asserting the client retries instead of raising.

Ran the source's test suite locally: `pytest products/warehouse_sources/backend/temporal/data_imports/sources/instagram/tests/` — 117 passed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error tracking issue for the Instagram data warehouse source (`ChunkedEncodingError` / `ConnectionResetError(104, 'Connection reset by peer')`), raised at `instagram.py:248` inside `InstagramClient.get`, wrapped by `tenacity`. The retry filter only listed `ConnectionError`, not the sibling `ChunkedEncodingError` `requests` raises for a reset mid-chunked-body, so this class of transient failure was never retried. Searched open PRs (by exception type, module path, and the maintainer's own branches) and found no existing fix for this issue. No skills from this repo's skill set were invoked beyond standard test running and linting.

---

Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)
