### PR TITLE
feat(data-warehouse): list the incoming webhook source in the source catalog

### DIFF
--- a/products/data_warehouse/frontend/scenes/NewSourceScene/sourceCatalogLogic.ts
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/sourceCatalogLogic.ts
@@ -4,7 +4,7 @@ import posthog from 'posthog-js'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
-import { FeatureFlagKey } from 'lib/constants'
+import { FEATURE_FLAGS, FeatureFlagKey } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { createFuse } from 'lib/utils/fuseSearch'
 import { objectsEqual } from 'lib/utils/objects'
@@ -84,6 +84,20 @@ export interface CatalogItem {
     selfManaged?: boolean
     /** The sources most people connect (Stripe, Postgres, the ad platforms, ...). Led with when browsing. */
     featured?: boolean
+}
+
+// PostHog's own webhook endpoint isn't a warehouse connector, so it never reaches this catalog
+// through `availableSources` — but it's where people look for one, and the only other entry point
+// is the sources list. Gated on the same preview flag as that list's section.
+const EVENT_WEBHOOK_CATALOG_ITEM: CatalogItem = {
+    name: 'event-webhook',
+    label: 'Incoming webhook',
+    iconType: 'PostHog',
+    category: 'Engineering & monitoring',
+    keywords: ['webhook', 'webhooks', 'http', 'https', 'endpoint', 'events', 'incoming', 'custom', 'real time'],
+    status: 'stable',
+    releaseStatus: 'alpha',
+    url: urls.hogFunctionNew('template-source-webhook'),
 }
 
 export interface CatalogCategory {
@@ -1646,7 +1660,12 @@ export const sourceCatalogLogic = kea<sourceCatalogLogicType>([
                     })
                 )
 
-                return [...managed, ...selfManaged, ...fileUpload]
+                // `allowedSources` restricts the catalog to warehouse connectors, so the webhook
+                // source has no place in it.
+                const eventWebhook =
+                    !allowedSources && featureFlags[FEATURE_FLAGS.CDP_HOG_SOURCES] ? [EVENT_WEBHOOK_CATALOG_ITEM] : []
+
+                return [...managed, ...selfManaged, ...fileUpload, ...eventWebhook]
             },
             // featureFlags is a broad dependency that changes identity on every flag refresh;
             // keeping the previous array when the derived catalog is unchanged stops the Fuse

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceCatalogLogic.test.ts
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceCatalogLogic.test.ts
@@ -1,3 +1,4 @@
+import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { useMocks } from '~/mocks/jest'
@@ -157,5 +158,38 @@ describe('sourceCatalogLogic', () => {
 
         expect(logic.values.catalogItems).toBe(initialItems)
         expect(logic.values.catalogFuse).toBe(initialFuse)
+    })
+
+    it.each([
+        { previewEnabled: true, expectedMatches: 1 },
+        { previewEnabled: false, expectedMatches: 0 },
+    ])(
+        'shows the incoming webhook source in a "webhook" search when the preview is $previewEnabled',
+        ({ previewEnabled, expectedMatches }) => {
+            const logic = sourceCatalogLogic()
+            featureFlagLogic.mount()
+            featureFlagLogic.actions.setFeatureFlags(previewEnabled ? [FEATURE_FLAGS.CDP_HOG_SOURCES] : [], {
+                [FEATURE_FLAGS.CDP_HOG_SOURCES]: previewEnabled,
+            })
+
+            logic.actions.setSearch('webhook')
+
+            expect(logic.values.filteredItems.filter((item) => item.name === 'event-webhook')).toHaveLength(
+                expectedMatches
+            )
+        }
+    )
+
+    it('leaves the incoming webhook source out of a catalog restricted to warehouse sources', () => {
+        const logic = sourceCatalogLogic({ allowedSources: ['Stripe'] })
+        const unmountRestricted = logic.mount()
+        featureFlagLogic.mount()
+        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.CDP_HOG_SOURCES], {
+            [FEATURE_FLAGS.CDP_HOG_SOURCES]: true,
+        })
+
+        expect(logic.values.catalogItems.some((item) => item.name === 'event-webhook')).toBe(false)
+
+        unmountRestricted()
     })
 })


### PR DESCRIPTION
## Problem

A user who wants another tool to send events straight into PostHog cannot find the incoming webhook source from the new source catalog, which is where they look for it. A Replay Vision scan of the new-source onboarding flow caught this: one user searched the catalog several times, gave up, and found the feature preview settings on their own.

- The catalog lists warehouse connectors only. The webhook endpoint is an event source, so it never reaches the list through `availableSources`.
- A search for "webhook" returns third-party webhook gateways, so the catalog looks like it answered the question.
- The only entry point is the "Event sources" section further down the sources list, behind the `cdp-hog-sources` preview.

## Changes

- Searching "webhook", "http" or "endpoint" in the new source catalog now returns an "Incoming webhook" tile that opens the event source setup.
- The tile appears only for users who have the same `cdp-hog-sources` preview that gates the sources list section, so the change adds no new exposure.
- A catalog restricted with `allowedSources` (the onboarding flows) keeps listing warehouse connectors only.
- The tile carries the "Alpha" tag, matching how the sources list marks that section experimental.

Nothing looks different for anyone without the preview. The tile renders through the existing `SourceTile`, so it inherits the grid's layout and needs no new styling. No screenshot: this scene has no story, and the app was not started in this sandbox.

## How did you test this code?

- `jest products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceCatalogLogic.test.ts` locally.
- The new tests catch the two ways this regresses: the tile dropping out of a "webhook" search when the preview is on, and the tile leaking into a catalog restricted to warehouse sources. No existing test covered either.
- `tsgo --noEmit` reports nothing on the touched files. It fails repo-wide in this sandbox on unbuilt quill packages, which the diff does not touch.
- Not run: the app was not started, so the tile was not clicked through to the event source form.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude Code (PostHog Desktop) from a Replay Vision scan of the data warehouse new-source onboarding flow. Skills invoked: `/writing-user-facing-copy`, `/writing-ui-components`, `/writing-pr-descriptions`. The CodeRabbit local pass is paused, so this PR opened without one.

The tile is a constant in the catalog logic rather than a second component rendered beside the grid, so it takes part in search, category counts and the browse ordering. A component beside the grid would have stayed invisible to the search that users actually run.

No duplicate: searches over open PRs for the source catalog, webhook sources and event sources found nothing on this path.

Public artifact: the diff and this description carry no material from the scanned sessions. The keywords come from the catalog's own vocabulary.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
