### PR TITLE
fix(custom): stop reporting egress-proxy 429s during oauth2 token mint

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/custom/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/custom/source.py
@@ -949,6 +949,20 @@ class CustomSource(SimpleSource[CustomSourceConfig]):
             "Couldn't resolve the host": "A host in the manifest (base_url, token_url, or a resource's URL) could not be resolved via DNS. Check that it's spelled correctly and reachable from the public internet, then try again.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # OAuth2Auth._obtain_token (integration-backed and manifest-driven alike) mints its
+        # token request with retry=Retry(total=0) — see its docstring — so a proxy CONNECT
+        # failure during token mint surfaces here as a bare ProxyError/OSError instead of being
+        # retried in-process. It's the same egress-proxy blip already classified this way for
+        # Salesforce and ClickHouse: Temporal's activity retry recovers once the proxy does, so
+        # keep it out of error tracking as noise.
+        return {
+            "Tunnel connection failed: 429",
+            "Tunnel connection failed: 502",
+            "Tunnel connection failed: 503",
+            "Tunnel connection failed: 504",
+        }
+
     def _assemble_manifest(self, config: CustomSourceConfig) -> dict[str, Any]:
         """Parse the stored manifest and rejoin it with the auth credentials.
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/custom/test_custom_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/custom/test_custom_source.py
@@ -1872,6 +1872,35 @@ class TestCustomSourceNonRetryableErrors(SimpleTestCase):
         assert any(key in str(message) for key in non_retryable)
 
 
+class TestCustomSourceRetryableErrors(SimpleTestCase):
+    @parameterized.expand(
+        [
+            "Tunnel connection failed: 429 Too Many Requests",
+            "Tunnel connection failed: 502 Bad gateway",
+            "Tunnel connection failed: 503 Service Unavailable",
+            "Tunnel connection failed: 504 Gateway Timeout",
+            "HTTPSConnectionPool(host='example.my.salesforce.com', port=443): Max retries exceeded "
+            "with url: /services/oauth2/token (Caused by ProxyError('Cannot connect to proxy.', "
+            "OSError('Tunnel connection failed: 429 Too Many Requests')))",
+        ]
+    )
+    def test_token_mint_proxy_tunnel_failure_is_retryable(self, error_message):
+        # OAuth2Auth._obtain_token mints its token request with retry=Retry(total=0), so a proxy
+        # CONNECT failure during token mint (integration-backed or manifest-driven) surfaces here
+        # as a bare ProxyError/OSError instead of being retried in-process. It's an egress-proxy
+        # blip Temporal's activity retry recovers from, so it must stay out of error tracking as
+        # noise instead of falling through to the unclassified path.
+        retryable = CustomSource().get_retryable_errors()
+        assert any(pattern in error_message for pattern in retryable)
+
+    def test_proxy_auth_failure_is_not_retryable(self):
+        # A 407 shares the "Tunnel connection failed" wording but is a deterministic proxy-auth
+        # misconfiguration, not a blip — it must not match the transient set here.
+        error_message = "Tunnel connection failed: 407 Proxy Authentication Required"
+        retryable = CustomSource().get_retryable_errors()
+        assert not any(pattern in error_message for pattern in retryable)
+
+
 def _fanout_manifest() -> dict:
     """A parent (`forms`) + fan-out child (`responses`) that binds the parent's
     `id` into its path via a `type: "resolve"` param."""


### PR DESCRIPTION
## Problem

A custom REST source connecting to a Salesforce-hosted API opened an error tracking issue when PostHog's own egress proxy rate-limited the OAuth2 token mint's CONNECT tunnel (`ProxyError`/`OSError('Tunnel connection failed: 429 Too Many Requests')`). Temporal already retries the activity and the next attempt recovers, but the exception was unclassified, so it was captured as noise on every retry instead of logged as a warning.

`OAuth2Auth._obtain_token` (used by both integration-backed and manifest-driven custom sources) mints its token request with `retry=Retry(total=0)` by design, so a transport-level failure like this is meant to reach the caller for classification — see its docstring. `CustomSource` had no `get_retryable_errors()` override to do that classification, unlike the Salesforce and ClickHouse connectors, which already recognize this exact egress-proxy blip shape.

## Changes

- `CustomSource.get_retryable_errors()` now matches `"Tunnel connection failed: 429/502/503/504"`, mirroring the pattern already used by the Salesforce and ClickHouse sources for the same egress-proxy CONNECT blip.
- A 407 (deterministic proxy-auth misconfiguration) is intentionally excluded, matching the sibling sources.

## How did you test this code?

Added `TestCustomSourceRetryableErrors` in `test_custom_source.py`: one parameterized case per tunnel-failure shape (429/502/503/504, plus the full wrapped `ProxyError` message) asserting it's classified retryable, and one case asserting a 407 is not — no existing test in this file covered `get_retryable_errors()` for the custom source (only `get_non_retryable_errors()` was covered).

Ran locally:
- `uv run pytest products/warehouse_sources/backend/temporal/data_imports/sources/custom/test_custom_source.py -k "Retryable or NonRetryableErrors"` — 39 passed
- `uv run ruff check` / `ruff format --check` on both changed files — clean

Not run: the full repo-wide `mypy --cache-fine-grained .` pass (time-boxed for this change); the diff only adds a `set[str]`-returning method matching the existing base-class and sibling-source signature exactly.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing or API-documented behavior changed; this only reduces error-tracking noise for a self-recovering condition.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error tracking issue for the `custom` data-warehouse import source (`ProxyError` on the OAuth2 token endpoint, single occurrence). Investigated the stack trace via the error-tracking MCP tools, confirmed the top in-app frame originates in `sources/custom/source.py`'s OAuth2 integration wiring, and traced the failure to `OAuth2Auth._obtain_token`'s deliberate `Retry(total=0)` policy, which pushes classification to the caller.

Searched open PRs (`gh pr list --search "ProxyError"` / `"Tunnel connection failed"`, plus all of this automation's own `posthog/`-branch PRs) and found several sibling fixes for the same egress-proxy-429 pattern on other connectors (Salesforce, ClickHouse, Google Ads, LinkedIn Ads, GitHub, HubSpot, Bing Ads, Databricks) — none of them touch `sources/custom/`, so this isn't a duplicate.

No skills were invoked beyond the mandatory `/writing-tests` and `/writing-pr-descriptions`. No CodeRabbit pass (paused).