### PR TITLE
fix(google_play_console): stop reporting egress-proxy 429s on the oauth token mint

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_play_console/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_play_console/source.py
@@ -95,6 +95,15 @@ class GooglePlayConsoleSource(ResumableSource[GooglePlayConsoleSourceConfig, Goo
             ),
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        return {
+            # PostHog's own egress proxy answering the token-mint CONNECT tunnel with a 429 —
+            # the auth session already retries via DEFAULT_RETRY, so this is a proxy throttling
+            # burst that outlasted those attempts, not a Google or customer problem. Same
+            # reasoning ClickHouse and Salesforce apply to a 502/503/504 tunnel gateway status.
+            "Tunnel connection failed: 429",
+        }
+
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_play_console/tests/test_google_play_console_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_play_console/tests/test_google_play_console_source.py
@@ -171,6 +171,37 @@ def test_list_endpoint_descriptions_document_their_primary_key_columns(name: str
     assert set(PRIMARY_KEYS[name]).issubset(columns)
 
 
+@pytest.mark.parametrize(
+    "observed_error",
+    [
+        "Tunnel connection failed: 429 Too Many Requests",
+        "HTTPSConnectionPool(host='oauth2.googleapis.com', port=443): Max retries exceeded with url: "
+        "/token (Caused by ProxyError('Cannot connect to proxy.', "
+        "OSError('Tunnel connection failed: 429 Too Many Requests')))",
+    ],
+)
+def test_token_mint_proxy_tunnel_429_is_retryable(observed_error: str) -> None:
+    # PostHog's own egress proxy throttling the OAuth token-mint CONNECT tunnel is transient and
+    # self-recovering on Temporal's activity retry, so it must stay out of error tracking as noise
+    # (the same reasoning already applied to ClickHouse's and Salesforce's tunnel gateway statuses).
+    retryable_errors = GooglePlayConsoleSource().get_retryable_errors()
+
+    assert any(pattern in observed_error for pattern in retryable_errors)
+
+
+def test_token_mint_proxy_auth_rejection_stays_reportable() -> None:
+    # A 407 shares the "Cannot connect to proxy." wording but is a deterministic proxy-auth
+    # rejection that repeats on every attempt, not a transient throttling burst — it must not be
+    # swallowed by the 429 tunnel pattern.
+    observed_error = (
+        "Caused by ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: "
+        "407 Proxy Authentication Required'))"
+    )
+    retryable_errors = GooglePlayConsoleSource().get_retryable_errors()
+
+    assert not any(pattern in observed_error for pattern in retryable_errors)
+
+
 def _inputs(**overrides: Any) -> mock.MagicMock:
     inputs = mock.MagicMock()
     inputs.schema_name = "crash_rate"


### PR DESCRIPTION
## Problem

A Google Play Console sync failed and opened a fresh error tracking issue after PostHog's own egress proxy throttled the OAuth token-mint request with a 429 on the CONNECT tunnel.

- Nothing is lost: the schema stays enabled and the next scheduled sync recovers.
- The whole cost is triage noise, since nothing here is a Google or customer problem.
- `GooglePlayConsoleSource` classifies no errors as retryable, so this proxy blip falls through to `_handle_import_error`'s default `aexception` plus a raw re-raise, which is what mints the issue.

## Changes

- A 429 on the token-mint CONNECT tunnel now reads as a transient blip instead of opening an error tracking issue.
- `GooglePlayConsoleSource.get_retryable_errors()` lists the fragment, the same way ClickHouse and Salesforce already classify their own tunnel gateway statuses.
- Retries are unchanged: the failure still surfaces to Temporal, which retries the whole activity: this only stops it from being reported as an unhandled exception.

## How did you test this code?

- Added two cases to `test_google_play_console_source.py`: a bare and a `ProxyError`-wrapped 429 tunnel message both match `get_retryable_errors()`, and a 407 (proxy auth rejection, which repeats on every attempt) does not. No existing test covered this classification for this source.
- Ran `pytest` on the source's test file (81 passed) and `ruff check`/`ruff format --check` on the changed files.
- Not checked: no live sync was run and no proxy rate limit was reproduced.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Written by Claude Code (PostHog Desktop) from a production error tracking issue. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/writing-code-comments`.
- No duplicate: searched open PRs for `ProxyError`, `oauth2.googleapis`, `google_play_console`, `Tunnel connection failed` and `429`. Found several open PRs applying the same classification to other sources (LinkedIn Ads, GitHub, HubSpot, Bing Ads, Meta Ads, Databricks, Azure Cost Management, Custom, Google Ads) and a shared-predicate PR covering 502/503/504, but none cover Google Play Console or a 429 tunnel status for it.
- Public artifact: the work drew on a PostHog error tracking issue. Nothing from it is committed; the test messages are invented, using the vendor's public API host.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
