### PR TITLE
fix(github): stop reporting egress-proxy 429s on the data import sync

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/source.py
@@ -368,7 +368,13 @@ If automatic creation failed with a permissions error, the fix depends on how yo
         # A GithubRetryableError (any transient upstream 5xx) that survives the same tenacity retry
         # gets the same treatment — a GitHub-side outage, not something reconnecting or reconfiguring
         # the source can fix.
-        return {"GitHub API rate limit exceeded", "Github API error (retryable)"}
+        #
+        # A `requests.ProxyError` (a `ConnectionError` subclass `_fetch_page`'s tenacity retry already
+        # covers) that still survives is PostHog's own egress proxy throttling the CONNECT tunnel, not
+        # GitHub or the customer — the same reasoning ClickHouse and Salesforce apply to a 502/503/504
+        # tunnel gateway status. Matches the narrower 429 status only, so a deterministic tunnel
+        # failure (e.g. 407 proxy-auth) still stays reportable.
+        return {"GitHub API rate limit exceeded", "Github API error (retryable)", "Tunnel connection failed: 429"}
 
     def get_oauth_accounts(
         self, integration_id: int, team_id: int, search: str | None = None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_source_class.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_source_class.py
@@ -148,6 +148,31 @@ class TestGithubSource:
         retryable_errors = self.source.get_retryable_errors()
         assert error_message_matches(observed_error, retryable_errors)
 
+    def test_proxy_tunnel_429_error_is_retryable_not_non_retryable(self):
+        # A `requests.ProxyError` from PostHog's own egress proxy throttling the CONNECT tunnel,
+        # surfaced once _fetch_page's tenacity retry (which already covers ConnectionError) is
+        # exhausted. Not GitHub's or the customer's fault, so it must stay retryable rather than
+        # disabling the source.
+        observed_error = (
+            "HTTPSConnectionPool(host='api.github.com', port=443): Max retries exceeded with url: "
+            "/repos/o/r/issues?per_page=100 (Caused by ProxyError('Cannot connect to proxy.', "
+            "OSError('Tunnel connection failed: 429 Too Many Requests')))"
+        )
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert not any(key in observed_error for key in non_retryable_errors)
+        retryable_errors = self.source.get_retryable_errors()
+        assert error_message_matches(observed_error, retryable_errors)
+
+    def test_proxy_tunnel_407_error_is_not_retryable(self):
+        # A deterministic proxy-auth rejection, not a transient tunnel gateway status — must stay
+        # reportable rather than being swallowed by the 429 tunnel pattern.
+        observed_error = (
+            "Caused by ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: "
+            "407 Proxy Authentication Required'))"
+        )
+        retryable_errors = self.source.get_retryable_errors()
+        assert not error_message_matches(observed_error, retryable_errors)
+
     @pytest.mark.parametrize(
         "raised_message,expected_key",
         [


### PR DESCRIPTION
## Problem

A GitHub source sync surfaces in [error tracking](https://us.posthog.com/project/2/error_tracking/01a0978d-f584-7b31-b42a-d6503bd6627b) when PostHog's own egress proxy throttles the CONNECT tunnel to `api.github.com` (`ProxyError: ... Tunnel connection failed: 429 Too Many Requests`).

This is PostHog's proxy rate-limiting itself, not GitHub or the customer. The request already retried in-process, and Temporal retries the whole activity, so the failure is self-recovering noise rather than an actionable bug.

## Changes

- `GithubSource.get_retryable_errors` now recognizes `Tunnel connection failed: 429`, so this exhausted-retry case logs as a warning and re-raises for a plain Temporal retry instead of reaching error tracking.
- Matches the narrower `429` status only, the same way ClickHouse, Salesforce and LinkedIn Ads already classify tunnel gateway statuses as transient without also swallowing a deterministic `407` proxy-auth rejection.

## How did you test this code?

Extended `test_github_source_class.py`'s existing retryable/non-retryable cases:
- A realistic `ProxyError` message with the `429` tunnel status now matches `get_retryable_errors`.
- A `407` proxy-auth tunnel failure (a real misconfiguration, not transient) still does not match, so it stays reportable.

Ran `pytest products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_source_class.py` locally: 98 passed. Not run: the wider warehouse-sources or Temporal integration suites.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing or documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code, triaging a webhook-delivered error tracking alert for this source.
- No skills from the mandatory-invocation list applied to the code change itself (no DRF/migration/frontend/dataclass touch); `/writing-tests` and `/writing-pr-descriptions` were invoked for the test and this body.
- Decision: classified this as a transient infrastructure error per the triage criteria, not a `NonRetryableErrors` case (nothing to tell the customer to fix) and not a code bug (the connection-level retry via tenacity already covers it) — the gap was purely in the retryable-error classification used to keep known-transient failures out of error tracking.
- No duplicate: searched open PRs for `github`/`ProxyError`/`tunnel`/`egress` and listed every open PR from this automation's author; found the same fix already landed for LinkedIn Ads (#99646), Bing Ads (#99716) and HubSpot (#99718), and a broader proxy-blip PR (#97144) that does not touch GitHub — none cover this source.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
