### PR TITLE
fix(csp): allow the Stripe and Turnstile scripts

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -1325,7 +1325,15 @@ class CSPMiddleware:
                 # nothing to an attacker who cannot already run script, and nothing further to one who
                 # can. Session replay decompresses snapshots with snappy-wasm and the HogQL editor
                 # parses with a WebAssembly build, so both break without it.
-                f"script-src 'self' 'nonce-{nonce}' 'wasm-unsafe-eval' {resource_url} https://*.i.posthog.com",
+                #
+                # Stripe and Turnstile are the two scripts we cannot serve ourselves: both vendors
+                # require the file to load from their own origin, so the flag-font trick of shipping
+                # a copy does not apply. `loadStripe` injects js.stripe.com for the payment entry
+                # modal, and the signup captcha loads the Turnstile API. `frame-src 'self' https:`
+                # already admits the iframes each one opens, and neither produced a connect-src
+                # violation while this policy was report-only, so their API calls run inside those
+                # frames rather than from our page.
+                f"script-src 'self' 'nonce-{nonce}' 'wasm-unsafe-eval' {resource_url} https://*.i.posthog.com https://js.stripe.com https://challenges.cloudflare.com",
                 # A data: font cannot execute script, and this directive governs font loading only,
                 # so the token widens nothing else. It also carries nothing out: a data: URL makes
                 # no request, which is what the CSS-injection attacks on this directive need. The


### PR DESCRIPTION
## Problem

Under enforcement, adding a payment method and the signup captcha would both fail. `script-src` lists no third-party host, so two scripts the app loads itself violate our own policy. The policy is report-only, so both still run today.

Over 24 hours, on documents carrying the current policy:

- `js.stripe.com`, 90 reports across 52 documents, on `/signup`, the user-navigation settings page and the onboarding plans step. `PaymentEntryModal.tsx` calls `loadStripe`, which injects the script.
- `challenges.cloudflare.com`, 14 reports across 7 documents, on `/signup`. `signupLogic.ts` drives the Turnstile widget, which loads the API.

The document counts are small because these are rare flows, not because the reports are noise. Each one is a person who reached checkout or a signup challenge.

## Changes

- Payment entry and the signup captcha keep working under an enforced policy. `script-src` gains `https://js.stripe.com` and `https://challenges.cloudflare.com`.
- Neither host can be dropped by self-hosting, which is how the country flag font was handled in #99625. Both vendors require the file to load from their own origin.
- Only `script-src` needs them. `frame-src 'self' https:` already admits the iframes each vendor opens, and neither reported a `connect-src` violation across those 52 documents, which says their API calls happen inside those frames rather than from our page.

## How did you test this code?

- No new tests. No test asserts the app's `script-src`, and an assertion on the directive text would pin the exact string and fail on every later edit.
- Not run: `TestCSPMiddleware` needs Postgres, which this sandbox does not have. CI covers it.
- Both call sites were read in the tree rather than inferred: `frontend/src/scenes/billing/PaymentEntryModal.tsx` and `frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts`.
- The production signal is direct: after deploy, both buckets should fall to zero.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 5). Skills invoked: `/writing-pr-descriptions`, `/writing-tests`, `/reviewing-with-coderabbit`.
- CodeRabbit CLI pass: paused, so this PR opened without a local pass.
- No duplicate: searched open PRs for Stripe, Turnstile and CSP. Nothing related.
- Patch coverage: the changed line is a policy string that no test asserts, so the patch is uncovered by design.
- Found by sweeping every violation bucket on documents carrying the newest policy, after #99477 changed it. That sweep also turned up the Tailwind play CDN on the messaging preference pages, which is a separate change because the fix there is to stop loading a third-party script rather than to allow one.
- Public artifact: nothing here draws on non-public material.
