### PR TITLE
chore(query-cache): split database-free storage tests

### DIFF
--- a/posthog/query_cache/test/test_storage.py
+++ b/posthog/query_cache/test/test_storage.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime, timedelta
 from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, patch
 
-from django.test import SimpleTestCase, override_settings
+from django.test import override_settings
 
 import zstd
 from parameterized import parameterized
@@ -15,18 +15,9 @@ from posthog.query_cache import (
     get_stale_insights,
     storage as qc_storage,
 )
-from posthog.query_cache.serialization import QUERY_CACHE_SPLIT_MAGIC, encode_split_cached_response
+from posthog.query_cache.serialization import encode_split_cached_response
 from posthog.query_cache.size_tracker import TeamCacheSizeTracker
-from posthog.query_cache.storage import (
-    S3_POINTER_MAGIC,
-    ZSTD_FRAME_MAGIC,
-    S3BlobPointer,
-    decode_pointer,
-    encode_pointer,
-    entry_redis_key,
-    is_s3_pointer,
-    s3_write_mode,
-)
+from posthog.query_cache.storage import S3_POINTER_MAGIC, ZSTD_FRAME_MAGIC, entry_redis_key
 from posthog.storage.object_storage import ObjectStorageError
 
 
@@ -54,84 +45,6 @@ class FakeObjectStorage:
 
     def delete(self, bucket: str, key: str) -> None:
         self.objects.pop((bucket, key), None)
-
-
-class TestS3PointerCodec(SimpleTestCase):
-    def test_pointer_round_trips(self):
-        pointer = S3BlobPointer(bucket="cache-bucket", key="query_cache/1/some_key")
-        assert decode_pointer(encode_pointer(pointer)) == pointer
-
-    @parameterized.expand(
-        [
-            ("legacy_json_blob", b'{"results": []}'),
-            ("split_format_blob", QUERY_CACHE_SPLIT_MAGIC + b"\x00rest"),
-            ("empty", b""),
-        ]
-    )
-    def test_blob_formats_are_not_pointers(self, _name, data):
-        assert not is_s3_pointer(data)
-        assert decode_pointer(data) is None
-
-    @parameterized.expand(
-        [
-            ("not_json", S3_POINTER_MAGIC + b"notjson"),
-            ("missing_keys", S3_POINTER_MAGIC + b'{"v": 1}'),
-            ("unknown_version", S3_POINTER_MAGIC + b'{"v": 2, "b": "bucket", "k": "key"}'),
-            ("non_string_key", S3_POINTER_MAGIC + b'{"v": 1, "b": "bucket", "k": [1, 2]}'),
-        ]
-    )
-    def test_corrupt_pointer_decodes_to_none(self, _name, data):
-        assert is_s3_pointer(data)
-        assert decode_pointer(data) is None
-
-
-@override_settings(OBJECT_STORAGE_ENABLED=True)
-class TestS3WriteMode(SimpleTestCase):
-    def test_disabled_object_storage_fails_closed(self):
-        # UnavailableStorage swallows writes silently, so routing while storage is off would
-        # store pointers to blobs that were never written.
-        with (
-            override_settings(OBJECT_STORAGE_ENABLED=False),
-            patch("posthog.query_cache.storage._organization_id_for_team") as org_mock,
-        ):
-            assert s3_write_mode(team_id=1) == "off"
-            org_mock.assert_not_called()
-
-    @parameterized.expand(
-        [
-            ("on", "on"),
-            ("shadow", "shadow"),
-            (True, "off"),
-            (False, "off"),
-            (None, "off"),
-            ("unknown-variant", "off"),
-        ]
-    )
-    def test_only_known_variants_activate(self, variant, expected):
-        with (
-            patch("posthog.query_cache.storage._organization_id_for_team", return_value="0189-org-uuid"),
-            patch("posthog.query_cache.storage.get_feature_flag_or_none", return_value=variant),
-        ):
-            assert s3_write_mode(team_id=1) == expected
-
-    def test_unresolvable_organization_fails_closed_without_flag_evaluation(self):
-        with (
-            patch("posthog.query_cache.storage._organization_id_for_team", return_value=None),
-            patch("posthog.query_cache.storage.get_feature_flag_or_none") as flag_mock,
-        ):
-            assert s3_write_mode(team_id=1) == "off"
-            flag_mock.assert_not_called()
-
-    def test_flag_evaluation_supplies_group_properties(self):
-        # Without group_properties, an id-filtered rollout evaluates inconclusive under
-        # only_evaluate_locally and silently reads as off.
-        with (
-            patch("posthog.query_cache.storage._organization_id_for_team", return_value="0189-org-uuid"),
-            patch("posthog.query_cache.storage.get_feature_flag_or_none", return_value="on") as flag_mock,
-        ):
-            assert s3_write_mode(team_id=1) == "on"
-        assert flag_mock.call_args.kwargs["groups"] == {"organization": "0189-org-uuid"}
-        assert flag_mock.call_args.kwargs["group_properties"] == {"organization": {"id": "0189-org-uuid"}}
 
 
 def _redis_raw(cache_key: str) -> bytes | None:

--- a/posthog/query_cache/test/test_storage_unit.py
+++ b/posthog/query_cache/test/test_storage_unit.py
@@ -1,0 +1,93 @@
+from unittest.mock import patch
+
+from django.test import SimpleTestCase, override_settings
+
+from parameterized import parameterized
+
+from posthog.query_cache.serialization import QUERY_CACHE_SPLIT_MAGIC
+from posthog.query_cache.storage import (
+    S3_POINTER_MAGIC,
+    S3BlobPointer,
+    decode_pointer,
+    encode_pointer,
+    is_s3_pointer,
+    s3_write_mode,
+)
+
+
+class TestS3PointerCodec(SimpleTestCase):
+    def test_pointer_round_trips(self):
+        pointer = S3BlobPointer(bucket="cache-bucket", key="query_cache/1/some_key")
+        assert decode_pointer(encode_pointer(pointer)) == pointer
+
+    @parameterized.expand(
+        [
+            ("legacy_json_blob", b'{"results": []}'),
+            ("split_format_blob", QUERY_CACHE_SPLIT_MAGIC + b"\x00rest"),
+            ("empty", b""),
+        ]
+    )
+    def test_blob_formats_are_not_pointers(self, _name, data):
+        assert not is_s3_pointer(data)
+        assert decode_pointer(data) is None
+
+    @parameterized.expand(
+        [
+            ("not_json", S3_POINTER_MAGIC + b"notjson"),
+            ("missing_keys", S3_POINTER_MAGIC + b'{"v": 1}'),
+            ("unknown_version", S3_POINTER_MAGIC + b'{"v": 2, "b": "bucket", "k": "key"}'),
+            ("non_string_key", S3_POINTER_MAGIC + b'{"v": 1, "b": "bucket", "k": [1, 2]}'),
+        ]
+    )
+    def test_corrupt_pointer_decodes_to_none(self, _name, data):
+        assert is_s3_pointer(data)
+        assert decode_pointer(data) is None
+
+
+@override_settings(OBJECT_STORAGE_ENABLED=True)
+class TestS3WriteMode(SimpleTestCase):
+    def test_disabled_object_storage_fails_closed(self):
+        # UnavailableStorage swallows writes silently, so routing while storage is off would
+        # store pointers to blobs that were never written.
+        with (
+            override_settings(OBJECT_STORAGE_ENABLED=False),
+            patch("posthog.query_cache.storage._organization_id_for_team") as org_mock,
+        ):
+            assert s3_write_mode(team_id=1) == "off"
+            org_mock.assert_not_called()
+
+    @parameterized.expand(
+        [
+            ("on", "on"),
+            ("shadow", "shadow"),
+            (True, "off"),
+            (False, "off"),
+            (None, "off"),
+            ("unknown-variant", "off"),
+        ]
+    )
+    def test_only_known_variants_activate(self, variant, expected):
+        with (
+            patch("posthog.query_cache.storage._organization_id_for_team", return_value="0189-org-uuid"),
+            patch("posthog.query_cache.storage.get_feature_flag_or_none", return_value=variant),
+        ):
+            assert s3_write_mode(team_id=1) == expected
+
+    def test_unresolvable_organization_fails_closed_without_flag_evaluation(self):
+        with (
+            patch("posthog.query_cache.storage._organization_id_for_team", return_value=None),
+            patch("posthog.query_cache.storage.get_feature_flag_or_none") as flag_mock,
+        ):
+            assert s3_write_mode(team_id=1) == "off"
+            flag_mock.assert_not_called()
+
+    def test_flag_evaluation_supplies_group_properties(self):
+        # Without group_properties, an id-filtered rollout evaluates inconclusive under
+        # only_evaluate_locally and silently reads as off.
+        with (
+            patch("posthog.query_cache.storage._organization_id_for_team", return_value="0189-org-uuid"),
+            patch("posthog.query_cache.storage.get_feature_flag_or_none", return_value="on") as flag_mock,
+        ):
+            assert s3_write_mode(team_id=1) == "on"
+        assert flag_mock.call_args.kwargs["groups"] == {"organization": "0189-org-uuid"}
+        assert flag_mock.call_args.kwargs["group_properties"] == {"organization": {"id": "0189-org-uuid"}}


### PR DESCRIPTION
## Problem

Developers cannot run database-free query-cache checks without starting storage-backed test setup.

## Changes

- The pure pointer codec and write-mode checks now run in their own SimpleTestCase module.
- The storage-backed BaseTest checks stay together. This is a mechanical test-only change.

## How did you test this code?

- Automated: hogli test posthog/query_cache/test/test_storage.py posthog/query_cache/test/test_storage_unit.py
- No user-visible changes.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This changes test layout only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- PostHog Slack app created this PR with the writing-tests, writing-code-comments, and writing-pr-descriptions skills.
- The open PR and issue searches found no matching change.
- CodeRabbit local pass is paused.
- The diff contains no data from the Slack thread.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0C0LU050GN/p1789207496411519?thread_ts=1789207496.411519&cid=C0C0LU050GN)*