### PR TITLE
fix(hubspot): stop reporting egress-proxy 429s on the token check

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/source.py
@@ -175,6 +175,12 @@ class HubspotSource(ResumableSource[HubspotSourceConfig | HubspotSourceOldConfig
             # documented rate-limit wording so this self-recovering condition doesn't get tracked
             # as noise once Temporal's activity retry picks it back up.
             "You have reached your rate limit.",
+            # PostHog's own egress proxy answering the CONNECT tunnel with a 429, surfaced by
+            # requests as a ProxyError. Not HubSpot's fault or the customer's — the proxy itself is
+            # throttling, which clears on its own, the same reasoning bing_ads and linkedin_ads apply
+            # to the same tunnel status. Match the status only; the message also carries a volatile
+            # access-token/report URL.
+            "Tunnel connection failed: 429",
         }
 
     # TODO: clean up hubspot job inputs to not have two auth config options

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/test/test_source_routing.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/test/test_source_routing.py
@@ -313,6 +313,11 @@ def test_missing_token_error_is_non_retryable(error_msg: str) -> None:
         "url=https://api.hubapi.com/crm/v4/associations/contacts/deals/batch/read",
         # auth.hubspot_refresh_access_token, exhausted after tenacity's 5 in-process attempts
         "You have reached your rate limit.",
+        # PostHog's own egress proxy throttling the CONNECT tunnel, surfaced by requests as a
+        # ProxyError from hubspot_access_token_is_valid or any other api.hubapi.com call.
+        "HTTPSConnectionPool(host='api.hubapi.com', port=443): Max retries exceeded with url: "
+        "/oauth/v1/access-tokens/redacted (Caused by ProxyError('Cannot connect to proxy.', "
+        "OSError('Tunnel connection failed: 429 Too Many Requests')))",
     ],
 )
 def test_transient_http_error_is_retryable(error_msg: str) -> None:
@@ -320,6 +325,14 @@ def test_transient_http_error_is_retryable(error_msg: str) -> None:
     assert any(pattern in error_msg for pattern in patterns), (
         f"HubSpot error {error_msg!r} did not match any retryable pattern"
     )
+
+
+def test_proxy_auth_rejection_is_not_mistaken_for_tunnel_429() -> None:
+    """A deterministic proxy-auth rejection is not a transient tunnel gateway status — it must
+    stay reportable rather than being swallowed by the 429 tunnel pattern."""
+    error_msg = "Caused by ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 407 Proxy Authentication Required'))"
+    patterns = HubspotSource().get_retryable_errors()
+    assert not any(pattern in error_msg for pattern in patterns)
 
 
 class TestApiVersion:


### PR DESCRIPTION
## Problem

A HubSpot sync using the legacy (non-OAuth-integration) credential path failed and was captured in error tracking as a `ProxyError`, not a HubSpot problem.

The token-validity check (`hubspot_access_token_is_valid`) hit PostHog's own egress proxy while it was throttling the CONNECT tunnel with a 429, which `requests` surfaces as `ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 429 Too Many Requests'))`. Neither HubSpot nor the customer's credentials are at fault, and the condition clears on its own once the proxy stops throttling.

[Error tracking issue](https://us.posthog.com/project/2/error_tracking/01a0971d-da29-7713-aa25-16f563e3fca6)

## Changes

- `HubspotSource.get_retryable_errors()` now matches `Tunnel connection failed: 429`, so this self-recovering condition is logged as a warning and Temporal retries the activity instead of it being reported as a bug.
- Matches the status only, not the request URL, which carries a volatile access token.
- Same reasoning and pattern already applied to `bing_ads` ([#99716](https://github.com/PostHog/posthog/pull/99716)) and `linkedin_ads` ([#99646](https://github.com/PostHog/posthog/pull/99646)) for the identical egress-proxy signature.

Not a fix to the retry behavior itself: Temporal's activity retry already recovers from this once the proxy clears. This only stops the noise from being tracked as a source-code defect.

## How did you test this code?

Added test cases:
- A retryable-pattern match for the exact `ProxyError` message shape seen in the error tracking issue (with the access token redacted).
- A negative-match case for a `407 Proxy Authentication Required` tunnel failure, confirming it is not swallowed by the new 429 pattern (a deterministic proxy-auth rejection must stay reportable).

Ran the full hubspot test suite locally: `pytest products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/test/test_source_routing.py` — 149 passed.
Also ran `ruff check` and `ruff format --diff` on both changed files — clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing or documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a live error-tracking webhook by Claude Code. Confirmed the failure originates in `hubspot/auth.py`'s `hubspot_access_token_is_valid` (called from `hubspot/source.py`'s `source_for_pipeline`) via the full stack trace, then classified it as a transient PostHog-side infrastructure blip rather than a HubSpot or customer credential problem, consistent with the precedent set for `bing_ads` and `linkedin_ads`.

No open PR already covers this signature for `hubspot` (searched by exception type, message substring, and module path, and checked every open PR authored by this automation).
