### PR TITLE
fix(linkedin_ads): stop reporting egress-proxy 429s on the ad analytics tunnel

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/source.py
@@ -145,6 +145,11 @@ class LinkedInAdsSource(ResumableSource[LinkedinAdsSourceConfig, LinkedInAdsResu
         return {
             "LinkedIn API error (retryable, ",
             "LinkedIn API returned a malformed (non-JSON) response",
+            # PostHog's own egress proxy answering the CONNECT tunnel with a 429 (`requests.ProxyError`,
+            # a `ConnectionError` subclass `_call_finder` already retries in-process). Not LinkedIn's
+            # fault or the customer's — the proxy itself is throttling, which clears on its own, the
+            # same reasoning ClickHouse and Salesforce apply to a 502/503/504 tunnel gateway status.
+            "Tunnel connection failed: 429",
         }
 
     @property

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py
@@ -64,6 +64,11 @@ class TestLinkedInAdsSource:
             'LinkedIn API error (retryable, 429): {"message":"Too many requests"}',
             'LinkedIn API error (retryable, 503): {"message":"Service Unavailable"}',
             "LinkedIn API returned a malformed (non-JSON) response: Expecting value: line 1 column 1 (char 0)",
+            # PostHog's own egress proxy throttling the CONNECT tunnel, surfaced by requests as a
+            # ProxyError once `_call_finder`'s tenacity retries are exhausted.
+            "HTTPSConnectionPool(host='api.linkedin.com', port=443): Max retries exceeded with url: "
+            "/rest/adAnalytics (Caused by ProxyError('Cannot connect to proxy.', "
+            "OSError('Tunnel connection failed: 429 Too Many Requests')))",
         ],
     )
     def test_retryable_errors_match_exhausted_transient_failures(self, observed_error):
@@ -76,6 +81,10 @@ class TestLinkedInAdsSource:
             'LinkedIn API error (404): {"status":404,"code":"RESOURCE_NOT_FOUND"}',
             'LinkedIn daily rate limit reached (429): {"message":"throttled"}',
             "Connection reset by peer",
+            # A deterministic proxy-auth rejection, not a transient tunnel gateway status — must stay
+            # reportable rather than being swallowed by the 429 tunnel pattern.
+            "Caused by ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: "
+            "407 Proxy Authentication Required'))",
         ],
     )
     def test_retryable_errors_does_not_match_unrelated(self, other_error):


### PR DESCRIPTION
## Problem

A LinkedIn Ads sync surfaces in [error tracking](https://us.posthog.com/project/2/error_tracking/01a0950b-1240-7711-a361-53701048a097) when PostHog's own egress proxy throttles the CONNECT tunnel to `api.linkedin.com` (`ProxyError: ... Tunnel connection failed: 429 Too Many Requests`).

This is PostHog's proxy rate-limiting itself, not LinkedIn or the customer. The request already retried in-process, and Temporal retries the whole activity, so the failure is self-recovering noise rather than an actionable bug.

## Changes

- `LinkedinAdsSource.get_retryable_errors` now recognizes `Tunnel connection failed: 429`, so this exhausted-retry case logs as a warning and re-raises for a plain Temporal retry instead of reaching error tracking.
- Matches the narrower `429` status only, the same way ClickHouse and Salesforce already classify `502`/`503`/`504` tunnel gateway statuses as transient without also swallowing a deterministic `407` proxy-auth rejection.

## How did you test this code?

Extended `test_linkedin_source.py`'s existing retryable/non-retryable parametrized cases:
- A realistic `ProxyError` message with the `429` tunnel status now matches `get_retryable_errors`.
- A `407` proxy-auth tunnel failure (a real misconfiguration, not transient) still does not match, so it stays reportable.

Ran `pytest products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py` locally: 44 passed. Not run: the wider warehouse-sources or Temporal integration suites.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing or documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code, triaging a webhook-delivered error tracking alert for this source.
- No skills from the mandatory-invocation list applied to this change (no DRF/migration/frontend/dataclass touch); `/writing-pr-descriptions` was used for this body.
- Decision: classified this as a transient infrastructure error per the triage criteria, not a `NonRetryableErrors` case (nothing to tell the customer to fix) and not a code bug (the connection-level retry via tenacity already covers it) — the gap was purely in the retryable-error classification used to keep known-transient failures out of error tracking.
- No duplicate: searched open PRs for `linkedin_ads`/`ProxyError`/`proxy`/`tunnel` and listed every open PR from this automation's author; none touch this source or error.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*