### PR TITLE
fix(signals): align inbox pr filters with report reader

### DIFF
--- a/products/signals/backend/implementation_pr.py
+++ b/products/signals/backend/implementation_pr.py
@@ -20,8 +20,14 @@ from products.signals.backend.models import (
     SignalReportArtefact,
     SignalReportAssignment,
     SignalReportPullRequest,
+    SignalReportTask,
 )
-from products.signals.backend.task_run_artefacts import NON_PR_BEARING_TASK_RUN_TYPES, SIGNALS_PRODUCT
+from products.signals.backend.task_run_artefacts import (
+    NON_PR_BEARING_TASK_RUN_TYPES,
+    SIGNALS_PRODUCT,
+    TASK_RUN_TYPE_DISCUSSION,
+    TASK_RUN_TYPE_IMPLEMENTATION,
+)
 from products.tasks.backend.facade import api as tasks_facade
 
 logger = structlog.get_logger(__name__)
@@ -34,6 +40,68 @@ if TYPE_CHECKING:
 _FINISHED_REPORT_STATUSES = frozenset(
     {SignalReport.Status.RESOLVED, SignalReport.Status.SUPPRESSED, SignalReport.Status.DELETED}
 )
+
+_PULL_REQUEST_URL_BODY = (
+    r"[A-Za-z][A-Za-z0-9+.-]*://(www\.)?github\.com/+[^/?#]+/+[^/?#]+/+pull/+[+-]?[ \t\r\n\f\v]*[0-9]+"
+)
+_PULL_REQUEST_URL_PATTERN = rf"^{_PULL_REQUEST_URL_BODY}([/?#].*)?$"
+_PULL_REQUEST_URL_ARRAY_PATTERN = rf'"{_PULL_REQUEST_URL_BODY}([/?#][^"]*)?"'
+_PR_BEARING_LEGACY_TASK_RELATIONSHIPS = (TASK_RUN_TYPE_IMPLEMENTATION, TASK_RUN_TYPE_DISCUSSION)
+
+
+def implementation_pr_report_filter(*, team_id: int, active_only: bool = False) -> Q:
+    assignment_pr = Q(assignment__team_id=team_id, assignment__pr_url__regex=_PULL_REQUEST_URL_PATTERN)
+    pull_request_links = SignalReportArtefact.objects.filter(
+        team_id=team_id,
+        type=SignalReportArtefact.ArtefactType.PULL_REQUEST,
+        pull_request__team_id=team_id,
+        pull_request__url__regex=_PULL_REQUEST_URL_PATTERN,
+    )
+    task_ids = tasks_facade.task_ids_with_pr_url_subquery(
+        team_id,
+        pr_bearing_task_run_filter(),
+        Q(output__pr_url__regex=_PULL_REQUEST_URL_PATTERN) | Q(output__pr_urls__regex=_PULL_REQUEST_URL_ARRAY_PATTERN),
+    )
+    task_run_artefacts = (
+        SignalReportArtefact.objects.filter(
+            team_id=team_id,
+            type=SignalReportArtefact.ArtefactType.TASK_RUN,
+            task_id__in=task_ids,
+            content__regex=rf'"product"\s*:\s*"{SIGNALS_PRODUCT}"',
+        )
+        .exclude(content__regex=rf'"type"\s*:\s*"({"|".join(sorted(NON_PR_BEARING_TASK_RUN_TYPES))})"')
+        .values("report_id")
+    )
+    legacy_tasks = SignalReportTask.objects.filter(
+        team_id=team_id,
+        task_id__in=task_ids,
+        relationship__in=_PR_BEARING_LEGACY_TASK_RELATIONSHIPS,
+    ).values("report_id")
+    assignment_tasks = SignalReportAssignment.all_teams.filter(
+        team_id=team_id,
+        actor_task_id__in=task_ids,
+    ).values("report_id")
+
+    if active_only:
+        active_states = [
+            SignalReportAssignment.PrState.UNKNOWN,
+            SignalReportAssignment.PrState.DRAFT,
+            SignalReportAssignment.PrState.OPEN,
+        ]
+        assignment_pr &= Q(assignment__pr_merged=False) & (
+            Q(assignment__pr_state__isnull=True)
+            | Q(assignment__pr_state="")
+            | Q(assignment__pr_state__in=active_states)
+        )
+        pull_request_links = pull_request_links.filter(pull_request__state__in=active_states)
+
+    return (
+        assignment_pr
+        | Q(id__in=pull_request_links.values("report_id"))
+        | Q(id__in=task_run_artefacts)
+        | Q(id__in=legacy_tasks)
+        | Q(id__in=assignment_tasks)
+    )
 
 
 @frozen

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -58,6 +58,7 @@ from products.signals.backend.models import (
 from products.signals.backend.signal_metadata import ReportSignalMeta
 from products.signals.backend.task_run_artefacts import (
     TASK_RUN_TYPE_IMPLEMENTATION,
+    TASK_RUN_TYPE_RESEARCH,
     append_task_run_artefact,
     record_implementation_task,
     record_report_task,
@@ -1183,6 +1184,60 @@ class TestSignalReportListAPI(APIBaseTest):
         assert str(report.id) in {item["id"] for item in with_pr.json()["results"]}
         unclaimed = self.client.get(self._list_url(unclaimed="true"))
         assert str(report.id) not in {item["id"] for item in unclaimed.json()["results"]}
+
+    def test_legacy_research_task_pr_does_not_match_implementation_pr_filters(self):
+        Task = apps.get_model("tasks", "Task")
+        TaskRun = apps.get_model("tasks", "TaskRun")
+        report = self._create_report(status=SignalReport.Status.IN_PROGRESS)
+        task = Task.objects.create(
+            team=self.team,
+            title="Research task",
+            description="Investigate the report",
+            origin_product=Task.OriginProduct.SIGNAL_REPORT,
+        )
+        SignalReportTask.objects.create(
+            team=self.team,
+            report=report,
+            task=task,
+            relationship=TASK_RUN_TYPE_RESEARCH,
+        )
+        run = TaskRun.objects.create(
+            team=self.team,
+            task=task,
+            status=TaskRun.Status.COMPLETED,
+            output={},
+            state={},
+        )
+        TaskRun.objects.filter(pk=run.pk).update(output={"pr_url": "https://github.com/example/repo/pull/7"})
+
+        list_response = self.client.get(self._list_url(include_all_statuses="true"))
+        list_row = next(row for row in list_response.json()["results"] if row["id"] == str(report.id))
+        detail_response = self.client.get(f"/api/projects/{self.team.id}/signals/reports/{report.id}/")
+
+        assert list_row["pull_requests"] == []
+        assert list_row["implementation_pr_url"] is None
+        assert detail_response.json()["pull_requests"] == []
+        assert detail_response.json()["implementation_pr_url"] is None
+        assert str(report.id) not in {
+            row["id"]
+            for row in self.client.get(
+                self._list_url(include_all_statuses="true", has_implementation_pr="true")
+            ).json()["results"]
+        }
+        assert str(report.id) in {
+            row["id"]
+            for row in self.client.get(
+                self._list_url(include_all_statuses="true", has_implementation_pr="false")
+            ).json()["results"]
+        }
+        assert str(report.id) in {
+            row["id"]
+            for row in self.client.get(self._list_url(include_all_statuses="true", unclaimed="true")).json()["results"]
+        }
+        assert str(report.id) not in {
+            row["id"]
+            for row in self.client.get(self._list_url(include_all_statuses="true", unclaimed="false")).json()["results"]
+        }
 
     @parameterized.expand([("legacy", True, 42), ("migrated", False, 42)])
     def test_distinct_legacy_pr_remains_visible_alongside_task_pr(self, _name, legacy, expected_number):

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -101,7 +101,7 @@ from products.signals.backend.facade.api import emit_signal
 from products.signals.backend.feedback_notes import forward_feedback_note
 from products.signals.backend.implementation_pr import (
     fetch_implementation_prs_for_reports,
-    pr_bearing_task_run_filter,
+    implementation_pr_report_filter,
     primary_pull_request,
     pull_request_matches_id,
 )
@@ -112,7 +112,6 @@ from products.signals.backend.models import (
     SignalReport,
     SignalReportAction,
     SignalReportArtefact,
-    SignalReportAssignment,
     SignalReportRefund,
     SignalSourceConfig,
     SignalTeamConfig,
@@ -1212,20 +1211,7 @@ class SignalReportViewSet(
         ).filter(~has_newer)
 
     def _implementation_pr_report_filter(self):
-        assignment_pr = Q(assignment__pr_url__isnull=False) & ~Q(assignment__pr_url="")
-        task_pr = SignalReport.reports_for_task_ids_filter(
-            tasks_facade.task_ids_with_pr_url_subquery(self.team.id, pr_bearing_task_run_filter()),
-            team_id=self.team.id,
-        )
-        return (
-            assignment_pr
-            | task_pr
-            | Q(
-                id__in=SignalReportArtefact.objects.filter(team_id=self.team.id, pull_request__isnull=False).values(
-                    "report_id"
-                )
-            )
-        )
+        return implementation_pr_report_filter(team_id=self.team.id)
 
     def _apply_signal_report_implementation_pr_filter(self, queryset):
         # `has_implementation_pr=true|false` filters reports by whether an attached
@@ -1259,23 +1245,7 @@ class SignalReportViewSet(
             wants_unclaimed = False
         else:
             raise serializers.ValidationError({"unclaimed": f"Invalid value: {raw!r}. Allowed: true, false."})
-        has_review_pr = Q(
-            assignment__pr_url__isnull=False,
-            assignment__pr_state__in=[
-                SignalReportAssignment.PrState.UNKNOWN,
-                SignalReportAssignment.PrState.DRAFT,
-                SignalReportAssignment.PrState.OPEN,
-            ],
-        ) & ~Q(assignment__pr_url="")
-        task_pr = SignalReport.reports_for_task_ids_filter(
-            tasks_facade.task_ids_with_pr_url_subquery(self.team.id, pr_bearing_task_run_filter()),
-            team_id=self.team.id,
-        )
-        new_links = SignalReportArtefact.objects.filter(team_id=self.team.id, pull_request__isnull=False)
-        active_prs = new_links.filter(pull_request__state__in=["unknown", "draft", "open"])
-        has_review_pr = Q(id__in=active_prs.values("report_id")) | (
-            (~Q(id__in=new_links.values("report_id")) & has_review_pr) | task_pr
-        )
+        has_review_pr = implementation_pr_report_filter(team_id=self.team.id, active_only=True)
         is_unclaimed = (
             ~Q(status=SignalReport.Status.RESOLVED) & ~reports_with_active_claim(team_id=self.team_id) & ~has_review_pr
         )


### PR DESCRIPTION
## Problem

Inbox views can classify a PR URL on a legacy research task as implementation work while report responses show no PR.

## Changes

- Align the PR queryset predicate with the canonical report reader across assignments, pull request artefacts, and task outputs.
- Exclude non-PR task roles, non-PR artefact links, and malformed PR URLs without writing artefacts during reads.
- Apply the shared predicate to `has_implementation_pr` and `unclaimed`.

## How did you test this code?

- `hogli test products/signals/backend/test/test_signal_report_api.py::TestSignalReportListAPI -- --reuse-db`
- `hogli ci:preflight --fix`
- The regression test covers a legacy research task with a stage-less PR-shaped output.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No docs update. The existing API parameter descriptions remain accurate.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex authored the change using `/improving-drf-endpoints`, `/writing-tests`, `/running-ci-preflight`, and `/writing-pr-descriptions`.
- The duplicate search found no open PR for this fix.
- The regression fixture uses invented data only.
- The local CodeRabbit pass is paused.