### PR TITLE
fix(ramp): stop reporting egress-proxy 429s on the token mint

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/ramp/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/ramp/source.py
@@ -69,6 +69,16 @@ class RampSource(ResumableSource[RampSourceConfig, RampResumeConfig]):
             "403 Client Error: Forbidden for url: https://demo-api.ramp.com": "Ramp denied access. Please check that your developer app has the read scope for this dataset.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        return {
+            # PostHog's own egress proxy answering the token-mint CONNECT tunnel with a 429 —
+            # the token mint disables its own retries (retry=Retry(total=0) in
+            # rest_source.auth) so it can classify the response itself, so this is a proxy
+            # throttling burst that outlasted the sync, not a Ramp or customer problem. Same
+            # reasoning already applied to other OAuth2 client-credentials sources.
+            "Tunnel connection failed: 429",
+        }
+
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/ramp/tests/test_ramp_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/ramp/tests/test_ramp_source.py
@@ -39,3 +39,30 @@ class TestRampSource:
     def test_non_retryable_errors_does_not_match_unrelated(self, other_error):
         non_retryable_errors = self.source.get_non_retryable_errors()
         assert not any(key in other_error for key in non_retryable_errors)
+
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            "Tunnel connection failed: 429 Too Many Requests",
+            "HTTPSConnectionPool(host='api.ramp.com', port=443): Max retries exceeded with url: "
+            "/developer/v1/token (Caused by ProxyError('Cannot connect to proxy.', "
+            "OSError('Tunnel connection failed: 429 Too Many Requests')))",
+        ],
+    )
+    def test_token_mint_proxy_tunnel_429_is_retryable(self, observed_error):
+        # PostHog's own egress proxy throttling the OAuth token-mint CONNECT tunnel is transient
+        # and self-recovering on Temporal's activity retry, so it must stay out of error tracking
+        # as noise rather than mint a fresh issue per burst.
+        retryable_errors = self.source.get_retryable_errors()
+        assert any(pattern in observed_error for pattern in retryable_errors)
+
+    def test_token_mint_proxy_auth_rejection_stays_reportable(self):
+        # A 407 shares the "Cannot connect to proxy." wording but is a deterministic proxy-auth
+        # rejection that repeats on every attempt, not a transient throttling burst — it must not
+        # be swallowed by the 429 tunnel pattern.
+        observed_error = (
+            "Caused by ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: "
+            "407 Proxy Authentication Required'))"
+        )
+        retryable_errors = self.source.get_retryable_errors()
+        assert not any(pattern in observed_error for pattern in retryable_errors)


### PR DESCRIPTION
## Problem

A Ramp sync fails with a `ProxyError` when minting its OAuth2 token, and error tracking files it as a defect even though the sync recovers on the next Temporal retry.

PostHog's own egress proxy throttled the CONNECT tunnel for the token-mint request (`Tunnel connection failed: 429 Too Many Requests`). The token mint disables its own HTTP retries (`retry=Retry(total=0)` in `rest_source.auth`) so it can classify the response itself, but nothing downstream recognized this specific proxy response as transient, so it reached error tracking as noise.

## Changes

- `RampSource.get_retryable_errors` now matches `Tunnel connection failed: 429`, so a proxy-throttled token mint is logged as a warning and left to Temporal's retry instead of opening an error tracking issue.
- Mirrors the same fix already shipped for other OAuth2 client-credentials sources on this egress path (Google Play Console, Azure Cost Management, Meta Ads, Databricks, HubSpot, GitHub, Bing Ads, LinkedIn Ads).

## How did you test this code?

Added two cases to `test_ramp_source.py::TestRampSource`: one confirming the tunnel 429 message matches `get_retryable_errors`, one confirming a proxy-auth 407 (same wording, different cause) does not. Ran the full file locally (9 passed).

Not run: a live sync against Ramp, since this only changes error classification, not request behavior.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error tracking issue showing `ProxyError` on `api.ramp.com`'s `/developer/v1/token` endpoint, stack-rooted in `posthog/temporal/common/posthog_client.py` (shared activity-exception reporting, not the Ramp connector). No open PR covered Ramp specifically; checked `gh pr list --search "ramp"` and the maintainer's open PR list, which has the same fix already shipped per-source for several other sources on this egress path.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.