### PR TITLE
fix(data-warehouse): separate a failed account load from an empty account list

### DIFF
--- a/products/data_warehouse/frontend/shared/components/forms/IntegrationAccountSelector.test.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/IntegrationAccountSelector.test.tsx
@@ -1,0 +1,12 @@
+import { accountsDropdownEmptyMessage } from './IntegrationAccountSelector'
+
+describe('IntegrationAccountSelector', () => {
+    // A failed listing request leaves the same empty list as a connection that reaches no accounts,
+    // and the picker used to report both as the second one.
+    it('separates a failed account listing from a connection with no accounts', () => {
+        expect(accountsDropdownEmptyMessage('Reconnect your Google account.')).not.toEqual(
+            accountsDropdownEmptyMessage(null)
+        )
+        expect(accountsDropdownEmptyMessage(null)).toContain('No accounts accessible')
+    })
+})

--- a/products/data_warehouse/frontend/shared/components/forms/IntegrationAccountSelector.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/IntegrationAccountSelector.tsx
@@ -88,6 +88,15 @@ export function normalizeMultiValue(value: unknown, legacySingle?: unknown): str
     return normalized
 }
 
+/** What the picker's dropdown says when it has no accounts to list. A failed listing request also
+ *  leaves the list empty, and claiming the connection reaches no accounts sends the user to fix
+ *  permissions they never lost. */
+export function accountsDropdownEmptyMessage(accountsError: string | null): string {
+    return accountsError
+        ? "Couldn't load your accounts. Reconnect the integration, or type the value in above."
+        : 'No accounts accessible by this integration.'
+}
+
 /** Generic account/resource picker for OAuth ad sources: a dropdown of the connected integration's
  *  accounts (shared IntegrationAccount contract), falling back to a text input until one is connected. */
 export function IntegrationAccountSelector(props: IntegrationAccountSelectorProps): JSX.Element {
@@ -496,7 +505,7 @@ function IntegrationAccountFieldWithDropdown({
                             suggestionsLoading={accountsLoading}
                             onSearchChange={setSearch}
                             searchPlaceholder="Filter accounts…"
-                            emptyMessage="No accounts accessible by this integration."
+                            emptyMessage={accountsDropdownEmptyMessage(accountsError)}
                             noMatchMessage={() =>
                                 'No accounts match your filter. Clear it to see every account this connection can reach.'
                             }


### PR DESCRIPTION
## Problem

A user finishing an OAuth handoff in the new-source wizard opens the account picker and reads "No accounts accessible by this integration." even when the request that fetches those accounts failed. The connection may be fine. The user goes back to the provider to grant access they never lost, and the source never gets created.

- The picker derives its dropdown message from an empty list alone.
- A failed request leaves the same empty list as a connection that genuinely reaches no accounts.
- The real reason does render under the field, but the dropdown opens on focus and states the opposite above it.

## Changes

- The dropdown now says "Couldn't load your accounts. Reconnect the integration, or type the value in above." when the listing request failed.
- The wording for a connection that genuinely reaches no accounts does not change.
- No request, retry, or validation behavior changes. The field still accepts a typed value in both cases.

Nothing else about the wizard changes, so there is no visual difference to screenshot beyond this one string.

## How did you test this code?

- `jest products/data_warehouse/frontend/shared/components/forms/IntegrationAccountSelector.test.tsx` locally.
- The new test catches the regression this PR fixes: the two states resolving to one message. No existing test covered the picker's empty slot.
- `pnpm --filter=@posthog/frontend typescript:check` reports nothing on the touched files.
- Not run: the app was not started, so the picker was not exercised against a live integration.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude Code (PostHog Desktop) from a Replay Vision scan of the data warehouse new-source onboarding flow. One scanned session showed a user complete an OAuth handoff, hit failed account-listing requests, and read the empty-list message as a permission problem.

Skills invoked: `/writing-pr-descriptions`, `/writing-ui-components`. The CodeRabbit local pass is paused, so this PR opened without one.

The message is a small exported function rather than an inline ternary, so the two branches can be tested without mounting the kea logic behind the picker.

No duplicate: searches over open PRs for the account picker, the integration selector, and OAuth account listing found nothing on this path.

Public artifact: the diff carries no material from the session. The scan observations stayed out of the code, the test, and this description.
