### PR TITLE
fix(meta_ads): stop reporting egress-proxy 429s on the OAuth token fetch

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/source.py
@@ -182,6 +182,11 @@ class MetaAdsSource(ResumableSource[MetaAdsSourceConfig, MetaAdsResumeConfig], O
             # for volume. Only waiting helps, and the sync already retries via Temporal, so this
             # shouldn't page us as a bug either.
             META_RATE_LIMIT_ERROR_MESSAGE,
+            # PostHog's own egress proxy answering the CONNECT tunnel with a 429 (`requests.ProxyError`,
+            # a `ConnectionError` subclass). Not Meta's fault or the customer's — the proxy itself is
+            # throttling, which clears on its own, the same reasoning applied to this pattern for other
+            # sources (LinkedIn Ads, GitHub, HubSpot, Bing Ads, Databricks).
+            "Tunnel connection failed: 429",
         }
 
     def get_schemas(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/test_meta_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/test_meta_ads.py
@@ -1460,6 +1460,17 @@ class TestRetryableErrors:
             _raise_meta_api_error(response)
         assert any(pattern in str(exc_info.value) for pattern in patterns)
 
+    def test_proxy_tunnel_429_matches_retryable_pattern(self) -> None:
+        # PostHog's own egress proxy throttling the CONNECT tunnel, surfaced by requests as a
+        # ProxyError once in-process retries are exhausted.
+        error_message = (
+            "HTTPSConnectionPool(host='graph.facebook.com', port=443): Max retries exceeded with url: "
+            "/v25.0/oauth/access_token (Caused by ProxyError('Cannot connect to proxy.', "
+            "OSError('Tunnel connection failed: 429 Too Many Requests')))"
+        )
+        patterns = MetaAdsSource().get_retryable_errors()
+        assert any(pattern in error_message for pattern in patterns)
+
     def test_too_much_data_timeout_does_not_match_retryable_pattern(self) -> None:
         # The too-much-data timeout keeps its own non-retryable classification (adaptive chunking
         # already exhausted) — plain retries never resolve it, so it must not also be tagged


### PR DESCRIPTION
## Problem

A Meta Ads sync fails and pages error tracking when PostHog's own egress proxy throttles its CONNECT tunnel while the source refreshes an OAuth token, even though the request itself succeeds on a later Temporal retry.

`requests` surfaces this as a `ProxyError` (an `OSError` wrapping `Tunnel connection failed: 429 Too Many Requests`), which is not Meta's fault or a customer credential problem, so it does not belong in `get_non_retryable_errors`. It also was not tagged in `get_retryable_errors`, so every occurrence reported as an unclassified failure.

## Changes

- `MetaAdsSource.get_retryable_errors` now matches `Tunnel connection failed: 429`, the same pattern already applied to LinkedIn Ads, GitHub, HubSpot, Bing Ads and Databricks in this codebase.
- Retry and timeout behavior for the source is unchanged; this only reclassifies an already-retryable failure so it stops being reported as a bug.

## How did you test this code?

Added a case to `TestRetryableErrors` in `test_meta_ads.py` asserting the observed proxy-tunnel error message matches the new pattern. Ran the full `test_meta_ads.py` retryable/non-retryable suite locally (33 passed) and `ruff check`/`ruff format --check` on both changed files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- No duplicate: searched open PRs by exception type, message phrase, and module path (`gh pr list --search`), and listed all open PRs from this automation's author. Found the same fix already shipped for other sources (#99646, #99727, #99718, #99716, #99740) but none for `meta_ads`.
- Patch coverage: the only changed line (the new retryable-error entry) is covered by the added test case.
- Public artifact: nothing in this PR beyond the public error message and API host (`graph.facebook.com`), which is not customer-specific.

Triggered by a PostHog error tracking webhook. Tools: Claude Code. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.