### PR TITLE
feat(chartmogul): promote the source from alpha to GA

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/chartmogul/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/chartmogul/source.py
@@ -58,7 +58,7 @@ class ChartMogulSource(ResumableSource[ChartMogulSourceConfig, ChartMogulResumeC
 You can find your API key in your [ChartMogul admin settings](https://app.chartmogul.com/#/admin/api).""",
             iconPath="/static/services/chartmogul.png",
             docsUrl="https://posthog.com/docs/cdp/sources/chartmogul",
-            releaseStatus=ReleaseStatus.ALPHA,
+            releaseStatus=ReleaseStatus.GA,
             fields=cast(
                 list[FieldType],
                 [


### PR DESCRIPTION
## Problem

Users browsing the data warehouse source catalog see ChartMogul tagged "alpha", which reads as unproven and discourages connecting it. The connector has outgrown that label.

It now clears both promotion criteria:

- Live for 3.1 months, past the 3-month bar.
- Import error rate of 0.0% over the last 7 days, under the 2.5% bar.

## Changes

- ChartMogul shows as generally available in the source catalog instead of alpha.
- `releaseStatus` on `ChartMogulSource.get_source_config` moves from `ReleaseStatus.ALPHA` to `ReleaseStatus.GA`.

Nothing else changes. The source carries no `unreleasedSource` flag and no `featureFlag`, so there is no gating to remove. Schemas, sync logic and transport are untouched.

## How did you test this code?

The existing ChartMogul suites pass locally: `pytest products/warehouse_sources/backend/temporal/data_imports/sources/chartmogul/tests/` (29 passed). No test asserted the old status, so none needed updating and no new test was added — a test that reads back a declared enum value cannot fail.

Not checked: a live ChartMogul sync. The diff does not touch sync behavior.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The public docs page renders release status from the `public_source_configs` API, so it follows this field.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Opened by a PostHog Desktop agent (Claude Opus 5) running the warehouse source promotion sweep. Skills invoked: `/implementing-warehouse-sources` for where release status lives and the `ReleaseStatus` enum convention, `/writing-pr-descriptions` for this body.

Duplicate check: `gh pr list --state open` searched for the source name, "releaseStatus", "promote", "ga warehouse-sources" and "release status source", plus the full list of open PRs from the maintainer. No open PR promotes ChartMogul.

CodeRabbit CLI pass: paused, so this PR opened without a local review pass.

Public artifact: the diff and this description carry only the source's own configuration. The promotion metrics are stated as the threshold comparison, with no customer or account detail.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
