### PR TITLE
fix(data-warehouse): say what to do when a join matches no sampled rows

### DIFF
--- a/frontend/src/scenes/data-warehouse/viewLinkLogic.test.tsx
+++ b/frontend/src/scenes/data-warehouse/viewLinkLogic.test.tsx
@@ -69,12 +69,19 @@ describe('viewLinkLogic', () => {
 
         validateHandler.mockReturnValue([
             200,
-            { is_valid: true, msg: 'Validation query returned no results', hogql: null, results: [] },
+            {
+                is_valid: true,
+                msg: 'None of the sampled rows matched on these keys. Check that both key columns hold the same values, then validate again.',
+                hogql: null,
+                results: [],
+            },
         ])
         logic.actions.setViewLinkValue('joining_table_key', 'id')
         await expectLogic(logic).toDispatchActions(['validateJoinSuccess'])
         expect(logic.values.saveDisabledReason).toBeNull()
-        expect(logic.values.joinValidation.msg).toBe('Validation query returned no results')
+        expect(logic.values.joinValidation.msg).toBe(
+            'None of the sampled rows matched on these keys. Check that both key columns hold the same values, then validate again.'
+        )
     })
 
     it('buckets tables into picker groups and keeps unknown types reachable', async () => {

--- a/products/data_warehouse/backend/presentation/views/view_link.py
+++ b/products/data_warehouse/backend/presentation/views/view_link.py
@@ -31,6 +31,11 @@ from products.data_tools.backend.facade.models import DataWarehouseJoin
 MATCH_RATE_SAMPLE_SIZE = 10_000
 PREVIEW_SCAN_ROWS = 1000
 PREVIEW_DISTINCT_PAIRS = 5
+NO_MATCHING_ROWS_MSG = (
+    "None of the sampled rows matched on these keys. Check that both key columns hold the same values, "
+    "then validate again."
+)
+
 # The match-rate stats query tests each sampled source key against the joining table's key column,
 # which reads that column in full. Cap its execution so this best-effort scan can't tie up warehouse
 # query capacity; over-limit runs raise and fall back to null stats rather than sampling the joining
@@ -388,7 +393,7 @@ class ViewLinkViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewset
             response_data["results"] = query_response.results
             response_data["is_valid"] = True
             if len(query_response.results) == 0:
-                response_data["msg"] = "Validation query returned no results"
+                response_data["msg"] = NO_MATCHING_ROWS_MSG
             total_rows, matched_rows, match_rate = _join_match_stats(
                 team=self.team,
                 database=database,

--- a/products/data_warehouse/backend/tests/api/test_view_link.py
+++ b/products/data_warehouse/backend/tests/api/test_view_link.py
@@ -12,6 +12,7 @@ from posthog.hogql.database.database import Database
 from posthog.hogql.query import HogQLQueryExecutor
 
 from products.data_tools.backend.models.join import DataWarehouseJoin
+from products.data_warehouse.backend.presentation.views.view_link import NO_MATCHING_ROWS_MSG
 from products.warehouse_sources.backend.facade.models import (
     DataWarehouseCredential,
     DataWarehouseTable,
@@ -370,6 +371,14 @@ def _mock_execute_hogql_with_stats_side_effect(*args, **kwargs):
     return query_response
 
 
+def _mock_execute_hogql_no_matching_rows_side_effect(*args, **kwargs):
+    """Like the plain side effect, but the sampled join finds no matching rows."""
+    query_response = _mock_execute_hogql_side_effect(*args, **kwargs)
+    if "countIf" not in (query_response.hogql or ""):
+        query_response.results = []
+    return query_response
+
+
 def _mock_execute_hogql_stats_error_side_effect(*args, **kwargs):
     query_response = _mock_execute_hogql_side_effect(*args, **kwargs)
     if "countIf" in (query_response.hogql or ""):
@@ -456,6 +465,23 @@ class TestViewLinkValidation(APIBaseTest):
                     data["hogql"],
                     f"SELECT DISTINCT source_key, joining_key FROM (SELECT {payload['source_table_key']} AS source_key, validation.{payload['joining_table_key']} AS joining_key FROM {payload['source_table_name']} LIMIT 1000) LIMIT 5",
                 )
+
+    @patch(f"{PATH}.execute_hogql_query", side_effect=_mock_execute_hogql_no_matching_rows_side_effect)
+    def test_validate_warns_when_no_sampled_rows_match(self, _):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/warehouse_view_links/validate/",
+            {
+                "source_table_name": "events",
+                "source_table_key": "uuid",
+                "joining_table_name": "persons",
+                "joining_table_key": "id",
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        data = response.json()
+        self.assertTrue(data["is_valid"])
+        self.assertEqual(data["msg"], NO_MATCHING_ROWS_MSG)
 
     @patch(f"{PATH}.execute_hogql_query", side_effect=_mock_execute_hogql_with_stats_side_effect)
     def test_validate_returns_columns_and_match_stats(self, _):


### PR DESCRIPTION
## Problem

A user linking a synced warehouse table to another table sees "Join is valid" and, right under it, a warning reading "Validation query returned no results". The two read as a contradiction, the warning names our query rather than their join, and it gives no next step. A Replay Vision scan of the new-source onboarding flow caught a user hitting this while setting up a join after connecting a source.

- The join sample runs over the first 1,000 source rows. When none of them match, the endpoint sets that warning.
- The message names the validation query, which is our machinery, not anything the user chose.
- Nothing tells the user that the two key columns are what to look at.

## Changes

- The warning now reads "None of the sampled rows matched on these keys. Check that both key columns hold the same values, then validate again."
- The message moves into a module constant, so the endpoint test asserts that the no-match path still warns instead of asserting the copy.
- The frontend logic test's mocked response carries the new string. That part is mechanical.

Nothing else about validation changes: the same path still returns `is_valid`, the same sample size, the same match-rate stats.

No screenshot: the change replaces the text inside a warning banner that already renders in this state, and the app was not started in this sandbox.

## How did you test this code?

- `pytest products/data_warehouse/backend/tests/api/test_view_link.py::TestViewLinkValidation` and `jest frontend/src/scenes/data-warehouse/viewLinkLogic.test.tsx` locally.
- The new backend case catches the no-match path going silent, which would leave a user reading only "Join is valid" for a join that matches nothing. No existing case exercised an empty result set.
- Not run: the app was not started, so the banner was not read in the browser.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude Code (PostHog Desktop) from a Replay Vision scan of the data warehouse new-source onboarding flow. Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/improving-drf-endpoints`, `/writing-pr-descriptions`. The CodeRabbit local pass is paused, so this PR opened without one.

The "Join is valid" status above the banner stays as it is. A join that compiles but matches nothing is still a valid join, and changing that verdict is a product decision rather than a copy fix.

No duplicate: searches over open PRs for join validation and the view link endpoint found nothing on this path.

Public artifact: the diff and this description carry no material from the scanned sessions.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
