### PR TITLE
fix(signals): prevent stale inbox visibility callbacks

### DIFF
--- a/products/signals/frontend/inbox/inboxSceneLogic.test.ts
+++ b/products/signals/frontend/inbox/inboxSceneLogic.test.ts
@@ -411,6 +411,33 @@ describe('inboxSceneLogic routing', () => {
             expect(reportGet).toHaveBeenCalledTimes(1)
         })
 
+        it('ignores a visibility callback captured before the scene unmounts', async () => {
+            const reportGet = mockReportGet()
+            const addEventListenerSpy = jest.spyOn(document, 'addEventListener')
+            const removeEventListenerSpy = jest.spyOn(document, 'removeEventListener')
+            try {
+                mountWithRedesign(true)
+                logic.actions.setSelectedReportId('report-1')
+                await expectLogic(logic).toDispatchActions(['loadSelectedReportSuccess'])
+
+                const onVisibilityChange = addEventListenerSpy.mock.calls.find(
+                    ([eventName]) => eventName === 'visibilitychange'
+                )?.[1]
+                if (typeof onVisibilityChange !== 'function') {
+                    throw new Error('Expected the report refresh visibility listener to be registered')
+                }
+
+                logic.unmount()
+                expect(removeEventListenerSpy).toHaveBeenCalledWith('visibilitychange', onVisibilityChange)
+                expect(() => onVisibilityChange(new Event('visibilitychange'))).not.toThrow()
+                await expectLogic(logic).toNotHaveDispatchedActions(['loadSelectedReport'])
+                expect(reportGet).toHaveBeenCalledTimes(1)
+            } finally {
+                addEventListenerSpy.mockRestore()
+                removeEventListenerSpy.mockRestore()
+            }
+        })
+
         // The lists behind the detail pane reconcile only on `reportStateChanged`, so a refresh that
         // lands a new status has to broadcast it. An unconditional broadcast is just as wrong: every
         // tab return would refresh every mounted section and the refund summary.

--- a/products/signals/frontend/inbox/inboxSceneLogic.ts
+++ b/products/signals/frontend/inbox/inboxSceneLogic.ts
@@ -1008,9 +1008,13 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
             // Same opt-out as above: the listener must be alive while hidden to see the return.
             cache.disposables.add(
                 () => {
+                    const disposables = cache.disposables
                     const onVisibilityChange = (): void => {
+                        if (document.visibilityState !== 'visible' || disposables.isDisposed) {
+                            return
+                        }
                         const id = values.selectedReportId
-                        if (document.visibilityState === 'visible' && id) {
+                        if (id) {
                             actions.loadSelectedReport({ id })
                         }
                     }


### PR DESCRIPTION
## Problem

- Inbox users who leave the scene can hit an error if a queued visibility callback runs after unmount.

## Changes

- The disposed listener now returns before it reads scene state.
- An active Inbox still refreshes the selected report when the tab becomes visible.
- This change has no visual difference.

## How did you test this code?

- `hogli test products/signals/frontend/inbox/inboxSceneLogic.test.ts` covers a captured callback after unmount, listener cleanup, and no extra request.
- `pnpm --filter=@posthog/frontend fix` and `pnpm --filter=@posthog/frontend typegen:check` pass.
- `typescript:check` remains blocked by unrelated workspace module resolution failures; the scoped output reports no Inbox errors.
- Not run: manual browser testing.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- Not needed: this change does not alter documented behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex authored the change with user direction. Skills used: `/using-kea-disposables`, `/writing-kea-logics`, `/writing-tests`, and `/writing-pr-descriptions`.
- The open-PR search found no duplicate.
- The local CodeRabbit pass is paused.
- The PR excludes private investigation data.