### PR TITLE
fix(bing_ads): stop reporting egress-proxy 429s on the report download

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/source.py
@@ -170,6 +170,12 @@ class BingAdsSource(ResumableSource[BingAdsSourceConfig, BingAdsResumeConfig], O
             # next Temporal attempt normally clears it. Match the exception name plus urllib's fixed
             # message prefix, which together carry no request or account values.
             "URLError: <urlopen error",
+            # PostHog's own egress proxy answering the CONNECT tunnel with a 429 while the SDK downloads
+            # a finished report, surfaced by requests as a ProxyError. The proxy is throttling itself —
+            # neither Bing nor the customer is at fault — and it clears on its own, the same reasoning
+            # ClickHouse and Salesforce apply to a 502/503/504 tunnel gateway status. Match the status
+            # only; the message also carries a volatile report URL.
+            "Tunnel connection failed: 429",
         }
 
     @property

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_source.py
@@ -379,6 +379,13 @@ class TestBingAdsSource:
             # customer-configured, so a refused connection is a network blip the next attempt clears —
             # it must stay retryable rather than report as a bug or disable the schema.
             "Failed to fetch customer ID: URLError: <urlopen error [Errno 111] Connection refused>",
+            # PostHog's egress proxy throttling the CONNECT tunnel while the SDK downloads a report Bing
+            # has already built. Nothing is wrong with the account or the request, so it must stay
+            # retryable rather than report as a bug or disable the schema.
+            "Failed to generate keyword_performance_report report: ProxyError: "
+            "HTTPSConnectionPool(host='bingadsappsstorageprod.blob.core.windows.net', port=443): "
+            "Max retries exceeded with url: <redacted> (Caused by ProxyError('Cannot connect to proxy.', "
+            "OSError('Tunnel connection failed: 429 Too Many Requests')))",
         ],
     )
     def test_transient_failures_are_retryable_not_disabling(self, error_message):


### PR DESCRIPTION
## Problem

A Bing Ads sync fails and reports as a bug when PostHog's own egress proxy throttles the connection that downloads a finished report ([error tracking issue](https://us.posthog.com/project/2/error_tracking/01a09714-b526-71b1-af29-350b5f16972f)).

- The proxy answers the CONNECT tunnel with `429 Too Many Requests`, which `requests` surfaces as a `ProxyError`.
- `_wrap_with_fault_detail` re-raises it as `ValueError("Failed to generate <resource> report: ProxyError: ...")`.
- Neither Bing nor the customer is at fault, and Temporal's next attempt normally clears it, so the failure is self-recovering noise.

## Changes

- `BingAdsSource.get_retryable_errors` now recognizes `Tunnel connection failed: 429`, so the sync retries with a warning instead of reaching error tracking.
- Matches the status only, the same way ClickHouse and Salesforce classify `502`/`503`/`504` tunnel gateway statuses. The rest of the message carries a volatile report URL.
- Nothing user-visible changes. The customer already reads the transient-egress message from `Transient_Error_Messages`, and the schema stays enabled either way.

## How did you test this code?

- Extended the parametrized transient-failure case in `test_bing_ads_source.py` with a proxy `429` tunnel message, with the report URL redacted.
- The regression: a future edit that narrows this classification would send a self-recovering proxy throttle back to error tracking as a bug.
- Ran `uv run pytest products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_source.py`. Not run: the wider warehouse-sources or Temporal integration suites.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing or documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code, triaging a webhook-delivered error tracking alert for this source.
- Skills invoked: `/writing-pr-descriptions` for this body. No other mandatory-list skill applied (no DRF, migration, frontend, or dataclass change). The CodeRabbit local pass is paused, so this PR opened without one.
- Decision: classified as a transient infrastructure error, not a `NonRetryableErrors` case (nothing the customer can fix) and not a code bug (the download itself is the SDK's, and a fresh attempt re-submits the report). The gap was only in the retryable classification that keeps known-transient failures out of error tracking.
- No duplicate: searched open PRs for `bing_ads`, `ProxyError`, and `Tunnel connection failed 429`, and listed every open PR from this automation's author. [#99646](https://github.com/PostHog/posthog/pull/99646) applies the same fix to the LinkedIn Ads source and does not touch this one.
- Nothing in this PR carries material from the agent session. The test message is a generic shape with the report URL redacted.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
