### PR TITLE
fix(app_store_connect): say which role fixes a rejected table

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/source.py
@@ -1,5 +1,7 @@
 from typing import Optional, cast
 
+import structlog
+
 from posthog.schema import (
     DataWarehouseSourceCategory,
     ExternalDataSourceType as SchemaExternalDataSourceType,
@@ -43,6 +45,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.generated_
     AppStoreConnectSourceConfig,
 )
 from products.warehouse_sources.backend.types import ExternalDataSourceType
+
+logger = structlog.get_logger(__name__)
+
+_UNEXPECTED_PROBE_STATUS = "App Store Connect is not answering correctly right now. Wait a few minutes, then try again."
 
 _MISSING_VENDOR_NUMBER = (
     "Add your vendor number in the source settings to sync sales and subscription reports. "
@@ -251,9 +257,12 @@ Leave **app IDs** blank to sync every app the key can read. To sync only some of
             # reports what it can't reach, so don't block source creation on it.
             return True, None
         if status == 403:
-            return False, "Your App Store Connect API key does not have permission to read this data."
+            return False, APP_STORE_CONNECT_READ_FORBIDDEN_ERROR
         if status != 200:
-            return False, f"App Store Connect returned status {status}"
+            # Apple answers a signed probe with 429 or a 5xx when it is busy. The status itself means
+            # nothing to the user, so keep it in the log and tell them what to do instead.
+            logger.warning("app_store_connect_credential_probe_unexpected_status", status=status)
+            return False, _UNEXPECTED_PROBE_STATUS
 
         # Create and edit only: the per-schema call runs once per table in the picker, and each
         # would list every app again.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/tests/test_app_store_connect_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/tests/test_app_store_connect_source.py
@@ -172,6 +172,8 @@ class TestAppStoreConnectSource:
 
         assert valid is expected_valid
         assert (error is None) is expected_valid
+        # The message is read in the source wizard, where an HTTP status tells the user nothing.
+        assert status is None or error is None or str(status) not in error
 
     def test_forbidden_is_accepted_at_source_create_but_not_per_schema(self) -> None:
         source = AppStoreConnectSource()
@@ -182,8 +184,8 @@ class TestAppStoreConnectSource:
 
         # A key whose role can't read `/v1/apps` is still a real key, so source creation must not fail.
         assert (created, create_error) == (True, None)
-        assert per_schema is False
-        assert schema_error is not None
+        # Naming the roles that can read the table is the only way out of this one.
+        assert (per_schema, schema_error) == (False, APP_STORE_CONNECT_READ_FORBIDDEN_ERROR)
 
     def test_an_unreadable_app_id_blocks_the_source_with_the_probe_message(self) -> None:
         probe_message = "This API key cannot read these app IDs: 999. It can read: Acme (1234567890)."


### PR DESCRIPTION
## Problem

A user connecting App Store Connect sees "Your App Store Connect API key does not have permission to read this data." on the tables their key cannot reach, and the message stops there. Apple gates each table behind a key role, so the user has no way to know that changing the key's role is the fix, and the tables stay unavailable.

- The same failure during a sync already resolves to a message that names the roles: "Give the key the Admin, Finance, or Sales role that can read it, then reconnect."
- The wizard's own copy for it is a truncated variant, so one problem reads two ways.
- An unexpected probe status renders as "App Store Connect returned status 503", which is a number the user cannot act on.

## Changes

- The table-level permission error now names the roles that can read the table, in the wording the sync path already uses.
- An unexpected status from Apple's credential probe now reads "App Store Connect is not answering correctly right now. Wait a few minutes, then try again." The status goes to the log.
- Source creation still passes with a key that cannot read `/v1/apps`. No validation outcome changes, only the text.

Nothing about sync behavior, schemas, or which tables validate changes.

## How did you test this code?

- `pytest products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/tests/test_app_store_connect_source.py` locally.
- The per-schema 403 test now pins the message to the shared constant. It caught nothing before: it asserted only that some message existed, so the truncated copy passed.
- The status-mapping test now asserts the status number never reaches the visible message.
- Not run: the app was not started, so the wizard was not exercised by hand.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude Code (PostHog Desktop) from a Replay Vision scan of the data warehouse new-source onboarding flow. One scanned session showed a user hitting an App Store Connect credential error whose next step was missing, then working around it by hand.

Skills invoked: `/writing-pr-descriptions`. The CodeRabbit local pass is paused, so this PR opened without one.

No duplicate: `gh pr list --state open --search "app store connect"` and a pass over the open warehouse-source PRs found nothing touching this validation path.

Public artifact: the diff carries no material from the session. The scan observations stayed out of the code, the tests, and this description.
