### PR TITLE
feat(warehouse-sources): sync appsflyer organic, retargeting, uninstall and fraud reports

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/COVERAGE_GAPS_APPENDIX.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/COVERAGE_GAPS_APPENDIX.md
@@ -433,7 +433,7 @@ Note: Full v2 endpoint list read from the docs nav (slugs encode the HTTP path).
 
 ## AppsFlyer — **thin**
 
-Today (9): `ad_revenue`, `ad_revenue_organic`, `ad_revenue_retargeting`, `daily_report`, `geo_report`, `in_app_events`, `installs`, `master_report`, `partners_report`
+Today (17): `ad_revenue`, `ad_revenue_organic`, `ad_revenue_retargeting`, `blocked_in_app_events`, `blocked_installs`, `daily_report`, `geo_report`, `in_app_events`, `in_app_events_organic`, `in_app_events_retargeting`, `installs`, `installs_organic`, `installs_retargeting`, `master_report`, `partners_report`, `post_attribution_installs`, `uninstall_events`
 
 Diffed against: <https://dev.appsflyer.com/hc/reference>
 
@@ -441,16 +441,16 @@ Diffed against: <https://dev.appsflyer.com/hc/reference>
 - [x] `/api/raw-data/export/app/{app_id}/in_app_events_report/v5` — raw in-app event rows, needed to join revenue and funnel events to media source (high)
 - [x] `/api/master-agg-data/v4/app/{app_id} (Master API)` — single aggregated cross-app report with cohort KPIs, the vendor's recommended aggregate feed (high)
 - [x] `/api/raw-data/export/app/{app_id}/ad_revenue_raw/v5 (plus organic and retargeting variants)` — ad monetization revenue per user, missing entirely from the aggregate reports (high)
-- [ ] `/api/raw-data/export/app/{app_id}/uninstall_events_report/v5` — uninstall events, required for retention and LTV net of churn (high)
-- [ ] `/api/raw-data/export/app/{app_id}/organic_installs_report/v5 and organic_in_app_events_report/v5` — organic baseline without which paid lift cannot be computed (high)
-- [ ] `/api/raw-data/export/app/{app_id}/installs_retarget/v5 and in_app_events_retarget/v5` — retargeting conversions, reported separately from UA and otherwise invisible (high)
-- [ ] `/api/raw-data/export/app/{app_id}/blocked_installs_report/v5, blocked_in_app_events_report/v5, detection/v5` — Protect360 fraud rows explaining gaps between gross and attributed installs (medium)
+- [x] `/api/raw-data/export/app/{app_id}/uninstall_events_report/v5` — uninstall events, required for retention and LTV net of churn (high)
+- [x] `/api/raw-data/export/app/{app_id}/organic_installs_report/v5 and organic_in_app_events_report/v5` — organic baseline without which paid lift cannot be computed (high)
+- [x] `/api/raw-data/export/app/{app_id}/installs-retarget/v5 and in-app-events-retarget/v5` — retargeting conversions, reported separately from UA and otherwise invisible (high)
+- [x] `/api/raw-data/export/app/{app_id}/blocked_installs_report/v5, blocked_in_app_events_report/v5, detection/v5` — Protect360 fraud rows explaining gaps between gross and attributed installs (medium)
 - [ ] `SKAN aggregate performance report and SKAN raw postbacks (skan-agg-performance-report, skan-pull-cs)` — the only iOS 14+ attribution signal for a large share of traffic (medium)
 - [ ] `/api/raw-data/export/app/{app_id}/postbacks/v5 (install, in-app-event and retargeting postbacks)` — partner postback delivery records for reconciling AppsFlyer against network dashboards (medium)
 - [ ] `/api/raw-data/export/app/{app_id}/reinstalls/v5 and reinstalls_organic/v5` — reinstall/resurrection cohorts, a distinct lifecycle state from installs (medium)
 - [ ] `/api/agg-data/export/app/{app_id}/geo_by_date_report/v5 and partners_by_date_report/v5` — daily time series of the geo and partner breakdowns we currently sync only as period totals (medium)
 
-Note: PostHog exposes three aggregate Pull API v5 reports (daily, geo, partners), the raw-data install and in-app-event reports, all three ad revenue raw reports, and the Master API LTV report. Still absent: uninstalls, reinstalls, the organic install/event baseline, retargeting conversions, Protect360 fraud, SKAN and the partner postback reports. Reference index enumerated from the docs nav (~160 slugs).
+Note: PostHog exposes three aggregate Pull API v5 reports (daily, geo, partners), the raw-data install and in-app-event reports in their non-organic, organic and retargeting variants, uninstalls, all three ad revenue raw reports, the Protect360 blocked-install, blocked-event and post-attribution reports, and the Master API LTV report. Still absent: reinstalls, SKAN and the partner postback reports. The retargeting slugs are hyphenated (`installs-retarget`, `in-app-events-retarget`), not underscored as listed above. Reference index enumerated from the docs nav (~160 slugs).
 
 ## Appsignal — gaps
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/appsflyer/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/appsflyer/canonical_descriptions.py
@@ -78,6 +78,24 @@ _RAW_COLUMNS = {
     "idfv": "Apple vendor identifier of the device.",
 }
 
+# Protect360 adds its fraud classification on top of the shared raw schema.
+_BLOCKED_COLUMNS = {
+    **_RAW_COLUMNS,
+    "blocked_reason": "Category of fraud the install or event was blocked for.",
+    "blocked_sub_reason": "More specific fraud classification within the blocked reason.",
+    "blocked_reason_value": "Value that triggered the fraud rule, such as the site id or IP address.",
+    "rejected_reason": "Reason the record was rejected, when it was rejected rather than blocked.",
+    "rejected_reason_value": "Value that triggered the rejection.",
+}
+
+_POST_ATTRIBUTION_COLUMNS = {
+    **_RAW_COLUMNS,
+    "detection_date": "Date AppsFlyer identified the install as fraudulent, after it had been attributed.",
+    "fraud_reason": "Category of fraud AppsFlyer assigned to the install.",
+    "rejected_reason": "Reason the install was rejected from attribution.",
+    "rejected_reason_value": "Value that triggered the rejection.",
+}
+
 _AD_REVENUE_COLUMNS = {
     **_RAW_COLUMNS,
     "monetization_network": "Ad network that paid for the impressions.",
@@ -114,6 +132,46 @@ CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
         "description": "One row per in-app event from an attributed user, carrying the event name, value and revenue alongside the install's attribution.",
         "docs_url": "https://dev.appsflyer.com/hc/reference/get_app-id-in-app-events-report-v5",
         "columns": _RAW_COLUMNS,
+    },
+    "installs_organic": {
+        "description": "One row per organic install — users who found the app themselves, the baseline paid campaigns are measured against.",
+        "docs_url": "https://dev.appsflyer.com/hc/reference/get_app-id-organic-installs-report-v5",
+        "columns": _RAW_COLUMNS,
+    },
+    "installs_retargeting": {
+        "description": "One row per retargeting conversion, where an existing user was brought back by a retargeting campaign rather than newly acquired.",
+        "docs_url": "https://dev.appsflyer.com/hc/reference/get_app-id-installs-retarget-v5",
+        "columns": _RAW_COLUMNS,
+    },
+    "in_app_events_organic": {
+        "description": "One row per in-app event from an organic user, carrying the event name, value and revenue.",
+        "docs_url": "https://dev.appsflyer.com/hc/reference/get_app-id-organic-in-app-events-report-v5",
+        "columns": _RAW_COLUMNS,
+    },
+    "in_app_events_retargeting": {
+        "description": "One row per in-app event from a user attributed to a retargeting campaign.",
+        "docs_url": "https://dev.appsflyer.com/hc/reference/get_app-id-in-app-events-retarget-v5",
+        "columns": _RAW_COLUMNS,
+    },
+    "uninstall_events": {
+        "description": "One row per uninstall AppsFlyer measured, with the attribution of the install it ends.",
+        "docs_url": "https://dev.appsflyer.com/hc/reference/get_app-id-uninstall-events-report-v5",
+        "columns": _RAW_COLUMNS,
+    },
+    "blocked_installs": {
+        "description": "Protect360 installs blocked as fraud in real time, so they were never attributed. Explains part of the gap between gross and attributed installs.",
+        "docs_url": "https://dev.appsflyer.com/hc/reference/get_app-id-blocked-installs-report-v5",
+        "columns": _BLOCKED_COLUMNS,
+    },
+    "blocked_in_app_events": {
+        "description": "Protect360 in-app events blocked as fraud, with the rule that blocked each one.",
+        "docs_url": "https://dev.appsflyer.com/hc/reference/get_app-id-blocked-in-app-events-report-v5",
+        "columns": _BLOCKED_COLUMNS,
+    },
+    "post_attribution_installs": {
+        "description": "Protect360 installs that were attributed first and found to be fraudulent later, with the date the fraud was detected.",
+        "docs_url": "https://dev.appsflyer.com/hc/reference/get_app-id-detection-v5",
+        "columns": _POST_ATTRIBUTION_COLUMNS,
     },
     "ad_revenue": {
         "description": "Ad monetization revenue per user for attributed installs, aggregated by monetization network, ad unit and placement.",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/appsflyer/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/appsflyer/settings.py
@@ -69,7 +69,24 @@ _MASTER_KPIS = (
 _AD_REVENUE_ADDITIONAL_FIELDS = ("monetization_network", "ad_unit", "placement", "impressions")
 
 _RAW_EVENT_PRIMARY_KEYS = ["appsflyer_id", "event_time"]
+_IN_APP_EVENT_PRIMARY_KEYS = [*_RAW_EVENT_PRIMARY_KEYS, "event_name"]
 _AD_REVENUE_PRIMARY_KEYS = [*_RAW_EVENT_PRIMARY_KEYS, "monetization_network", "ad_unit", "placement"]
+
+# Protect360's fraud classification rides on additional_fields rather than the standard raw
+# schema, so ask for it by name: without it a blocked row says nothing about why it was blocked.
+_BLOCKED_ADDITIONAL_FIELDS = (
+    "blocked_reason",
+    "blocked_sub_reason",
+    "blocked_reason_value",
+    "rejected_reason",
+    "rejected_reason_value",
+)
+_POST_ATTRIBUTION_ADDITIONAL_FIELDS = (
+    "detection_date",
+    "fraud_reason",
+    "rejected_reason",
+    "rejected_reason_value",
+)
 
 
 @frozen
@@ -118,14 +135,93 @@ APPSFLYER_ENDPOINTS: dict[str, AppsFlyerEndpointConfig] = {
         partition_key="event_time",
         partition_format="day",
     ),
+    "installs_organic": AppsFlyerEndpointConfig(
+        name="installs_organic",
+        report="organic_installs_report",
+        kind=AppsFlyerReportKind.RAW,
+        primary_keys=list(_RAW_EVENT_PRIMARY_KEYS),
+        incremental_fields=list(_EVENT_TIME_INCREMENTAL_FIELDS),
+        partition_key="event_time",
+        partition_format="day",
+    ),
+    "installs_retargeting": AppsFlyerEndpointConfig(
+        name="installs_retargeting",
+        report="installs-retarget",
+        kind=AppsFlyerReportKind.RAW,
+        primary_keys=list(_RAW_EVENT_PRIMARY_KEYS),
+        incremental_fields=list(_EVENT_TIME_INCREMENTAL_FIELDS),
+        partition_key="event_time",
+        partition_format="day",
+    ),
     "in_app_events": AppsFlyerEndpointConfig(
         name="in_app_events",
         report="in_app_events_report",
         kind=AppsFlyerReportKind.RAW,
-        primary_keys=[*_RAW_EVENT_PRIMARY_KEYS, "event_name"],
+        primary_keys=list(_IN_APP_EVENT_PRIMARY_KEYS),
         incremental_fields=list(_EVENT_TIME_INCREMENTAL_FIELDS),
         partition_key="event_time",
         partition_format="day",
+    ),
+    "in_app_events_organic": AppsFlyerEndpointConfig(
+        name="in_app_events_organic",
+        report="organic_in_app_events_report",
+        kind=AppsFlyerReportKind.RAW,
+        primary_keys=list(_IN_APP_EVENT_PRIMARY_KEYS),
+        incremental_fields=list(_EVENT_TIME_INCREMENTAL_FIELDS),
+        partition_key="event_time",
+        partition_format="day",
+    ),
+    "in_app_events_retargeting": AppsFlyerEndpointConfig(
+        name="in_app_events_retargeting",
+        report="in-app-events-retarget",
+        kind=AppsFlyerReportKind.RAW,
+        primary_keys=list(_IN_APP_EVENT_PRIMARY_KEYS),
+        incremental_fields=list(_EVENT_TIME_INCREMENTAL_FIELDS),
+        partition_key="event_time",
+        partition_format="day",
+    ),
+    "uninstall_events": AppsFlyerEndpointConfig(
+        name="uninstall_events",
+        report="uninstall_events_report",
+        kind=AppsFlyerReportKind.RAW,
+        primary_keys=list(_RAW_EVENT_PRIMARY_KEYS),
+        incremental_fields=list(_EVENT_TIME_INCREMENTAL_FIELDS),
+        partition_key="event_time",
+        partition_format="day",
+    ),
+    "blocked_installs": AppsFlyerEndpointConfig(
+        name="blocked_installs",
+        report="blocked_installs_report",
+        kind=AppsFlyerReportKind.RAW,
+        primary_keys=list(_RAW_EVENT_PRIMARY_KEYS),
+        incremental_fields=list(_EVENT_TIME_INCREMENTAL_FIELDS),
+        partition_key="event_time",
+        partition_format="day",
+        extra_params={"additional_fields": ",".join(_BLOCKED_ADDITIONAL_FIELDS)},
+    ),
+    "blocked_in_app_events": AppsFlyerEndpointConfig(
+        name="blocked_in_app_events",
+        report="blocked_in_app_events_report",
+        kind=AppsFlyerReportKind.RAW,
+        primary_keys=list(_IN_APP_EVENT_PRIMARY_KEYS),
+        incremental_fields=list(_EVENT_TIME_INCREMENTAL_FIELDS),
+        partition_key="event_time",
+        partition_format="day",
+        extra_params={"additional_fields": ",".join(_BLOCKED_ADDITIONAL_FIELDS)},
+    ),
+    "post_attribution_installs": AppsFlyerEndpointConfig(
+        name="post_attribution_installs",
+        report="detection",
+        kind=AppsFlyerReportKind.RAW,
+        primary_keys=list(_RAW_EVENT_PRIMARY_KEYS),
+        # Rows appear here only once fraud is found, which is after the install they describe, so
+        # the report keeps growing backwards in event time. The from/to window filters on event
+        # time, not detection date, so an event-time watermark would skip every late detection —
+        # full refresh over the raw lookback is the only way to see them.
+        incremental_fields=[],
+        partition_key="event_time",
+        partition_format="day",
+        extra_params={"additional_fields": ",".join(_POST_ATTRIBUTION_ADDITIONAL_FIELDS)},
     ),
     "ad_revenue": AppsFlyerEndpointConfig(
         name="ad_revenue",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/appsflyer/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/appsflyer/source.py
@@ -81,7 +81,7 @@ class AppsFlyerSource(SimpleSource[AppsFlyerSourceConfig]):
 
 You can find your API token (V2) in AppsFlyer under your account menu > Security center > AppsFlyer API tokens. The app id is your app's identifier as shown in the dashboard (e.g. `id123456789` for iOS or the package name for Android). Add one source per app.
 
-Raw data tables (installs, in-app events and ad revenue) and the Master API report need an AppsFlyer subscription that covers them, and AppsFlyer limits raw data to the last 90 days.""",
+Raw data tables (installs, in-app events, uninstalls, retargeting conversions, ad revenue and the Protect360 fraud reports) and the Master API report need an AppsFlyer subscription that covers them. Protect360 is a separate add-on. AppsFlyer limits raw data to the last 90 days.""",
             iconPath="/static/services/appsflyer.png",
             docsUrl="https://posthog.com/docs/cdp/sources/appsflyer",
             releaseStatus=ReleaseStatus.ALPHA,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/appsflyer/tests/test_appsflyer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/appsflyer/tests/test_appsflyer.py
@@ -218,7 +218,17 @@ class TestGetRows:
             ("geo_report", "/api/agg-data/export/app/id123/geo_by_date_report/v5"),
             ("partners_report", "/api/agg-data/export/app/id123/partners_by_date_report/v5"),
             ("installs", "/api/raw-data/export/app/id123/installs_report/v5"),
+            ("installs_organic", "/api/raw-data/export/app/id123/organic_installs_report/v5"),
+            # AppsFlyer spells the retargeting slugs with hyphens while every other raw report
+            # uses underscores, so a "consistent" rename here 404s.
+            ("installs_retargeting", "/api/raw-data/export/app/id123/installs-retarget/v5"),
             ("in_app_events", "/api/raw-data/export/app/id123/in_app_events_report/v5"),
+            ("in_app_events_organic", "/api/raw-data/export/app/id123/organic_in_app_events_report/v5"),
+            ("in_app_events_retargeting", "/api/raw-data/export/app/id123/in-app-events-retarget/v5"),
+            ("uninstall_events", "/api/raw-data/export/app/id123/uninstall_events_report/v5"),
+            ("blocked_installs", "/api/raw-data/export/app/id123/blocked_installs_report/v5"),
+            ("blocked_in_app_events", "/api/raw-data/export/app/id123/blocked_in_app_events_report/v5"),
+            ("post_attribution_installs", "/api/raw-data/export/app/id123/detection/v5"),
             ("ad_revenue", "/api/raw-data/export/app/id123/ad_revenue_raw/v5"),
             ("ad_revenue_organic", "/api/raw-data/export/app/id123/ad_revenue_organic_raw/v5"),
             ("ad_revenue_retargeting", "/api/raw-data/export/app/id123/ad-revenue-raw-retarget/v5"),
@@ -373,6 +383,26 @@ class TestRawAndMasterWindows:
         requested = set(query["additional_fields"][0].split(","))
         assert {"monetization_network", "ad_unit", "placement"} <= requested
         assert set(APPSFLYER_ENDPOINTS["ad_revenue"].primary_keys) - {"appsflyer_id", "event_time"} <= requested
+
+    @pytest.mark.parametrize(
+        "endpoint, expected_field",
+        [
+            ("blocked_installs", "blocked_reason"),
+            ("blocked_in_app_events", "blocked_reason"),
+            ("post_attribution_installs", "fraud_reason"),
+            ("post_attribution_installs", "detection_date"),
+        ],
+    )
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_protect360_pull_requests_its_fraud_columns(self, mock_session, endpoint, expected_field):
+        # The fraud classification is an additional field, so a report pulled without asking for it
+        # comes back saying nothing about why the row was blocked.
+        mock_session.return_value.get.side_effect = _serve()
+
+        list(get_rows("token", "id123", endpoint, mock.MagicMock()))
+
+        query = parse_qs(urlparse(mock_session.return_value.get.call_args.args[0]).query)
+        assert expected_field in query["additional_fields"][0].split(",")
 
     @mock.patch(f"{_MODULE}.make_tracked_session")
     def test_master_pull_sends_groupings_and_kpis(self, mock_session):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/appsflyer/tests/test_appsflyer_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/appsflyer/tests/test_appsflyer_source.py
@@ -56,9 +56,12 @@ class TestAppsFlyerSource:
         schemas = self.source.get_schemas(self.config, self.team_id)
 
         assert {schema.name for schema in schemas} == set(ENDPOINTS)
-        # Every aggregate report takes a server-side from/to date window.
-        assert all(schema.supports_incremental for schema in schemas)
-        assert all(schema.supports_append for schema in schemas)
+        # Every report takes a server-side from/to window on a timestamp that only moves forward,
+        # except post-attribution installs: fraud is found after the install it describes, so that
+        # one has to be pulled in full or late detections are never seen.
+        full_refresh_only = {"post_attribution_installs"}
+        assert {schema.name for schema in schemas if not schema.supports_incremental} == full_refresh_only
+        assert {schema.name for schema in schemas if not schema.supports_append} == full_refresh_only
 
     @mock.patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.appsflyer.source.validate_appsflyer_credentials"


### PR DESCRIPTION
## Problem

- Anyone syncing AppsFlyer into the warehouse sees only paid installs and paid in-app events, so organic activity, retargeting conversions, uninstalls and blocked fraud have no table at all.
- Without the organic baseline, paid lift cannot be computed: the source has no row for a user who found the app without a campaign.
- Without uninstalls, retention and lifetime value cannot be taken net of churn.
- Retargeting conversions are reported on their own endpoints, so they are invisible today rather than merged into the install tables.
- Protect360 blocked rows explain part of the gap between gross and attributed installs, and nothing in the source surfaces them.

These are long-standing gaps from `COVERAGE_GAPS_APPENDIX.md`, not a new vendor release.

## Changes

- Eight new tables appear in the AppsFlyer schema picker: `installs_organic`, `installs_retargeting`, `in_app_events_organic`, `in_app_events_retargeting`, `uninstall_events`, `blocked_installs`, `blocked_in_app_events` and `post_attribution_installs`.
- Seven of them sync incrementally on `event_time`, the same server-side window the existing raw reports use.
- `post_attribution_installs` syncs full refresh only. The report gains rows when fraud is found after attribution, and the from/to window filters on event time rather than detection date, so an event-time watermark would silently skip every late detection.
- The Protect360 tables request their fraud classification through `additional_fields`, because `blocked_reason` and `fraud_reason` are not in the standard raw schema.
- The source caption now names the wider raw table set and states that Protect360 is a separate AppsFlyer add-on.
- Mechanical: canonical column descriptions for the new tables, and the appendix checkboxes.

No endpoint from the audit list was skipped. Two slugs in the audit were wrong: the retargeting reports are `installs-retarget` and `in-app-events-retarget`, hyphenated, not `installs_retarget` / `in_app_events_retarget`. Each path was read off the vendor reference before wiring, and the appendix note records the correction.

Nothing renders differently in the UI beyond the new table names and the caption text, so no screenshot applies.

## How did you test this code?

- Extended the existing slug table in `test_appsflyer.py` with the eight new paths. This catches a wrong report slug, which is the only failure mode the code cannot show on its own, and the hyphenated retargeting slugs are the case a "consistent" rename would break.
- Added a parameterized case asserting the Protect360 pulls request `blocked_reason`, `fraud_reason` and `detection_date`. Without those columns the tables carry no fraud classification and nothing else would fail.
- Changed `test_get_schemas` to pin which endpoints are full refresh only. This catches someone advertising an event-time cursor on `post_attribution_installs`, which would drop late detections with no error.
- Ran the AppsFlyer suite and the shared `sources/tests` suite locally.
- Not run: anything against the live AppsFlyer API. No account or token was available in this sandbox, so every endpoint path, query parameter and freshness claim comes from the vendor reference rather than a response.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The posthog.com AppsFlyer page renders its table list from `public_source_configs`, so the new tables and their descriptions appear there without a docs change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude Opus 5 in a PostHog Desktop cloud task, from the AppsFlyer entry in `COVERAGE_GAPS_APPENDIX.md`. Skills invoked: `/implementing-warehouse-sources`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`. The CodeRabbit local pass is paused, so this PR opened without one.

Each of the seven endpoints was checked against the vendor's own reference pages before any code was written, which is where the two wrong retargeting slugs surfaced. The post-attribution report started out wired like every other raw report, on an `event_time` cursor; reading what the report actually contains showed that its rows arrive backwards in event time, so it became full refresh instead.

No duplicate: `gh pr list --state open` found no PR touching the AppsFlyer source. The maintainer's open PRs were listed and read for branch prefix; none of them covers this.

Public artifact: everything here comes from this repository and the vendor's public API reference. No customer or session material is in the diff or this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
