### PR TITLE
fix(mssql): stop retrying an ambiguous column name from a stale view

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/source.py
@@ -111,6 +111,13 @@ class MSSQLSource(SQLSource[MSSQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             # whose definition selects a column that's no longer present. Fixed source-data shape,
             # so retrying won't help.
             "Invalid column name": "One of the columns being synced no longer exists in your SQL Server. A column was likely dropped or renamed, or a view's definition references a column that's no longer present. Fix the column or view definition at the source, then re-enable the sync.",
+            # SQL Server error 209 — a name in the object we select from resolves to more than one
+            # column. Our SELECT reads a single qualified object and only ever names columns
+            # discovered from information_schema, so the ambiguity is inside a view body: most often
+            # a `SELECT *` over a join that went stale when a base table gained a same-named column.
+            # The view keeps failing until it is refreshed or rewritten, so retrying replays the
+            # identical 209. Match the stable error text, not the column name that follows it.
+            "Ambiguous column name": "A view you're syncing has a column name that exists in more than one of the tables it reads, so SQL Server can't resolve it. Fix or refresh the view definition at the source, then re-enable the sync.",
             # SQL Server error 245 — an implicit type conversion fails on a specific row's value
             # (e.g. converting the varchar 'SFDR' to int). Our SELECT does no casts and the
             # incremental predicate only ever compares like types, so this conversion lives in the

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/tests/test_mssql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/tests/test_mssql.py
@@ -731,6 +731,21 @@ class TestMSSQLSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # SQL Server error 209 — a stale view whose body joins two tables that now share a
+            # column name. Real pymssql message shape, with the driver's trailing DB-Lib frame.
+            "(209, b\"Ambiguous column name 'modified_at'.DB-Lib error message 20018, severity 16:\\n"
+            'General SQL Server error: Check messages from the SQL Server\\n")',
+            # Different column name must still match the stable substring.
+            "Ambiguous column name 'order_id'.",
+        ],
+    )
+    def test_ambiguous_column_name_is_non_retryable(self, error_msg):
+        non_retryable = MSSQLSource().get_non_retryable_errors()
+        assert any(pattern in error_msg for pattern in non_retryable.keys()), error_msg
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # Real pymssql MSSQLDatabaseException for SQL Server error 245 raised mid-fetch when a
             # view body implicitly converts a varchar value to int.
             "SQL Server message 245, severity 16, state 1, procedure b'@\\x88[\\xd4\\xfe\\xff', line 1:\n"


### PR DESCRIPTION
## Problem

A SQL Server sync that reads a stale view fails every run, and the customer sees the raw pymssql tuple instead of anything they can act on.

- SQL Server raises error 209 when a name in the object being selected resolves to more than one column.
- Our SELECT reads a single qualified object and only names columns discovered from `information_schema`, so the ambiguity lives inside the view body. A `SELECT *` over a join goes stale once a base table gains a same-named column.
- Nothing in `MSSQLSource.get_non_retryable_errors()` matched it, so the schema stayed enabled and burned a job on every schedule.
- The stored `latest_error` was the driver tuple: an error number, a `b"..."` payload, and a DB-Lib severity frame.

## Changes

- The sync now stops on error 209 and stores an actionable message naming the view and the fix. It no longer retries.
- `Ambiguous column name` joins the sibling entries for errors 207, 208 and 245 in `get_non_retryable_errors()`, matched on the stable error text so the column name that follows it can vary.
- No frontend change, so nothing looks different.

## How did you test this code?

- Added `test_ambiguous_column_name_is_non_retryable`, parameterized over the full pymssql message shape and a bare one-line variant. It catches a mapping keyed to the driver's framing rather than to the stable text, which would stop matching the moment pymssql changes its wrapper.
- Ran the `non_retryable` selection of `products/warehouse_sources/backend/temporal/data_imports/sources/mssql/tests/test_mssql.py` locally, plus `ruff check` and `ruff format` over both touched files.
- Not run: anything needing a live SQL Server. The 209 path was not reproduced against a real server.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Written by Claude Code (Opus 5) during a triage pass over a day of data-warehouse sync failures.
- Skills invoked: `/writing-pr-descriptions`. The CodeRabbit local pass is paused, so this PR opened without one.
- No duplicate: `gh pr list --state open --author Gilbert09` and searches for `mssql`, `SQL Server error` and `Ambiguous column` found no open PR touching error 209. PR #98765 also edits `mssql/source.py`, but it covers error 207 (a dropped column) and never mentions 209.
- Public artifact: the failure that prompted this came from production job records. The committed test fixtures use invented column names and carry nothing from that material.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
