### PR TITLE
fix(databricks): stop reporting egress-proxy 429s on the OAuth token fetch

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/databricks/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/databricks/source.py
@@ -194,6 +194,16 @@ class DatabricksSource(SQLSource[DatabricksSourceConfig], ValidateDatabaseHostMi
             "databricks-sql-access or workspace-consume entitlements": "Your Databricks credentials don't have the databricks-sql-access or workspace-consume entitlement. Grant one of those entitlements to the connecting user or service principal in your Databricks workspace admin settings, then resync.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # `ThriftBackend.make_request` already retries a 429 from Databricks itself before
+        # re-raising, so a 429 that still reaches us here came from PostHog's own egress proxy
+        # throttling the CONNECT tunnel (the same class ClickHouse and Salesforce already treat
+        # this way), not from Databricks or the customer. Once Temporal retries the whole activity
+        # the failure is transient and self-recovering, so don't surface it as tracked exception
+        # noise. Matches only the 429 gateway status; a deterministic tunnel failure (e.g. 407
+        # proxy-auth) still stays reportable.
+        return {"Tunnel connection failed: 429"}
+
     def validate_credentials(
         self,
         config: DatabricksSourceConfig,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/databricks/tests/test_databricks.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/databricks/tests/test_databricks.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 import pyarrow as pa
 from databricks.sql.exc import RequestError
 
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import error_message_matches
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.sql.implementation import TableStats
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.typings import SourceInputs
 from products.warehouse_sources.backend.temporal.data_imports.sources.databricks.databricks import (
@@ -519,6 +520,31 @@ class TestDatabricksSource:
     def test_permanent_failures_are_non_retryable(self, source, error_msg):
         non_retryable = source.get_non_retryable_errors()
         assert any(pattern in error_msg for pattern in non_retryable), f"Error should be non-retryable: {error_msg}"
+
+    def test_proxy_tunnel_429_error_is_retryable_not_non_retryable(self, source):
+        # A `requests.ProxyError` from PostHog's own egress proxy throttling the CONNECT tunnel
+        # while fetching the service-principal OAuth token, surfaced once the connector's own
+        # request-retry loop is exhausted. Not Databricks' or the customer's fault, so it must
+        # stay retryable rather than disabling the source.
+        observed_error = (
+            "Error during request to server: HTTPSConnectionPool(host='dbc-abc123.cloud.databricks.com', port=443):"
+            " Max retries exceeded with url: /oidc/v1/token (Caused by ProxyError('Cannot connect to proxy.',"
+            " OSError('Tunnel connection failed: 429 Too Many Requests')))"
+        )
+        non_retryable_errors = source.get_non_retryable_errors()
+        assert not any(key in observed_error for key in non_retryable_errors)
+        retryable_errors = source.get_retryable_errors()
+        assert error_message_matches(observed_error, retryable_errors)
+
+    def test_proxy_tunnel_407_error_is_not_retryable(self, source):
+        # A deterministic proxy-auth rejection, not a transient tunnel gateway status — must stay
+        # reportable rather than being swallowed by the 429 tunnel pattern.
+        observed_error = (
+            "Caused by ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed:"
+            " 407 Proxy Authentication Required'))"
+        )
+        retryable_errors = source.get_retryable_errors()
+        assert not error_message_matches(observed_error, retryable_errors)
 
     def test_validate_credentials_requires_access_token(self, source):
         config = DatabricksSourceConfig.from_dict(


### PR DESCRIPTION
## Problem

A Databricks import using service-principal auth failed and disabled a sync path after PostHog's own egress proxy throttled the CONNECT tunnel while fetching the OAuth token, not because of anything wrong with the customer's Databricks workspace or credentials. ([Error tracking issue](https://us.posthog.com/project/2/error_tracking/01a09871-983f-7031-b265-46c01d49d848))

The connector's own request-retry loop already retries a 429 returned by Databricks itself before giving up, but a 429 from our own proxy in front of the connection isn't something that loop is built to distinguish, so it surfaces as a tracked exception once retries there are exhausted.

## Changes

- `DatabricksSource.get_retryable_errors` now matches `Tunnel connection failed: 429`, so this failure is logged as a warning and left to Temporal's activity retry instead of being surfaced as tracked exception noise.
- Matches only the 429 gateway status; a deterministic tunnel failure such as 407 (proxy auth required) still stays reportable.
- Mirrors the same fix already shipped for ClickHouse, Salesforce and GitHub, which hit the identical egress-proxy signature.

## How did you test this code?

Added two cases to `TestDatabricksSource`: one confirms the observed 429 tunnel message is retryable and not swallowed by `get_non_retryable_errors`, the other confirms a 407 tunnel message stays out of the retryable set. Ran the full `test_databricks.py` suite locally (79 passed).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing behavior or documented workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged directly from a webhook-delivered error tracking issue. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`. Confirmed no open PR already covers this exact source/error before opening; the same egress-proxy 429 pattern has separate open fixes for other sources (GitHub, HubSpot, Bing Ads, LinkedIn Ads) but none for Databricks.

---
Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)
